### PR TITLE
feat: add support for dynamic credentials hostname override

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -33,6 +33,9 @@ public class DynamicCredentialsService {
     @Value("${io.terrakube.hostname}")
     String hostname;
 
+    @Value("${io.terrakube.dynamic.credentials.hostname}")
+    String overrideHostname;
+
     @Value("${io.terrakube.dynamic.credentials.public-key-path}")
     String publicKeyPath;
 
@@ -133,7 +136,7 @@ public class DynamicCredentialsService {
                         .claim("terrakube_organization_name", organizationName)
                         .claim("terrakube_job_id", String.valueOf(jobId))
                         .setIssuedAt(Date.from(now))
-                        .setIssuer(String.format("https://%s", hostname))
+                        .setIssuer(String.format("https://%s", overrideHostname.isEmpty() ? hostname : overrideHostname))
                         .setExpiration(Date.from(now.plus(dynamicCredentialTtl, ChronoUnit.MINUTES)))
                         .signWith(getPrivateKey())
                         .compact();

--- a/api/src/main/java/io/terrakube/api/plugin/token/dynamic/OpenIdConfigurationController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/token/dynamic/OpenIdConfigurationController.java
@@ -22,6 +22,9 @@ public class OpenIdConfigurationController {
     @Value("${io.terrakube.hostname}")
     String hostname;
 
+    @Value("${io.terrakube.dynamic.credentials.hostname}")
+    String overrideHostname;
+
     OpenIdConfiguration openIdConfiguration;
 
     @GetMapping(produces = "application/json")
@@ -38,7 +41,7 @@ public class OpenIdConfigurationController {
         log.info("Loading default OpenId Configuration data...");
         OpenIdConfiguration openIdData = new OpenIdConfiguration();
 
-        String issuer = String.format("https://%s", hostname);
+        String issuer = String.format("https://%s", overrideHostname.isEmpty() ? hostname: overrideHostname);
 
         openIdData.setIssuer(issuer);
         openIdData.setJwksUri(issuer + "/.well-known/jwks");

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -192,6 +192,7 @@ io.terrakube.api.module.cache.schedule=${ModuleCacheSchedule:0 */3 * ? * *}
 #######################
 # Dynamic Credentials #
 #######################
+io.terrakube.dynamic.credentials.hostname=${DynamicCredentialHostname:}
 io.terrakube.dynamic.credentials.public-key-path=${DynamicCredentialPublicKeyPath:}
 io.terrakube.dynamic.credentials.private-key-path=${DynamicCredentialPrivateKeyPath:}
 

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -194,6 +194,7 @@ io.terrakube.api.module.cache.schedule=${ModuleCacheSchedule:0 */3 * ? * *}
 #######################
 # Dynamic Credentials #
 #######################
+io.terrakube.dynamic.credentials.hostname=${DynamicCredentialHostname:}
 io.terrakube.dynamic.credentials.kid=${DynamicCredentialId:03446895-220d-47e1-9564-4eeaa3691b42}
 io.terrakube.dynamic.credentials.ttl=${DynamicCredentialTtl:30}
 io.terrakube.dynamic.credentials.public-key-path=${DynamicCredentialPublicKeyPath:}


### PR DESCRIPTION
Allows to override the hostname for the dynamic credentials jwt token, this will allow to expose the openid configuration in a different endpoint when using a private cluster.

Example:

<img width="774" height="556" alt="image" src="https://github.com/user-attachments/assets/0d2ed33e-a858-40d8-834d-c829514d7564" />
