### PR TITLE
fix: postcommit transaction phase when creating new modules

### DIFF
--- a/api/src/main/java/io/terrakube/api/rs/module/Module.java
+++ b/api/src/main/java/io/terrakube/api/rs/module/Module.java
@@ -43,7 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 @UpdatePermission(expression = "team manage module OR user is a super service")
 @DeletePermission(expression = "team manage module")
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.DELETE, hook = ModuleManageHook.class)
-@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, hook = ModuleManageHook.class)
+@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = ModuleManageHook.class)
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE, hook = ModuleManageHook.class)
 @Include(rootLevel = false)
 @Getter


### PR DESCRIPTION
The transaction phase in the module entity is missing,

https://github.com/terrakube-io/terrakube/blob/5aa94ae198ed5df596c6570def8f57e4ac7be690/api/src/main/java/io/terrakube/api/rs/module/Module.java#L46

The correct way should be 

```
@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = ModuleManageHook.class)
```

Adding the above generate the following logs and correctly create the job to refresh modules:
```shell
2025-08-01T01:20:40.509Z  INFO 20023 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port 8080 (http) with context path '/'
2025-08-01T01:20:40.909Z  INFO 20023 --- [           main] io.terrakube.api.ServerApplication       : Started ServerApplication in 28.25 seconds (process running for 29.115)
2025-08-01T01:20:41.146Z  INFO 20023 --- [nio-8080-exec-2] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring DispatcherServlet 'dispatcherServlet'
2025-08-01T01:20:41.147Z  INFO 20023 --- [nio-8080-exec-2] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
2025-08-01T01:20:41.150Z  INFO 20023 --- [nio-8080-exec-2] o.s.web.servlet.DispatcherServlet        : Completed initialization in 3 ms
2025-08-01T01:20:57.202Z  INFO 20023 --- [         task-1] i.t.a.r.h.o.OrganizationManageHook       : OrganizationManageHook d9b58bd3-f3fc-4056-a026-1163297e80a8
2025-08-01T01:20:57.219Z  INFO 20023 --- [         task-1] i.t.a.rs.hooks.module.ModuleManageHook   : Phase POSTCOMMIT
2025-08-01T01:20:57.219Z  INFO 20023 --- [         task-1] i.t.a.rs.hooks.module.ModuleManageHook   : ModuleManageHook creation hook for simple/rg/azurerm
2025-08-01T01:20:57.219Z  INFO 20023 --- [         task-1] i.t.a.rs.hooks.module.ModuleManageHook   : Creating schedule task 30 seconds
2025-08-01T01:20:57.227Z  INFO 20023 --- [         task-1] i.t.a.p.scheduler.ScheduleServiceBase    : Create ModuleRefresh Trigger DEFAULT.TerrakubeV2_ModuleRefresh_9def10f8-8ae4-40b2-86ac-43b6582762e7
2025-08-01T01:20:59.878Z  INFO 20023 --- [         task-1] i.t.a.rs.hooks.module.ModuleManageHook   : Phase PRECOMMIT
2025-08-01T01:20:59.878Z  INFO 20023 --- [         task-1] i.t.a.rs.hooks.module.ModuleManageHook   : ModuleManageHookd update hook for simple/rg/azurerm
2025-08-01T01:20:59.879Z  INFO 20023 --- [         task-1] i.t.a.p.scheduler.ScheduleServiceBase    : JobId 9def10f8-8ae4-40b2-86ac-43b6582762e7 on ModuleRefresh exists
2025-08-01T01:20:59.879Z  INFO 20023 --- [         task-1] i.t.a.p.scheduler.ScheduleServiceBase    : Delete ModuleRefresh Trigger 9def10f8-8ae4-40b2-86ac-43b6582762e7
2025-08-01T01:20:59.888Z  INFO 20023 --- [         task-1] i.t.a.p.scheduler.ScheduleServiceBase    : Create ModuleRefresh Trigger DEFAULT.TerrakubeV2_ModuleRefresh_9def10f8-8ae4-40b2-86ac-43b6582762e7
2025-08-01T01:21:00.251Z  INFO 20023 --- [         task-6] i.t.a.rs.hooks.module.ModuleManageHook   : Phase PRECOMMIT
2025-08-01T01:21:00.251Z  INFO 20023 --- [         task-6] i.t.a.rs.hooks.module.ModuleManageHook   : ModuleManageHookd update hook for simple/rg/azurerm
2025-08-01T01:21:00.252Z  INFO 20023 --- [         task-6] i.t.a.p.scheduler.ScheduleServiceBase    : JobId 9def10f8-8ae4-40b2-86ac-43b6582762e7 on ModuleRefresh exists
2025-08-01T01:21:00.252Z  INFO 20023 --- [         task-6] i.t.a.p.scheduler.ScheduleServiceBase    : Delete ModuleRefresh Trigger 9def10f8-8ae4-40b2-86ac-43b6582762e7
2025-08-01T01:21:00.254Z  INFO 20023 --- [         task-6] i.t.a.p.scheduler.ScheduleServiceBase    : Create ModuleRefresh Trigger DEFAULT.TerrakubeV2_ModuleRefresh_9def10f8-8ae4-40b2-86ac-43b6582762e7
```

Without the POSTCOMMIT only PRECOMMIT phase is executed as shown below and the job to refresh new modules is never executed.

https://github.com/terrakube-io/terrakube/blob/5aa94ae198ed5df596c6570def8f57e4ac7be690/api/src/main/java/io/terrakube/api/rs/hooks/module/ModuleManageHook.java#L55

```
2025-08-01T01:24:40.962Z  INFO 21512 --- [           main] io.terrakube.api.ServerApplication       : Started ServerApplication in 23.478 seconds (process running for 24.339)
2025-08-01T01:24:46.394Z  INFO 21512 --- [nio-8080-exec-2] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring DispatcherServlet 'dispatcherServlet'
2025-08-01T01:24:46.395Z  INFO 21512 --- [nio-8080-exec-2] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
2025-08-01T01:24:46.399Z  INFO 21512 --- [nio-8080-exec-2] o.s.web.servlet.DispatcherServlet        : Completed initialization in 4 ms
2025-08-01T01:25:06.207Z  INFO 21512 --- [         task-2] i.t.a.rs.hooks.module.ModuleManageHook   : Phase PRECOMMIT
2025-08-01T01:25:06.207Z  INFO 21512 --- [         task-2] i.t.a.rs.hooks.module.ModuleManageHook   : ModuleManageHook creation hook for simple/rg/azurerm
2025-08-01T01:25:06.207Z  INFO 21512 --- [         task-2] i.t.a.r.h.o.OrganizationManageHook       : OrganizationManageHook d9b58bd3-f3fc-4056-a026-1163297e80a8
```