### PR TITLE
fix: Add Bouncy Castle dependency in API, Executor, and Registry modules

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -22,6 +22,7 @@
         <msal4j.version>1.21.0</msal4j.version>
         <lombok.version>1.18.38</lombok.version>
         <jgit.version>7.3.0.202506031305-r</jgit.version>
+        <bouncy.castle>1.81</bouncy.castle>
         <rest-assured.version>5.5.5</rest-assured.version>
         <!--groovy.version>4.0.20</groovy.version-->
         <postgresql.version>42.7.7</postgresql.version>
@@ -176,6 +177,11 @@
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
             <version>${jgit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${bouncy.castle}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -23,6 +23,7 @@
 		<okhttp.version>4.12.0</okhttp.version>
 		<azure-storage-blob.version>12.30.1</azure-storage-blob.version>
 		<jgit.version>7.3.0.202506031305-r</jgit.version>
+		<bouncy.castle>1.81</bouncy.castle>
 		<lombok.version>1.18.38</lombok.version>
 		<groovy.version>4.0.27</groovy.version>
 		<ivy.version>2.5.3</ivy.version>
@@ -114,6 +115,11 @@
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
 			<version>${jgit.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcpkix-jdk18on</artifactId>
+			<version>${bouncy.castle}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>

--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -19,6 +19,7 @@
         <lombok.version>1.18.38</lombok.version>
         <terrakube-client-starter.version>1.0.0</terrakube-client-starter.version>
         <jgit.version>7.3.0.202506031305-r</jgit.version>
+        <bouncy.castle>1.81</bouncy.castle>
         <commons-io.version>2.19.0</commons-io.version>
         <mockserver-spring-test-listener.version>5.13.2</mockserver-spring-test-listener.version>
         <rest-assured.version>5.5.5</rest-assured.version>
@@ -92,6 +93,11 @@
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
             <version>${jgit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${bouncy.castle}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>


### PR DESCRIPTION
This PR fixes the issue when using ssh workspace or modules after upgrading jgit to `7.2.1.202505142326-r`

https://github.com/terrakube-io/terrakube/pull/2191

I guess this is related to https://github.com/terrakube-io/terrakube/issues/2225 but I am not really sure 

```shell
Caused by: java.security.NoSuchAlgorithmException: Unsupported key type (ssh-ed25519) in /home/cnb/.terraform-spring-boot/ssh/registry/f655cc2b-0293-4847-8703-f22fc23bb36d/id_ed25519
2025-07-01T21:24:16.589038508Z 	at org.apache.sshd.common.config.keys.loader.openssh.OpenSSHKeyPairResourceParser.readPublicKey(OpenSSHKeyPairResourceParser.java:221) ~[sshd-osgi-2.15.0.jar:2.15.0]
2025-07-01T21:24:16.589041694Z 	at org.apache.sshd.common.config.keys.loader.openssh.OpenSSHKeyPairResourceParser.extractKeyPairs(OpenSSHKeyPairResourceParser.java:133) ~[sshd-osgi-2.15.0.jar:2.15.0]
2025-07-01T21:24:16.589045071Z 	at org.apache.sshd.common.config.keys.loader.AbstractKeyPairResourceParser.extractKeyPairs(AbstractKeyPairResourceParser.java:198) ~[sshd-osgi-2.15.0.jar:2.15.0]
2025-07-01T21:24:16.589048207Z 	at org.apache.sshd.common.config.keys.loader.AbstractKeyPairResourceParser.extractKeyPairs(AbstractKeyPairResourceParser.java:167) ~[sshd-osgi-2.15.0.jar:2.15.0]
2025-07-01T21:24:16.589056733Z 	at org.apache.sshd.common.config.keys.loader.AbstractKeyPairResourceParser.loadKeyPairs(AbstractKeyPairResourceParser.java:117) ~[sshd-osgi-2.15.0.jar:2.15.0]
```