### PR TITLE
feat: Support merge_request event in gitlab

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
@@ -69,7 +69,7 @@ public class WebhookService {
                 break;
             case GITLAB:
                 webhookResult = gitLabWebhookService.processWebhook(jsonPayload, headers,
-                        base64WorkspaceId);
+                        base64WorkspaceId, workspace);
                 break;
             case BITBUCKET:
                 webhookResult = bitBucketWebhookService.processWebhook(jsonPayload, headers,

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
@@ -130,7 +130,7 @@ public class WebhookService {
                 webhookRemoteId = gitHubWebhookService.createOrUpdateWebhook(workspace, webhook);
                 break;
             case GITLAB:
-                webhookRemoteId = gitLabWebhookService.createWebhook(workspace, webhook.getId().toString());
+                webhookRemoteId = gitLabWebhookService.createOrUpdateWebhook(workspace, webhook);
                 break;
             case BITBUCKET:
                 webhookRemoteId = bitBucketWebhookService.createWebhook(workspace, webhook.getId().toString());

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -125,7 +125,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
 
     private WebhookResult handleMergeRequestEvent(WebhookResult result, String jsonPayload, Workspace workspace) throws IOException, InterruptedException {
         String ownerAndRepo = extractOwnerAndRepoGitlab(workspace.getSource());
-        result.setEvent("pull_request");
+        result.setEvent("pull_request"); // hard coded pull_request to change the type from gitlab that is merge_request
         try {
             GitlabMergeRequestModel mrModel = objectMapper.readValue(jsonPayload, GitlabMergeRequestModel.class);
 
@@ -144,7 +144,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
 
                     result.setFileChanges(
                             getFileChanges(
-                                mrModel.getObjectAttributes().getId().toString(),
+                                mrModel.getObjectAttributes().getIid().toString(),
                                 getGitlabProjectId(ownerAndRepo, workspace.getVcs().getAccessToken(), workspace.getVcs().getApiUrl()),
                                 workspace.getVcs().getAccessToken(),
                                 workspace.getVcs().getApiUrl()
@@ -176,6 +176,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
                     .defaultHeader("Content-Type", "application/json")
                     .build();
 
+            log.info("Fetching MR changes for merge request {} in project {}", mergeRequestId, projectId);
             String diffContentGitlab = webClient.get()
                     .uri("/projects/{id}/merge_requests/{mergeRequestId}/raw_diffs", projectId, mergeRequestId)
                     .retrieve()

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -125,7 +125,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
 
     private WebhookResult handleMergeRequestEvent(WebhookResult result, String jsonPayload, Workspace workspace) throws IOException, InterruptedException {
         String ownerAndRepo = extractOwnerAndRepoGitlab(workspace.getSource());
-
+        result.setEvent("pull_request");
         try {
             GitlabMergeRequestModel mrModel = objectMapper.readValue(jsonPayload, GitlabMergeRequestModel.class);
 

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -344,14 +344,19 @@ public class GitLabWebhookService extends WebhookServiceBase {
     }
 
     public void deleteWebhook(Workspace workspace, String webhookRemoteId) {
-        String ownerAndRepo = extractOwnerAndRepoGitlab(workspace.getSource());
-        String apiUrl = workspace.getVcs().getApiUrl() + "/projects/" + ownerAndRepo + "/hooks/" + webhookRemoteId;
+        try {
+            String ownerAndRepo = extractOwnerAndRepoGitlab(workspace.getSource());
+            String projectId = getGitlabProjectId(ownerAndRepo, workspace.getVcs().getAccessToken(), workspace.getVcs().getApiUrl());
+            String apiUrl = workspace.getVcs().getApiUrl() + "/projects/" + projectId + "/hooks/" + webhookRemoteId;
 
-        ResponseEntity<String> response = callGitlabApi(workspace.getVcs().getAccessToken(), "", apiUrl, HttpMethod.DELETE);
-        if (response.getStatusCode().value() == 204) {
-            log.info("Webhook with remote hook id {} on repository {} deleted successfully", webhookRemoteId, ownerAndRepo);
-        } else {
-            log.warn("Failed to delete webhook with remote hook id {} on repository {}, message {}", webhookRemoteId, ownerAndRepo, response.getBody());
+            ResponseEntity<String> response = callGitlabApi(workspace.getVcs().getAccessToken(), "", apiUrl, HttpMethod.DELETE);
+            if (response.getStatusCode().value() == 204) {
+                log.info("Webhook with remote hook id {} on repository {} deleted successfully", webhookRemoteId, ownerAndRepo);
+            } else {
+                log.warn("Failed to delete webhook with remote hook id {} on repository {}, message {}", webhookRemoteId, ownerAndRepo, response.getBody());
+            }
+        } catch (Exception e) {
+            log.error("Failed to delete webhook with remote hook id {} on repository {}: {}", webhookRemoteId, workspace.getSource(), e.getMessage());
         }
     }
 

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -355,8 +355,11 @@ public class GitLabWebhookService extends WebhookServiceBase {
             } else {
                 log.warn("Failed to delete webhook with remote hook id {} on repository {}, message {}", webhookRemoteId, ownerAndRepo, response.getBody());
             }
-        } catch (Exception e) {
-            log.error("Failed to delete webhook with remote hook id {} on repository {}: {}", webhookRemoteId, workspace.getSource(), e.getMessage());
+        } catch (IOException e) {
+            log.error("Failed to delete webhook IOException with remote hook id {} on repository {}: {}", webhookRemoteId, workspace.getSource(), e.getMessage());
+        } catch (InterruptedException ex) {
+            log.error("Failed to delete webhook InterruptedException with remote hook id {} on repository {}: {}", webhookRemoteId, workspace.getSource(), ex.getMessage());
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitlabMergeRequestModel.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitlabMergeRequestModel.java
@@ -22,6 +22,7 @@ public class GitlabMergeRequestModel {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ObjectAttributes {
         private Long id;
+        private Long iid;
         private String title;
         private String description;
         private String state;

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitlabMergeRequestModel.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitlabMergeRequestModel.java
@@ -1,0 +1,65 @@
+package io.terrakube.api.plugin.vcs.provider.gitlab;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GitlabMergeRequestModel {
+    @JsonProperty("object_kind")
+    private String objectKind;
+
+    @JsonProperty("object_attributes")
+    private ObjectAttributes objectAttributes;
+
+    private User user;
+
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ObjectAttributes {
+        private Long id;
+        private String title;
+        private String description;
+        private String state;
+        private String action;
+
+        @JsonProperty("source_branch")
+        private String sourceBranch;
+
+        @JsonProperty("target_branch")
+        private String targetBranch;
+
+        @JsonProperty("last_commit")
+        private LastCommit lastCommit;
+
+        @JsonProperty("merge_status")
+        private String mergeStatus;
+
+        @JsonProperty("work_in_progress")
+        private boolean workInProgress;
+
+        private String url;
+    }
+
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class LastCommit {
+        private String id;
+        private String message;
+        private String url;
+    }
+
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class User {
+        private String name;
+        private String username;
+        private String email;
+    }
+}


### PR DESCRIPTION
This PR will allow to trigger a job when a merge request is created in Gitlab

Example configuration:

<img width="1556" height="572" alt="image" src="https://github.com/user-attachments/assets/b8f27fd1-d7d1-4f02-bb32-f615601405d1" />

<img width="1396" height="381" alt="image" src="https://github.com/user-attachments/assets/b4424567-81bf-42a0-8407-5f7bcf0a0652" />

It also fix some logic to delete the webhook from gitlab that was not executed correctly, this is related to https://github.com/terrakube-io/terrakube/issues/2300#issuecomment-3063006873

Merge request will look like this 

<img width="1396" height="381" alt="image" src="https://github.com/user-attachments/assets/732c0450-d49f-467d-b7c1-aaee2f2d9749" />

<img width="580" height="381" alt="image" src="https://github.com/user-attachments/assets/2a3bbfe7-008e-4846-972f-2e1d2be108f9" />

This is related also to this issue

https://github.com/terrakube-io/terrakube/issues/396
