### PR TITLE
fix: changing column name commit is reserved word in mssql

### DIFF
--- a/api/src/main/java/io/terrakube/api/rs/module/ModuleVersion.java
+++ b/api/src/main/java/io/terrakube/api/rs/module/ModuleVersion.java
@@ -35,6 +35,6 @@ public class ModuleVersion {
     @Column(name = "version")
     private String version;
     
-    @Column(name = "commit")
+    @Column(name = "commit_info")
     private String commit;
 }

--- a/api/src/main/resources/db/changelog/local/changelog-2.27.1-module-versions.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.27.1-module-versions.xml
@@ -14,7 +14,7 @@
             <column name="version" type="varchar(256)">
                 <constraints nullable="false"/>
             </column>
-            <column name="commit" type="varchar(256)">
+            <column name="commit_info" type="varchar(256)">
                 <constraints nullable="false"/>
             </column>
         </createTable>


### PR DESCRIPTION
Related to #2324 , "commit" is a reserved work for mssql