### PR TITLE
fix: handle self-hosted Git SSH URLs in formatSshUrl

### DIFF
--- a/ui/src/modules/workspaces/utils/formatSshUrl.spec.ts
+++ b/ui/src/modules/workspaces/utils/formatSshUrl.spec.ts
@@ -35,4 +35,35 @@ describe("formatSshUrl", () => {
     const result = formatSshUrl("git@gitlab.com:org-name/project-name/repo-name.git");
     expect(result).toBe("https://gitlab.com/org-name/project-name/repo-name");
   });
+
+  // Self-hosted instances (issue #2925)
+  test("Self-hosted GitLab SSH url is formatted correctly", () => {
+    const result = formatSshUrl("git@gitlab.example.com:org-name/repo-name.git");
+    expect(result).toBe("https://gitlab.example.com/org-name/repo-name");
+  });
+
+  test("Self-hosted GitHub Enterprise SSH url is formatted correctly", () => {
+    const result = formatSshUrl("git@github.mycompany.com:org-name/repo-name.git");
+    expect(result).toBe("https://github.mycompany.com/org-name/repo-name");
+  });
+
+  test("Self-hosted Gitea SSH url is formatted correctly", () => {
+    const result = formatSshUrl("git@gitea.internal.dev:team/project.git");
+    expect(result).toBe("https://gitea.internal.dev/team/project");
+  });
+
+  test("Self-hosted SSH url with nested path is formatted correctly", () => {
+    const result = formatSshUrl("git@git.company.io:group/subgroup/repo-name.git");
+    expect(result).toBe("https://git.company.io/group/subgroup/repo-name");
+  });
+
+  test("Self-hosted HTTPS url with credentials is formatted correctly", () => {
+    const result = formatSshUrl("https://user@gitlab.example.com/org-name/repo-name.git");
+    expect(result).toBe("https://gitlab.example.com/org-name/repo-name");
+  });
+
+  test("Plain HTTPS url is returned unchanged", () => {
+    const result = formatSshUrl("https://github.com/org-name/repo-name");
+    expect(result).toBe("https://github.com/org-name/repo-name");
+  });
 });

--- a/ui/src/modules/workspaces/utils/formatSshUrl.ts
+++ b/ui/src/modules/workspaces/utils/formatSshUrl.ts
@@ -3,27 +3,27 @@ export default function (source: string): string {
     source = source.replace(".git", "");
   }
 
-  if (source.startsWith("git@")) {
-    source = source.replace("git@", "https://");
-  }
-
+  // Azure DevOps SSH urls have a special format: git@ssh.dev.azure.com:v3/org/project/repo
   if (source.includes("dev.azure.com")) {
     source = source.replace(":v3", "").replace("ssh.", "");
     source = stripUserFromHost(source);
     source = source.replace("/_git", "");
+    if (source.startsWith("git@")) {
+      source = source.replace("git@", "https://");
+    }
+    return source;
   }
 
-  if (source.includes("github.com") || source.includes("ghe.com")) {
-    source = source.replace(".com:", ".com/");
+  // Generic SSH url handling: git@host:path → https://host/path
+  // Works for github.com, gitlab.com, bitbucket.org, and any self-hosted instance
+  if (source.startsWith("git@")) {
+    source = source.replace(/^git@([^:]+):(.*)$/, "https://$1/$2");
+    return source;
   }
 
-  if (source.includes("bitbucket.org")) {
-    source = source.replace(".org:", ".org/");
+  // HTTPS urls with embedded credentials: https://user@host/path → https://host/path
+  if (source.includes("@") && source.startsWith("https://")) {
     source = stripUserFromHost(source);
-  }
-
-  if (source.includes("gitlab.com")) {
-    source = source.replace(".com:", ".com/");
   }
 
   return source;


### PR DESCRIPTION
## Summary

- Replaces hardcoded domain-specific colon replacements (`.com:`, `.org:`) in `formatSshUrl` with a generic regex `^git@([^:]+):(.*)$` → `https://$1/$2`
- Fixes broken VCS links for self-hosted GitLab, GitHub Enterprise, Gitea, and any other Git instance
- Azure DevOps kept as special case due to its unique `:v3` path format

## Problem

The previous implementation only handled known domains (`github.com`, `gitlab.com`, `bitbucket.org`) by replacing domain-specific colons. Self-hosted instances like `git@gitlab.example.com:org/repo.git` were left with the SSH colon format, producing invalid URLs.

## Solution

Use a single generic regex that handles ANY SSH `git@host:path` URL, regardless of the hostname. This is the same approach already used by `fixSshURL()` in `Details.tsx`.

## Test plan

- [x] All 7 existing tests pass (GitHub, GitLab, Bitbucket, Azure DevOps)
- [x] Added 6 new tests for self-hosted instances:
  - Self-hosted GitLab SSH
  - Self-hosted GitHub Enterprise SSH
  - Self-hosted Gitea SSH
  - Self-hosted SSH with nested paths (group/subgroup/repo)
  - Self-hosted HTTPS with credentials
  - Plain HTTPS passthrough

Closes #2925