### PR TITLE
fix: legacy quartz module refresh job cleanup

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -285,6 +285,8 @@ services:
       - POSTGRESQL_DATABASE=${TK_POSTGRESQL_DATABASE_NAME}
     volumes:
       - postgresql_data:/bitnami/postgresql
+    ports:
+      - 5432:5432
   mssql-service:
     image: mcr.microsoft.com/mssql/server:2022-latest
     container_name: mssql-service

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -85,4 +85,5 @@
     <include file="/db/changelog/local/changelog-2.26.1-webhook-data-fix.xml" />
     <include file="/db/changelog/local/changelog-2.27.0-quartz-job-class-migration.xml" />
     <include file="/db/changelog/local/changelog-2.27.1-module-versions.xml"/>
+    <!--include file="/db/changelog/local/changelog-2.27.2-delete-legacy-module-refresh.xml"/-->
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -85,5 +85,5 @@
     <include file="/db/changelog/local/changelog-2.26.1-webhook-data-fix.xml" />
     <include file="/db/changelog/local/changelog-2.27.0-quartz-job-class-migration.xml" />
     <include file="/db/changelog/local/changelog-2.27.1-module-versions.xml"/>
-    <!--include file="/db/changelog/local/changelog-2.27.2-delete-legacy-module-refresh.xml"/-->
+    <include file="/db/changelog/local/changelog-2.27.2-delete-legacy-module-refresh.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.27.2-delete-legacy-module-refresh.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.27.2-delete-legacy-module-refresh.xml
@@ -5,7 +5,9 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
     <changeSet id="2-27-0-4" author="alfespa17@gmail.com">
         <sql dbms="postgresql, mssql">
-            delete from QRTZ_JOB_DETAILS where JOB_CLASS_NAME='io.terrakube.api.plugin.scheduler.module.CacheJob';
+            delete from qrtz_cron_triggers where trigger_name in (select trigger_name from qrtz_triggers where job_name in (select job_name from qrtz_job_details where JOB_CLASS_NAME='io.terrakube.api.plugin.scheduler.module.CacheJob'));
+            delete from qrtz_triggers where job_name in (select job_name from qrtz_job_details where JOB_CLASS_NAME='io.terrakube.api.plugin.scheduler.module.CacheJob');
+            delete from qrtz_job_details where JOB_CLASS_NAME='io.terrakube.api.plugin.scheduler.module.CacheJob';
         </sql>
     </changeSet>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.27.2-delete-legacy-module-refresh.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.27.2-delete-legacy-module-refresh.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-27-0-4" author="alfespa17@gmail.com">
+        <sql dbms="postgresql, mssql">
+            delete from QRTZ_JOB_DETAILS where JOB_CLASS_NAME='io.terrakube.api.plugin.scheduler.module.CacheJob';
+        </sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
Fix the following error related to a class that was deleted `io.terrakube.api.plugin.scheduler.module.CacheJob` in #2324 

```shell
2025-07-28T19:34:20.596Z ERROR 6155 --- [_MisfireHandler] o.s.s.quartz.LocalDataSourceJobStore     : Error updating misfired trigger: DEFAULT.TerrakubeV2_ModuleRefresh
org.quartz.JobPersistenceException: Couldn't store trigger 'DEFAULT.TerrakubeV2_ModuleRefresh' for 'DEFAULT.TerrakubeV2_ModuleRefresh' job:Couldn't retrieve job because a required class was not found: io.terrakube.api.plugin.scheduler.module.CacheJob
        at org.quartz.impl.jdbcjobstore.JobStoreSupport.storeTrigger(JobStoreSupport.java:1224) ~[quartz-2.5.0.jar:2.5.0]
        at org.quartz.impl.jdbcjobstore.JobStoreSupport.doUpdateOfMisfiredTrigger(JobStoreSupport.java:1037) ~[quartz-2.5.0.jar:2.5.0]
        at org.quartz.impl.jdbcjobstore.JobStoreSupport.recoverMisfiredJobs(JobStoreSupport.java:983) ~[quartz-2.5.0.jar:2.5.0]
        at org.quartz.impl.jdbcjobstore.JobStoreSupport.doRecoverMisfires(JobStoreSupport.java:3147) ~[quartz-2.5.0.jar:2.5.0]
        at org.quartz.impl.jdbcjobstore.JobStoreSupport$MisfireHandler.manage(JobStoreSupport.java:3877) ~[quartz-2.5.0.jar:2.5.0]
        at org.quartz.impl.jdbcjobstore.JobStoreSupport$MisfireHandler.run(JobStoreSupport.java:3896) ~[quartz-2.5.0.jar:2.5.0]
Caused by: org.quartz.JobPersistenceException: Couldn't retrieve job because a required class was not found: io.terrakube.api.plugin.scheduler.module.CacheJob
        at org.quartz.impl.jdbcjobstore.JobStoreSupport.retrieveJob(JobStoreSupport.java:1384) ~[quartz-2.5.0.jar:2.5.0]
        at org.quartz.impl.jdbcjobstore.JobStoreSupport.storeTrigger(JobStoreSupport.java:1205) ~[quartz-2.5.0.jar:2.5.0]
        ... 5 common frames omitted
```

