### PR TITLE
Moving setCompletedStatus at the end of execution

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/service/executor/ExecutorJobImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/executor/ExecutorJobImpl.java
@@ -80,14 +80,14 @@ public class ExecutorJobImpl implements ExecutorJob {
         }
 
 
-        executionSuccess = terraformResult.isSuccessfulExecution();
-        updateJobStatus.setCompletedStatus(executionSuccess, terraformResult.isPlan, terraformResult.getExitCode(), terraformJob, terraformResult.getOutputLog(), terraformResult.getOutputErrorLog(), terraformResult.getPlanFile(), commitId);
-
         try {
             FileUtils.cleanDirectory(terraformWorkingDir);
         } catch (IOException e) {
             log.error(e.getMessage());
         }
+
+        executionSuccess = terraformResult.isSuccessfulExecution();
+        updateJobStatus.setCompletedStatus(executionSuccess, terraformResult.isPlan, terraformResult.getExitCode(), terraformJob, terraformResult.getOutputLog(), terraformResult.getOutputErrorLog(), terraformResult.getPlanFile(), commitId);
 
         if (executorFlagsProperties.isEphemeral())
             shutdownService.shutdownApplication();


### PR DESCRIPTION
This update is to run the setCompletedStatus method after all cleanup operations part of an executor job are finished.
