### PR TITLE
feat: Implement web client for fetching terraform/tofu index

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/json/TerraformJsonController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/json/TerraformJsonController.java
@@ -8,10 +8,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.IOException;
-import java.net.URI;
-import java.nio.charset.Charset;
 
 @Slf4j
 @AllArgsConstructor
@@ -19,20 +19,42 @@ import java.nio.charset.Charset;
 @RequestMapping("/terraform")
 public class TerraformJsonController {
 
-    TerraformJsonProperties terraformJsonProperties;
+    private TerraformJsonProperties terraformJsonProperties;
+    private WebClient.Builder webClientBuilder;
 
     @GetMapping(value= "/index.json", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> createToken() throws IOException {
+
         String terraformIndex = "";
         if(terraformJsonProperties.getReleasesUrl() != null && !terraformJsonProperties.getReleasesUrl().isEmpty()) {
             log.info("Using terraform releases URL {}", terraformJsonProperties.getReleasesUrl());
-            terraformIndex = IOUtils.toString(URI.create(terraformJsonProperties.getReleasesUrl()), Charset.defaultCharset().toString());
+            terraformIndex = terraformJsonProperties.getReleasesUrl();
         } else {
-            String defaultUrl="https://releases.hashicorp.com/terraform/index.json";
-            log.warn("Using terraform releases URL {}", defaultUrl);
-            terraformIndex = IOUtils.toString(URI.create(defaultUrl), Charset.defaultCharset().toString());
+            log.warn("Using terraform releases URL https://releases.hashicorp.com/terraform/index.json");
+            terraformIndex = "https://releases.hashicorp.com/terraform/index.json";
         }
-        return new ResponseEntity<>(terraformIndex, HttpStatus.OK);
+
+        WebClient webClient = webClientBuilder
+                .exchangeStrategies(ExchangeStrategies.builder()
+                        .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(10 * 1024 * 1024))
+                        .build())
+                .baseUrl(terraformIndex)
+                .build();
+
+        try {
+            terraformIndex = webClient.get()
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            return new ResponseEntity<>(terraformIndex, HttpStatus.OK);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            return new ResponseEntity<>(terraformIndex, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+
     }
 }
 

--- a/api/src/test/java/io/terrakube/api/IndexTests.java
+++ b/api/src/test/java/io/terrakube/api/IndexTests.java
@@ -1,0 +1,44 @@
+package io.terrakube.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.Mockito.when;
+
+public class IndexTests extends ServerApplicationTests {
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    void terraformIndexSearch() {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .get("/terraform/index.json")
+                .then()
+                .assertThat()
+                //.log() dont show terraform response it is a lot of data
+                //.all()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void tofuIndexSearch() {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .get("/tofu/index.json")
+                .then()
+                .assertThat()
+                //.log() dont show terraform response it is a lot of data
+                //.all()
+                .statusCode(HttpStatus.OK.value());
+    }
+}

--- a/api/src/test/resources/application-test.properties
+++ b/api/src/test/resources/application-test.properties
@@ -16,6 +16,8 @@ spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.Ph
 
 io.terrakube.owner=TERRAKUBE_ADMIN
 
+io.terrakube.terraform.json.releasesUrl=
+
 #############
 #ELIDE SETUP#
 #############


### PR DESCRIPTION
Implement web client for fetching terraform/tofu index, `IOUtils.toString` was not managing the proxy settings correctly from the below code:

https://github.com/terrakube-io/terrakube/blob/14c33621bf9fc171c36b04e1ef2c5b3e291b45b1/api/src/main/java/io/terrakube/api/plugin/json/TerraformJsonController.java#L29C30-L29C46

fix #2276 