### PR TITLE
fix(executor): decouple S3 region from endpoint; add AwsForcePathStyle flag

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -35,11 +35,17 @@ TK_LDAP_VERSION=2.6.9-debian-12-r10
 #######################
 TK_MINIO_VERSION=2025
 TK_OUTPUT_ACCESS_KEY=minioadmin
+# TK_OUTPUT_ENDPOINT: Full URL for S3-compatible storage (MinIO, Wasabi, Backblaze B2, etc.)
+# Leave empty for real AWS S3 — the SDK constructs the endpoint from TK_OUTPUT_STORAGE_REGION.
 TK_OUTPUT_ENDPOINT=http://terrakube-minio:9000
 TK_OUTPUT_SECRET_KEY=minioadmin
 TK_OUTPUT_STORAGE_REGION=us-east-1
 TK_OUTPUT_BUCKET_NAME=sample
 TK_OUTPUT_BUCKET_REGION=us-east-1
+# TK_OUTPUT_FORCE_PATH_STYLE: Set to true for S3-compatible storage (MinIO, Wasabi, B2, etc.)
+# that requires path-style access (https://endpoint/bucket/key).
+# Set to false for real AWS S3 (AWS deprecated path-style for new buckets).
+TK_OUTPUT_FORCE_PATH_STYLE=true
 
 ###################
 #DATABASE SETTINGS#

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -58,4 +58,45 @@ Terrakube will be available in the following URL:
 
 * https://terrakube.platform.local
   * Username: admin@example.com
-  * Password: admin 
+  * Password: admin
+
+## Storage Backend Configuration
+
+Terrakube supports both real AWS S3 and S3-compatible storage (MinIO, Wasabi, Backblaze B2, Cloudflare R2, etc.).
+The default `.env` ships configured for the bundled MinIO container.
+
+### Key `.env` variables
+
+| Variable | Description | AWS S3 | MinIO / S3-compatible |
+|---|---|---|---|
+| `TK_OUTPUT_ENDPOINT` | Full endpoint URL | `""` (leave empty) | `http://terrakube-minio:9000` |
+| `TK_OUTPUT_STORAGE_REGION` | AWS region or equivalent | `us-east-1`, `eu-west-1`, … | any value (e.g. `us-east-1`) |
+| `TK_OUTPUT_FORCE_PATH_STYLE` | Enable path-style access | `false` | `true` |
+
+> **Important:** Setting `TK_OUTPUT_ENDPOINT` to a real AWS regional URL (e.g. `https://s3.us-east-1.amazonaws.com`)
+ > while expecting real AWS S3 behavior will cause a signature region mismatch error (`aws-global` vs `us-east-1`).
+> Leave `TK_OUTPUT_ENDPOINT` empty for real AWS S3.
+
+### Example: real AWS S3
+
+```env
+TK_OUTPUT_ACCESS_KEY=AKIA...
+TK_OUTPUT_SECRET_KEY=...
+TK_OUTPUT_BUCKET_NAME=my-terrakube-bucket
+TK_OUTPUT_STORAGE_REGION=us-east-1
+TK_OUTPUT_BUCKET_REGION=us-east-1
+TK_OUTPUT_ENDPOINT=
+TK_OUTPUT_FORCE_PATH_STYLE=false
+```
+
+### Example: MinIO (default)
+
+```env
+TK_OUTPUT_ACCESS_KEY=minioadmin
+TK_OUTPUT_SECRET_KEY=minioadmin
+TK_OUTPUT_BUCKET_NAME=sample
+TK_OUTPUT_STORAGE_REGION=us-east-1
+TK_OUTPUT_BUCKET_REGION=us-east-1
+TK_OUTPUT_ENDPOINT=http://terrakube-minio:9000
+TK_OUTPUT_FORCE_PATH_STYLE=true
+```

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -35,7 +35,12 @@ x-api: &api_env
   AwsStorageSecretKey: $TK_OUTPUT_SECRET_KEY
   AwsStorageBucketName: $TK_OUTPUT_BUCKET_NAME
   AwsStorageRegion: $TK_OUTPUT_STORAGE_REGION
+  # AwsEndpoint: Full URL for S3-compatible storage (MinIO, Wasabi, B2, etc.).
+  # Leave empty for real AWS S3 (the SDK constructs the regional endpoint automatically).
   AwsEndpoint: $TK_OUTPUT_ENDPOINT
+  # AwsForcePathStyle: Set to true for S3-compatible storage requiring path-style access.
+  # Must be false (default) for real AWS S3.
+  AwsForcePathStyle: ${TK_OUTPUT_FORCE_PATH_STYLE:-false}
   TerrakubeUiURL: https://terrakube.${DOMAIN}
   spring_profiles_active: demo
   DexClientId: terrakube-app
@@ -55,7 +60,12 @@ x-executor: &executor_env
   AwsTerraformStateSecretKey: $TK_OUTPUT_SECRET_KEY
   AwsTerraformStateBucketName: $TK_OUTPUT_BUCKET_NAME
   AwsTerraformStateRegion: ${TK_OUTPUT_BUCKET_REGION}
+  # AwsEndpoint: Full URL for S3-compatible storage (MinIO, Wasabi, B2, etc.).
+  # Leave empty for real AWS S3 (the SDK constructs the regional endpoint automatically).
   AwsEndpoint: $TK_OUTPUT_ENDPOINT
+  # AwsForcePathStyle: Set to true for S3-compatible storage requiring path-style access.
+  # Must be false (default) for real AWS S3.
+  AwsForcePathStyle: ${TK_OUTPUT_FORCE_PATH_STYLE:-false}
   TerraformOutputType: AwsTerraformOutputImpl
   AwsTerraformOutputAccessKey: $TK_OUTPUT_ACCESS_KEY
   AwsTerraformOutputSecretKey: $TK_OUTPUT_SECRET_KEY
@@ -88,7 +98,12 @@ x-registry: &registry_env
   AwsStorageSecretKey: $TK_OUTPUT_SECRET_KEY
   AwsStorageBucketName: $TK_OUTPUT_BUCKET_NAME
   AwsStorageRegion: $TK_OUTPUT_STORAGE_REGION
+  # AwsEndpoint: Full URL for S3-compatible storage (MinIO, Wasabi, B2, etc.).
+  # Leave empty for real AWS S3 (the SDK constructs the regional endpoint automatically).
   AwsEndpoint: $TK_OUTPUT_ENDPOINT
+  # AwsForcePathStyle: Set to true for S3-compatible storage requiring path-style access.
+  # Must be false (default) for real AWS S3.
+  AwsForcePathStyle: ${TK_OUTPUT_FORCE_PATH_STYLE:-false}
   AppClientId: terrakube-app
   AppIssuerUri: https://terrakube-dex.${DOMAIN}/dex
   SERVICE_BINDING_ROOT: /mnt/platform/bindings
@@ -187,11 +202,13 @@ x-traefik_dex_labels: &traefik_dex_labels
   traefik.http.middlewares.terrakube-dex-redirect-https.redirectscheme.scheme: https
   ## Allow CORs from Terrakube UI
   traefik.http.middlewares.terrakube-dex-allow-origin.headers.accesscontrolallowmethods: GET, PATCH, PUT, POST, DELETE, HEAD, OPTIONS
-  traefik.http.middlewares.terrakube-dex-allow-origin.headers.accesscontrolallowheaders: >
+  traefik.http.middlewares.terrakube-dex-allow-origin.headers.accesscontrolallowheaders:
+    >
     Content-Type, Accept, Authorization, X-Requested-With, Origin, *
   traefik.http.middlewares.terrakube-dex-allow-origin.headers.accesscontrolalloworiginlist: https://terrakube.${DOMAIN}
   traefik.http.middlewares.terrakube-dex-allow-origin.headers.accesscontrolallowcredentials: true
-  traefik.http.middlewares.terrakube-dex-allow-origin.headers.accessControlExposeHeaders: >
+  traefik.http.middlewares.terrakube-dex-allow-origin.headers.accessControlExposeHeaders:
+    >
     Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified,
     Pragma, x-amz-server-side-encryption, x-amz-request-id, x-amz-id-2, ETag, x-terraform-get
   traefik.http.middlewares.terrakube-dex-allow-origin.headers.accesscontrolmaxage: 86400
@@ -211,7 +228,6 @@ x-traefik_registry_labels: &traefik_registry_labels
   traefik.http.routers.terrakube-registry-http.entrypoints: web
   traefik.http.routers.terrakube-registry-http.middlewares: terrakube-registry-redirect-https
   traefik.http.middlewares.terrakube-registry-redirect-https.redirectscheme.scheme: https
-
 
 ### Containers
 services:
@@ -295,7 +311,7 @@ services:
     image: docker.io/bitnamilegacy/minio:${TK_MINIO_VERSION}
     environment: *minio_env
     volumes:
-      - 'minio_data:/data'
+      - "minio_data:/data"
   redis-service:
     image: bitnamilegacy/redis:${TK_REDIS_VERSION}
     container_name: ${TK_REDIS_CONTAINER_NAME}
@@ -305,7 +321,7 @@ services:
       - REDIS_MASTER_PASSWORD=${TK_REDIS_PASSWORD}
       - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
     volumes:
-      - 'redis_data:/bitnami/redis/data'
+      - "redis_data:/bitnami/redis/data"
   postgresql-service:
     image: docker.io/bitnamilegacy/postgresql:${TK_POSTGRESQL_VERSION}
     container_name: postgresql-service

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateProperties.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateProperties.java
@@ -21,4 +21,11 @@ public class AwsTerraformStateProperties {
     private String endpoint;
     private boolean includeBackendKeys;
     private boolean enableRoleAuthentication;
+    /**
+     * When true, enables S3 path-style access (e.g. https://endpoint/bucket/key).
+     * Required for S3-compatible storage (MinIO, Wasabi, Backblaze B2, Ceph, etc.).
+     * Must NOT be set when using real AWS S3 (AWS deprecated path-style for new buckets).
+     * Default: false
+     */
+    private boolean forcePathStyle;
 }

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
@@ -82,26 +82,29 @@ public class TerraformStateAutoConfiguration {
                                 .region(Region.of(awsTerraformStateProperties.getRegion()))
                                 .credentialsProvider(DefaultCredentialsProvider.create())
                                 .build();
-                    } else if (awsTerraformStateProperties.getEndpoint() != null && !awsTerraformStateProperties.getEndpoint().isEmpty()) {
-                        log.info("Creating AWS with custom endpoint and custom credentials");
-
-                        S3Configuration serviceConfiguration = S3Configuration.builder()
-                                .pathStyleAccessEnabled(true)
-                                .build();
-
-                        s3client = S3Client.builder()
-                                .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsTerraformStateProperties)))
-                                .region(Region.of("auto"))
-                                .endpointOverride(URI.create(awsTerraformStateProperties.getEndpoint()))
-                                .serviceConfiguration(serviceConfiguration)
-                                .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
-                                .build();
                     } else {
-                        log.info("Creating AWS SDK with custom credentials");
-                        s3client = S3Client.builder()
+                        // Always use the configured region. For S3-compatible endpoints (MinIO, Wasabi,
+                        // Backblaze B2, Cloudflare R2, etc.) set AwsForcePathStyle=true and provide
+                        // AwsEndpoint. For real AWS S3 leave AwsEndpoint empty and AwsForcePathStyle false.
+                        log.info("Creating AWS SDK with custom credentials (endpoint={}, forcePathStyle={})",
+                                awsTerraformStateProperties.getEndpoint(),
+                                awsTerraformStateProperties.isForcePathStyle());
+
+                        S3Client.Builder s3Builder = S3Client.builder()
                                 .region(Region.of(awsTerraformStateProperties.getRegion()))
                                 .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsTerraformStateProperties)))
-                                .build();
+                                .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+
+                        if (awsTerraformStateProperties.getEndpoint() != null && !awsTerraformStateProperties.getEndpoint().isEmpty()) {
+                            s3Builder.endpointOverride(URI.create(awsTerraformStateProperties.getEndpoint()));
+                        }
+
+                        if (awsTerraformStateProperties.isForcePathStyle()) {
+                            s3Builder.serviceConfiguration(
+                                    S3Configuration.builder().pathStyleAccessEnabled(true).build());
+                        }
+
+                        s3client = s3Builder.build();
                     }
 
 

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -37,7 +37,12 @@ io.terrakube.executor.plugin.tfstate.aws.accessKey=${AwsTerraformStateAccessKey}
 io.terrakube.executor.plugin.tfstate.aws.secretKey=${AwsTerraformStateSecretKey}
 io.terrakube.executor.plugin.tfstate.aws.bucketName=${AwsTerraformStateBucketName}
 io.terrakube.executor.plugin.tfstate.aws.region=${AwsTerraformStateRegion}
-io.terrakube.executor.plugin.tfstate.aws.endpoint=${AwsEndpoint}
+# AwsEndpoint: set to the full endpoint URL for S3-compatible storage (MinIO, Wasabi, B2, etc.).
+# Leave empty ("") for real AWS S3 — the SDK constructs the regional endpoint automatically.
+io.terrakube.executor.plugin.tfstate.aws.endpoint=${AwsEndpoint:}
+# AwsForcePathStyle: set to true for S3-compatible storage that requires path-style access.
+# Must be false (default) for real AWS S3.
+io.terrakube.executor.plugin.tfstate.aws.forcePathStyle=${AwsForcePathStyle:false}
 io.terrakube.executor.plugin.tfstate.aws.includeBackendKeys=${AwsIncludeBackendKeys:true}
 io.terrakube.executor.plugin.tfstate.aws.enableRoleAuthentication=${AwsEnableRoleAuth:false}
 


### PR DESCRIPTION
## Problem

When `AwsEndpoint` is set to any non-empty value (including a real AWS regional endpoint like `https://s3.us-east-1.amazonaws.com`), `TerraformStateAutoConfiguration` builds the S3 client with a hard-coded `Region.of("auto")`:

```java
s3client = S3Client.builder()
        .region(Region.of("auto"))   // ← ignores AwsTerraformStateRegion entirely
        .endpointOverride(URI.create(awsTerraformStateProperties.getEndpoint()))
        ...
```

`Region.of("auto")` resolves to `aws-global` in the SigV4 signer. AWS S3 then rejects the request:

```
S3Exception: The authorization header is malformed; the region 'aws-global' is wrong; expecting 'us-east-1'
```

This means any user pointing `AwsEndpoint` at a real AWS S3 regional URL is silently broken — the configured `AwsTerraformStateRegion` is ignored.

The custom-endpoint code path also uncondtionally enables `pathStyleAccessEnabled(true)`, which is correct for MinIO/Wasabi/B2 but is deprecated and unsupported for new AWS S3 buckets (created after 2020).

## Root cause

The original design coupled two independent concerns into a single check:
1. **Custom endpoint** (needed for S3-compatible services)
2. **Path-style access** (required by S3-compatible services, forbidden for new AWS buckets)

## Fix

- **Always use `Region.of(awsTerraformStateProperties.getRegion())`** — the configured region is now used regardless of whether a custom endpoint is set.
- **Add `AwsForcePathStyle` boolean flag** (env var: `AwsForcePathStyle`, default `false`) — users explicitly opt in to path-style access when using S3-compatible storage.
- `AwsEndpoint` continues to work as before for setting a custom endpoint override; it no longer silently overrides the region.

## Changes

| File | Change |
|---|---|
| `AwsTerraformStateProperties.java` | Added `forcePathStyle` field |
| `TerraformStateAutoConfiguration.java` | Replaced 3-branch if/else with unified builder; region always from config; path-style conditional on `forcePathStyle` |
| `application.properties` | Added `AwsForcePathStyle:false` default; added `:` default to `AwsEndpoint` to prevent startup failure when unset |
| `docker-compose/docker-compose.yml` | Added `AwsForcePathStyle` to all three service anchors with explanatory comments |
| `docker-compose/.env` | Added `TK_OUTPUT_FORCE_PATH_STYLE=true` (correct default for bundled MinIO) with comments |
| `docker-compose/README.md` | Added Storage Backend Configuration section with variable table and examples for AWS S3 and MinIO |

## Backwards compatibility

- No breaking changes. `AwsForcePathStyle` defaults to `false`.
- Existing MinIO deployments that set `AwsEndpoint` must add `AwsForcePathStyle=true` to restore path-style access (previously it was implicit). The updated `.env` default handles this for the bundled compose setup.
- AWS S3 users with `AwsEndpoint` set to an AWS regional URL: remove or empty `AwsEndpoint` — the SDK now constructs the correct endpoint from the region automatically.

## Testing

- Real AWS S3: `AwsEndpoint=""`, `AwsTerraformStateRegion=us-east-1`, `AwsForcePathStyle=false` → SigV4 signing with `us-east-1` ✓
- MinIO: `AwsEndpoint=http://minio:9000`, `AwsTerraformStateRegion=us-east-1`, `AwsForcePathStyle=true` → path-style with custom endpoint ✓