### PR TITLE
feat: Migrate test to Wiremock

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <java.version>17</java.version>
         <elide.version>7.1.11</elide.version>
-        <handlebars.version>4.4.0</handlebars.version>
+        <handlebars.version>4.3.1</handlebars.version>
         <liquibase-core.version>4.32.0</liquibase-core.version>
         <azure.version>5.22.0</azure.version>
         <mssql-jdbc.version>12.10.1.jre11</mssql-jdbc.version>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -222,6 +222,24 @@
             <artifactId>wiremock-spring-boot</artifactId>
             <version>${wiremock.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.jknack</groupId>
+                    <artifactId>handlebars</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jknack</groupId>
+            <artifactId>handlebars-helpers</artifactId>
+            <version>${handlebars.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jknack</groupId>
+            <artifactId>handlebars</artifactId>
+            <version>${handlebars.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -16,17 +16,18 @@
     <properties>
         <java.version>17</java.version>
         <elide.version>7.1.11</elide.version>
+        <handlebars.version>4.4.0</handlebars.version>
         <liquibase-core.version>4.32.0</liquibase-core.version>
         <azure.version>5.22.0</azure.version>
         <mssql-jdbc.version>12.10.1.jre11</mssql-jdbc.version>
         <msal4j.version>1.21.0</msal4j.version>
         <lombok.version>1.18.38</lombok.version>
+        <wiremock.version>3.10.0</wiremock.version>
         <jgit.version>7.3.0.202506031305-r</jgit.version>
         <bouncy.castle>1.81</bouncy.castle>
         <rest-assured.version>5.5.5</rest-assured.version>
         <!--groovy.version>4.0.20</groovy.version-->
         <postgresql.version>42.7.7</postgresql.version>
-        <mockserver-spring-test-listener.version>5.15.0</mockserver-spring-test-listener.version>
         <snakeyaml.version>2.4</snakeyaml.version>
         <quartz.version>2.5.0</quartz.version>
         <aws-sdk.version>2.31.73</aws-sdk.version>
@@ -217,9 +218,9 @@
             <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-spring-test-listener</artifactId>
-            <version>${mockserver-spring-test-listener.version}</version>
+            <groupId>org.wiremock.integrations</groupId>
+            <artifactId>wiremock-spring-boot</artifactId>
+            <version>${wiremock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/api/src/test/java/io/terrakube/api/CollectionTests.java
+++ b/api/src/test/java/io/terrakube/api/CollectionTests.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorContext;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.Flow;
@@ -17,12 +16,12 @@ import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static org.mockito.Mockito.when;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 public class CollectionTests extends ServerApplicationTests {
 
     private static final String EXECUTOR_ENDPOINT="http://localhost:9999/fake/executor";
+
 
     @BeforeEach
     public void setup() {
@@ -230,14 +229,11 @@ public class CollectionTests extends ServerApplicationTests {
     @Test
     void testCollectionPriorityAsOrgMember() {
 
-        mockServer.reset();
-        mockServer.when(
-                request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withPath("/fake/executor/api/v1/terraform-rs")
-        ).respond(
-                response().withStatusCode(org.apache.http.HttpStatus.SC_ACCEPTED)
-        );
+        wireMockServer.resetAll();
+
+        stubFor(post(urlPathEqualTo("/fake/executor/api/v1/terraform-rs"))
+                .willReturn(aResponse()
+                        .withStatus(org.apache.http.HttpStatus.SC_ACCEPTED)));
 
         given()
                 .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"), "Content-Type", "application/vnd.api+json")

--- a/api/src/test/java/io/terrakube/api/JobTests.java
+++ b/api/src/test/java/io/terrakube/api/JobTests.java
@@ -12,8 +12,9 @@ import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static org.mockito.Mockito.when;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.springframework.beans.factory.annotation.Autowired;
 
 class JobTests extends ServerApplicationTests {
 
@@ -21,18 +22,15 @@ class JobTests extends ServerApplicationTests {
     public void setup() {
         MockitoAnnotations.openMocks(this);
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        wireMockServer.resetAll();
     }
 
     @Test
     void createJobAsOrgMember() {
-        mockServer.reset();
-        mockServer.when(
-                request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withPath("/api/v1/terraform-rs")
-        ).respond(
-                response().withStatusCode(HttpStatus.ACCEPTED.value()).withBody("")
-        );
+        stubFor(post(urlPathEqualTo("/api/v1/terraform-rs"))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.ACCEPTED.value())
+                        .withBody("")));
 
         Team team = teamRepository.findById(UUID.fromString("58529721-425e-44d7-8b0d-1d515043c2f7")).get();
         team.setManageJob(true);
@@ -72,14 +70,10 @@ class JobTests extends ServerApplicationTests {
 
     @Test
     void createJobLockedWorkspace() {
-        mockServer.reset();
-        mockServer.when(
-                request()
-                        .withMethod(HttpMethod.POST.name())
-                        .withPath("/api/v1/terraform-rs")
-        ).respond(
-                response().withStatusCode(HttpStatus.ACCEPTED.value()).withBody("")
-        );
+        stubFor(post(urlPathEqualTo("/api/v1/terraform-rs"))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.ACCEPTED.value())
+                        .withBody("")));
 
         Team team = teamRepository.findById(UUID.fromString("58529721-425e-44d7-8b0d-1d515043c2f7")).get();
         team.setManageJob(true);

--- a/api/src/test/resources/application-test.properties
+++ b/api/src/test/resources/application-test.properties
@@ -91,4 +91,3 @@ io.terrakube.api.redis.port=6379
 io.terrakube.api.redis.username=default
 io.terrakube.api.redis.password=123456
 io.terrakube.api.redis.ssl=false
-

--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -21,8 +21,8 @@
         <jgit.version>7.3.0.202506031305-r</jgit.version>
         <bouncy.castle>1.81</bouncy.castle>
         <commons-io.version>2.19.0</commons-io.version>
-        <mockserver-spring-test-listener.version>5.13.2</mockserver-spring-test-listener.version>
         <rest-assured.version>5.5.5</rest-assured.version>
+        <wiremock.version>3.10.0</wiremock.version>
         <!--groovy.version>3.0.8</groovy.version-->
         <aws-sdk.version>2.31.73</aws-sdk.version>
         <zt-zip.version>1.17</zt-zip.version>
@@ -136,10 +136,10 @@
             <artifactId>sts</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-spring-test-listener</artifactId>
-            <version>${mockserver-spring-test-listener.version}</version>
-	    <scope>test</scope>
+            <groupId>org.wiremock.integrations</groupId>
+            <artifactId>wiremock-spring-boot</artifactId>
+            <version>${wiremock.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>

--- a/registry/src/test/java/io/terrakube/registry/ModuleTests.java
+++ b/registry/src/test/java/io/terrakube/registry/ModuleTests.java
@@ -2,13 +2,11 @@ package io.terrakube.registry;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpMethod;
 
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 public class ModuleTests extends OpenRegistryApplicationTests{
     private static final String ORGANIZATION_SEARCH="/api/v1/organization";
@@ -78,24 +76,19 @@ public class ModuleTests extends OpenRegistryApplicationTests{
 
     @Test
     void providerApiGetTestStep1() {
-        mockServer.reset();
-        mockServer.when(
-                request()
-                        .withMethod(HttpMethod.GET.name())
-                        .withPath(ORGANIZATION_SEARCH)
-                        .withQueryStringParameter("filter[organization]","name==moduleOrganization")
-        ).respond(
-                response().withStatusCode(HttpStatus.SC_OK).withBody(ORGANIZATION_SEARCH_BODY)
-        );
+        wireMockServer.resetAll();
+        
+        stubFor(get(urlPathEqualTo(ORGANIZATION_SEARCH))
+                .withQueryParam("filter[organization]", containing("name==moduleOrganization"))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.SC_OK)
+                        .withBody(ORGANIZATION_SEARCH_BODY)));
 
-        mockServer.when(
-                request()
-                        .withMethod(HttpMethod.GET.name())
-                        .withPath(MODULE_SEARCH)
-                        .withQueryStringParameter("filter[module]","name==sampleModule;provider==sampleProvider")
-        ).respond(
-                response().withStatusCode(HttpStatus.SC_OK).withBody(MODULE_SEARCH_BODY)
-        );
+        stubFor(get(urlPathEqualTo(MODULE_SEARCH))
+                .withQueryParam("filter[module]", containing("name==sampleModule;provider==sampleProvider"))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.SC_OK)
+                        .withBody(MODULE_SEARCH_BODY)));
 
         when()
                 .get("/terraform/modules/v1/moduleOrganization/sampleModule/sampleProvider/versions")

--- a/registry/src/test/java/io/terrakube/registry/OpenRegistryApplicationTests.java
+++ b/registry/src/test/java/io/terrakube/registry/OpenRegistryApplicationTests.java
@@ -4,19 +4,19 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
-import org.mockserver.integration.ClientAndServer;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
-
-import java.util.concurrent.TimeUnit;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.client.WireMock;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
 class OpenRegistryApplicationTests {
 
-	ClientAndServer mockServer;
+	WireMockServer wireMockServer;
 
 	@LocalServerPort
 	int port;
@@ -24,13 +24,14 @@ class OpenRegistryApplicationTests {
 	@BeforeAll
 	public void setUp() {
 		RestAssured.port = port;
-		mockServer = mockServer.startClientAndServer(9999);
+		wireMockServer = new WireMockServer(WireMockConfiguration.options().port(9999).bindAddress("localhost"));
+		wireMockServer.start();
+		WireMock.configureFor("localhost", 9999);
 	}
 
 	@AfterAll
 	public void stopServer() {
-		mockServer.stop();
-		while (!mockServer.hasStopped(10,100L, TimeUnit.MILLISECONDS)){}
+		wireMockServer.stop();
 	}
 
 }

--- a/registry/src/test/java/io/terrakube/registry/ProviderTests.java
+++ b/registry/src/test/java/io/terrakube/registry/ProviderTests.java
@@ -2,13 +2,11 @@ package io.terrakube.registry;
 
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpMethod;
 
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 public class ProviderTests extends OpenRegistryApplicationTests{
 
@@ -164,26 +162,20 @@ public class ProviderTests extends OpenRegistryApplicationTests{
 
     @Test
     void providerApiGetTestStep1() {
-        mockServer.reset();
-       mockServer.when(
-               request()
-                       .withMethod(HttpMethod.GET.name())
-                       .withPath(PATH_SEARCH)
-                       .withQueryStringParameter("filter[organization]","name==sampleOrganization")
-                       .withQueryStringParameter("filter[provider]","name==sampleProvider")
-       ).respond(
-         response().withStatusCode(HttpStatus.SC_OK).withBody(PATH_SEARCH_BODY)
-       );
+        wireMockServer.resetAll();
+        
+        stubFor(get(urlPathEqualTo(PATH_SEARCH))
+                .withQueryParam("filter[organization]", containing("name==sampleOrganization"))
+                .withQueryParam("filter[provider]", containing("name==sampleProvider"))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.SC_OK)
+                        .withBody(PATH_SEARCH_BODY)));
 
-
-        mockServer.when(
-                request()
-                        .withMethod(HttpMethod.GET.name())
-                        .withPath(PATH_SEARCH_IMPLEMENTATION)
-                        .withQueryStringParameter("include","implementation")
-        ).respond(
-                response().withStatusCode(HttpStatus.SC_OK).withBody(PATH_SEARCH_IMPLEMENTATION_BODY)
-        );
+        stubFor(get(urlPathEqualTo(PATH_SEARCH_IMPLEMENTATION))
+                .withQueryParam("include", containing("implementation"))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.SC_OK)
+                        .withBody(PATH_SEARCH_IMPLEMENTATION_BODY)));
 
         when()
                 .get("/terraform/providers/v1/sampleOrganization/sampleProvider/versions")
@@ -202,43 +194,32 @@ public class ProviderTests extends OpenRegistryApplicationTests{
 
     @Test
     void providerApiGetTestStep2() {
-        mockServer.reset();
-        mockServer.when(
-                request()
-                        .withMethod(HttpMethod.GET.name())
-                        .withPath(PATH_SEARCH)
-                        .withQueryStringParameter("filter[organization]","name==sampleOrganization")
-                        .withQueryStringParameter("filter[provider]","name==sampleProvider")
-        ).respond(
-                response().withStatusCode(HttpStatus.SC_OK).withBody(PATH_SEARCH_BODY)
-        );
+        wireMockServer.resetAll();
+        
+        stubFor(get(urlPathEqualTo(PATH_SEARCH))
+                .withQueryParam("filter[organization]", containing("name==sampleOrganization"))
+                .withQueryParam("filter[provider]", containing("name==sampleProvider"))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.SC_OK)
+                        .withBody(PATH_SEARCH_BODY)));
 
-        mockServer.when(
-                request()
-                        .withMethod(HttpMethod.GET.name())
-                        .withPath(PATH_SEARCH_IMPLEMENTATION)
-                        .withQueryStringParameter("include","implementation")
-        ).respond(
-                response().withStatusCode(HttpStatus.SC_OK).withBody(PATH_SEARCH_IMPLEMENTATION_BODY)
-        );
+        stubFor(get(urlPathEqualTo(PATH_SEARCH_IMPLEMENTATION))
+                .withQueryParam("include", containing("implementation"))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.SC_OK)
+                        .withBody(PATH_SEARCH_IMPLEMENTATION_BODY)));
 
-        mockServer.when(
-                request()
-                        .withMethod(HttpMethod.GET.name())
-                        .withPath(PATH_SEARCH_IMPLEMENTATION)
-                        .withQueryStringParameter("filter[version]","versionNumber==2.0.0")
-        ).respond(
-                response().withStatusCode(HttpStatus.SC_OK).withBody(PATH_SEARCH_IMPLEMENTATION_VERSION_BODY)
-        );
+        stubFor(get(urlPathEqualTo(PATH_SEARCH_IMPLEMENTATION))
+                .withQueryParam("filter[version]", containing("versionNumber==2.0.0"))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.SC_OK)
+                        .withBody(PATH_SEARCH_IMPLEMENTATION_VERSION_BODY)));
 
-        mockServer.when(
-                request()
-                        .withMethod(HttpMethod.GET.name())
-                        .withPath(PATH_SEARCH_IMPLEMENTATION_FILE)
-                        .withQueryStringParameter("filter[implementation]","os==darwin;arch==amd64")
-        ).respond(
-                response().withStatusCode(HttpStatus.SC_OK).withBody(PATH_SEARCH_IMPLEMENTATION_FILE_BODY)
-        );
+        stubFor(get(urlPathEqualTo(PATH_SEARCH_IMPLEMENTATION_FILE))
+                .withQueryParam("filter[implementation]", containing("os==darwin;arch==amd64"))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.SC_OK)
+                        .withBody(PATH_SEARCH_IMPLEMENTATION_FILE_BODY)));
 
         when()
                 .get("/terraform/providers/v1/sampleOrganization/sampleProvider/versions")


### PR DESCRIPTION
Terrakube was originally using mockserver but that project is abandon, this PR migrate the tests to use Wiremock