### PR TITLE
fix: Validate module not using semantic versioning

### DIFF
--- a/api/src/main/java/io/terrakube/api/rs/module/Module.java
+++ b/api/src/main/java/io/terrakube/api/rs/module/Module.java
@@ -88,7 +88,7 @@ public class Module extends GenericAuditFields {
     @OneToOne
     private Ssh ssh;
 
-    @OneToMany(cascade = { CascadeType.REMOVE }, mappedBy = "module")
+    @OneToMany(cascade = {CascadeType.REMOVE}, mappedBy = "module")
     private List<ModuleVersion> version;
 
     @Transient
@@ -102,10 +102,18 @@ public class Module extends GenericAuditFields {
     public String getLatestVersion() {
         return version != null && !version.isEmpty()
                 ? version.stream()
-                        .map(ModuleVersion::getVersion)
-                        .max((v1, v2) -> Version.parse(v1.replace("v", ""))
-                                .compareTo(Version.parse(v2.replace("v", ""))))
-                        .orElse("Version pending")
+                .map(ModuleVersion::getVersion)
+                .filter(v -> {
+                    try {
+                        Version.parse(v.replace("v", ""));
+                        return true; // Valid version format
+                    } catch (IllegalArgumentException e) {
+                        return false; // Invalid version format
+                    }
+                })
+                .max((v1, v2) -> Version.parse(v1.replace("v", ""))
+                        .compareTo(Version.parse(v2.replace("v", ""))))
+                .orElse("Version pending")
                 : "Version pending";
     }
 }


### PR DESCRIPTION
Modules that are not using semantic versioning are breaking the modules page

<img width="855" height="613" alt="image" src="https://github.com/user-attachments/assets/5d525325-5cd0-424a-886e-b262d35e9e43" />


Example

https://github.com/mongodb/terraform-provider-mongodbatlas.git

<img width="1334" height="728" alt="image" src="https://github.com/user-attachments/assets/56a095f2-def5-4d26-a482-64a0a082c60a" />


Without the above this will be show in the logs:

```shell
terrakube-api-554d59c8b8-d8tbw terrakube-api java.lang.reflect.InvocationTargetException: null
terrakube-api-554d59c8b8-d8tbw terrakube-api    at jdk.internal.reflect.GeneratedMethodAccessor173.invoke(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.core.type.MethodType.invoke(MethodType.java:83) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.core.dictionary.EntityDictionary.getValue(EntityDictionary.java:1758) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at jdk.internal.reflect.GeneratedMethodAccessor170.invoke(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at org.springframework.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:281) ~[spring-core-6.2.9.jar:6.2.9]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at org.springframework.cloud.context.scope.GenericScope$LockedScopedProxyFactoryBean.invoke(GenericScope.java:482) ~[spring-cloud-context-4.1.4.jar:4.1.4]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.2.9.jar:6.2.9]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:728) ~[spring-aop-6.2.9.jar:6.2.9]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.core.dictionary.EntityDictionary$$SpringCGLIB$$0.getValue(<generated>) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.core.PersistentResource.getValue(PersistentResource.java:487) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.core.datastore.DataStoreTransaction.getAttribute(DataStoreTransaction.java:276) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.core.datastore.inmemory.InMemoryStoreTransaction.getAttribute(InMemoryStoreTransaction.java:184) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.core.PersistentResource.getValueChecked(PersistentResource.java:1742) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.core.PersistentResource.getAttribute(PersistentResource.java:1422) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.core.PersistentResource.getAttribute(PersistentResource.java:1407) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.core.PersistentResource.getAttributes(PersistentResource.java:1694) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.core.PersistentResource.toResource(PersistentResource.java:1566) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.core.PersistentResource.toResource(PersistentResource.java:1545) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.jsonapi.document.processors.IncludedProcessor.lambda$addResourcesForPath$3(IncludedProcessor.java:104) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.lang.Iterable.forEach(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.jsonapi.document.processors.IncludedProcessor.addResourcesForPath(IncludedProcessor.java:103) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.jsonapi.document.processors.IncludedProcessor.lambda$addIncludedResources$1(IncludedProcessor.java:78) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.Arrays$ArrayList.forEach(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.jsonapi.document.processors.IncludedProcessor.lambda$addIncludedResources$2(IncludedProcessor.java:76) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.ArrayList.forEach(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.jsonapi.document.processors.IncludedProcessor.addIncludedResources(IncludedProcessor.java:73) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.jsonapi.document.processors.IncludedProcessor.execute(IncludedProcessor.java:41) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.jsonapi.parser.state.BaseState.getResponseBody(BaseState.java:192) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.jsonapi.parser.state.RecordTerminalState.lambda$handleGet$0(RecordTerminalState.java:48) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.jsonapi.JsonApi.handleRequest(JsonApi.java:290) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.jsonapi.JsonApi.get(JsonApi.java:104) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at org.springframework.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:281) ~[spring-core-6.2.9.jar:6.2.9]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at org.springframework.cloud.context.scope.GenericScope$LockedScopedProxyFactoryBean.invoke(GenericScope.java:482) ~[spring-cloud-context-4.1.4.jar:4.1.4]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184) ~[spring-aop-6.2.9.jar:6.2.9]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:728) ~[spring-aop-6.2.9.jar:6.2.9]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.jsonapi.JsonApi$$SpringCGLIB$$0.get(<generated>) ~[elide-core-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.spring.controllers.JsonApiController$1.call(JsonApiController.java:81) ~[elide-spring-boot-autoconfigure-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at com.yahoo.elide.spring.controllers.JsonApiController$1.call(JsonApiController.java:78) ~[elide-spring-boot-autoconfigure-7.1.11.jar:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at org.springframework.web.context.request.async.WebAsyncManager.lambda$startCallableProcessing$4(WebAsyncManager.java:373) ~[spring-web-6.2.9.jar:6.2.9]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.concurrent.FutureTask.run(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.lang.Thread.run(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api Caused by: java.lang.IllegalArgumentException: test-1.37.0: Version string does not start with a number
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.lang.module.ModuleDescriptor$Version.<init>(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.lang.module.ModuleDescriptor$Version.parse(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at io.terrakube.api.rs.module.Module.lambda$getLatestVersion$0(Module.java:107) ~[classes/:2.27.1]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.function.BinaryOperator.lambda$maxBy$1(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.stream.ReduceOps$2ReducingSink.accept(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.stream.ReferencePipeline$3$1.accept(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.Iterator.forEachRemaining(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.stream.ReferencePipeline.reduce(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at java.base/java.util.stream.ReferencePipeline.max(Unknown Source) ~[na:na]
terrakube-api-554d59c8b8-d8tbw terrakube-api    at io.terrakube.api.rs.module.Module.getLatestVersion(Module.java:106) ~[classes/:2.27.1]
```