### PR TITLE
feat: Bitbucket support for push, pull request and tag creation events

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
@@ -133,7 +133,7 @@ public class WebhookService {
                 webhookRemoteId = gitLabWebhookService.createOrUpdateWebhook(workspace, webhook);
                 break;
             case BITBUCKET:
-                webhookRemoteId = bitBucketWebhookService.createWebhook(workspace, webhook.getId().toString());
+                webhookRemoteId = bitBucketWebhookService.createOrUpdateWebhook(workspace, webhook);
                 break;
             default:
                 break;

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
@@ -47,18 +47,10 @@ public class BitBucketWebhookService extends WebhookServiceBase {
         // Extract event
         String event = headers.get("x-event-key");
         log.info("Bitbucket event: {}", event);
-        if (event != null) {
-            String[] parts = event.split(":");
-            if (parts.length > 1) {
-                result.setEvent(parts[1]); // Set the second part of the split string
-            } else {
-                result.setEvent(event); // If there's no ":", set the whole event
-            }
-        }
 
-        if (result.getEvent().equals("push")) {
+        if (event.equals("push")) {
             return handlePushEvent(jsonPayload, result);
-        } else if (result.getEvent().equals("pullrequest:created")) {
+        } else if (event.equals("pullrequest:created")) {
             return handlePullRequestEvent(jsonPayload, result);
         } else {
             log.error("Unsupported Bitbucket event: {}", result.getEvent());

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
@@ -58,7 +58,7 @@ public class BitBucketWebhookService extends WebhookServiceBase {
 
         if (result.getEvent().equals("push")) {
             return handlePushEvent(jsonPayload, result);
-        } else if (result.getEvent().equals("pullrequest")) {
+        } else if (result.getEvent().equals("pullrequest:created")) {
             return handlePullRequestEvent(jsonPayload, result);
         } else {
             log.error("Unsupported Bitbucket event: {}", result.getEvent());

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
@@ -151,6 +151,9 @@ public class BitBucketWebhookService extends WebhookServiceBase {
             // Extract commit information if available
             String commit = releaseNode.path("target").path("hash").asText();
             result.setCommit(commit);
+
+            result.setValid(true);
+            result.setRelease(true);
             
             log.info("Bitbucket release event processed for tag: {}", tagName);
         } catch (Exception e) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
@@ -72,11 +72,12 @@ public class BitBucketWebhookService extends WebhookServiceBase {
 
             // Check if this is a tag creation event
             String changeType = changesNode.path("new").path("type").asText();
+            String targetType = changesNode.path("new").path("target").path("type").asText();
 
             log.info("Bitbucket change type is empty: {}", changeType.isEmpty());
-            if ("tag".equals(changeType)) {
+            if (changeType.equals("tag")) {
                 return handleTagCreationEvent(jsonPayload, result);
-            } else if ("commit".equals(changeType)) {
+            } else if (changeType.equals("branch") && targetType.equals("commit")) {
                 return handlePushCommit(jsonPayload, result, changesNode);
             } else {
                 log.error("Unsupported Bitbucket change type: {}", changeType);

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
@@ -178,6 +178,7 @@ public class BitBucketWebhookService extends WebhookServiceBase {
             String accessToken = "Bearer "
                     + workspaceRepository.findById(UUID.fromString(workspaceId)).get().getVcs().getAccessToken();
             URL urlBitbucketApi = new URL(diffFile);
+            //https://api.bitbucket.org/2.0/repositories/alfespa17/simple-terraform/diff/alfespa17/simple-terraform:383254320963%0Df7647c752c7e?from_pullrequest_id=6&topic=true
             log.info("Base URL: {}",
                     String.format("%s://%s", urlBitbucketApi.getProtocol(), urlBitbucketApi.getHost()));
             log.info("URI: {}", urlBitbucketApi.getPath());
@@ -186,8 +187,14 @@ public class BitBucketWebhookService extends WebhookServiceBase {
                     .defaultHeader(HttpHeaders.AUTHORIZATION, accessToken)
                     .build();
 
+            // Build the complete URI with path and query parameters
+            String completeUri = urlBitbucketApi.getPath();
+            if (urlBitbucketApi.getQuery() != null && !urlBitbucketApi.getQuery().isEmpty()) {
+                completeUri += "?" + urlBitbucketApi.getQuery();
+            }
+
             String diffContent = webClient.get()
-                    .uri(urlBitbucketApi.getPath())
+                    .uri(completeUri)
                     .retrieve()
                     .bodyToMono(String.class)
                     .timeout(Duration.ofSeconds(10))

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
@@ -193,6 +193,7 @@ public class BitBucketWebhookService extends WebhookServiceBase {
                 completeUri += "?" + urlBitbucketApi.getQuery();
             }
 
+            log.info("Complete URI: {}", completeUri);
             String diffContent = webClient.get()
                     .uri(completeUri)
                     .retrieve()

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
@@ -48,7 +48,7 @@ public class BitBucketWebhookService extends WebhookServiceBase {
         String event = headers.get("x-event-key");
         log.info("Bitbucket event: {}", event);
 
-        if (event.equals("push")) {
+        if (event.equals("repo:push")) {
             return handlePushEvent(jsonPayload, result);
         } else if (event.equals("pullrequest:created")) {
             return handlePullRequestEvent(jsonPayload, result);
@@ -178,6 +178,7 @@ public class BitBucketWebhookService extends WebhookServiceBase {
             String accessToken = "Bearer "
                     + workspaceRepository.findById(UUID.fromString(workspaceId)).get().getVcs().getAccessToken();
             URL urlBitbucketApi = new URL(diffFile);
+            log.info("Bitbucket diff file: {}", diffFile);
             //https://api.bitbucket.org/2.0/repositories/alfespa17/simple-terraform/diff/alfespa17/simple-terraform:383254320963%0Df7647c752c7e?from_pullrequest_id=6&topic=true
             log.info("Base URL: {}",
                     String.format("%s://%s", urlBitbucketApi.getProtocol(), urlBitbucketApi.getHost()));

--- a/api/src/test/java/io/terrakube/api/ServerApplicationTests.java
+++ b/api/src/test/java/io/terrakube/api/ServerApplicationTests.java
@@ -6,6 +6,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import io.restassured.RestAssured;
+import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
 import io.terrakube.api.repository.*;
 import net.minidev.json.JSONArray;
 import org.junit.jupiter.api.AfterAll;
@@ -47,6 +48,9 @@ class ServerApplicationTests {
 
     @LocalServerPort
     int port;
+
+    @Autowired
+    BitBucketWebhookService bitBucketWebhookService;
 
     @Autowired
     EncryptionService encryptionService;

--- a/api/src/test/java/io/terrakube/api/VcsTests.java
+++ b/api/src/test/java/io/terrakube/api/VcsTests.java
@@ -1,30 +1,38 @@
 package io.terrakube.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.api.plugin.vcs.WebhookResult;
 import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
+import io.terrakube.api.repository.VcsRepository;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.vcs.VcsType;
+import io.terrakube.api.rs.workspace.Workspace;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.util.Assert;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.util.Assert;
 
 
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.when;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import com.github.tomakehurst.wiremock.WireMockServer;
-import org.springframework.web.reactive.function.client.WebClient;
 
 class VcsTests extends ServerApplicationTests{
+
+    @Autowired
+    private VcsRepository vcsRepository;
 
     @BeforeEach
     public void setup() {
@@ -226,7 +234,7 @@ class VcsTests extends ServerApplicationTests{
 
         GitLabWebhookService gitLabWebhookService = new GitLabWebhookService(new ObjectMapper(), "localhost", "http://localhost", WebClient.builder());
 
-        Assert.equals("5397249", gitLabWebhookService.getGitlabProjectId("alfespa17/simple-terraform", "12345", "http://localhost:9999"));
+        Assert.isTrue("5397249".equals(gitLabWebhookService.getGitlabProjectId("alfespa17/simple-terraform", "12345", "http://localhost:9999")), "Gitlab project id not found");
 
         String projectSearch="[\n" +
                 "    {\n" +
@@ -245,7 +253,7 @@ class VcsTests extends ServerApplicationTests{
                         .withStatus(HttpStatus.OK.value())
                         .withBody(projectSearch)));
 
-        Assert.equals("7107040", gitLabWebhookService.getGitlabProjectId("terraform2745926/test/simple-terraform", "12345", "http://localhost:9999"));
+        Assert.isTrue(("7107040".equals(gitLabWebhookService.getGitlabProjectId("terraform2745926/test/simple-terraform", "12345", "http://localhost:9999"))), "Gitlab project id not found");
 
         stubFor(get(urlPathEqualTo("/projects"))
                 .withQueryParam("membership", equalTo("true"))
@@ -253,7 +261,1214 @@ class VcsTests extends ServerApplicationTests{
                         .withStatus(HttpStatus.OK.value())
                         .withBody(projectSearch)));
 
-        Assert.equals("7138024", gitLabWebhookService.getGitlabProjectId("terraform2745926/simple-terraform", "12345", "http://localhost:9999"));
+        Assert.isTrue("7138024".equals(gitLabWebhookService.getGitlabProjectId("terraform2745926/simple-terraform", "12345", "http://localhost:9999")), "Gitlab project id not found");
+
+    }
+
+    @Test
+    void bitbucketWebhookPullRequest() throws IOException, InterruptedException {
+        String payload="{\n" +
+                "   \"repository\":{\n" +
+                "      \"type\":\"repository\",\n" +
+                "      \"full_name\":\"dummyuser/simple-terraform\",\n" +
+                "      \"links\":{\n" +
+                "         \"self\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform\"\n" +
+                "         },\n" +
+                "         \"html\":{\n" +
+                "            \"href\":\"https://bitbucket.org/dummyuser/simple-terraform\"\n" +
+                "         },\n" +
+                "         \"avatar\":{\n" +
+                "            \"href\":\"https://bytebucket.org/ravatar/%7B5c5211c0-00f6-43d6-ac3e-00963b65241d%7D?ts=default\"\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"name\":\"simple-terraform\",\n" +
+                "      \"scm\":\"git\",\n" +
+                "      \"website\":null,\n" +
+                "      \"owner\":{\n" +
+                "         \"display_name\":\"dummyuser\",\n" +
+                "         \"links\":{\n" +
+                "            \"self\":{\n" +
+                "               \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "            },\n" +
+                "            \"avatar\":{\n" +
+                "               \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "            },\n" +
+                "            \"html\":{\n" +
+                "               \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "            }\n" +
+                "         },\n" +
+                "         \"type\":\"user\",\n" +
+                "         \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "         \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "         \"nickname\":\"dummyuser\"\n" +
+                "      },\n" +
+                "      \"workspace\":{\n" +
+                "         \"type\":\"workspace\",\n" +
+                "         \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "         \"name\":\"dummyuser\",\n" +
+                "         \"slug\":\"dummyuser\",\n" +
+                "         \"links\":{\n" +
+                "            \"avatar\":{\n" +
+                "               \"href\":\"https://bitbucket.org/workspaces/dummyuser/avatar/?ts=1543720870\"\n" +
+                "            },\n" +
+                "            \"html\":{\n" +
+                "               \"href\":\"https://bitbucket.org/dummyuser/\"\n" +
+                "            },\n" +
+                "            \"self\":{\n" +
+                "               \"href\":\"http://localhost:9999/2.0/workspaces/dummyuser\"\n" +
+                "            }\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"is_private\":true,\n" +
+                "      \"project\":{\n" +
+                "         \"type\":\"project\",\n" +
+                "         \"key\":\"TER\",\n" +
+                "         \"uuid\":\"{dc8d4f59-d6da-4cf6-9aee-e2b3e75f8a47}\",\n" +
+                "         \"name\":\"Terraform\",\n" +
+                "         \"links\":{\n" +
+                "            \"self\":{\n" +
+                "               \"href\":\"http://localhost:9999/2.0/workspaces/dummyuser/projects/TER\"\n" +
+                "            },\n" +
+                "            \"html\":{\n" +
+                "               \"href\":\"https://bitbucket.org/dummyuser/workspace/projects/TER\"\n" +
+                "            },\n" +
+                "            \"avatar\":{\n" +
+                "               \"href\":\"https://bitbucket.org/dummyuser/workspace/projects/TER/avatar/32?ts=1633189494\"\n" +
+                "            }\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"uuid\":\"{5c5211c0-00f6-43d6-ac3e-00963b65241d}\",\n" +
+                "      \"parent\":null\n" +
+                "   },\n" +
+                "   \"actor\":{\n" +
+                "      \"display_name\":\"dummyuser\",\n" +
+                "      \"links\":{\n" +
+                "         \"self\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "         },\n" +
+                "         \"avatar\":{\n" +
+                "            \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "         },\n" +
+                "         \"html\":{\n" +
+                "            \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"type\":\"user\",\n" +
+                "      \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "      \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "      \"nickname\":\"dummyuser\"\n" +
+                "   },\n" +
+                "   \"pullrequest\":{\n" +
+                "      \"comment_count\":0,\n" +
+                "      \"task_count\":0,\n" +
+                "      \"type\":\"pullrequest\",\n" +
+                "      \"id\":6,\n" +
+                "      \"title\":\"main.tf edited online with Bitbucket\",\n" +
+                "      \"description\":\"main.tf edited online with Bitbucket\",\n" +
+                "      \"rendered\":{\n" +
+                "         \"title\":{\n" +
+                "            \"type\":\"rendered\",\n" +
+                "            \"raw\":\"main.tf edited online with Bitbucket\",\n" +
+                "            \"markup\":\"markdown\",\n" +
+                "            \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
+                "         },\n" +
+                "         \"description\":{\n" +
+                "            \"type\":\"rendered\",\n" +
+                "            \"raw\":\"main.tf edited online with Bitbucket\",\n" +
+                "            \"markup\":\"markdown\",\n" +
+                "            \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"state\":\"OPEN\",\n" +
+                "      \"draft\":false,\n" +
+                "      \"merge_commit\":null,\n" +
+                "      \"close_source_branch\":true,\n" +
+                "      \"closed_by\":null,\n" +
+                "      \"author\":{\n" +
+                "         \"display_name\":\"dummyuser\",\n" +
+                "         \"links\":{\n" +
+                "            \"self\":{\n" +
+                "               \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "            },\n" +
+                "            \"avatar\":{\n" +
+                "               \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "            },\n" +
+                "            \"html\":{\n" +
+                "               \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "            }\n" +
+                "         },\n" +
+                "         \"type\":\"user\",\n" +
+                "         \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "         \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "         \"nickname\":\"dummyuser\"\n" +
+                "      },\n" +
+                "      \"reason\":\"\",\n" +
+                "      \"created_on\":\"2025-07-18T16:27:48.770315+00:00\",\n" +
+                "      \"updated_on\":\"2025-07-18T16:27:49.582116+00:00\",\n" +
+                "      \"destination\":{\n" +
+                "         \"branch\":{\n" +
+                "            \"name\":\"main\"\n" +
+                "         },\n" +
+                "         \"commit\":{\n" +
+                "            \"hash\":\"f7647c752c7e\",\n" +
+                "            \"links\":{\n" +
+                "               \"self\":{\n" +
+                "                  \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/f7647c752c7e\"\n" +
+                "               },\n" +
+                "               \"html\":{\n" +
+                "                  \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/f7647c752c7e\"\n" +
+                "               }\n" +
+                "            },\n" +
+                "            \"type\":\"commit\"\n" +
+                "         },\n" +
+                "         \"repository\":{\n" +
+                "            \"type\":\"repository\",\n" +
+                "            \"full_name\":\"dummyuser/simple-terraform\",\n" +
+                "            \"links\":{\n" +
+                "               \"self\":{\n" +
+                "                  \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform\"\n" +
+                "               },\n" +
+                "               \"html\":{\n" +
+                "                  \"href\":\"https://bitbucket.org/dummyuser/simple-terraform\"\n" +
+                "               },\n" +
+                "               \"avatar\":{\n" +
+                "                  \"href\":\"https://bytebucket.org/ravatar/%7B5c5211c0-00f6-43d6-ac3e-00963b65241d%7D?ts=default\"\n" +
+                "               }\n" +
+                "            },\n" +
+                "            \"name\":\"simple-terraform\",\n" +
+                "            \"uuid\":\"{5c5211c0-00f6-43d6-ac3e-00963b65241d}\"\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"source\":{\n" +
+                "         \"branch\":{\n" +
+                "            \"name\":\"feat/maintf-edited-online-with-bitbucket-1752856064555\",\n" +
+                "            \"links\":{\n" +
+                "               \n" +
+                "            },\n" +
+                "            \"sync_strategies\":[\n" +
+                "               \"merge_commit\",\n" +
+                "               \"rebase\"\n" +
+                "            ]\n" +
+                "         },\n" +
+                "         \"commit\":{\n" +
+                "            \"hash\":\"383254320963\",\n" +
+                "            \"links\":{\n" +
+                "               \"self\":{\n" +
+                "                  \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/383254320963\"\n" +
+                "               },\n" +
+                "               \"html\":{\n" +
+                "                  \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/383254320963\"\n" +
+                "               }\n" +
+                "            },\n" +
+                "            \"type\":\"commit\"\n" +
+                "         },\n" +
+                "         \"repository\":{\n" +
+                "            \"type\":\"repository\",\n" +
+                "            \"full_name\":\"dummyuser/simple-terraform\",\n" +
+                "            \"links\":{\n" +
+                "               \"self\":{\n" +
+                "                  \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform\"\n" +
+                "               },\n" +
+                "               \"html\":{\n" +
+                "                  \"href\":\"https://bitbucket.org/dummyuser/simple-terraform\"\n" +
+                "               },\n" +
+                "               \"avatar\":{\n" +
+                "                  \"href\":\"https://bytebucket.org/ravatar/%7B5c5211c0-00f6-43d6-ac3e-00963b65241d%7D?ts=default\"\n" +
+                "               }\n" +
+                "            },\n" +
+                "            \"name\":\"simple-terraform\",\n" +
+                "            \"uuid\":\"{5c5211c0-00f6-43d6-ac3e-00963b65241d}\"\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"reviewers\":[\n" +
+                "         \n" +
+                "      ],\n" +
+                "      \"participants\":[\n" +
+                "         \n" +
+                "      ],\n" +
+                "      \"links\":{\n" +
+                "         \"self\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/pullrequests/6\"\n" +
+                "         },\n" +
+                "         \"html\":{\n" +
+                "            \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/pull-requests/6\"\n" +
+                "         },\n" +
+                "         \"commits\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/pullrequests/6/commits\"\n" +
+                "         },\n" +
+                "         \"approve\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/pullrequests/6/approve\"\n" +
+                "         },\n" +
+                "         \"request-changes\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/pullrequests/6/request-changes\"\n" +
+                "         },\n" +
+                "         \"diff\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/diff/dummyuser/simple-terraform:383254320963%0Df7647c752c7e?from_pullrequest_id=1&topic=true\"\n" +
+                "         },\n" +
+                "         \"diffstat\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/diffstat/dummyuser/simple-terraform:383254320963%0Df7647c752c7e?from_pullrequest_id=6&topic=true\"\n" +
+                "         },\n" +
+                "         \"comments\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/pullrequests/6/comments\"\n" +
+                "         },\n" +
+                "         \"activity\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/pullrequests/6/activity\"\n" +
+                "         },\n" +
+                "         \"merge\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/pullrequests/6/merge\"\n" +
+                "         },\n" +
+                "         \"decline\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/pullrequests/6/decline\"\n" +
+                "         },\n" +
+                "         \"statuses\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/pullrequests/6/statuses\"\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"summary\":{\n" +
+                "         \"type\":\"rendered\",\n" +
+                "         \"raw\":\"main.tf edited online with Bitbucket\",\n" +
+                "         \"markup\":\"markdown\",\n" +
+                "         \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
+                "      }\n" +
+                "   }\n" +
+                "}";
+
+        String diffResponse = "diff --git a/main.tf b/main.tf\n" +
+                "index f7884af..66c627b 100644\n" +
+                "--- a/main.tf\n" +
+                "+++ b/main.tf\n" +
+                "@@ -23,6 +23,8 @@ output \"creation_time\" {\n" +
+                " \n" +
+                " \n" +
+                " \n" +
+                "+\n" +
+                "+\n" +
+                " output \"fake_data\" {\n" +
+                "     value = local.fake\n" +
+                " }\n";
+
+        stubFor(get(urlPathEqualTo("/2.0/repositories/dummyuser/simple-terraform/diff/dummyuser/simple-terraform:383254320963%0Df7647c752c7e"))
+                .withQueryParam("from_pullrequest_id", equalTo("1"))
+                .withQueryParam("topic", equalTo("true"))
+               .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withBody(diffResponse)));
+
+        Vcs vcs = new Vcs();
+        vcs.setAccessToken("1234567890");
+        vcs.setClientId("123");
+        vcs.setClientSecret("123");
+        vcs.setName("bitbucket");
+        vcs.setDescription("1234");
+        vcs.setVcsType(VcsType.BITBUCKET);
+        vcs.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
+        vcs = vcsRepository.save(vcs);
+
+        Workspace workspace = new Workspace();
+        workspace.setName(UUID.randomUUID().toString());
+        workspace.setSource("1234");
+        workspace.setBranch("main");
+        workspace.setIacType("terraform");
+        workspace.setTerraformVersion("1.0");
+        workspace.setVcs(vcs);
+        workspace.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
+        workspace = workspaceRepository.save(workspace);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("x-event-key", "pullrequest:created");
+        WebhookResult webhookResult = new WebhookResult();
+        webhookResult.setWorkspaceId(workspace.getId().toString());
+        webhookResult = bitBucketWebhookService.handleEvent(payload,webhookResult, headers);
+
+        Assert.isTrue(webhookResult.getFileChanges().size()==1,"File changes is not 1");
+
+    }
+
+    @Test
+    void bitbucketWebhookTag() throws IOException, InterruptedException {
+        String payload="{\n" +
+                "   \"push\":{\n" +
+                "      \"changes\":[\n" +
+                "         {\n" +
+                "            \"old\":null,\n" +
+                "            \"new\":{\n" +
+                "               \"name\":\"release/v1.0\",\n" +
+                "               \"type\":\"tag\",\n" +
+                "               \"message\":null,\n" +
+                "               \"date\":null,\n" +
+                "               \"tagger\":null,\n" +
+                "               \"target\":{\n" +
+                "                  \"type\":\"commit\",\n" +
+                "                  \"hash\":\"f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\",\n" +
+                "                  \"date\":\"2024-01-19T17:25:41+00:00\",\n" +
+                "                  \"author\":{\n" +
+                "                     \"type\":\"author\",\n" +
+                "                     \"raw\":\"dummyuser <dummyuser@gmail.com>\",\n" +
+                "                     \"user\":{\n" +
+                "                        \"display_name\":\"dummyuser\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"https://api.bitbucket.org/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "                           },\n" +
+                "                           \"avatar\":{\n" +
+                "                              \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"user\",\n" +
+                "                        \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "                        \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "                        \"nickname\":\"dummyuser\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"committer\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"message\":\"main.tf edited online with Bitbucket\",\n" +
+                "                  \"summary\":{\n" +
+                "                     \"type\":\"rendered\",\n" +
+                "                     \"raw\":\"main.tf edited online with Bitbucket\",\n" +
+                "                     \"markup\":\"markdown\",\n" +
+                "                     \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
+                "                  },\n" +
+                "                  \"links\":{\n" +
+                "                     \"self\":{\n" +
+                "                        \"href\":\"https://api.bitbucket.org/2.0/repositories/dummyuser/simple-terraform/commit/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
+                "                     },\n" +
+                "                     \"html\":{\n" +
+                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"parents\":[\n" +
+                "                     {\n" +
+                "                        \"hash\":\"ee99ab866b3151b10f817ea1ff127fe8b51cb57c\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"https://api.bitbucket.org/2.0/repositories/dummyuser/simple-terraform/commit/ee99ab866b3151b10f817ea1ff127fe8b51cb57c\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/ee99ab866b3151b10f817ea1ff127fe8b51cb57c\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"commit\"\n" +
+                "                     }\n" +
+                "                  ],\n" +
+                "                  \"rendered\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"properties\":{\n" +
+                "                     \n" +
+                "                  }\n" +
+                "               },\n" +
+                "               \"links\":{\n" +
+                "                  \"self\":{\n" +
+                "                     \"href\":\"https://api.bitbucket.org/2.0/repositories/dummyuser/simple-terraform/refs/tags/release/v1.0\"\n" +
+                "                  },\n" +
+                "                  \"commits\":{\n" +
+                "                     \"href\":\"https://api.bitbucket.org/2.0/repositories/dummyuser/simple-terraform/commits/release/v1.0\"\n" +
+                "                  },\n" +
+                "                  \"html\":{\n" +
+                "                     \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/tag/release/v1.0\"\n" +
+                "                  }\n" +
+                "               }\n" +
+                "            },\n" +
+                "            \"truncated\":false,\n" +
+                "            \"created\":true,\n" +
+                "            \"forced\":false,\n" +
+                "            \"closed\":false,\n" +
+                "            \"links\":{\n" +
+                "               \"commits\":{\n" +
+                "                  \"href\":\"https://api.bitbucket.org/2.0/repositories/dummyuser/simple-terraform/commits?include=f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
+                "               }\n" +
+                "            }\n" +
+                "         }\n" +
+                "      ]\n" +
+                "   },\n" +
+                "   \"repository\":{\n" +
+                "      \"type\":\"repository\",\n" +
+                "      \"full_name\":\"dummyuser/simple-terraform\",\n" +
+                "      \"links\":{\n" +
+                "         \"self\":{\n" +
+                "            \"href\":\"https://api.bitbucket.org/2.0/repositories/dummyuser/simple-terraform\"\n" +
+                "         },\n" +
+                "         \"html\":{\n" +
+                "            \"href\":\"https://bitbucket.org/dummyuser/simple-terraform\"\n" +
+                "         },\n" +
+                "         \"avatar\":{\n" +
+                "            \"href\":\"https://bytebucket.org/ravatar/%7B5c5211c0-00f6-43d6-ac3e-00963b65241d%7D?ts=default\"\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"name\":\"simple-terraform\",\n" +
+                "      \"scm\":\"git\",\n" +
+                "      \"website\":null,\n" +
+                "      \"owner\":{\n" +
+                "         \"display_name\":\"dummyuser\",\n" +
+                "         \"links\":{\n" +
+                "            \"self\":{\n" +
+                "               \"href\":\"https://api.bitbucket.org/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "            },\n" +
+                "            \"avatar\":{\n" +
+                "               \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "            },\n" +
+                "            \"html\":{\n" +
+                "               \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "            }\n" +
+                "         },\n" +
+                "         \"type\":\"user\",\n" +
+                "         \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "         \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "         \"nickname\":\"dummyuser\"\n" +
+                "      },\n" +
+                "      \"workspace\":{\n" +
+                "         \"type\":\"workspace\",\n" +
+                "         \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "         \"name\":\"dummyuser\",\n" +
+                "         \"slug\":\"dummyuser\",\n" +
+                "         \"links\":{\n" +
+                "            \"avatar\":{\n" +
+                "               \"href\":\"https://bitbucket.org/workspaces/dummyuser/avatar/?ts=1543720870\"\n" +
+                "            },\n" +
+                "            \"html\":{\n" +
+                "               \"href\":\"https://bitbucket.org/dummyuser/\"\n" +
+                "            },\n" +
+                "            \"self\":{\n" +
+                "               \"href\":\"https://api.bitbucket.org/2.0/workspaces/dummyuser\"\n" +
+                "            }\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"is_private\":true,\n" +
+                "      \"project\":{\n" +
+                "         \"type\":\"project\",\n" +
+                "         \"key\":\"TER\",\n" +
+                "         \"uuid\":\"{dc8d4f59-d6da-4cf6-9aee-e2b3e75f8a47}\",\n" +
+                "         \"name\":\"Terraform\",\n" +
+                "         \"links\":{\n" +
+                "            \"self\":{\n" +
+                "               \"href\":\"https://api.bitbucket.org/2.0/workspaces/dummyuser/projects/TER\"\n" +
+                "            },\n" +
+                "            \"html\":{\n" +
+                "               \"href\":\"https://bitbucket.org/dummyuser/workspace/projects/TER\"\n" +
+                "            },\n" +
+                "            \"avatar\":{\n" +
+                "               \"href\":\"https://bitbucket.org/dummyuser/workspace/projects/TER/avatar/32?ts=1633189494\"\n" +
+                "            }\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"uuid\":\"{5c5211c0-00f6-43d6-ac3e-00963b65241d}\",\n" +
+                "      \"parent\":null\n" +
+                "   },\n" +
+                "   \"actor\":{\n" +
+                "      \"display_name\":\"dummyuser\",\n" +
+                "      \"links\":{\n" +
+                "         \"self\":{\n" +
+                "            \"href\":\"https://api.bitbucket.org/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "         },\n" +
+                "         \"avatar\":{\n" +
+                "            \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "         },\n" +
+                "         \"html\":{\n" +
+                "            \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"type\":\"user\",\n" +
+                "      \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "      \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "      \"nickname\":\"dummyuser\"\n" +
+                "   }\n" +
+                "}";
+
+        Vcs vcs = new Vcs();
+        vcs.setAccessToken("1234567890");
+        vcs.setClientId("123");
+        vcs.setClientSecret("123");
+        vcs.setName("bitbucket");
+        vcs.setDescription("1234");
+        vcs.setVcsType(VcsType.BITBUCKET);
+        vcs.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
+        vcs = vcsRepository.save(vcs);
+
+        Workspace workspace = new Workspace();
+        workspace.setName(UUID.randomUUID().toString());
+        workspace.setSource("1234");
+        workspace.setBranch("main");
+        workspace.setIacType("terraform");
+        workspace.setTerraformVersion("1.0");
+        workspace.setVcs(vcs);
+        workspace.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
+        workspace = workspaceRepository.save(workspace);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("x-event-key", "repo:push");
+        WebhookResult webhookResult = new WebhookResult();
+        webhookResult.setWorkspaceId(workspace.getId().toString());
+        webhookResult = bitBucketWebhookService.handleEvent(payload,webhookResult, headers);
+
+        Assert.isTrue(webhookResult.isRelease(),"Bitbucket release is not true");
+
+    }
+
+    @Test
+    void bitbucketWebhookPush() throws IOException, InterruptedException {
+        String payload="{\n" +
+                "   \"push\":{\n" +
+                "      \"changes\":[\n" +
+                "         {\n" +
+                "            \"old\":null,\n" +
+                "            \"new\":{\n" +
+                "               \"name\":\"dummyuser/maintf-edited-online-with-bitbucket-1752695846323\",\n" +
+                "               \"target\":{\n" +
+                "                  \"type\":\"commit\",\n" +
+                "                  \"hash\":\"53580d154140650af84b438d6d7b99f33740441b\",\n" +
+                "                  \"date\":\"2025-07-16T19:57:29+00:00\",\n" +
+                "                  \"author\":{\n" +
+                "                     \"type\":\"author\",\n" +
+                "                     \"raw\":\"dummyuser <dummyuser@gmail.com>\",\n" +
+                "                     \"user\":{\n" +
+                "                        \"display_name\":\"dummyuser\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "                           },\n" +
+                "                           \"avatar\":{\n" +
+                "                              \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"user\",\n" +
+                "                        \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "                        \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "                        \"nickname\":\"dummyuser\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"committer\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"message\":\"main.tf edited online with Bitbucket\",\n" +
+                "                  \"summary\":{\n" +
+                "                     \"type\":\"rendered\",\n" +
+                "                     \"raw\":\"main.tf edited online with Bitbucket\",\n" +
+                "                     \"markup\":\"markdown\",\n" +
+                "                     \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
+                "                  },\n" +
+                "                  \"links\":{\n" +
+                "                     \"self\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/53580d154140650af84b438d6d7b99f33740441b\"\n" +
+                "                     },\n" +
+                "                     \"html\":{\n" +
+                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/53580d154140650af84b438d6d7b99f33740441b\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"parents\":[\n" +
+                "                     {\n" +
+                "                        \"hash\":\"f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"commit\"\n" +
+                "                     }\n" +
+                "                  ],\n" +
+                "                  \"rendered\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"properties\":{\n" +
+                "                     \n" +
+                "                  }\n" +
+                "               },\n" +
+                "               \"links\":{\n" +
+                "                  \"self\":{\n" +
+                "                     \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/refs/branches/dummyuser/maintf-edited-online-with-bitbucket-1752695846323\"\n" +
+                "                  },\n" +
+                "                  \"commits\":{\n" +
+                "                     \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commits/dummyuser/maintf-edited-online-with-bitbucket-1752695846323\"\n" +
+                "                  },\n" +
+                "                  \"html\":{\n" +
+                "                     \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/branch/dummyuser/maintf-edited-online-with-bitbucket-1752695846323\"\n" +
+                "                  },\n" +
+                "                  \"pullrequest_create\":{\n" +
+                "                     \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/pull-requests/new?source=dummyuser/maintf-edited-online-with-bitbucket-1752695846323&t=1\"\n" +
+                "                  }\n" +
+                "               },\n" +
+                "               \"type\":\"branch\",\n" +
+                "               \"merge_strategies\":[\n" +
+                "                  \"merge_commit\",\n" +
+                "                  \"squash\",\n" +
+                "                  \"fast_forward\",\n" +
+                "                  \"squash_fast_forward\",\n" +
+                "                  \"rebase_fast_forward\",\n" +
+                "                  \"rebase_merge\"\n" +
+                "               ],\n" +
+                "               \"sync_strategies\":[\n" +
+                "                  \"merge_commit\",\n" +
+                "                  \"rebase\"\n" +
+                "               ],\n" +
+                "               \"default_merge_strategy\":\"merge_commit\"\n" +
+                "            },\n" +
+                "            \"truncated\":true,\n" +
+                "            \"created\":true,\n" +
+                "            \"forced\":false,\n" +
+                "            \"closed\":false,\n" +
+                "            \"links\":{\n" +
+                "               \"commits\":{\n" +
+                "                  \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commits?include=53580d154140650af84b438d6d7b99f33740441b\"\n" +
+                "               },\n" +
+                "               \"html\":{\n" +
+                "                  \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/branch/dummyuser/maintf-edited-online-with-bitbucket-1752695846323\"\n" +
+                "               }\n" +
+                "            },\n" +
+                "            \"commits\":[\n" +
+                "               {\n" +
+                "                  \"type\":\"commit\",\n" +
+                "                  \"hash\":\"53580d154140650af84b438d6d7b99f33740441b\",\n" +
+                "                  \"date\":\"2025-07-16T19:57:29+00:00\",\n" +
+                "                  \"author\":{\n" +
+                "                     \"type\":\"author\",\n" +
+                "                     \"raw\":\"dummyuser <dummyuser@gmail.com>\",\n" +
+                "                     \"user\":{\n" +
+                "                        \"display_name\":\"dummyuser\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "                           },\n" +
+                "                           \"avatar\":{\n" +
+                "                              \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"user\",\n" +
+                "                        \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "                        \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "                        \"nickname\":\"dummyuser\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"committer\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"message\":\"main.tf edited online with Bitbucket\",\n" +
+                "                  \"summary\":{\n" +
+                "                     \"type\":\"rendered\",\n" +
+                "                     \"raw\":\"main.tf edited online with Bitbucket\",\n" +
+                "                     \"markup\":\"markdown\",\n" +
+                "                     \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
+                "                  },\n" +
+                "                  \"links\":{\n" +
+                "                     \"self\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/53580d154140650af84b438d6d7b99f33740441b\"\n" +
+                "                     },\n" +
+                "                     \"html\":{\n" +
+                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/53580d154140650af84b438d6d7b99f33740441b\"\n" +
+                "                     },\n" +
+                "                     \"diff\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/diff/53580d154140650af84b438d6d7b99f33740441b\"\n" +
+                "                     },\n" +
+                "                     \"approve\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/53580d154140650af84b438d6d7b99f33740441b/approve\"\n" +
+                "                     },\n" +
+                "                     \"comments\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/53580d154140650af84b438d6d7b99f33740441b/comments\"\n" +
+                "                     },\n" +
+                "                     \"statuses\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/53580d154140650af84b438d6d7b99f33740441b/statuses\"\n" +
+                "                     },\n" +
+                "                     \"patch\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/patch/53580d154140650af84b438d6d7b99f33740441b\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"parents\":[\n" +
+                "                     {\n" +
+                "                        \"hash\":\"f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"commit\"\n" +
+                "                     }\n" +
+                "                  ],\n" +
+                "                  \"rendered\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"properties\":{\n" +
+                "                     \n" +
+                "                  }\n" +
+                "               },\n" +
+                "               {\n" +
+                "                  \"type\":\"commit\",\n" +
+                "                  \"hash\":\"f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\",\n" +
+                "                  \"date\":\"2024-01-19T17:25:41+00:00\",\n" +
+                "                  \"author\":{\n" +
+                "                     \"type\":\"author\",\n" +
+                "                     \"raw\":\"dummyuser <dummyuser@gmail.com>\",\n" +
+                "                     \"user\":{\n" +
+                "                        \"display_name\":\"dummyuser\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "                           },\n" +
+                "                           \"avatar\":{\n" +
+                "                              \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"user\",\n" +
+                "                        \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "                        \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "                        \"nickname\":\"dummyuser\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"committer\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"message\":\"main.tf edited online with Bitbucket\",\n" +
+                "                  \"summary\":{\n" +
+                "                     \"type\":\"rendered\",\n" +
+                "                     \"raw\":\"main.tf edited online with Bitbucket\",\n" +
+                "                     \"markup\":\"markdown\",\n" +
+                "                     \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
+                "                  },\n" +
+                "                  \"links\":{\n" +
+                "                     \"self\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
+                "                     },\n" +
+                "                     \"html\":{\n" +
+                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
+                "                     },\n" +
+                "                     \"diff\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/diff/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
+                "                     },\n" +
+                "                     \"approve\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c/approve\"\n" +
+                "                     },\n" +
+                "                     \"comments\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c/comments\"\n" +
+                "                     },\n" +
+                "                     \"statuses\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c/statuses\"\n" +
+                "                     },\n" +
+                "                     \"patch\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/patch/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"parents\":[\n" +
+                "                     {\n" +
+                "                        \"hash\":\"ee99ab866b3151b10f817ea1ff127fe8b51cb57c\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/ee99ab866b3151b10f817ea1ff127fe8b51cb57c\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/ee99ab866b3151b10f817ea1ff127fe8b51cb57c\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"commit\"\n" +
+                "                     }\n" +
+                "                  ],\n" +
+                "                  \"rendered\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"properties\":{\n" +
+                "                     \n" +
+                "                  }\n" +
+                "               },\n" +
+                "               {\n" +
+                "                  \"type\":\"commit\",\n" +
+                "                  \"hash\":\"ee99ab866b3151b10f817ea1ff127fe8b51cb57c\",\n" +
+                "                  \"date\":\"2024-01-19T17:18:29+00:00\",\n" +
+                "                  \"author\":{\n" +
+                "                     \"type\":\"author\",\n" +
+                "                     \"raw\":\"dummyuser <dummyuser@gmail.com>\",\n" +
+                "                     \"user\":{\n" +
+                "                        \"display_name\":\"dummyuser\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "                           },\n" +
+                "                           \"avatar\":{\n" +
+                "                              \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"user\",\n" +
+                "                        \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "                        \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "                        \"nickname\":\"dummyuser\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"committer\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"message\":\"main.tf edited online with Bitbucket\",\n" +
+                "                  \"summary\":{\n" +
+                "                     \"type\":\"rendered\",\n" +
+                "                     \"raw\":\"main.tf edited online with Bitbucket\",\n" +
+                "                     \"markup\":\"markdown\",\n" +
+                "                     \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
+                "                  },\n" +
+                "                  \"links\":{\n" +
+                "                     \"self\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/ee99ab866b3151b10f817ea1ff127fe8b51cb57c\"\n" +
+                "                     },\n" +
+                "                     \"html\":{\n" +
+                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/ee99ab866b3151b10f817ea1ff127fe8b51cb57c\"\n" +
+                "                     },\n" +
+                "                     \"diff\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/diff/ee99ab866b3151b10f817ea1ff127fe8b51cb57c\"\n" +
+                "                     },\n" +
+                "                     \"approve\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/ee99ab866b3151b10f817ea1ff127fe8b51cb57c/approve\"\n" +
+                "                     },\n" +
+                "                     \"comments\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/ee99ab866b3151b10f817ea1ff127fe8b51cb57c/comments\"\n" +
+                "                     },\n" +
+                "                     \"statuses\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/ee99ab866b3151b10f817ea1ff127fe8b51cb57c/statuses\"\n" +
+                "                     },\n" +
+                "                     \"patch\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/patch/ee99ab866b3151b10f817ea1ff127fe8b51cb57c\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"parents\":[\n" +
+                "                     {\n" +
+                "                        \"hash\":\"d28224b45f7def76c8b399a15391bc4676581bc7\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/d28224b45f7def76c8b399a15391bc4676581bc7\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/d28224b45f7def76c8b399a15391bc4676581bc7\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"commit\"\n" +
+                "                     }\n" +
+                "                  ],\n" +
+                "                  \"rendered\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"properties\":{\n" +
+                "                     \n" +
+                "                  }\n" +
+                "               },\n" +
+                "               {\n" +
+                "                  \"type\":\"commit\",\n" +
+                "                  \"hash\":\"d28224b45f7def76c8b399a15391bc4676581bc7\",\n" +
+                "                  \"date\":\"2024-01-19T17:15:07+00:00\",\n" +
+                "                  \"author\":{\n" +
+                "                     \"type\":\"author\",\n" +
+                "                     \"raw\":\"dummyuser <dummyuser@gmail.com>\",\n" +
+                "                     \"user\":{\n" +
+                "                        \"display_name\":\"dummyuser\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "                           },\n" +
+                "                           \"avatar\":{\n" +
+                "                              \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"user\",\n" +
+                "                        \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "                        \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "                        \"nickname\":\"dummyuser\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"committer\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"message\":\"main.tf edited online with Bitbucket\",\n" +
+                "                  \"summary\":{\n" +
+                "                     \"type\":\"rendered\",\n" +
+                "                     \"raw\":\"main.tf edited online with Bitbucket\",\n" +
+                "                     \"markup\":\"markdown\",\n" +
+                "                     \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
+                "                  },\n" +
+                "                  \"links\":{\n" +
+                "                     \"self\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/d28224b45f7def76c8b399a15391bc4676581bc7\"\n" +
+                "                     },\n" +
+                "                     \"html\":{\n" +
+                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/d28224b45f7def76c8b399a15391bc4676581bc7\"\n" +
+                "                     },\n" +
+                "                     \"diff\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/diff/d28224b45f7def76c8b399a15391bc4676581bc7\"\n" +
+                "                     },\n" +
+                "                     \"approve\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/d28224b45f7def76c8b399a15391bc4676581bc7/approve\"\n" +
+                "                     },\n" +
+                "                     \"comments\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/d28224b45f7def76c8b399a15391bc4676581bc7/comments\"\n" +
+                "                     },\n" +
+                "                     \"statuses\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/d28224b45f7def76c8b399a15391bc4676581bc7/statuses\"\n" +
+                "                     },\n" +
+                "                     \"patch\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/patch/d28224b45f7def76c8b399a15391bc4676581bc7\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"parents\":[\n" +
+                "                     {\n" +
+                "                        \"hash\":\"091b43c903ff41245b3d48887237738225857134\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/091b43c903ff41245b3d48887237738225857134\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/091b43c903ff41245b3d48887237738225857134\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"commit\"\n" +
+                "                     }\n" +
+                "                  ],\n" +
+                "                  \"rendered\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"properties\":{\n" +
+                "                     \n" +
+                "                  }\n" +
+                "               },\n" +
+                "               {\n" +
+                "                  \"type\":\"commit\",\n" +
+                "                  \"hash\":\"091b43c903ff41245b3d48887237738225857134\",\n" +
+                "                  \"date\":\"2024-01-19T17:11:10+00:00\",\n" +
+                "                  \"author\":{\n" +
+                "                     \"type\":\"author\",\n" +
+                "                     \"raw\":\"dummyuser <dummyuser@gmail.com>\",\n" +
+                "                     \"user\":{\n" +
+                "                        \"display_name\":\"dummyuser\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "                           },\n" +
+                "                           \"avatar\":{\n" +
+                "                              \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"user\",\n" +
+                "                        \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "                        \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "                        \"nickname\":\"dummyuser\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"committer\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"message\":\"main.tf edited online with Bitbucket\",\n" +
+                "                  \"summary\":{\n" +
+                "                     \"type\":\"rendered\",\n" +
+                "                     \"raw\":\"main.tf edited online with Bitbucket\",\n" +
+                "                     \"markup\":\"markdown\",\n" +
+                "                     \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
+                "                  },\n" +
+                "                  \"links\":{\n" +
+                "                     \"self\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/091b43c903ff41245b3d48887237738225857134\"\n" +
+                "                     },\n" +
+                "                     \"html\":{\n" +
+                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/091b43c903ff41245b3d48887237738225857134\"\n" +
+                "                     },\n" +
+                "                     \"diff\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/diff/091b43c903ff41245b3d48887237738225857134\"\n" +
+                "                     },\n" +
+                "                     \"approve\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/091b43c903ff41245b3d48887237738225857134/approve\"\n" +
+                "                     },\n" +
+                "                     \"comments\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/091b43c903ff41245b3d48887237738225857134/comments\"\n" +
+                "                     },\n" +
+                "                     \"statuses\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/091b43c903ff41245b3d48887237738225857134/statuses\"\n" +
+                "                     },\n" +
+                "                     \"patch\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/patch/091b43c903ff41245b3d48887237738225857134\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"parents\":[\n" +
+                "                     {\n" +
+                "                        \"hash\":\"655558d16be7034c312593d303f05d7ced7d436f\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/655558d16be7034c312593d303f05d7ced7d436f\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/655558d16be7034c312593d303f05d7ced7d436f\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"commit\"\n" +
+                "                     }\n" +
+                "                  ],\n" +
+                "                  \"rendered\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"properties\":{\n" +
+                "                     \n" +
+                "                  }\n" +
+                "               }\n" +
+                "            ]\n" +
+                "         }\n" +
+                "      ]\n" +
+                "   },\n" +
+                "   \"repository\":{\n" +
+                "      \"type\":\"repository\",\n" +
+                "      \"full_name\":\"dummyuser/simple-terraform\",\n" +
+                "      \"links\":{\n" +
+                "         \"self\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform\"\n" +
+                "         },\n" +
+                "         \"html\":{\n" +
+                "            \"href\":\"https://bitbucket.org/dummyuser/simple-terraform\"\n" +
+                "         },\n" +
+                "         \"avatar\":{\n" +
+                "            \"href\":\"https://bytebucket.org/ravatar/%7B5c5211c0-00f6-43d6-ac3e-00963b65241d%7D?ts=default\"\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"name\":\"simple-terraform\",\n" +
+                "      \"scm\":\"git\",\n" +
+                "      \"website\":null,\n" +
+                "      \"owner\":{\n" +
+                "         \"display_name\":\"dummyuser\",\n" +
+                "         \"links\":{\n" +
+                "            \"self\":{\n" +
+                "               \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "            },\n" +
+                "            \"avatar\":{\n" +
+                "               \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "            },\n" +
+                "            \"html\":{\n" +
+                "               \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "            }\n" +
+                "         },\n" +
+                "         \"type\":\"user\",\n" +
+                "         \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "         \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "         \"nickname\":\"dummyuser\"\n" +
+                "      },\n" +
+                "      \"workspace\":{\n" +
+                "         \"type\":\"workspace\",\n" +
+                "         \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "         \"name\":\"dummyuser\",\n" +
+                "         \"slug\":\"dummyuser\",\n" +
+                "         \"links\":{\n" +
+                "            \"avatar\":{\n" +
+                "               \"href\":\"https://bitbucket.org/workspaces/dummyuser/avatar/?ts=1543720870\"\n" +
+                "            },\n" +
+                "            \"html\":{\n" +
+                "               \"href\":\"https://bitbucket.org/dummyuser/\"\n" +
+                "            },\n" +
+                "            \"self\":{\n" +
+                "               \"href\":\"http://localhost:9999/2.0/workspaces/dummyuser\"\n" +
+                "            }\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"is_private\":true,\n" +
+                "      \"project\":{\n" +
+                "         \"type\":\"project\",\n" +
+                "         \"key\":\"TER\",\n" +
+                "         \"uuid\":\"{dc8d4f59-d6da-4cf6-9aee-e2b3e75f8a47}\",\n" +
+                "         \"name\":\"Terraform\",\n" +
+                "         \"links\":{\n" +
+                "            \"self\":{\n" +
+                "               \"href\":\"http://localhost:9999/2.0/workspaces/dummyuser/projects/TER\"\n" +
+                "            },\n" +
+                "            \"html\":{\n" +
+                "               \"href\":\"https://bitbucket.org/dummyuser/workspace/projects/TER\"\n" +
+                "            },\n" +
+                "            \"avatar\":{\n" +
+                "               \"href\":\"https://bitbucket.org/dummyuser/workspace/projects/TER/avatar/32?ts=1633189494\"\n" +
+                "            }\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"uuid\":\"{5c5211c0-00f6-43d6-ac3e-00963b65241d}\",\n" +
+                "      \"parent\":null\n" +
+                "   },\n" +
+                "   \"actor\":{\n" +
+                "      \"display_name\":\"dummyuser\",\n" +
+                "      \"links\":{\n" +
+                "         \"self\":{\n" +
+                "            \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "         },\n" +
+                "         \"avatar\":{\n" +
+                "            \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "         },\n" +
+                "         \"html\":{\n" +
+                "            \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "         }\n" +
+                "      },\n" +
+                "      \"type\":\"user\",\n" +
+                "      \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "      \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "      \"nickname\":\"dummyuser\"\n" +
+                "   }\n" +
+                "}";
+
+        String diffResponse = "diff --git a/main.tf b/main.tf\n" +
+                "index f7884af..66c627b 100644\n" +
+                "--- a/main.tf\n" +
+                "+++ b/main.tf\n" +
+                "@@ -23,6 +23,8 @@ output \"creation_time\" {\n" +
+                " \n" +
+                " \n" +
+                " \n" +
+                "+\n" +
+                "+\n" +
+                " output \"fake_data\" {\n" +
+                "     value = local.fake\n" +
+                " }\n";
+
+        stubFor(get(urlPathEqualTo("/2.0/repositories/dummyuser/simple-terraform/diff/53580d154140650af84b438d6d7b99f33740441b"))
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withBody(diffResponse)));
+
+        Vcs vcs = new Vcs();
+        vcs.setAccessToken("1234567890");
+        vcs.setClientId("123");
+        vcs.setClientSecret("123");
+        vcs.setName("bitbucket");
+        vcs.setDescription("1234");
+        vcs.setVcsType(VcsType.BITBUCKET);
+        vcs.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
+        vcs = vcsRepository.save(vcs);
+
+        Workspace workspace = new Workspace();
+        workspace.setName(UUID.randomUUID().toString());
+        workspace.setSource("1234");
+        workspace.setBranch("main");
+        workspace.setIacType("terraform");
+        workspace.setTerraformVersion("1.0");
+        workspace.setVcs(vcs);
+        workspace.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
+        workspace = workspaceRepository.save(workspace);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("x-event-key", "repo:push");
+        WebhookResult webhookResult = new WebhookResult();
+        webhookResult.setWorkspaceId(workspace.getId().toString());
+        webhookResult = bitBucketWebhookService.handleEvent(payload,webhookResult, headers);
+
+        Assert.isTrue(webhookResult.getFileChanges().size()==1,"File changes is not 1");
 
     }
 }

--- a/api/src/test/java/io/terrakube/api/VcsTests.java
+++ b/api/src/test/java/io/terrakube/api/VcsTests.java
@@ -816,13 +816,12 @@ class VcsTests extends ServerApplicationTests{
                 "   \"push\":{\n" +
                 "      \"changes\":[\n" +
                 "         {\n" +
-                "            \"old\":null,\n" +
-                "            \"new\":{\n" +
-                "               \"name\":\"dummyuser/maintf-edited-online-with-bitbucket-1752695846323\",\n" +
+                "            \"old\":{\n" +
+                "               \"name\":\"main\",\n" +
                 "               \"target\":{\n" +
                 "                  \"type\":\"commit\",\n" +
-                "                  \"hash\":\"53580d154140650af84b438d6d7b99f33740441b\",\n" +
-                "                  \"date\":\"2025-07-16T19:57:29+00:00\",\n" +
+                "                  \"hash\":\"71085ceb4314ac77d1a36ab687b3e067814c9395\",\n" +
+                "                  \"date\":\"2025-07-18T21:09:50+00:00\",\n" +
                 "                  \"author\":{\n" +
                 "                     \"type\":\"author\",\n" +
                 "                     \"raw\":\"dummyuser <dummyuser@gmail.com>\",\n" +
@@ -857,21 +856,21 @@ class VcsTests extends ServerApplicationTests{
                 "                  },\n" +
                 "                  \"links\":{\n" +
                 "                     \"self\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/53580d154140650af84b438d6d7b99f33740441b\"\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/71085ceb4314ac77d1a36ab687b3e067814c9395\"\n" +
                 "                     },\n" +
                 "                     \"html\":{\n" +
-                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/53580d154140650af84b438d6d7b99f33740441b\"\n" +
+                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/71085ceb4314ac77d1a36ab687b3e067814c9395\"\n" +
                 "                     }\n" +
                 "                  },\n" +
                 "                  \"parents\":[\n" +
                 "                     {\n" +
-                "                        \"hash\":\"f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\",\n" +
+                "                        \"hash\":\"fc3154e151fea0ca3ae2c4e6f8fbffe54a5a8568\",\n" +
                 "                        \"links\":{\n" +
                 "                           \"self\":{\n" +
-                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/fc3154e151fea0ca3ae2c4e6f8fbffe54a5a8568\"\n" +
                 "                           },\n" +
                 "                           \"html\":{\n" +
-                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
+                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/fc3154e151fea0ca3ae2c4e6f8fbffe54a5a8568\"\n" +
                 "                           }\n" +
                 "                        },\n" +
                 "                        \"type\":\"commit\"\n" +
@@ -886,16 +885,16 @@ class VcsTests extends ServerApplicationTests{
                 "               },\n" +
                 "               \"links\":{\n" +
                 "                  \"self\":{\n" +
-                "                     \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/refs/branches/dummyuser/maintf-edited-online-with-bitbucket-1752695846323\"\n" +
+                "                     \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/refs/branches/main\"\n" +
                 "                  },\n" +
                 "                  \"commits\":{\n" +
-                "                     \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commits/dummyuser/maintf-edited-online-with-bitbucket-1752695846323\"\n" +
+                "                     \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commits/main\"\n" +
                 "                  },\n" +
                 "                  \"html\":{\n" +
-                "                     \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/branch/dummyuser/maintf-edited-online-with-bitbucket-1752695846323\"\n" +
+                "                     \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/branch/main\"\n" +
                 "                  },\n" +
                 "                  \"pullrequest_create\":{\n" +
-                "                     \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/pull-requests/new?source=dummyuser/maintf-edited-online-with-bitbucket-1752695846323&t=1\"\n" +
+                "                     \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/pull-requests/new?source=main&t=1\"\n" +
                 "                  }\n" +
                 "               },\n" +
                 "               \"type\":\"branch\",\n" +
@@ -913,23 +912,122 @@ class VcsTests extends ServerApplicationTests{
                 "               ],\n" +
                 "               \"default_merge_strategy\":\"merge_commit\"\n" +
                 "            },\n" +
-                "            \"truncated\":true,\n" +
-                "            \"created\":true,\n" +
+                "            \"new\":{\n" +
+                "               \"name\":\"main\",\n" +
+                "               \"target\":{\n" +
+                "                  \"type\":\"commit\",\n" +
+                "                  \"hash\":\"c7eae9b0c5450123c943a4baf7c357fc2564c316\",\n" +
+                "                  \"date\":\"2025-07-18T21:20:52+00:00\",\n" +
+                "                  \"author\":{\n" +
+                "                     \"type\":\"author\",\n" +
+                "                     \"raw\":\"dummyuser <dummyuser@gmail.com>\",\n" +
+                "                     \"user\":{\n" +
+                "                        \"display_name\":\"dummyuser\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
+                "                           },\n" +
+                "                           \"avatar\":{\n" +
+                "                              \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"user\",\n" +
+                "                        \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
+                "                        \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
+                "                        \"nickname\":\"dummyuser\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"committer\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"message\":\"main.tf edited online with Bitbucket\",\n" +
+                "                  \"summary\":{\n" +
+                "                     \"type\":\"rendered\",\n" +
+                "                     \"raw\":\"main.tf edited online with Bitbucket\",\n" +
+                "                     \"markup\":\"markdown\",\n" +
+                "                     \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
+                "                  },\n" +
+                "                  \"links\":{\n" +
+                "                     \"self\":{\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/c7eae9b0c5450123c943a4baf7c357fc2564c316\"\n" +
+                "                     },\n" +
+                "                     \"html\":{\n" +
+                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/c7eae9b0c5450123c943a4baf7c357fc2564c316\"\n" +
+                "                     }\n" +
+                "                  },\n" +
+                "                  \"parents\":[\n" +
+                "                     {\n" +
+                "                        \"hash\":\"71085ceb4314ac77d1a36ab687b3e067814c9395\",\n" +
+                "                        \"links\":{\n" +
+                "                           \"self\":{\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/71085ceb4314ac77d1a36ab687b3e067814c9395\"\n" +
+                "                           },\n" +
+                "                           \"html\":{\n" +
+                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/71085ceb4314ac77d1a36ab687b3e067814c9395\"\n" +
+                "                           }\n" +
+                "                        },\n" +
+                "                        \"type\":\"commit\"\n" +
+                "                     }\n" +
+                "                  ],\n" +
+                "                  \"rendered\":{\n" +
+                "                     \n" +
+                "                  },\n" +
+                "                  \"properties\":{\n" +
+                "                     \n" +
+                "                  }\n" +
+                "               },\n" +
+                "               \"links\":{\n" +
+                "                  \"self\":{\n" +
+                "                     \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/refs/branches/main\"\n" +
+                "                  },\n" +
+                "                  \"commits\":{\n" +
+                "                     \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commits/main\"\n" +
+                "                  },\n" +
+                "                  \"html\":{\n" +
+                "                     \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/branch/main\"\n" +
+                "                  },\n" +
+                "                  \"pullrequest_create\":{\n" +
+                "                     \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/pull-requests/new?source=main&t=1\"\n" +
+                "                  }\n" +
+                "               },\n" +
+                "               \"type\":\"branch\",\n" +
+                "               \"merge_strategies\":[\n" +
+                "                  \"merge_commit\",\n" +
+                "                  \"squash\",\n" +
+                "                  \"fast_forward\",\n" +
+                "                  \"squash_fast_forward\",\n" +
+                "                  \"rebase_fast_forward\",\n" +
+                "                  \"rebase_merge\"\n" +
+                "               ],\n" +
+                "               \"sync_strategies\":[\n" +
+                "                  \"merge_commit\",\n" +
+                "                  \"rebase\"\n" +
+                "               ],\n" +
+                "               \"default_merge_strategy\":\"merge_commit\"\n" +
+                "            },\n" +
+                "            \"truncated\":false,\n" +
+                "            \"created\":false,\n" +
                 "            \"forced\":false,\n" +
                 "            \"closed\":false,\n" +
                 "            \"links\":{\n" +
                 "               \"commits\":{\n" +
-                "                  \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commits?include=53580d154140650af84b438d6d7b99f33740441b\"\n" +
+                "                  \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commits?include=c7eae9b0c5450123c943a4baf7c357fc2564c316&exclude=71085ceb4314ac77d1a36ab687b3e067814c9395\"\n" +
+                "               },\n" +
+                "               \"diff\":{\n" +
+                "                  \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/diff/c7eae9b0c5450123c943a4baf7c357fc2564c316..71085ceb4314ac77d1a36ab687b3e067814c9395\"\n" +
                 "               },\n" +
                 "               \"html\":{\n" +
-                "                  \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/branch/dummyuser/maintf-edited-online-with-bitbucket-1752695846323\"\n" +
+                "                  \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/branches/compare/c7eae9b0c5450123c943a4baf7c357fc2564c316..71085ceb4314ac77d1a36ab687b3e067814c9395\"\n" +
                 "               }\n" +
                 "            },\n" +
                 "            \"commits\":[\n" +
                 "               {\n" +
                 "                  \"type\":\"commit\",\n" +
-                "                  \"hash\":\"53580d154140650af84b438d6d7b99f33740441b\",\n" +
-                "                  \"date\":\"2025-07-16T19:57:29+00:00\",\n" +
+                "                  \"hash\":\"c7eae9b0c5450123c943a4baf7c357fc2564c316\",\n" +
+                "                  \"date\":\"2025-07-18T21:20:52+00:00\",\n" +
                 "                  \"author\":{\n" +
                 "                     \"type\":\"author\",\n" +
                 "                     \"raw\":\"dummyuser <dummyuser@gmail.com>\",\n" +
@@ -964,356 +1062,36 @@ class VcsTests extends ServerApplicationTests{
                 "                  },\n" +
                 "                  \"links\":{\n" +
                 "                     \"self\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/53580d154140650af84b438d6d7b99f33740441b\"\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/c7eae9b0c5450123c943a4baf7c357fc2564c316\"\n" +
                 "                     },\n" +
                 "                     \"html\":{\n" +
-                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/53580d154140650af84b438d6d7b99f33740441b\"\n" +
+                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/c7eae9b0c5450123c943a4baf7c357fc2564c316\"\n" +
                 "                     },\n" +
                 "                     \"diff\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/diff/53580d154140650af84b438d6d7b99f33740441b\"\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/diff/c7eae9b0c5450123c943a4baf7c357fc2564c316\"\n" +
                 "                     },\n" +
                 "                     \"approve\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/53580d154140650af84b438d6d7b99f33740441b/approve\"\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/c7eae9b0c5450123c943a4baf7c357fc2564c316/approve\"\n" +
                 "                     },\n" +
                 "                     \"comments\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/53580d154140650af84b438d6d7b99f33740441b/comments\"\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/c7eae9b0c5450123c943a4baf7c357fc2564c316/comments\"\n" +
                 "                     },\n" +
                 "                     \"statuses\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/53580d154140650af84b438d6d7b99f33740441b/statuses\"\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/c7eae9b0c5450123c943a4baf7c357fc2564c316/statuses\"\n" +
                 "                     },\n" +
                 "                     \"patch\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/patch/53580d154140650af84b438d6d7b99f33740441b\"\n" +
+                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/patch/c7eae9b0c5450123c943a4baf7c357fc2564c316\"\n" +
                 "                     }\n" +
                 "                  },\n" +
                 "                  \"parents\":[\n" +
                 "                     {\n" +
-                "                        \"hash\":\"f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\",\n" +
+                "                        \"hash\":\"71085ceb4314ac77d1a36ab687b3e067814c9395\",\n" +
                 "                        \"links\":{\n" +
                 "                           \"self\":{\n" +
-                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
+                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/71085ceb4314ac77d1a36ab687b3e067814c9395\"\n" +
                 "                           },\n" +
                 "                           \"html\":{\n" +
-                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
-                "                           }\n" +
-                "                        },\n" +
-                "                        \"type\":\"commit\"\n" +
-                "                     }\n" +
-                "                  ],\n" +
-                "                  \"rendered\":{\n" +
-                "                     \n" +
-                "                  },\n" +
-                "                  \"properties\":{\n" +
-                "                     \n" +
-                "                  }\n" +
-                "               },\n" +
-                "               {\n" +
-                "                  \"type\":\"commit\",\n" +
-                "                  \"hash\":\"f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\",\n" +
-                "                  \"date\":\"2024-01-19T17:25:41+00:00\",\n" +
-                "                  \"author\":{\n" +
-                "                     \"type\":\"author\",\n" +
-                "                     \"raw\":\"dummyuser <dummyuser@gmail.com>\",\n" +
-                "                     \"user\":{\n" +
-                "                        \"display_name\":\"dummyuser\",\n" +
-                "                        \"links\":{\n" +
-                "                           \"self\":{\n" +
-                "                              \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
-                "                           },\n" +
-                "                           \"avatar\":{\n" +
-                "                              \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
-                "                           },\n" +
-                "                           \"html\":{\n" +
-                "                              \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
-                "                           }\n" +
-                "                        },\n" +
-                "                        \"type\":\"user\",\n" +
-                "                        \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
-                "                        \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
-                "                        \"nickname\":\"dummyuser\"\n" +
-                "                     }\n" +
-                "                  },\n" +
-                "                  \"committer\":{\n" +
-                "                     \n" +
-                "                  },\n" +
-                "                  \"message\":\"main.tf edited online with Bitbucket\",\n" +
-                "                  \"summary\":{\n" +
-                "                     \"type\":\"rendered\",\n" +
-                "                     \"raw\":\"main.tf edited online with Bitbucket\",\n" +
-                "                     \"markup\":\"markdown\",\n" +
-                "                     \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
-                "                  },\n" +
-                "                  \"links\":{\n" +
-                "                     \"self\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
-                "                     },\n" +
-                "                     \"html\":{\n" +
-                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
-                "                     },\n" +
-                "                     \"diff\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/diff/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
-                "                     },\n" +
-                "                     \"approve\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c/approve\"\n" +
-                "                     },\n" +
-                "                     \"comments\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c/comments\"\n" +
-                "                     },\n" +
-                "                     \"statuses\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c/statuses\"\n" +
-                "                     },\n" +
-                "                     \"patch\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/patch/f7647c752c7e7191b49ed4fcf832f8f1ea60cc5c\"\n" +
-                "                     }\n" +
-                "                  },\n" +
-                "                  \"parents\":[\n" +
-                "                     {\n" +
-                "                        \"hash\":\"ee99ab866b3151b10f817ea1ff127fe8b51cb57c\",\n" +
-                "                        \"links\":{\n" +
-                "                           \"self\":{\n" +
-                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/ee99ab866b3151b10f817ea1ff127fe8b51cb57c\"\n" +
-                "                           },\n" +
-                "                           \"html\":{\n" +
-                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/ee99ab866b3151b10f817ea1ff127fe8b51cb57c\"\n" +
-                "                           }\n" +
-                "                        },\n" +
-                "                        \"type\":\"commit\"\n" +
-                "                     }\n" +
-                "                  ],\n" +
-                "                  \"rendered\":{\n" +
-                "                     \n" +
-                "                  },\n" +
-                "                  \"properties\":{\n" +
-                "                     \n" +
-                "                  }\n" +
-                "               },\n" +
-                "               {\n" +
-                "                  \"type\":\"commit\",\n" +
-                "                  \"hash\":\"ee99ab866b3151b10f817ea1ff127fe8b51cb57c\",\n" +
-                "                  \"date\":\"2024-01-19T17:18:29+00:00\",\n" +
-                "                  \"author\":{\n" +
-                "                     \"type\":\"author\",\n" +
-                "                     \"raw\":\"dummyuser <dummyuser@gmail.com>\",\n" +
-                "                     \"user\":{\n" +
-                "                        \"display_name\":\"dummyuser\",\n" +
-                "                        \"links\":{\n" +
-                "                           \"self\":{\n" +
-                "                              \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
-                "                           },\n" +
-                "                           \"avatar\":{\n" +
-                "                              \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
-                "                           },\n" +
-                "                           \"html\":{\n" +
-                "                              \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
-                "                           }\n" +
-                "                        },\n" +
-                "                        \"type\":\"user\",\n" +
-                "                        \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
-                "                        \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
-                "                        \"nickname\":\"dummyuser\"\n" +
-                "                     }\n" +
-                "                  },\n" +
-                "                  \"committer\":{\n" +
-                "                     \n" +
-                "                  },\n" +
-                "                  \"message\":\"main.tf edited online with Bitbucket\",\n" +
-                "                  \"summary\":{\n" +
-                "                     \"type\":\"rendered\",\n" +
-                "                     \"raw\":\"main.tf edited online with Bitbucket\",\n" +
-                "                     \"markup\":\"markdown\",\n" +
-                "                     \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
-                "                  },\n" +
-                "                  \"links\":{\n" +
-                "                     \"self\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/ee99ab866b3151b10f817ea1ff127fe8b51cb57c\"\n" +
-                "                     },\n" +
-                "                     \"html\":{\n" +
-                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/ee99ab866b3151b10f817ea1ff127fe8b51cb57c\"\n" +
-                "                     },\n" +
-                "                     \"diff\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/diff/ee99ab866b3151b10f817ea1ff127fe8b51cb57c\"\n" +
-                "                     },\n" +
-                "                     \"approve\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/ee99ab866b3151b10f817ea1ff127fe8b51cb57c/approve\"\n" +
-                "                     },\n" +
-                "                     \"comments\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/ee99ab866b3151b10f817ea1ff127fe8b51cb57c/comments\"\n" +
-                "                     },\n" +
-                "                     \"statuses\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/ee99ab866b3151b10f817ea1ff127fe8b51cb57c/statuses\"\n" +
-                "                     },\n" +
-                "                     \"patch\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/patch/ee99ab866b3151b10f817ea1ff127fe8b51cb57c\"\n" +
-                "                     }\n" +
-                "                  },\n" +
-                "                  \"parents\":[\n" +
-                "                     {\n" +
-                "                        \"hash\":\"d28224b45f7def76c8b399a15391bc4676581bc7\",\n" +
-                "                        \"links\":{\n" +
-                "                           \"self\":{\n" +
-                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/d28224b45f7def76c8b399a15391bc4676581bc7\"\n" +
-                "                           },\n" +
-                "                           \"html\":{\n" +
-                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/d28224b45f7def76c8b399a15391bc4676581bc7\"\n" +
-                "                           }\n" +
-                "                        },\n" +
-                "                        \"type\":\"commit\"\n" +
-                "                     }\n" +
-                "                  ],\n" +
-                "                  \"rendered\":{\n" +
-                "                     \n" +
-                "                  },\n" +
-                "                  \"properties\":{\n" +
-                "                     \n" +
-                "                  }\n" +
-                "               },\n" +
-                "               {\n" +
-                "                  \"type\":\"commit\",\n" +
-                "                  \"hash\":\"d28224b45f7def76c8b399a15391bc4676581bc7\",\n" +
-                "                  \"date\":\"2024-01-19T17:15:07+00:00\",\n" +
-                "                  \"author\":{\n" +
-                "                     \"type\":\"author\",\n" +
-                "                     \"raw\":\"dummyuser <dummyuser@gmail.com>\",\n" +
-                "                     \"user\":{\n" +
-                "                        \"display_name\":\"dummyuser\",\n" +
-                "                        \"links\":{\n" +
-                "                           \"self\":{\n" +
-                "                              \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
-                "                           },\n" +
-                "                           \"avatar\":{\n" +
-                "                              \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
-                "                           },\n" +
-                "                           \"html\":{\n" +
-                "                              \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
-                "                           }\n" +
-                "                        },\n" +
-                "                        \"type\":\"user\",\n" +
-                "                        \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
-                "                        \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
-                "                        \"nickname\":\"dummyuser\"\n" +
-                "                     }\n" +
-                "                  },\n" +
-                "                  \"committer\":{\n" +
-                "                     \n" +
-                "                  },\n" +
-                "                  \"message\":\"main.tf edited online with Bitbucket\",\n" +
-                "                  \"summary\":{\n" +
-                "                     \"type\":\"rendered\",\n" +
-                "                     \"raw\":\"main.tf edited online with Bitbucket\",\n" +
-                "                     \"markup\":\"markdown\",\n" +
-                "                     \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
-                "                  },\n" +
-                "                  \"links\":{\n" +
-                "                     \"self\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/d28224b45f7def76c8b399a15391bc4676581bc7\"\n" +
-                "                     },\n" +
-                "                     \"html\":{\n" +
-                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/d28224b45f7def76c8b399a15391bc4676581bc7\"\n" +
-                "                     },\n" +
-                "                     \"diff\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/diff/d28224b45f7def76c8b399a15391bc4676581bc7\"\n" +
-                "                     },\n" +
-                "                     \"approve\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/d28224b45f7def76c8b399a15391bc4676581bc7/approve\"\n" +
-                "                     },\n" +
-                "                     \"comments\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/d28224b45f7def76c8b399a15391bc4676581bc7/comments\"\n" +
-                "                     },\n" +
-                "                     \"statuses\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/d28224b45f7def76c8b399a15391bc4676581bc7/statuses\"\n" +
-                "                     },\n" +
-                "                     \"patch\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/patch/d28224b45f7def76c8b399a15391bc4676581bc7\"\n" +
-                "                     }\n" +
-                "                  },\n" +
-                "                  \"parents\":[\n" +
-                "                     {\n" +
-                "                        \"hash\":\"091b43c903ff41245b3d48887237738225857134\",\n" +
-                "                        \"links\":{\n" +
-                "                           \"self\":{\n" +
-                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/091b43c903ff41245b3d48887237738225857134\"\n" +
-                "                           },\n" +
-                "                           \"html\":{\n" +
-                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/091b43c903ff41245b3d48887237738225857134\"\n" +
-                "                           }\n" +
-                "                        },\n" +
-                "                        \"type\":\"commit\"\n" +
-                "                     }\n" +
-                "                  ],\n" +
-                "                  \"rendered\":{\n" +
-                "                     \n" +
-                "                  },\n" +
-                "                  \"properties\":{\n" +
-                "                     \n" +
-                "                  }\n" +
-                "               },\n" +
-                "               {\n" +
-                "                  \"type\":\"commit\",\n" +
-                "                  \"hash\":\"091b43c903ff41245b3d48887237738225857134\",\n" +
-                "                  \"date\":\"2024-01-19T17:11:10+00:00\",\n" +
-                "                  \"author\":{\n" +
-                "                     \"type\":\"author\",\n" +
-                "                     \"raw\":\"dummyuser <dummyuser@gmail.com>\",\n" +
-                "                     \"user\":{\n" +
-                "                        \"display_name\":\"dummyuser\",\n" +
-                "                        \"links\":{\n" +
-                "                           \"self\":{\n" +
-                "                              \"href\":\"http://localhost:9999/2.0/users/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D\"\n" +
-                "                           },\n" +
-                "                           \"avatar\":{\n" +
-                "                              \"href\":\"https://secure.gravatar.com/avatar/629e77d25d888fc2115bd7626ae004f2?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAE-4.png\"\n" +
-                "                           },\n" +
-                "                           \"html\":{\n" +
-                "                              \"href\":\"https://bitbucket.org/%7Bed8beedc-3d28-4a7d-9ff3-de5dccead5f1%7D/\"\n" +
-                "                           }\n" +
-                "                        },\n" +
-                "                        \"type\":\"user\",\n" +
-                "                        \"uuid\":\"{ed8beedc-3d28-4a7d-9ff3-de5dccead5f1}\",\n" +
-                "                        \"account_id\":\"557058:807b67c7-225d-4ed1-b3e0-1e044e0c07af\",\n" +
-                "                        \"nickname\":\"dummyuser\"\n" +
-                "                     }\n" +
-                "                  },\n" +
-                "                  \"committer\":{\n" +
-                "                     \n" +
-                "                  },\n" +
-                "                  \"message\":\"main.tf edited online with Bitbucket\",\n" +
-                "                  \"summary\":{\n" +
-                "                     \"type\":\"rendered\",\n" +
-                "                     \"raw\":\"main.tf edited online with Bitbucket\",\n" +
-                "                     \"markup\":\"markdown\",\n" +
-                "                     \"html\":\"<p>main.tf edited online with Bitbucket</p>\"\n" +
-                "                  },\n" +
-                "                  \"links\":{\n" +
-                "                     \"self\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/091b43c903ff41245b3d48887237738225857134\"\n" +
-                "                     },\n" +
-                "                     \"html\":{\n" +
-                "                        \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/091b43c903ff41245b3d48887237738225857134\"\n" +
-                "                     },\n" +
-                "                     \"diff\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/diff/091b43c903ff41245b3d48887237738225857134\"\n" +
-                "                     },\n" +
-                "                     \"approve\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/091b43c903ff41245b3d48887237738225857134/approve\"\n" +
-                "                     },\n" +
-                "                     \"comments\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/091b43c903ff41245b3d48887237738225857134/comments\"\n" +
-                "                     },\n" +
-                "                     \"statuses\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/091b43c903ff41245b3d48887237738225857134/statuses\"\n" +
-                "                     },\n" +
-                "                     \"patch\":{\n" +
-                "                        \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/patch/091b43c903ff41245b3d48887237738225857134\"\n" +
-                "                     }\n" +
-                "                  },\n" +
-                "                  \"parents\":[\n" +
-                "                     {\n" +
-                "                        \"hash\":\"655558d16be7034c312593d303f05d7ced7d436f\",\n" +
-                "                        \"links\":{\n" +
-                "                           \"self\":{\n" +
-                "                              \"href\":\"http://localhost:9999/2.0/repositories/dummyuser/simple-terraform/commit/655558d16be7034c312593d303f05d7ced7d436f\"\n" +
-                "                           },\n" +
-                "                           \"html\":{\n" +
-                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/655558d16be7034c312593d303f05d7ced7d436f\"\n" +
+                "                              \"href\":\"https://bitbucket.org/dummyuser/simple-terraform/commits/71085ceb4314ac77d1a36ab687b3e067814c9395\"\n" +
                 "                           }\n" +
                 "                        },\n" +
                 "                        \"type\":\"commit\"\n" +
@@ -1437,7 +1215,7 @@ class VcsTests extends ServerApplicationTests{
                 "     value = local.fake\n" +
                 " }\n";
 
-        stubFor(get(urlPathEqualTo("/2.0/repositories/dummyuser/simple-terraform/diff/53580d154140650af84b438d6d7b99f33740441b"))
+        stubFor(get(urlPathEqualTo("/2.0/repositories/dummyuser/simple-terraform/diff/c7eae9b0c5450123c943a4baf7c357fc2564c316..71085ceb4314ac77d1a36ab687b3e067814c9395"))
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.OK.value())
                         .withBody(diffResponse)));


### PR DESCRIPTION
This pull request is addgin support for different bitbucket events, pull request, push and tag creation (this one is managed as a release event in terrakube)

Example:

<img width="1771" height="801" alt="image" src="https://github.com/user-attachments/assets/adf8cd12-24c1-489f-97c1-a65f8d639baf" />

> Pull request are triggered for any branch different from main using regex` ^(?!.*main).*$`

Related to #396 