### PR TITLE
fix: 401 unauthenticated error

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/service/workspace/security/WorkspaceSecurityImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/security/WorkspaceSecurityImpl.java
@@ -1,6 +1,7 @@
 package io.terrakube.executor.service.workspace.security;
 
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
@@ -55,6 +56,7 @@ public class WorkspaceSecurityImpl implements WorkspaceSecurity {
         SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(this.internalSecret));
 
         newToken = Jwts.builder()
+                .setHeaderParam("typ", "JWT")
                 .setIssuer(WorkspaceSecurityImpl.ISSUER)
                 .setSubject(WorkspaceSecurityImpl.SUBJECT)
                 .setAudience(WorkspaceSecurityImpl.ISSUER)
@@ -63,7 +65,7 @@ public class WorkspaceSecurityImpl implements WorkspaceSecurity {
                 .claim("name", WorkspaceSecurityImpl.NAME)
                 .setIssuedAt(Date.from(Instant.now()))
                 .setExpiration(Date.from(Instant.now().plus(30, ChronoUnit.DAYS)))
-                .signWith(key)
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 
         return newToken;
@@ -73,7 +75,8 @@ public class WorkspaceSecurityImpl implements WorkspaceSecurity {
     public String generateAccessToken(int minutes) {
         SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(this.internalSecret));
 
-        return Jwts.builder()
+        String token = Jwts.builder()
+                .setHeaderParam("typ", "JWT")
                 .setIssuer(WorkspaceSecurityImpl.ISSUER)
                 .setSubject(WorkspaceSecurityImpl.SUBJECT)
                 .setAudience(WorkspaceSecurityImpl.ISSUER)
@@ -82,8 +85,10 @@ public class WorkspaceSecurityImpl implements WorkspaceSecurity {
                 .claim("name", WorkspaceSecurityImpl.NAME)
                 .setIssuedAt(Date.from(Instant.now()))
                 .setExpiration(Date.from(Instant.now().plus(minutes, ChronoUnit.MINUTES)))
-                .signWith(key)
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
+        log.info("Generated Token {}", token);
+        return token;   
     }
 
     @Override


### PR DESCRIPTION
Another one that I missed.

```
2025-07-29T21:57:37.930Z ERROR 1 --- [nio-8075-exec-5] o.t.c.dex.DexCredentialAuthentication    : Generate Dex Authentication Private Token
2025-07-29T21:57:37.933Z ERROR 1 --- [nio-8075-exec-5] o.a.c.c.C.[.[.[/].[dispatcherServlet]    : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: feign.RetryableException: Too many follow-up requests: 21 executing GET http://terrakube-api-service:8080/api/v1/organization?filter%5Borganization%5D=name==Omniscient] with root cause

java.net.ProtocolException: Too many follow-up requests: 21
```