### PR TITLE
fix: when validating github versions it only tries to looks for version that contains v

### DIFF
--- a/registry/src/main/java/io/terrakube/registry/service/git/GitServiceImpl.java
+++ b/registry/src/main/java/io/terrakube/registry/service/git/GitServiceImpl.java
@@ -115,8 +115,11 @@ public class GitServiceImpl implements GitService {
             versionList.add(key.replace("refs/tags/", ""));
         });
 
-        if (versionList.contains((tagPrefix == null ? "" : tagPrefix) + "v" + originalTag))
+        if (versionList.contains((tagPrefix == null ? "" : tagPrefix) + "v" + originalTag)) {
             finalTag = (tagPrefix == null ? "" : tagPrefix) + "v" + originalTag;
+        } else if (!versionList.isEmpty()) {
+            finalTag = versionList.get(versionList.size() - 1);
+        }
 
         return finalTag;
     }


### PR DESCRIPTION
when validating github versions it only tries to looks for version that contains v or version that contains `v`. This fix takes other versions into account.