### PR TITLE
feat: Add detailed debug and info logging for module and git services

### DIFF
--- a/registry/src/main/java/io/terrakube/registry/service/git/GitServiceImpl.java
+++ b/registry/src/main/java/io/terrakube/registry/service/git/GitServiceImpl.java
@@ -100,6 +100,7 @@ public class GitServiceImpl implements GitService {
             String folderName, String tagPrefix) {
         List<String> versionList = new ArrayList<>();
         String finalTag = (tagPrefix == null ? "" : tagPrefix) + originalTag;
+        log.info("Checking if tag {} exists in repository {}", finalTag, repository);
         Map<String, Ref> tags = null;
         try {
             tags = Git.lsRemoteRepository()
@@ -115,8 +116,19 @@ public class GitServiceImpl implements GitService {
             versionList.add(key.replace("refs/tags/", ""));
         });
 
-        if (versionList.contains((tagPrefix == null ? "" : tagPrefix) + "v" + originalTag))
+        log.debug("Current repository tags {}", versionList);
+
+        if (versionList.contains((tagPrefix == null ? "" : tagPrefix) + "v" + originalTag)) {
             finalTag = (tagPrefix == null ? "" : tagPrefix) + "v" + originalTag;
+            log.info("Tag with letter v exists: {}", finalTag);
+        } else if (versionList.contains((tagPrefix == null ? "" : tagPrefix) + originalTag)) {
+            finalTag = (tagPrefix == null ? "" : tagPrefix) + originalTag;
+            log.info("Tag without letter v exists: {}", finalTag);
+        } else {
+            log.info("Tag {} does not exist", finalTag);
+            throw new RuntimeException(
+                    String.format("Tag %s does not exist in repository %s", finalTag, repository));
+        }
 
         return finalTag;
     }

--- a/registry/src/main/java/io/terrakube/registry/service/module/ModuleServiceImpl.java
+++ b/registry/src/main/java/io/terrakube/registry/service/module/ModuleServiceImpl.java
@@ -46,8 +46,11 @@ public class ModuleServiceImpl implements ModuleService {
         }
 
         List<ModuleVersion> versionList = terrakubeClient.getAllVersionsByOrganizationIdAndModuleId(organizationId, module.getId()).getData();
+        log.debug("Version list: {}", (Object) versionList.stream()
+                .map(version -> version.getAttributes().getVersion())
+                .toArray(String[]::new));
+
         for (ModuleVersion version : versionList) {
-            log.info("Version: {}", version);
             definitionVersions.add(version.getAttributes().getVersion());
         }
         return definitionVersions;


### PR DESCRIPTION
- Enhanced logging in `ModuleServiceImpl` to debug version lists.
- Improved logging in `GitServiceImpl` to trace tag existence checks and repository tags.

To enable logs this environment variable should be added for the registry component 


```env
JAVA_TOOL_OPTIONS="-Dlogging.level.io.terrakube.registry.service.module=DEBUG -Dlogging.level.io.terrakube.registry.service.git=DEBUG"
```

The logs will look like this:

```shell
2025-07-31T22:36:28.723Z  INFO 12616 --- [nio-8075-exec-1] i.t.r.service.module.ModuleServiceImpl   : Search Organization: aws 3a130a1c-d96f-4f99-83b8-58d472567e3a
2025-07-31T22:36:28.723Z  INFO 12616 --- [nio-8075-exec-1] i.t.r.service.module.ModuleServiceImpl   : Search Module iam/aws in Organization aws
2025-07-31T22:36:28.790Z DEBUG 12616 --- [nio-8075-exec-1] i.t.r.service.module.ModuleServiceImpl   : Version list: [v5.33.0, v5.52.2, v5.33.1, v5.56.0, v2.11.0, v3.3.0, v4.9.0, v5.37.0, v5.37.1, v5.37.2, v4.22.1, v3.7.0, v2.15.0, v4.22.0, v4.5.0, v2.19.0, v4.1.0, v5.3.2, v5.3.3, v0.2.0, v5.7.0, v5.14.4, v5.18.0, v5.14.3, v5.14.2, v5.3.0, v5.14.1, v5.3.1, v5.14.0, v5.52.1, v5.52.0, v5.10.0, v4.19.0, v5.45.0, v2.22.0, v5.49.0, v4.11.0, v0.1.0, v4.15.0, v4.15.1, v2.2.0, v3.14.0, v2.6.0, v3.10.0, v5.26.0, v5.41.0, v5.22.0, v5.55.0, v5.32.0, v3.0.0, v5.32.1, v2.10.0, v5.59.0, v5.36.0, v3.4.0, v4.6.0, v2.14.0, v4.23.0, v3.8.0, v4.2.0, v2.18.0, v0.5.0, v5.8.0, v5.17.1, v5.17.0, v5.4.0, v5.51.0, v5.13.0, v5.0.0, v5.44.0, v5.44.1, v2.21.0, v5.44.2, v5.48.0, v2.25.0, v4.12.0, v0.0.1, v4.16.0, v3.15.0, v2.1.0, v5.29.2, v5.29.1, v3.11.0, v2.5.0, v5.29.0, v2.9.0, v5.25.0, v5.40.0, v5.21.0, v5.54.1, v5.54.0, v3.1.0, v5.35.0, v5.58.0, v2.13.0, v3.5.0, v4.7.0, v5.39.0, v5.39.1, v4.20.2, v4.20.3, v2.17.0, v3.9.0, v4.20.0, v4.3.0, v4.20.1, v4.24.1, v4.24.0, v5.5.4, v5.9.0, v0.0.7, v5.5.5, v5.9.1, v0.0.6, v5.5.6, v5.9.2, v5.5.7, v5.5.0, v0.0.3, v5.5.1, v0.0.2, v5.5.2, v0.0.5, v5.5.3, v0.0.4, v0.4.0, v5.1.0, v5.16.0, v5.50.0, v5.12.0, v5.31.0, v5.20.0, v5.43.0, v4.17.2, v4.17.0, v2.20.0, v4.17.1, v5.47.0, v5.47.1, v2.24.0, v4.13.2, v4.13.0, v4.13.1, v3.12.0, v2.0.0, v2.4.0, v5.28.0, v2.8.0, v5.24.0, v3.16.0, v5.30.2, v5.57.0, v5.34.0, v3.2.0, v4.8.0, v2.12.0, v5.38.0, v3.6.0, v4.4.0, v2.16.0, v4.21.1, v4.21.0, v4.0.0, v0.3.0, v5.6.0, v5.19.0, v5.2.0, v5.15.0, v5.11.2, v1.0.0, v5.11.1, v5.30.0, v5.11.0, v5.53.0, v5.30.1, v5.46.0, v4.18.0, v2.23.0, v4.10.1, v4.10.0, v4.14.0, v3.13.0, v2.3.0, v2.7.0, v5.27.0, v5.23.1, v5.23.0, v5.42.0]
2025-07-31T22:36:28.863Z  INFO 12616 --- [nio-8075-exec-2] i.t.r.p.s.local.LocalStorageServiceImpl  : moduleZip: /.terraform-spring-boot/local/modules/aws/iam/aws/5.59.0/module.zip
2025-07-31T22:36:28.867Z  INFO 12616 --- [nio-8075-exec-2] i.t.r.service.module.ModuleServiceImpl   : Update module download count
2025-07-31T22:36:28.914Z  INFO 12616 --- [nio-8075-exec-2] i.t.r.service.module.ModuleServiceImpl   : Registry Path: https://terrakube-registry.platform.local/terraform/modules/v1/download/aws/iam/aws/5.59.0/module.zip
2025-07-31T22:37:12.034Z  INFO 12616 --- [nio-8075-exec-6] i.t.r.service.module.ModuleServiceImpl   : Search Organization: aws 3a130a1c-d96f-4f99-83b8-58d472567e3a
2025-07-31T22:37:12.034Z  INFO 12616 --- [nio-8075-exec-6] i.t.r.service.module.ModuleServiceImpl   : Search Module eks/aws in Organization aws
2025-07-31T22:37:12.073Z DEBUG 12616 --- [nio-8075-exec-6] i.t.r.service.module.ModuleServiceImpl   : Version list: [v8.0.0, v18.3.1, v18.3.0, v19.15.4, v19.15.3, v19.15.2, v12.0.0, v19.15.1, v19.15.0, v20.27.0, v20.30.1, v19.1.1, v18.19.0, v20.30.0, v20.0.1, v20.0.0, v0.2.0, v19.1.0, v18.11.0, v15.2.0, v19.9.0, v1.8.0, v20.15.0, v20.9.0, v0.1.0, v17.15.0, v18.22.0, v17.5.0, v18.4.1, v18.4.0, v17.20.0, v20.28.0, v19.14.0, v18.18.0, v20.31.1, v19.2.0, v20.31.0, v16.0.0, v20.31.5, v20.7.0, v20.31.4, v0.1.1, v20.31.3, v20.31.2, v18.10.0, v18.10.1, v18.10.2, v5.0.0, v11.1.0, v15.1.0, v1.7.0, v20.8.3, v20.8.2, v20.8.1, v16.0.1, v20.16.0, v20.31.6, v20.8.0, v17.16.0, v20.8.5, v20.8.4, v18.29.1, v18.29.0, v18.21.0, v17.6.0, v18.5.1, v18.5.0, v19.17.4, v19.17.3, v19.17.2, v19.17.1, v19.17.0, v8.2.0, v12.2.0, v19.3.0, v18.17.1, v9.0.0, v19.3.1, v18.17.0, v20.13.0, v20.36.0, v20.13.1, v20.6.0, v1.6.0, v17.13.0, v20.36.1, v16.1.0, v19.21.0, v18.28.0, v20.24.0, v20.24.1, v18.20.2, v18.20.1, v18.20.0, v18.20.5, v13.0.0, v18.20.4, v17.7.0, v18.20.3, v18.6.0, v8.1.0, v19.16.0, v20.26.0, v4.0.2, v20.26.1, v4.0.0, v4.0.1, v18.6.1, v12.1.0, v19.4.1, v18.16.0, v19.4.0, v20.5.2, v20.5.1, v20.14.0, v20.5.0, v18.31.2, v18.31.1, v18.31.0, v19.4.3, v19.4.2, v1.5.0, v17.14.0, v20.37.2, v20.37.1, v16.2.0, v20.37.0, v19.20.0, v2.3.0, v17.8.0, v18.27.1, v18.27.0, v20.25.0, v2.3.1, v17.0.1, v17.0.0, v17.0.3, v17.0.2, v17.23.0, v19.19.1, v19.19.0, v18.7.3, v19.11.0, v18.7.2, v18.7.1, v18.7.0, v19.5.0, v20.34.0, v20.11.0, v20.4.0, v20.11.1, v18.30.3, v18.30.2, v18.30.1, v18.30.0, v18.15.0, v19.5.1, v17.11.0, v1.4.0, v17.19.0, v20.5.3, v20.19.0, v18.26.4, v2.2.0, v17.9.0, v18.26.3, v2.2.1, v18.26.2, v14.0.0, v18.26.1, v18.26.6, v20.22.0, v18.26.5, v20.22.1, v17.1.0, v18.26.0, v13.2.1, v13.2.0, v17.24.0, v18.0.6, v3.0.0, v18.0.5, v18.0.4, v18.0.3, v18.0.2, v18.0.1, v19.18.0, v18.0.0, v20.24.2, v20.24.3, v19.10.3, v19.10.2, v19.10.1, v18.8.1, v19.10.0, v18.8.0, v20.3.0, v20.35.0, v20.12.0, v18.14.0, v19.6.0, v18.14.1, v17.12.0, v1.3.0, v2.1.0, v20.23.0, v17.2.0, v13.1.0, v7.0.0, v18.25.0, v7.0.1, v21.0.0, v21.0.2, v21.0.1, v21.0.4, v18.1.0, v21.0.3, v17.21.0, v21.0.6, v21.0.5, v20.29.0, v19.13.1, v19.13.0, v18.9.0, v20.32.0, v20.2.1, v20.2.0, v20.2.2, v5.1.0, v19.7.0, v11.0.0, v18.13.0, v15.0.0, v1.2.0, v20.17.0, v20.17.1, v20.17.2, v17.17.0, v20.20.0, v2.0.0, v17.3.0, v18.24.1, v18.24.0, v18.2.4, v18.2.3, v18.2.2, v17.22.0, v18.2.1, v18.2.0, v19.12.0, v18.2.7, v18.2.6, v18.2.5, v19.0.3, v20.1.1, v19.0.2, v20.10.0, v20.1.0, v19.0.4, v19.0.1, v20.33.1, v19.0.0, v20.33.0, v1.0.0, v18.12.0, v19.8.0, v1.1.0, v17.10.0, v20.18.0, v6.0.2, v17.18.0, v6.0.0, v10.0.0, v6.0.1, v20.21.0, v17.4.0, v18.23.0]
```
