### PR TITLE
feat: Support gitlab releases event to trigger jobs

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -173,9 +173,9 @@ public class GitLabWebhookService extends WebhookServiceBase {
         try {
             GitlabReleaseModel releaseModel = objectMapper.readValue(jsonPayload, GitlabReleaseModel.class);
 
-            String action = releaseModel.getObjectAttributes().getAction();
-            String tagName = releaseModel.getObjectAttributes().getTag();
-            String releaseName = releaseModel.getObjectAttributes().getName();
+            String action = releaseModel.getAction();
+            String tagName = releaseModel.getTag();
+            String releaseName = releaseModel.getName();
 
             log.info("Processing GitLab release event: {} - {} (tag: {})", action, releaseName, tagName);
 
@@ -188,7 +188,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
                     result.setEvent("release");
                     result.setValid(true);
                     result.setRelease(true);
-                    result.setBranch(tagName);
+                    result.setBranch(releaseName);
                     break;
                 default:
                     log.info("Release action '{}' for: {} not specifically handled", action, releaseName);

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -259,7 +259,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
 
         // Create the body
         String body = "{\"url\":\"" + webhookUrl
-                + "\",\"push_events\":\"true\", \"merge_requests_events\": \"true\", \"enable_ssl_verification\":\"false\",\"token\":\"" + secret + "\"}";
+                + "\",\"push_events\":\"true\", \"merge_requests_events\": \"true\", \"releases_events\": true, \"enable_ssl_verification\":\"false\",\"token\":\"" + secret + "\"}";
 
         log.info(body);
         // Create the entity

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitlabReleaseModel.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitlabReleaseModel.java
@@ -1,0 +1,79 @@
+
+package io.terrakube.api.plugin.vcs.provider.gitlab;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GitlabReleaseModel {
+    @JsonProperty("object_kind")
+    private String objectKind;
+
+    @JsonProperty("object_attributes")
+    private ObjectAttributes objectAttributes;
+
+    private Project project;
+
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ObjectAttributes {
+        private String id;
+        private String name;
+        private String description;
+        private String tag;
+        private String action;
+        private String url;
+
+        @JsonProperty("created_at")
+        private String createdAt;
+
+        @JsonProperty("released_at")
+        private String releasedAt;
+    }
+
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Project {
+        private String id;
+        private String name;
+        private String description;
+
+        @JsonProperty("web_url")
+        private String webUrl;
+
+        @JsonProperty("git_ssh_url")
+        private String gitSshUrl;
+
+        @JsonProperty("git_http_url")
+        private String gitHttpUrl;
+
+        @JsonProperty("namespace")
+        private String namespace;
+
+        @JsonProperty("visibility_level")
+        private int visibilityLevel;
+
+        @JsonProperty("path_with_namespace")
+        private String pathWithNamespace;
+
+        @JsonProperty("default_branch")
+        private String defaultBranch;
+
+        private String homepage;
+        private String url;
+
+        @JsonProperty("ssh_url")
+        private String sshUrl;
+
+        @JsonProperty("http_url")
+        private String httpUrl;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitlabReleaseModel.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitlabReleaseModel.java
@@ -12,42 +12,41 @@ import java.util.List;
 @Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GitlabReleaseModel {
+    private Long id;
+
+    @JsonProperty("created_at")
+    private String createdAt;
+
+    private String description;
+    private String name;
+
+    @JsonProperty("released_at")
+    private String releasedAt;
+
+    private String tag;
+
     @JsonProperty("object_kind")
     private String objectKind;
 
-    @JsonProperty("object_attributes")
-    private ObjectAttributes objectAttributes;
-
     private Project project;
-
-    @Getter
-    @Setter
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class ObjectAttributes {
-        private String id;
-        private String name;
-        private String description;
-        private String tag;
-        private String action;
-        private String url;
-
-        @JsonProperty("created_at")
-        private String createdAt;
-
-        @JsonProperty("released_at")
-        private String releasedAt;
-    }
+    private String url;
+    private String action;
+    private Assets assets;
+    private Commit commit;
 
     @Getter
     @Setter
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Project {
-        private String id;
+        private Long id;
         private String name;
         private String description;
 
         @JsonProperty("web_url")
         private String webUrl;
+
+        @JsonProperty("avatar_url")
+        private String avatarUrl;
 
         @JsonProperty("git_ssh_url")
         private String gitSshUrl;
@@ -55,17 +54,19 @@ public class GitlabReleaseModel {
         @JsonProperty("git_http_url")
         private String gitHttpUrl;
 
-        @JsonProperty("namespace")
         private String namespace;
 
         @JsonProperty("visibility_level")
-        private int visibilityLevel;
+        private Integer visibilityLevel;
 
         @JsonProperty("path_with_namespace")
         private String pathWithNamespace;
 
         @JsonProperty("default_branch")
         private String defaultBranch;
+
+        @JsonProperty("ci_config_path")
+        private String ciConfigPath;
 
         private String homepage;
         private String url;
@@ -75,5 +76,51 @@ public class GitlabReleaseModel {
 
         @JsonProperty("http_url")
         private String httpUrl;
+    }
+
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Assets {
+        private Integer count;
+        private List<Link> links;
+        private List<Source> sources;
+
+        @Getter
+        @Setter
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Link {
+            // This would contain any custom links added to the release
+            private String name;
+            private String url;
+        }
+
+        @Getter
+        @Setter
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Source {
+            private String format;
+            private String url;
+        }
+    }
+
+    @Getter
+    @Setter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Commit {
+        private String id;
+        private String message;
+        private String title;
+        private String timestamp;
+        private String url;
+        private Author author;
+
+        @Getter
+        @Setter
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Author {
+            private String name;
+            private String email;
+        }
     }
 }


### PR DESCRIPTION
This will allow to use releases events to trigger jobs like the following

<img width="1738" height="619" alt="image" src="https://github.com/user-attachments/assets/795d2931-995d-47a8-8400-3d759320ef65" />

Creating release like this in gitlab

> To correctly trigger the job, make sure the release name and tag matches

<img width="1141" height="595" alt="image" src="https://github.com/user-attachments/assets/de757149-5fa1-4aaf-bf93-36982f7e047c" />


