### PR TITLE
feat: Use github arm runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
         os: [jammy, jammy-arm, alpaquita]
     env:
       VERSION: ${{ github.event.release.tag_name }}
-    runs-on: ${{ matrix.os == 'jammy-arm' && 'ARM64' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.os == 'jammy-arm' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Github arm64 hosted runners are now generally available for public repositories.

This updates the release pipeline to use those instead of the self hosted one

<img width="919" height="329" alt="image" src="https://github.com/user-attachments/assets/5940b311-1ffe-4498-990f-e00d81304c52" />

fix #2426 
