### PR TITLE
feat: Adding project support

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolver.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolver.java
@@ -82,8 +82,12 @@ public class DexAuthenticationManagerResolver implements AuthenticationManagerRe
         String payloadFromToken = new String(decoder.decode(chunksToken[1]));
         String claimJwt = "";
         try {
+            log.debug("Extracting JWT claim: {}", claim);
             Map<String,Object> resultMap = new ObjectMapper().readValue(payloadFromToken, HashMap.class);
-            claimJwt = resultMap.get(claim).toString();
+            if (resultMap.get(claim) != null) {
+                claimJwt = resultMap.get(claim).toString();
+                log.debug("JWT Claim: {} = {}", claim, claimJwt);
+            }
         } catch (JsonProcessingException e) {
             log.error(e.getMessage());
         }
@@ -91,7 +95,7 @@ public class DexAuthenticationManagerResolver implements AuthenticationManagerRe
     }
 
     private boolean isTokenDeleted(String tokenId) {
-        if (tokenId != null) {
+        if (tokenId != null && !tokenId.isEmpty()) {
             Optional<Pat> searchPat = patRepository.findById(UUID.fromString(tokenId));
             Optional<Group> searchGroupToken = teamTokenRepository.findById(UUID.fromString(tokenId));
             if (searchPat.isPresent()) {

--- a/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeController.java
@@ -1,6 +1,24 @@
 package io.terrakube.api.plugin.state;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.terrakube.api.plugin.state.model.apply.ApplyRunData;
+import io.terrakube.api.plugin.state.model.configuration.ConfigurationData;
+import io.terrakube.api.plugin.state.model.entitlement.EntitlementData;
+import io.terrakube.api.plugin.state.model.organization.OrganizationData;
+import io.terrakube.api.plugin.state.model.organization.capacity.OrgCapacityData;
+import io.terrakube.api.plugin.state.model.outputs.StateOutputs;
+import io.terrakube.api.plugin.state.model.plan.PlanRunData;
+import io.terrakube.api.plugin.state.model.project.ProjectData;
+import io.terrakube.api.plugin.state.model.project.ProjectList;
+import io.terrakube.api.plugin.state.model.runs.RunsData;
+import io.terrakube.api.plugin.state.model.runs.RunsDataList;
+import io.terrakube.api.plugin.state.model.state.StateData;
+import io.terrakube.api.plugin.state.model.workspace.WorkspaceData;
+import io.terrakube.api.plugin.state.model.workspace.WorkspaceError;
+import io.terrakube.api.plugin.state.model.workspace.WorkspaceList;
+import io.terrakube.api.plugin.state.model.workspace.state.consumers.StateConsumerList;
+import io.terrakube.api.plugin.state.model.workspace.tags.TagDataList;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.SchedulerException;
@@ -11,27 +29,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
-import io.terrakube.api.plugin.state.model.configuration.ConfigurationData;
-import io.terrakube.api.plugin.state.model.entitlement.EntitlementData;
-import io.terrakube.api.plugin.state.model.organization.OrganizationData;
-import io.terrakube.api.plugin.state.model.organization.capacity.OrgCapacityData;
-import io.terrakube.api.plugin.state.model.outputs.StateOutputs;
-import io.terrakube.api.plugin.state.model.plan.PlanRunData;
-import io.terrakube.api.plugin.state.model.apply.ApplyRunData;
-import io.terrakube.api.plugin.state.model.runs.RunsData;
-import io.terrakube.api.plugin.state.model.runs.RunsDataList;
-import io.terrakube.api.plugin.state.model.state.StateData;
-import io.terrakube.api.plugin.state.model.workspace.WorkspaceData;
-import io.terrakube.api.plugin.state.model.workspace.WorkspaceError;
-import io.terrakube.api.plugin.state.model.workspace.WorkspaceList;
-import io.terrakube.api.plugin.state.model.workspace.state.consumers.StateConsumerList;
-import io.terrakube.api.plugin.state.model.workspace.tags.TagDataList;
-
-import java.nio.charset.StandardCharsets;
-
-import jakarta.servlet.http.HttpServletRequest;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -124,8 +124,9 @@ public class RemoteTfeController {
     @Transactional
     @PostMapping(produces = "application/vnd.api+json", path = "organizations/{organizationName}/workspaces")
     public ResponseEntity<WorkspaceData> createWorkspace(@PathVariable("organizationName") String organizationName,
-            @RequestBody WorkspaceData workspaceData, Principal principal) {
-        log.info("Create {}", workspaceData.toString());
+            @RequestBody WorkspaceData workspaceData, Principal principal) throws IOException {
+        log.info("Create workspace with: {}", workspaceData.toString());
+
         Optional<WorkspaceData> newWorkspace = Optional.ofNullable(
                 remoteTfeService.createWorkspace(organizationName, workspaceData, (JwtAuthenticationToken) principal));
         if (newWorkspace.isPresent()) {
@@ -328,6 +329,24 @@ public class RemoteTfeController {
     @GetMapping(value = "configuration-versions/{planId}/terraformContent.tar.gz", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public @ResponseBody byte[] getTerraformPlanBinary(@PathVariable("planId") String planId) {
         return remoteTfeService.getContentFile(planId);
+    }
+
+    @Transactional
+    @GetMapping(produces = "application/vnd.api+json", path = "/organizations/{organizationName}/projects")
+    public ResponseEntity<ProjectList> searchOrgProjects(@PathVariable("organizationName") String organizationName, @RequestParam("filter[names]") Optional<String> filterNames, Principal principal) throws IOException {
+        log.info("Searching projects: org: {} filter: {}", organizationName, filterNames.orElse(null));
+        return ResponseEntity.of(Optional.ofNullable(remoteTfeService.searchOrganizationProjects(organizationName, ((JwtAuthenticationToken) principal))));
+    }
+
+    @Transactional
+    @PostMapping(produces = "application/vnd.api+json", path = "/organizations/{organizationName}/projects")
+    public ResponseEntity<ProjectData> createOrgProjects(@PathVariable("organizationName") String organizationName, @RequestBody ProjectData projectData , Principal principal) throws IOException {
+        log.info("Creating project: org: {}  body: {}", organizationName, projectData);
+        ProjectData projectDataResponse = remoteTfeService.createOrganizationProject(organizationName, projectData, ((JwtAuthenticationToken) principal));
+        if (projectDataResponse != null) {
+          return ResponseEntity.status(201).body(projectDataResponse);
+        } else
+          return ResponseEntity.status(403).body(null);
     }
 
 }

--- a/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeController.java
@@ -125,7 +125,7 @@ public class RemoteTfeController {
     @PostMapping(produces = "application/vnd.api+json", path = "organizations/{organizationName}/workspaces")
     public ResponseEntity<WorkspaceData> createWorkspace(@PathVariable("organizationName") String organizationName,
             @RequestBody WorkspaceData workspaceData, Principal principal) throws IOException {
-        log.info("Create workspace with: {}", workspaceData.toString());
+        log.info("Create workspace with data: {}", workspaceData.toString());
 
         Optional<WorkspaceData> newWorkspace = Optional.ofNullable(
                 remoteTfeService.createWorkspace(organizationName, workspaceData, (JwtAuthenticationToken) principal));

--- a/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
@@ -565,7 +565,7 @@ public class RemoteTfeService {
             newWorkspace.setBranch("remote-content");
             newWorkspace.setOrganization(organization);
 
-            if (workspaceData.getData().getRelationships().getProject() != null) {
+            if (workspaceData.getData().getRelationships() != null && workspaceData.getData().getRelationships().getProject() != null) {
                 log.info("Setting project for workspace {}", newWorkspace.getName());
                 String projectId = workspaceData.getData().getRelationships().getProject().getData().getId();
                 log.info("Project Id: {}", projectId);

--- a/api/src/main/java/io/terrakube/api/plugin/state/model/project/OrganizationModel.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/model/project/OrganizationModel.java
@@ -1,0 +1,13 @@
+package io.terrakube.api.plugin.state.model.project;
+
+import io.terrakube.api.plugin.state.model.generic.Resource;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class OrganizationModel {
+    Resource data;
+}

--- a/api/src/main/java/io/terrakube/api/plugin/state/model/project/ProjectData.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/model/project/ProjectData.java
@@ -1,0 +1,14 @@
+package io.terrakube.api.plugin.state.model.project;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
+@Setter
+@ToString
+public class ProjectData {
+    ProjectModel data;
+}

--- a/api/src/main/java/io/terrakube/api/plugin/state/model/project/ProjectList.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/model/project/ProjectList.java
@@ -1,0 +1,12 @@
+package io.terrakube.api.plugin.state.model.project;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class ProjectList {
+    List<ProjectModel> data;
+}

--- a/api/src/main/java/io/terrakube/api/plugin/state/model/project/ProjectModel.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/model/project/ProjectModel.java
@@ -1,0 +1,18 @@
+package io.terrakube.api.plugin.state.model.project;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.terrakube.api.plugin.state.model.generic.Resource;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
+@Setter
+@ToString
+public class ProjectModel extends Resource {
+    Map<String, Object> attributes;
+    Relationships relationships;
+}

--- a/api/src/main/java/io/terrakube/api/plugin/state/model/project/Relationships.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/model/project/Relationships.java
@@ -1,0 +1,12 @@
+package io.terrakube.api.plugin.state.model.project;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class Relationships {
+    OrganizationModel organization;
+}

--- a/api/src/main/java/io/terrakube/api/plugin/state/model/workspace/CurrentRunRelationship.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/model/workspace/CurrentRunRelationship.java
@@ -1,11 +1,13 @@
 package io.terrakube.api.plugin.state.model.workspace;
 
+import io.terrakube.api.plugin.state.model.generic.Resource;
 import lombok.Getter;
 import lombok.Setter;
-import io.terrakube.api.plugin.state.model.generic.Resource;
+import lombok.ToString;
 
 @Getter
 @Setter
-public class CurrentRunModel {
+@ToString
+public class CurrentRunRelationship {
     Resource data;
 }

--- a/api/src/main/java/io/terrakube/api/plugin/state/model/workspace/ProjectRelationship.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/model/workspace/ProjectRelationship.java
@@ -1,0 +1,13 @@
+package io.terrakube.api.plugin.state.model.workspace;
+
+import io.terrakube.api.plugin.state.model.generic.Resource;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class ProjectRelationship {
+    Resource data;
+}

--- a/api/src/main/java/io/terrakube/api/plugin/state/model/workspace/Relationships.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/model/workspace/Relationships.java
@@ -11,5 +11,8 @@ import lombok.ToString;
 public class Relationships {
 
     @JsonProperty("current-run")
-    CurrentRunModel currentRun;
+    CurrentRunRelationship currentRun;
+
+    @JsonProperty("project")
+    ProjectRelationship project;
 }

--- a/api/src/main/java/io/terrakube/api/plugin/token/team/TeamTokenController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/token/team/TeamTokenController.java
@@ -1,31 +1,24 @@
 package io.terrakube.api.plugin.token.team;
 
-import java.security.Principal;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
-import lombok.ToString;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import io.terrakube.api.repository.AccessRepository;
 import io.terrakube.api.repository.TeamRepository;
 import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.rs.token.group.Group;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 @Slf4j
 @RestController
@@ -109,7 +102,7 @@ public class TeamTokenController {
             });
         });
 
-        log.info("Permissions with Workspace: {}", permissions);
+        log.debug("Permissions with Workspace: {}", permissions);
         return new ResponseEntity<>(permissions, HttpStatus.ACCEPTED);
     }
 

--- a/api/src/main/java/io/terrakube/api/repository/ProjectRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/ProjectRepository.java
@@ -1,0 +1,9 @@
+package io.terrakube.api.repository;
+
+import io.terrakube.api.rs.project.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ProjectRepository extends JpaRepository<Project, UUID> {
+}

--- a/api/src/main/java/io/terrakube/api/rs/Organization.java
+++ b/api/src/main/java/io/terrakube/api/rs/Organization.java
@@ -1,17 +1,13 @@
 package io.terrakube.api.rs;
 
-import java.sql.Types;
-import java.util.List;
-import java.util.UUID;
-
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.SQLRestriction;
+import com.yahoo.elide.annotation.*;
 import io.terrakube.api.rs.agent.Agent;
 import io.terrakube.api.rs.collection.Collection;
 import io.terrakube.api.rs.globalvar.Globalvar;
 import io.terrakube.api.rs.hooks.organization.OrganizationManageHook;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.module.Module;
+import io.terrakube.api.rs.project.Project;
 import io.terrakube.api.rs.provider.Provider;
 import io.terrakube.api.rs.ssh.Ssh;
 import io.terrakube.api.rs.tag.Tag;
@@ -19,23 +15,15 @@ import io.terrakube.api.rs.team.Team;
 import io.terrakube.api.rs.template.Template;
 import io.terrakube.api.rs.vcs.Vcs;
 import io.terrakube.api.rs.workspace.Workspace;
-
-import com.yahoo.elide.annotation.CreatePermission;
-import com.yahoo.elide.annotation.DeletePermission;
-import com.yahoo.elide.annotation.Include;
-import com.yahoo.elide.annotation.LifeCycleHookBinding;
-import com.yahoo.elide.annotation.ReadPermission;
-import com.yahoo.elide.annotation.UpdatePermission;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.sql.Types;
+import java.util.List;
+import java.util.UUID;
 
 @ReadPermission(expression = "user belongs organization")
 @CreatePermission(expression = "user is a superuser")
@@ -72,6 +60,10 @@ public class Organization {
     @UpdatePermission(expression = "user belongs organization")
     @OneToMany(mappedBy = "organization")
     private List<Workspace> workspace;
+
+    @UpdatePermission(expression = "user belongs organization")
+    @OneToMany(mappedBy = "organization")
+    private List<Project> project;
 
     @UpdatePermission(expression = "user belongs organization")
     @OneToMany(mappedBy = "organization")

--- a/api/src/main/java/io/terrakube/api/rs/checks/project/TeamManageProject.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/project/TeamManageProject.java
@@ -1,0 +1,48 @@
+package io.terrakube.api.rs.checks.project;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import io.terrakube.api.plugin.security.groups.GroupService;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.team.Team;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamManageProject.RULE)
+public class TeamManageProject extends OperationCheck<Project> {
+
+    public static final String RULE = "team manage project";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    GroupService groupService;
+
+    @Override
+    public boolean ok(Project project, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team manage project {}", project.getId());
+        List<Team> teamList = project.getOrganization().getTeam();
+        for (Team team : teamList) {
+            if (authenticatedUser.isServiceAccount(requestScope.getUser())){
+                if (groupService.isServiceMember(requestScope.getUser(), team.getName()) && team.isManageWorkspace() ){
+                    return true;
+                }
+            } else {
+                if (groupService.isMember(requestScope.getUser(), team.getName()) && team.isManageWorkspace())
+                    return true;
+            }
+        }
+        return false;
+    }
+}
+
+
+

--- a/api/src/main/java/io/terrakube/api/rs/checks/project/TeamViewProject.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/project/TeamViewProject.java
@@ -1,0 +1,36 @@
+package io.terrakube.api.rs.checks.project;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.team.Team;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamViewProject.RULE)
+public class TeamViewProject extends OperationCheck<Project> {
+
+    public static final String RULE = "team view project";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Override
+    public boolean ok(Project project, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team view project {}", project.getId());
+        List<Team> teamList = project.getOrganization().getTeam();
+        return authenticatedUser.isSuperUser(requestScope.getUser()) ? true : membershipService.checkMembership(requestScope.getUser(), teamList);
+    }
+
+}

--- a/api/src/main/java/io/terrakube/api/rs/project/Project.java
+++ b/api/src/main/java/io/terrakube/api/rs/project/Project.java
@@ -1,0 +1,39 @@
+package io.terrakube.api.rs.project;
+
+import com.yahoo.elide.annotation.*;
+import io.terrakube.api.plugin.security.audit.GenericAuditFields;
+import io.terrakube.api.rs.IdConverter;
+import io.terrakube.api.rs.Organization;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+
+import java.sql.Types;
+import java.util.UUID;
+
+@ReadPermission(expression = "team view project")
+@CreatePermission(expression = "team manage project")
+@UpdatePermission(expression = "team manage project")
+@DeletePermission(expression = "team manage project")
+@Include
+@Getter
+@Setter
+@Entity(name = "project")
+public class Project extends GenericAuditFields {
+
+    @Id
+    @JdbcTypeCode(Types.VARCHAR)
+    @Convert(converter = IdConverter.class)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "description")
+    private String description;
+
+    @ManyToOne
+    private Organization organization;
+}

--- a/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
@@ -1,14 +1,6 @@
 package io.terrakube.api.rs.workspace;
 
-import java.sql.Types;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
-
-import io.terrakube.api.rs.job.JobStatus;
-import jakarta.persistence.*;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.SQLRestriction;
+import com.yahoo.elide.annotation.*;
 import io.terrakube.api.plugin.security.audit.GenericAuditFields;
 import io.terrakube.api.rs.IdConverter;
 import io.terrakube.api.rs.Organization;
@@ -16,6 +8,8 @@ import io.terrakube.api.rs.agent.Agent;
 import io.terrakube.api.rs.collection.Reference;
 import io.terrakube.api.rs.hooks.workspace.WorkspaceManageHook;
 import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.project.Project;
 import io.terrakube.api.rs.ssh.Ssh;
 import io.terrakube.api.rs.vcs.Vcs;
 import io.terrakube.api.rs.webhook.Webhook;
@@ -25,17 +19,16 @@ import io.terrakube.api.rs.workspace.history.History;
 import io.terrakube.api.rs.workspace.parameters.Variable;
 import io.terrakube.api.rs.workspace.schedule.Schedule;
 import io.terrakube.api.rs.workspace.tag.WorkspaceTag;
-
-import com.yahoo.elide.annotation.CreatePermission;
-import com.yahoo.elide.annotation.DeletePermission;
-import com.yahoo.elide.annotation.Exclude;
-import com.yahoo.elide.annotation.Include;
-import com.yahoo.elide.annotation.LifeCycleHookBinding;
-import com.yahoo.elide.annotation.ReadPermission;
-import com.yahoo.elide.annotation.UpdatePermission;
-
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.sql.Types;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
 
 @ReadPermission(expression = "team view workspace OR team limited view workspace")
 @CreatePermission(expression = "team manage workspace")
@@ -127,6 +120,9 @@ public class Workspace extends GenericAuditFields {
 
     @OneToMany(mappedBy = "workspace")
     private List<WorkspaceTag> workspaceTag;
+
+    @OneToOne
+    private Project project;
 
     @ManyToOne
     private Vcs vcs;

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -87,4 +87,5 @@
     <include file="/db/changelog/local/changelog-2.27.1-module-versions.xml"/>
     <include file="/db/changelog/local/changelog-2.27.2-delete-legacy-module-refresh.xml"/>
     <include file="/db/changelog/local/changelog-2.28.0-workspace-last-status.xml" />
+    <include file="/db/changelog/local/changelog-2.28.0-project-support.xml" />
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.28.0-project-support.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.28.0-project-support.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-28-0-2" author="alfespa17@gmail.com">
+        <createTable tableName="project">
+            <column name="id" type="varchar(36)">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="varchar(256)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="varchar(256)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="created_date" type="datetime"/>
+            <column name="updated_date" type="datetime"/>
+            <column name="created_by" type="varchar2(128)"/>
+            <column name="updated_by" type="varchar2(128)"/>
+            <column name="organization_id" type="varchar(36)">
+                <constraints nullable="false" foreignKeyName="fk_organization_project" references="organization(id)" deleteCascade="false"/>
+            </column>
+        </createTable>
+        <addUniqueConstraint
+                columnNames="organization_id, name"
+                constraintName="const_projects"
+                deferrable="true"
+                disabled="true"
+                initiallyDeferred="true"
+                tableName="project"
+                validate="true"/>
+        <addColumn tableName="workspace">
+            <column name="project_id" type="varchar(36)">
+                <constraints nullable="true" foreignKeyName="fk_workspace_project" references="project(id)" deleteCascade="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/ProjectTests.java
+++ b/api/src/test/java/io/terrakube/api/ProjectTests.java
@@ -1,0 +1,94 @@
+package io.terrakube.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.Mockito.when;
+
+public class ProjectTests extends ServerApplicationTests {
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    void createHistoryAsOrgMember() {
+        String projectId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"),"Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"test-project\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/project")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+        
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"),"Content-Type", "application/vnd.api+json")
+                .when()
+                .get("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/project/" + projectId )
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/project/"+projectId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    void createHistoryAsOrgMemberCli() {
+        String projectId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"),"Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"test-sample\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/remote/tfe/v2/organizations/simple/projects")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"),"Content-Type", "application/vnd.api+json")
+                .when()
+                .get("/remote/tfe/v2/organizations/simple/projects")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value());
+
+        projectRepository.deleteAll();
+    }
+
+
+}

--- a/api/src/test/java/io/terrakube/api/ProjectTests.java
+++ b/api/src/test/java/io/terrakube/api/ProjectTests.java
@@ -35,7 +35,7 @@ public class ProjectTests extends ServerApplicationTests {
                 .log()
                 .all()
                 .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
-        
+
         given()
                 .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"),"Content-Type", "application/vnd.api+json")
                 .when()

--- a/api/src/test/java/io/terrakube/api/ServerApplicationTests.java
+++ b/api/src/test/java/io/terrakube/api/ServerApplicationTests.java
@@ -72,6 +72,9 @@ class ServerApplicationTests {
     TemplateRepository templateRepository;
 
     @Autowired
+    ProjectRepository projectRepository;
+
+    @Autowired
     ExecutorService executorService;
 
     @Autowired


### PR DESCRIPTION
This will allow to run the following when using the CLI driven workflow

```terraform
terraform {

  cloud {
    organization = "simple"
    hostname = "terrakube-api.platform.local"

    workspaces {
      name = "test3"
      project = "newproject"
    }
  }
}
```

This PR also added support for this endpoints that are required by the terraform/tofu CLI when using the CLI driven workflow

```
GET /organizations/{organizationName}/projects
POST /organizations/{organizationName}/projects
```

This feature was tested using terraform 1.13.3