### PR TITLE
Fix postgres AWS IAM token expiry issue

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/datasource/PostgresAwsIamAuthDataSource.java
+++ b/api/src/main/java/io/terrakube/api/plugin/datasource/PostgresAwsIamAuthDataSource.java
@@ -11,38 +11,52 @@ import java.sql.SQLException;
 
 @Slf4j
 public class PostgresAwsIamAuthDataSource extends PGSimpleDataSource {
-    public void setRegion(String region) {
-        this.awsRegion = Region.of(region);
-    }
 
     private Region awsRegion;
     private String authToken;
     private long lastTokenRefresh = 0;
-    private static final long TOKEN_EXPIRY_TIME = 10L * 60L * 1000L;
+    private static final long TOKEN_EXPIRY_TIME = 5L * 60L * 1000L;
+
+    public void setRegion(String region) {
+        this.awsRegion = Region.of(region);
+    }
 
     @Override
     public Connection getConnection(String user, String password) throws SQLException {
-        // If the token is older than 10 minutes, refresh it
+        refreshAuthTokenIfNeeded();
+
+        try {
+            return super.getConnection(user, authToken);
+        } catch (SQLException e) {
+            log.warn("Initial connection attempt failed, refreshing token and retrying...", e);
+            refreshAuthToken(); // force refresh
+            return super.getConnection(user, authToken);
+        }
+    }
+
+    private void refreshAuthTokenIfNeeded() {
         long currentTime = System.currentTimeMillis();
         if (currentTime - lastTokenRefresh > TOKEN_EXPIRY_TIME) {
-            lastTokenRefresh = currentTime;
-
-            log.debug("Refreshing postgres password using AWS SDK");
-
-            RdsUtilities rdsUtilities = RdsUtilities.builder()
-                    .region(awsRegion)
-                    .credentialsProvider(DefaultCredentialsProvider.create())
-                    .build();
-
-            authToken = rdsUtilities.generateAuthenticationToken(r -> r
-                    .hostname(getServerNames()[0])
-                    .port(getPortNumbers()[0])
-                    .username(getUser())
-                    .region(awsRegion)
-                    .build()
-            );
+            refreshAuthToken();
         }
+    }
 
-        return super.getConnection(user, authToken);
+    private void refreshAuthToken() {
+        log.debug("Refreshing Postgres IAM token using AWS SDK");
+
+        RdsUtilities rdsUtilities = RdsUtilities.builder()
+                .region(awsRegion)
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+
+        authToken = rdsUtilities.generateAuthenticationToken(r -> r
+                .hostname(getServerNames()[0])
+                .port(getPortNumbers()[0])
+                .username(getUser())
+                .region(awsRegion)
+                .build()
+        );
+
+        lastTokenRefresh = System.currentTimeMillis();
     }
 }


### PR DESCRIPTION
We have found that the token issued by the AWS RDS service for connections to an AWS Postgres intance often times expires earlier than the documented 10 minutes, which causes requests to the database to fail.

Incressing the refresh frequency to 5 minutes has resolved 99% of the occurances of these errors, however they still occur every now and then.

The try - catch block ensures that when such a failure does occur due to a timing issue, the token is refreshed before another attempt to establish a connection to the database is made.

General formatatting changes included.