### PR TITLE
feat: Migrate terrakube UI dockerfile to use nginxinc/nginx-unprivileged instead of bitnami

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -213,13 +213,13 @@ public class GitLabWebhookService extends WebhookServiceBase {
                     .filter(ExchangeFilterFunction.ofRequestProcessor(clientRequest -> {
                         log.info("WebClient Request: {} {}", clientRequest.method(), clientRequest.url());
                         clientRequest.headers().forEach((name, values) ->
-                                log.info("Request Header: {}: {}", name, String.join(", ", values)));
+                                log.debug("Request Header: {}: {}", name, String.join(", ", values)));
                         return Mono.just(clientRequest);
                     }))
                     .filter(ExchangeFilterFunction.ofResponseProcessor(clientResponse -> {
                         log.info("WebClient Response: {}", clientResponse.statusCode());
                         clientResponse.headers().asHttpHeaders().forEach((name, values) ->
-                                log.info("Response Header: {}: {}", name, String.join(", ", values)));
+                                log.debug("Response Header: {}: {}", name, String.join(", ", values)));
                         return Mono.just(clientResponse);
                     }))
                     .build();

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.3</version>
+        <version>3.5.4</version>
     </parent>
 
     <groupId>io.terrakube</groupId>

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -12,11 +12,13 @@ ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN yarn build
 
 # => Run container
-FROM bitnami/nginx:latest
+FROM nginxinc/nginx-unprivileged:latest
 
 # Default Terraform version, updated at build time
 ARG REACT_APP_TERRAKUBE_VERSION=2.0.0
 
+WORKDIR /usr/share/nginx/html
+
 # Static build
-COPY --from=builder /app/build /app
-COPY ./conf/conf.d/bitnami.conf /opt/bitnami/nginx/conf/server_blocks/my_server_block.conf
+COPY --from=builder /app/build .
+COPY conf/conf.d/terrakube-ui.conf /etc/nginx/conf.d/default.conf

--- a/ui/conf/conf.d/terrakube-ui.conf
+++ b/ui/conf/conf.d/terrakube-ui.conf
@@ -3,7 +3,7 @@ server {
   listen [::]:8080;
 
   location / {
-    root   /app;
+    root   /usr/share/nginx/html/;
     index  index.html index.htm;
     try_files $uri $uri/ /index.html;
   }


### PR DESCRIPTION
- Migreate terrakube-ui to a new docker image
- Upgrade springboot version
- Remove some logging information for gitlab