### PR TITLE
fix: Add precommit lifecycle hook for module creation and enhance logging

### DIFF
--- a/api/src/main/java/io/terrakube/api/rs/hooks/module/ModuleManageHook.java
+++ b/api/src/main/java/io/terrakube/api/rs/hooks/module/ModuleManageHook.java
@@ -43,7 +43,7 @@ public class ModuleManageHook implements LifeCycleHook<Module> {
     public void execute(LifeCycleHookBinding.Operation operation,
             LifeCycleHookBinding.TransactionPhase transactionPhase, Module module, RequestScope requestScope,
             Optional<ChangeSpec> optional) {
-
+        log.info("ModuleManageHook {}/{}/{} phase {}", module.getOrganization().getName(), module.getName(), module.getProvider(), transactionPhase);
         switch (operation) {
             case CREATE:
                 log.info("ModuleManageHook creation hook for {}/{}/{}", module.getOrganization().getName(),
@@ -54,10 +54,11 @@ public class ModuleManageHook implements LifeCycleHook<Module> {
                         break;
                     case POSTCOMMIT:
                         try {
+                            log.info("Create module refresh task for {}/{}/{}", module.getOrganization().getName(), module.getName(), module.getProvider());
                             moduleRefreshService.createTask(300, module.getId().toString(), true);
                         } catch (SchedulerException e) {
                             log.error("Failed to create module refresh task for {}/{}/{}, error {}",
-                                    module.getOrganization().getName(), module.getName(), module.getProvider(), e);
+                                    module.getOrganization().getName(), module.getName(), module.getProvider(), e.getMessage());
                         }
                     default:
                         break;
@@ -71,7 +72,7 @@ public class ModuleManageHook implements LifeCycleHook<Module> {
                     moduleRefreshService.createTask(300, module.getId().toString(), true);
                 } catch (SchedulerException e) {
                     log.error("Failed to create module refresh task for {}/{}/{}, error {}",
-                            module.getOrganization().getName(), module.getName(), module.getProvider(), e);
+                            module.getOrganization().getName(), module.getName(), module.getProvider(), e.getMessage());
                 }
                 break;
             case DELETE:
@@ -123,7 +124,7 @@ public class ModuleManageHook implements LifeCycleHook<Module> {
                     module.getName(), module.getProvider());
         } catch (URISyntaxException | JsonProcessingException | NoSuchAlgorithmException | InvalidKeySpecException e) {
             log.error("Failed to fetch GitHub App Token for module {}/{}/{}, error {}",
-                    module.getOrganization().getName(), module.getName(), module.getProvider(), e);
+                    module.getOrganization().getName(), module.getName(), module.getProvider(), e.getMessage());
         }
     }
 }

--- a/api/src/main/java/io/terrakube/api/rs/module/Module.java
+++ b/api/src/main/java/io/terrakube/api/rs/module/Module.java
@@ -44,6 +44,7 @@ import lombok.extern.slf4j.Slf4j;
 @DeletePermission(expression = "team manage module")
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.DELETE, hook = ModuleManageHook.class)
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = ModuleManageHook.class)
+@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT, hook = ModuleManageHook.class)
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE, hook = ModuleManageHook.class)
 @Include(rootLevel = false)
 @Getter

--- a/api/src/test/java/io/terrakube/api/ServerApplicationTests.java
+++ b/api/src/test/java/io/terrakube/api/ServerApplicationTests.java
@@ -7,13 +7,13 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import io.restassured.RestAssured;
 import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
-import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
 import io.terrakube.api.repository.*;
 import net.minidev.json.JSONArray;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mock;
+import org.quartz.Scheduler;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -94,6 +94,9 @@ class ServerApplicationTests {
 
     @Autowired
     VcsRepository vcsRepository;
+
+    @Autowired
+    Scheduler scheduler;
 
     private static final String ISSUER = "Terrakube";
     private static final String ISSUER_INTERNAL = "TerrakubeInternal";


### PR DESCRIPTION

- Introduced `PRECOMMIT` phase lifecycle hook for module creation.
- Improved logging in `ModuleManageHook` to include module details during lifecycle operations.
- Added assertions and job validation in module creation tests to ensure refresh tasks are scheduled correctly.

The test case is showing the PRECOMMIT and POSTCOMMIT logic

Command to run test
```shell
cd api
mvn test -Dtest=ModuleTests#createModuleAsOrgMember
```
Example
```shell
2025-08-01T08:27:14.758-06:00  INFO 14058 --- [           main] i.t.api.plugin.token.pat.PatService      : Generated Pat c157824f-4363-42ae-95e6-6f733e84f65f
2025-08-01T08:27:14.758-06:00  INFO 14058 --- [           main] i.t.api.plugin.token.pat.PatService      : Pat will expire
2025-08-01T08:27:15.272-06:00  INFO 14058 --- [           main] .b.BouncyCastleSecurityProviderRegistrar : getOrCreateProvider(BC) created instance of org.bouncycastle.jce.provider.BouncyCastleProvider
2025-08-01T08:27:15.430-06:00  INFO 14058 --- [           main] o.a.s.c.i.DefaultIoServiceFactoryFactory : No detected/configured IoServiceFactoryFactory; using Nio2ServiceFactoryFactory
2025-08-01T08:27:15.789-06:00  INFO 14058 --- [o-auto-1-exec-1] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring DispatcherServlet 'dispatcherServlet'
2025-08-01T08:27:15.790-06:00  INFO 14058 --- [o-auto-1-exec-1] o.s.web.servlet.DispatcherServlet        : Initializing Servlet 'dispatcherServlet'
2025-08-01T08:27:15.791-06:00  INFO 14058 --- [o-auto-1-exec-1] o.s.web.servlet.DispatcherServlet        : Completed initialization in 1 ms
2025-08-01T08:27:15.811-06:00 DEBUG 14058 --- [o-auto-1-exec-1] o.s.security.web.FilterChainProxy        : Securing POST /api/v1/organization/f5365c9e-bc11-4781-b649-45a281ccdd4a/module
2025-08-01T08:27:15.906-06:00 DEBUG 14058 --- [o-auto-1-exec-1] o.s.s.o.s.r.a.JwtAuthenticationProvider  : Authenticated token
2025-08-01T08:27:15.906-06:00 DEBUG 14058 --- [o-auto-1-exec-1] .s.r.w.a.BearerTokenAuthenticationFilter : Set SecurityContextHolder to JwtAuthenticationToken [Principal=org.springframework.security.oauth2.jwt.Jwt@f5cdd584, Credentials=[PROTECTED], Authenticated=true, Details=WebAuthenticationDetails [RemoteIpAddress=127.0.0.1, SessionId=null], Granted Authorities=[]]
2025-08-01T08:27:15.913-06:00 DEBUG 14058 --- [o-auto-1-exec-1] o.s.security.web.FilterChainProxy        : Secured POST /api/v1/organization/f5365c9e-bc11-4781-b649-45a281ccdd4a/module
2025-08-01T08:27:16.058-06:00 DEBUG 14058 --- [         task-1] i.t.a.r.c.o.UserBelongsOrganization      : isServiceMember GCP_DEVELOPERS false
2025-08-01T08:27:16.058-06:00 DEBUG 14058 --- [         task-1] i.t.a.r.c.o.UserBelongsOrganization      : isServiceMember TERRAKUBE_DEVELOPERS true
2025-08-01T08:27:16.073-06:00 DEBUG 14058 --- [         task-1] i.t.a.r.c.o.UserBelongsOrganization      : isServiceMember GCP_DEVELOPERS false
2025-08-01T08:27:16.073-06:00 DEBUG 14058 --- [         task-1] i.t.a.r.c.o.UserBelongsOrganization      : isServiceMember TERRAKUBE_DEVELOPERS true
2025-08-01T08:27:16.092-06:00  INFO 14058 --- [         task-1] i.t.a.rs.hooks.module.ModuleManageHook   : ModuleManageHook gcp/terrakube-storage/azurerm phase PRECOMMIT
2025-08-01T08:27:16.093-06:00  INFO 14058 --- [         task-1] i.t.a.rs.hooks.module.ModuleManageHook   : ModuleManageHook creation hook for gcp/terrakube-storage/azurerm
2025-08-01T08:27:16.093-06:00  INFO 14058 --- [         task-1] i.t.a.r.h.o.OrganizationManageHook       : OrganizationManageHook f5365c9e-bc11-4781-b649-45a281ccdd4a
2025-08-01T08:27:16.103-06:00 DEBUG 14058 --- [         task-1] i.t.a.r.c.o.UserBelongsOrganization      : isServiceMember GCP_DEVELOPERS false
2025-08-01T08:27:16.103-06:00 DEBUG 14058 --- [         task-1] i.t.a.r.c.o.UserBelongsOrganization      : isServiceMember TERRAKUBE_DEVELOPERS true
2025-08-01T08:27:16.133-06:00  INFO 14058 --- [         task-1] i.t.a.rs.hooks.module.ModuleManageHook   : ModuleManageHook gcp/terrakube-storage/azurerm phase POSTCOMMIT
2025-08-01T08:27:16.133-06:00  INFO 14058 --- [         task-1] i.t.a.rs.hooks.module.ModuleManageHook   : ModuleManageHook creation hook for gcp/terrakube-storage/azurerm
2025-08-01T08:27:16.133-06:00  INFO 14058 --- [         task-1] i.t.a.rs.hooks.module.ModuleManageHook   : Create module refresh task for gcp/terrakube-storage/azurerm
2025-08-01T08:27:16.138-06:00  INFO 14058 --- [         task-1] i.t.a.p.scheduler.ScheduleServiceBase    : Create ModuleRefresh Trigger DEFAULT.TerrakubeV2_ModuleRefresh_1d5742dd-b16a-4bcd-9d47-fdc49e57b90b
2025-08-01T08:27:16.149-06:00 DEBUG 14058 --- [o-auto-1-exec-2] o.s.security.web.FilterChainProxy        : Securing POST /api/v1/organization/f5365c9e-bc11-4781-b649-45a281ccdd4a/module
2025-08-01T08:27:16.151-06:00 DEBUG 14058 --- [o-auto-1-exec-2] o.s.security.web.FilterChainProxy        : Secured POST /api/v1/organization/f5365c9e-bc11-4781-b649-45a281ccdd4a/module
HTTP/1.1 201 
Vary: Origin
Vary: Access-Control-Request-Method
Vary: Access-Control-Request-Headers
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: application/vnd.api+json
Content-Length: 697
Date: Fri, 01 Aug 2025 14:27:16 GMT
Keep-Alive: timeout=60
Connection: keep-alive

{
    "data": {
        "type": "module",
        "id": "1d5742dd-b16a-4bcd-9d47-fdc49e57b90b",
        "attributes": {
            "createdBy": "test@terrakube.io",
            "createdDate": "2025-08-01T14:27Z",
            "description": "Terrakube Storage Module",
            "downloadQuantity": 0,
            "folder": null,
            "latestVersion": "Version pending",
            "name": "terrakube-storage",
            "provider": "azurerm",
            "registryPath": "gcp/terrakube-storage/azurerm",
            "source": "https://github.com/AzBuilder/terraform-azurerm-terrakube-cloud-storage.git",
            "tagPrefix": null,
            "updatedBy": "test@terrakube.io",
            "updatedDate": "2025-08-01T14:27Z"
        },
        "relationships": {
            "organization": {
                "data": {
                    "type": "organization",
                    "id": "f5365c9e-bc11-4781-b649-45a281ccdd4a"
                }
            },
            "ssh": {
                "data": null
            },
            "vcs": {
                "data": null
            },
            "version": {
                "data": [
                    
                ]
            }
        }
    }
}
```
