### PR TITLE
feat: add project-level team permissions

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/security/groups/GroupService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/groups/GroupService.java
@@ -15,4 +15,6 @@ public interface GroupService {
 
      boolean isMemberWithLimitedAccessV2(User user, Organization organization);
 
+     boolean isMemberWithProjectAccess(User user, Organization organization);
+
 }

--- a/api/src/main/java/io/terrakube/api/plugin/security/groups/dex/DexGroupServiceImpl.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/groups/dex/DexGroupServiceImpl.java
@@ -12,7 +12,9 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.stereotype.Service;
 import io.terrakube.api.plugin.security.groups.GroupService;
 import io.terrakube.api.repository.AccessRepository;
+import io.terrakube.api.repository.ProjectAccessRepository;
 import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.project.access.ProjectAccess;
 import io.terrakube.api.rs.workspace.Workspace;
 import io.terrakube.api.rs.workspace.access.Access;
 
@@ -29,6 +31,8 @@ public class DexGroupServiceImpl implements GroupService {
     RedisTemplate redisTemplate;
 
     AccessRepository accessRepository;
+
+    ProjectAccessRepository projectAccessRepository;
 
     FederatedRepository federatedRepository;
 
@@ -138,5 +142,14 @@ public class DexGroupServiceImpl implements GroupService {
         Optional<List<Access>> accessList = accessRepository.findAllByWorkspaceOrganizationIdAndNameIn(organization.getId(), groups);
         log.debug("Groups Size: {}, IsPresent: {},  Group Access {}", groups.size(), accessList.isPresent(), accessList.get().isEmpty());
         return !accessList.get().isEmpty();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean isMemberWithProjectAccess(User user, Organization organization){
+        List<String> groups = (List<String>)((JwtAuthenticationToken) user.getPrincipal()).getTokenAttributes().get("groups");
+        Optional<List<ProjectAccess>> accessList = projectAccessRepository.findAllByProjectOrganizationIdAndNameIn(organization.getId(), groups);
+        log.debug("ProjectAccess check - Groups Size: {}, IsPresent: {}, HasAccess: {}", groups.size(), accessList.isPresent(), accessList.map(l -> !l.isEmpty()).orElse(false));
+        return accessList.map(l -> !l.isEmpty()).orElse(false);
     }
 }

--- a/api/src/main/java/io/terrakube/api/plugin/security/rbac/RbacService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/rbac/RbacService.java
@@ -1,5 +1,6 @@
 package io.terrakube.api.plugin.security.rbac;
 
+import io.terrakube.api.rs.project.access.ProjectAccess;
 import io.terrakube.api.rs.team.Team;
 import io.terrakube.api.rs.workspace.access.Access;
 
@@ -56,4 +57,16 @@ public interface RbacService {
     boolean canApproveJob(Access access);
 
     boolean canManageJob(Access access);
+
+    // --- Project-level (ProjectAccess) checks ---
+
+    boolean canManageWorkspace(ProjectAccess access);
+
+    boolean canManageState(ProjectAccess access);
+
+    boolean canPlanJob(ProjectAccess access);
+
+    boolean canApproveJob(ProjectAccess access);
+
+    boolean canManageJob(ProjectAccess access);
 }

--- a/api/src/main/java/io/terrakube/api/plugin/security/rbac/RbacService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/rbac/RbacService.java
@@ -69,4 +69,6 @@ public interface RbacService {
     boolean canApproveJob(ProjectAccess access);
 
     boolean canManageJob(ProjectAccess access);
+
+    boolean canManageProject(ProjectAccess access);
 }

--- a/api/src/main/java/io/terrakube/api/plugin/security/rbac/RbacV2Service.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/rbac/RbacV2Service.java
@@ -244,6 +244,16 @@ public class RbacV2Service implements RbacService {
         return canPlanJob(access) || canApproveJob(access);
     }
 
+    @Override
+    public boolean canManageProject(ProjectAccess access) {
+        String role = normalizeRole(access.getRole());
+        return switch (role) {
+            case ROLE_ADMIN -> true;
+            case ROLE_WRITE, ROLE_PLAN, ROLE_READ, ROLE_CUSTOM -> false;
+            default -> false;
+        };
+    }
+
     // --- Helpers ---
 
     private String normalizeRole(String role) {

--- a/api/src/main/java/io/terrakube/api/plugin/security/rbac/RbacV2Service.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/rbac/RbacV2Service.java
@@ -1,5 +1,6 @@
 package io.terrakube.api.plugin.security.rbac;
 
+import io.terrakube.api.rs.project.access.ProjectAccess;
 import io.terrakube.api.rs.team.Team;
 import io.terrakube.api.rs.workspace.access.Access;
 import lombok.extern.slf4j.Slf4j;
@@ -189,6 +190,57 @@ public class RbacV2Service implements RbacService {
 
     @Override
     public boolean canManageJob(Access access) {
+        return canPlanJob(access) || canApproveJob(access);
+    }
+
+    // --- Project-level (ProjectAccess) checks ---
+
+    @Override
+    public boolean canManageWorkspace(ProjectAccess access) {
+        String role = normalizeRole(access.getRole());
+        return switch (role) {
+            case ROLE_ADMIN, ROLE_WRITE -> true;
+            case ROLE_PLAN, ROLE_READ -> false;
+            case ROLE_CUSTOM -> access.isManageWorkspace();
+            default -> false;
+        };
+    }
+
+    @Override
+    public boolean canManageState(ProjectAccess access) {
+        String role = normalizeRole(access.getRole());
+        return switch (role) {
+            case ROLE_ADMIN, ROLE_WRITE -> true;
+            case ROLE_PLAN, ROLE_READ -> false;
+            case ROLE_CUSTOM -> access.isManageState();
+            default -> false;
+        };
+    }
+
+    @Override
+    public boolean canPlanJob(ProjectAccess access) {
+        String role = normalizeRole(access.getRole());
+        return switch (role) {
+            case ROLE_ADMIN, ROLE_WRITE, ROLE_PLAN -> true;
+            case ROLE_READ -> false;
+            case ROLE_CUSTOM -> access.isPlanJob();
+            default -> false;
+        };
+    }
+
+    @Override
+    public boolean canApproveJob(ProjectAccess access) {
+        String role = normalizeRole(access.getRole());
+        return switch (role) {
+            case ROLE_ADMIN, ROLE_WRITE -> true;
+            case ROLE_PLAN, ROLE_READ -> false;
+            case ROLE_CUSTOM -> access.isApproveJob();
+            default -> false;
+        };
+    }
+
+    @Override
+    public boolean canManageJob(ProjectAccess access) {
         return canPlanJob(access) || canApproveJob(access);
     }
 

--- a/api/src/main/java/io/terrakube/api/plugin/token/team/TeamTokenController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/token/team/TeamTokenController.java
@@ -122,6 +122,17 @@ public class TeamTokenController {
                permissions.setPlanJob(permissions.planJob || rbacService.canPlanJob(access));
                permissions.setApproveJob(permissions.approveJob || rbacService.canApproveJob(access));
             });
+            if (workspace.getProject() != null) {
+                workspace.getProject().getProjectAccess().stream()
+                        .filter(pa -> groups.contains(pa.getName()))
+                        .forEach(pa -> {
+                            permissions.setManageState(permissions.manageState || rbacService.canManageState(pa));
+                            permissions.setManageWorkspace(permissions.manageWorkspace || rbacService.canManageWorkspace(pa));
+                            permissions.setManageJob(permissions.manageJob || rbacService.canManageJob(pa));
+                            permissions.setPlanJob(permissions.planJob || rbacService.canPlanJob(pa));
+                            permissions.setApproveJob(permissions.approveJob || rbacService.canApproveJob(pa));
+                        });
+            }
         });
 
         log.debug("Permissions with Workspace: {}", permissions);

--- a/api/src/main/java/io/terrakube/api/repository/ProjectAccessRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/ProjectAccessRepository.java
@@ -1,0 +1,14 @@
+package io.terrakube.api.repository;
+
+import io.terrakube.api.rs.project.access.ProjectAccess;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ProjectAccessRepository extends JpaRepository<ProjectAccess, UUID> {
+
+    Optional<List<ProjectAccess>> findAllByProjectOrganizationIdAndNameIn(UUID projectOrganizationId, List<String> names);
+
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/job/TeamProjectLimitedApproveJob.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/job/TeamProjectLimitedApproveJob.java
@@ -1,0 +1,43 @@
+package io.terrakube.api.rs.checks.job;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamProjectLimitedApproveJob.RULE)
+public class TeamProjectLimitedApproveJob extends OperationCheck<Job> {
+    public static final String RULE = "team project limited approve job";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    RbacService rbacService;
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Override
+    public boolean ok(Job job, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team project limited approve job {}", job.getId());
+        Project project = job.getWorkspace().getProject();
+        if (project == null) return false;
+        List<ProjectAccess> accessList = project.getProjectAccess();
+        if (accessList == null || accessList.isEmpty()) return false;
+        return membershipService.checkProjectMembership(
+                requestScope.getUser(), accessList, pa -> rbacService.canApproveJob(pa));
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/job/TeamProjectLimitedManageJob.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/job/TeamProjectLimitedManageJob.java
@@ -1,0 +1,43 @@
+package io.terrakube.api.rs.checks.job;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamProjectLimitedManageJob.RULE)
+public class TeamProjectLimitedManageJob extends OperationCheck<Job> {
+    public static final String RULE = "team project limited manage job";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    RbacService rbacService;
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Override
+    public boolean ok(Job job, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team project limited manage job {}", job.getId());
+        Project project = job.getWorkspace().getProject();
+        if (project == null) return false;
+        List<ProjectAccess> accessList = project.getProjectAccess();
+        if (accessList == null || accessList.isEmpty()) return false;
+        return membershipService.checkProjectMembership(
+                requestScope.getUser(), accessList, pa -> rbacService.canManageJob(pa));
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/job/TeamProjectLimitedPlanJob.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/job/TeamProjectLimitedPlanJob.java
@@ -1,0 +1,43 @@
+package io.terrakube.api.rs.checks.job;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamProjectLimitedPlanJob.RULE)
+public class TeamProjectLimitedPlanJob extends OperationCheck<Job> {
+    public static final String RULE = "team project limited plan job";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    RbacService rbacService;
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Override
+    public boolean ok(Job job, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team project limited plan job {}", job.getId());
+        Project project = job.getWorkspace().getProject();
+        if (project == null) return false;
+        List<ProjectAccess> accessList = project.getProjectAccess();
+        if (accessList == null || accessList.isEmpty()) return false;
+        return membershipService.checkProjectMembership(
+                requestScope.getUser(), accessList, pa -> rbacService.canPlanJob(pa));
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/job/TeamProjectLimitedViewJob.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/job/TeamProjectLimitedViewJob.java
@@ -1,0 +1,39 @@
+package io.terrakube.api.rs.checks.job;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamProjectLimitedViewJob.RULE)
+public class TeamProjectLimitedViewJob extends OperationCheck<Job> {
+    public static final String RULE = "team project limited view job";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Override
+    public boolean ok(Job job, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team project limited view job {}", job.getId());
+        Project project = job.getWorkspace().getProject();
+        if (project == null) return false;
+        List<ProjectAccess> accessList = project.getProjectAccess();
+        if (accessList == null || accessList.isEmpty()) return false;
+        return membershipService.checkProjectMembership(
+                requestScope.getUser(), accessList, pa -> true);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/membership/MembershipService.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/membership/MembershipService.java
@@ -7,9 +7,11 @@ import io.terrakube.api.plugin.security.user.AuthenticatedUser;
 import io.terrakube.api.rs.team.Team;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import io.terrakube.api.rs.project.access.ProjectAccess;
 import io.terrakube.api.rs.workspace.access.Access;
 
 import java.util.List;
+import java.util.function.Function;
 
 @Service
 @Slf4j
@@ -57,6 +59,25 @@ public class MembershipService {
                 String userMail = authenticatedUser.getEmail(user);
                 if (groupService.isMember(user, team.getName())) {
                     log.debug("user {} is limited member of {}", userMail, team.getName());
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public boolean checkProjectMembership(User user, List<ProjectAccess> accessList, Function<ProjectAccess, Boolean> permissionCheck) {
+        for (ProjectAccess access : accessList) {
+            if (authenticatedUser.isServiceAccount(user)) {
+                String applicationServiceName = authenticatedUser.getApplication(user);
+                if (groupService.isServiceMember(user, access.getName()) && permissionCheck.apply(access)) {
+                    log.debug("application service {} has project-level access via {}", applicationServiceName, access.getName());
+                    return true;
+                }
+            } else {
+                String userMail = authenticatedUser.getEmail(user);
+                if (groupService.isMember(user, access.getName()) && permissionCheck.apply(access)) {
+                    log.debug("user {} has project-level access via {}", userMail, access.getName());
                     return true;
                 }
             }

--- a/api/src/main/java/io/terrakube/api/rs/checks/organization/UserBelongsOrganization.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/organization/UserBelongsOrganization.java
@@ -34,8 +34,10 @@ public class UserBelongsOrganization extends OperationCheck<Organization> {
         }else{
             if (isMemberOrganization(requestScope.getUser(), organization)) {
                 return true;
+            } else if (groupService.isMemberWithLimitedAccessV2(requestScope.getUser(), organization)) {
+                return true;
             } else {
-                return groupService.isMemberWithLimitedAccessV2(requestScope.getUser(), organization);
+                return groupService.isMemberWithProjectAccess(requestScope.getUser(), organization);
             }
         }
     }

--- a/api/src/main/java/io/terrakube/api/rs/checks/project/TeamManageProjectAccess.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/project/TeamManageProjectAccess.java
@@ -7,7 +7,7 @@ import com.yahoo.elide.core.security.checks.OperationCheck;
 import io.terrakube.api.plugin.security.groups.GroupService;
 import io.terrakube.api.plugin.security.rbac.RbacService;
 import io.terrakube.api.plugin.security.user.AuthenticatedUser;
-import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.project.access.ProjectAccess;
 import io.terrakube.api.rs.team.Team;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,10 +16,10 @@ import java.util.List;
 import java.util.Optional;
 
 @Slf4j
-@SecurityCheck(TeamViewProject.RULE)
-public class TeamViewProject extends OperationCheck<Project> {
+@SecurityCheck(TeamManageProjectAccess.RULE)
+public class TeamManageProjectAccess extends OperationCheck<ProjectAccess> {
 
-    public static final String RULE = "team view project";
+    public static final String RULE = "team manage project access";
 
     @Autowired
     AuthenticatedUser authenticatedUser;
@@ -31,20 +31,20 @@ public class TeamViewProject extends OperationCheck<Project> {
     RbacService rbacService;
 
     @Override
-    public boolean ok(Project project, RequestScope requestScope, Optional<ChangeSpec> optional) {
-        log.debug("team view project {}", project.getId());
-        if (authenticatedUser.isSuperUser(requestScope.getUser())) return true;
-        List<Team> teamList = project.getOrganization().getTeam();
+    public boolean ok(ProjectAccess projectAccess, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team manage project access {}", projectAccess.getId());
+        List<Team> teamList = projectAccess.getProject().getOrganization().getTeam();
         for (Team team : teamList) {
             if (authenticatedUser.isServiceAccount(requestScope.getUser())) {
-                if (groupService.isServiceMember(requestScope.getUser(), team.getName()) && rbacService.canManageWorkspace(team))
+                if (groupService.isServiceMember(requestScope.getUser(), team.getName()) && rbacService.canManageWorkspace(team)) {
                     return true;
+                }
             } else {
-                if (groupService.isMember(requestScope.getUser(), team.getName()) && rbacService.canManageWorkspace(team))
+                if (groupService.isMember(requestScope.getUser(), team.getName()) && rbacService.canManageWorkspace(team)) {
                     return true;
+                }
             }
         }
         return false;
     }
-
 }

--- a/api/src/main/java/io/terrakube/api/rs/checks/project/TeamProjectAccessViewProject.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/project/TeamProjectAccessViewProject.java
@@ -1,0 +1,37 @@
+package io.terrakube.api.rs.checks.project;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamProjectAccessViewProject.RULE)
+public class TeamProjectAccessViewProject extends OperationCheck<Project> {
+
+    public static final String RULE = "team project access view project";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Override
+    public boolean ok(Project project, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team project access view project {}", project.getId());
+        List<ProjectAccess> accessList = project.getProjectAccess();
+        if (accessList == null || accessList.isEmpty()) return false;
+        return membershipService.checkProjectMembership(
+                requestScope.getUser(), accessList, pa -> true);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/project/TeamProjectAdminManagesProjectAccessField.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/project/TeamProjectAdminManagesProjectAccessField.java
@@ -1,0 +1,37 @@
+package io.terrakube.api.rs.checks.project;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamProjectAdminManagesProjectAccessField.RULE)
+public class TeamProjectAdminManagesProjectAccessField extends OperationCheck<Project> {
+
+    public static final String RULE = "team project admin manages project access field";
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Autowired
+    RbacService rbacService;
+
+    @Override
+    public boolean ok(Project project, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team project admin manages project access field {}", project.getId());
+        List<ProjectAccess> accessList = project.getProjectAccess();
+        if (accessList == null || accessList.isEmpty()) return false;
+        return membershipService.checkProjectMembership(
+                requestScope.getUser(), accessList, pa -> rbacService.canManageProject(pa));
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/project/TeamProjectLimitedManageProjectAccess.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/project/TeamProjectLimitedManageProjectAccess.java
@@ -1,0 +1,39 @@
+package io.terrakube.api.rs.checks.project;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamProjectLimitedManageProjectAccess.RULE)
+public class TeamProjectLimitedManageProjectAccess extends OperationCheck<ProjectAccess> {
+
+    public static final String RULE = "team project limited manage project access";
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Autowired
+    RbacService rbacService;
+
+    @Override
+    public boolean ok(ProjectAccess projectAccess, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team project limited manage project access {}", projectAccess.getId());
+        Project project = projectAccess.getProject();
+        if (project == null) return false;
+        List<ProjectAccess> accessList = project.getProjectAccess();
+        if (accessList == null || accessList.isEmpty()) return false;
+        return membershipService.checkProjectMembership(
+                requestScope.getUser(), accessList, pa -> rbacService.canManageProject(pa));
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamProjectLimitedCreateWorkspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamProjectLimitedCreateWorkspace.java
@@ -1,0 +1,44 @@
+package io.terrakube.api.rs.checks.workspace;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+import io.terrakube.api.rs.workspace.Workspace;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamProjectLimitedCreateWorkspace.RULE)
+public class TeamProjectLimitedCreateWorkspace extends OperationCheck<Workspace> {
+
+    public static final String RULE = "team project limited create workspace";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    RbacService rbacService;
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Override
+    public boolean ok(Workspace workspace, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team project limited create workspace {}", workspace.getId());
+        Project project = workspace.getProject();
+        if (project == null) return false;
+        List<ProjectAccess> accessList = project.getProjectAccess();
+        if (accessList == null || accessList.isEmpty()) return false;
+        return membershipService.checkProjectMembership(
+                requestScope.getUser(), accessList, pa -> rbacService.canManageWorkspace(pa));
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamProjectLimitedManageWorkspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamProjectLimitedManageWorkspace.java
@@ -1,0 +1,44 @@
+package io.terrakube.api.rs.checks.workspace;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+import io.terrakube.api.rs.workspace.Workspace;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamProjectLimitedManageWorkspace.RULE)
+public class TeamProjectLimitedManageWorkspace extends OperationCheck<Workspace> {
+
+    public static final String RULE = "team project limited manage workspace";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    RbacService rbacService;
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Override
+    public boolean ok(Workspace workspace, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team project limited manage workspace {}", workspace.getId());
+        Project project = workspace.getProject();
+        if (project == null) return false;
+        List<ProjectAccess> accessList = project.getProjectAccess();
+        if (accessList == null || accessList.isEmpty()) return false;
+        return membershipService.checkProjectMembership(
+                requestScope.getUser(), accessList, pa -> rbacService.canManageWorkspace(pa));
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamProjectLimitedReassignWorkspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamProjectLimitedReassignWorkspace.java
@@ -1,0 +1,41 @@
+package io.terrakube.api.rs.checks.workspace;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+import io.terrakube.api.rs.workspace.Workspace;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamProjectLimitedReassignWorkspace.RULE)
+public class TeamProjectLimitedReassignWorkspace extends OperationCheck<Workspace> {
+
+    public static final String RULE = "team project limited reassign workspace";
+
+    @Autowired
+    RbacService rbacService;
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Override
+    public boolean ok(Workspace workspace, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team project limited reassign workspace {}", workspace.getId());
+        if (optional.isEmpty()) return false;
+        Object modified = optional.get().getModified();
+        if (!(modified instanceof Project newProject)) return false;
+        List<ProjectAccess> accessList = newProject.getProjectAccess();
+        if (accessList == null || accessList.isEmpty()) return false;
+        return membershipService.checkProjectMembership(
+                requestScope.getUser(), accessList, pa -> rbacService.canManageWorkspace(pa));
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamProjectLimitedViewWorkspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamProjectLimitedViewWorkspace.java
@@ -1,0 +1,44 @@
+package io.terrakube.api.rs.checks.workspace;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+import io.terrakube.api.rs.workspace.Workspace;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamProjectLimitedViewWorkspace.RULE)
+public class TeamProjectLimitedViewWorkspace extends OperationCheck<Workspace> {
+
+    public static final String RULE = "team project limited view workspace";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    RbacService rbacService;
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Override
+    public boolean ok(Workspace workspace, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team project limited view workspace {}", workspace.getId());
+        Project project = workspace.getProject();
+        if (project == null) return false;
+        List<ProjectAccess> accessList = project.getProjectAccess();
+        if (accessList == null || accessList.isEmpty()) return false;
+        return membershipService.checkProjectMembership(
+                requestScope.getUser(), accessList, pa -> true);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamViewWorkspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamViewWorkspace.java
@@ -5,6 +5,8 @@ import com.yahoo.elide.core.security.ChangeSpec;
 import com.yahoo.elide.core.security.RequestScope;
 import com.yahoo.elide.core.security.checks.OperationCheck;
 import lombok.extern.slf4j.Slf4j;
+import io.terrakube.api.plugin.security.groups.GroupService;
+import io.terrakube.api.plugin.security.rbac.RbacService;
 import io.terrakube.api.plugin.security.user.AuthenticatedUser;
 import io.terrakube.api.rs.checks.membership.MembershipService;
 import io.terrakube.api.rs.team.Team;
@@ -24,13 +26,32 @@ public class TeamViewWorkspace extends OperationCheck<Workspace> {
     AuthenticatedUser authenticatedUser;
 
     @Autowired
+    GroupService groupService;
+
+    @Autowired
+    RbacService rbacService;
+
+    @Autowired
     MembershipService membershipService;
 
     @Override
     public boolean ok(Workspace workspace, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.debug("team view workspace {}", workspace.getId());
+        if (authenticatedUser.isSuperUser(requestScope.getUser())) return true;
         List<Team> teamList = workspace.getOrganization().getTeam();
-        return authenticatedUser.isSuperUser(requestScope.getUser()) ? true : membershipService.checkMembership(requestScope.getUser(), teamList);
+        if (workspace.getProject() != null) {
+            for (Team team : teamList) {
+                if (authenticatedUser.isServiceAccount(requestScope.getUser())) {
+                    if (groupService.isServiceMember(requestScope.getUser(), team.getName()) && rbacService.canManageWorkspace(team))
+                        return true;
+                } else {
+                    if (groupService.isMember(requestScope.getUser(), team.getName()) && rbacService.canManageWorkspace(team))
+                        return true;
+                }
+            }
+            return false;
+        }
+        return membershipService.checkMembership(requestScope.getUser(), teamList);
     }
 
 }

--- a/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamViewWorkspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamViewWorkspace.java
@@ -39,19 +39,19 @@ public class TeamViewWorkspace extends OperationCheck<Workspace> {
         log.debug("team view workspace {}", workspace.getId());
         if (authenticatedUser.isSuperUser(requestScope.getUser())) return true;
         List<Team> teamList = workspace.getOrganization().getTeam();
-        if (workspace.getProject() != null) {
-            for (Team team : teamList) {
-                if (authenticatedUser.isServiceAccount(requestScope.getUser())) {
-                    if (groupService.isServiceMember(requestScope.getUser(), team.getName()) && rbacService.canManageWorkspace(team))
-                        return true;
-                } else {
-                    if (groupService.isMember(requestScope.getUser(), team.getName()) && rbacService.canManageWorkspace(team))
-                        return true;
-                }
-            }
-            return false;
+        if (workspace.getProject() == null) {
+            return membershipService.checkMembership(requestScope.getUser(), teamList);
         }
-        return membershipService.checkMembership(requestScope.getUser(), teamList);
+        for (Team team : teamList) {
+            if (authenticatedUser.isServiceAccount(requestScope.getUser())) {
+                if (groupService.isServiceMember(requestScope.getUser(), team.getName()) && rbacService.canManageWorkspace(team))
+                    return true;
+            } else {
+                if (groupService.isMember(requestScope.getUser(), team.getName()) && rbacService.canManageWorkspace(team))
+                    return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/api/src/main/java/io/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/Job.java
@@ -30,9 +30,9 @@ import lombok.Setter;
 
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = JobManageHook.class)
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = JobManageHook.class)
-@ReadPermission(expression = "team view job OR team limited view job")
-@CreatePermission(expression = "team manage job OR team limited manage job OR team plan job OR team limited plan job")
-@UpdatePermission(expression = "team manage job OR team limited manage job OR user is a super service")
+@ReadPermission(expression = "team view job OR team project limited view job OR team limited view job")
+@CreatePermission(expression = "team manage job OR team limited manage job OR team plan job OR team limited plan job OR team project limited plan job")
+@UpdatePermission(expression = "team manage job OR team limited manage job OR team project limited manage job OR user is a super service")
 @Include(rootLevel = false)
 @Getter
 @Setter
@@ -46,7 +46,7 @@ public class Job extends GenericAuditFields {
     @Column(name = "comments")
     private String comments;
 
-    @UpdatePermission(expression = "team approve job OR team approve job rbac OR team limited approve job OR user is a super service")
+    @UpdatePermission(expression = "team approve job OR team approve job rbac OR team limited approve job OR team project limited approve job OR user is a super service")
     @Enumerated(EnumType.STRING)
     private JobStatus status = JobStatus.pending;
 

--- a/api/src/main/java/io/terrakube/api/rs/project/Project.java
+++ b/api/src/main/java/io/terrakube/api/rs/project/Project.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 
 @ReadPermission(expression = "team view project OR team project access view project")
 @CreatePermission(expression = "team manage project")
-@UpdatePermission(expression = "team manage project")
+@UpdatePermission(expression = "team manage project OR team project admin manages project access field")
 @DeletePermission(expression = "team manage project")
 @Include
 @Getter
@@ -40,6 +40,7 @@ public class Project extends GenericAuditFields {
     @ManyToOne
     private Organization organization;
 
+    @UpdatePermission(expression = "team manage project OR team project admin manages project access field")
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProjectAccess> projectAccess = new ArrayList<>();
 }

--- a/api/src/main/java/io/terrakube/api/rs/project/Project.java
+++ b/api/src/main/java/io/terrakube/api/rs/project/Project.java
@@ -4,15 +4,18 @@ import com.yahoo.elide.annotation.*;
 import io.terrakube.api.plugin.security.audit.GenericAuditFields;
 import io.terrakube.api.rs.IdConverter;
 import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.project.access.ProjectAccess;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
 
 import java.sql.Types;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
-@ReadPermission(expression = "team view project")
+@ReadPermission(expression = "team view project OR team project access view project")
 @CreatePermission(expression = "team manage project")
 @UpdatePermission(expression = "team manage project")
 @DeletePermission(expression = "team manage project")
@@ -36,4 +39,7 @@ public class Project extends GenericAuditFields {
 
     @ManyToOne
     private Organization organization;
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectAccess> projectAccess = new ArrayList<>();
 }

--- a/api/src/main/java/io/terrakube/api/rs/project/access/ProjectAccess.java
+++ b/api/src/main/java/io/terrakube/api/rs/project/access/ProjectAccess.java
@@ -1,0 +1,57 @@
+package io.terrakube.api.rs.project.access;
+
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.DeletePermission;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.UpdatePermission;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import io.terrakube.api.rs.IdConverter;
+import io.terrakube.api.rs.project.Project;
+
+import java.sql.Types;
+import java.util.UUID;
+
+@ReadPermission(expression = "team manage project access")
+@CreatePermission(expression = "user is a superuser")
+@UpdatePermission(expression = "user is a superuser")
+@DeletePermission(expression = "user is a superuser")
+@Include(rootLevel = false)
+@Getter
+@Setter
+@Entity(name = "project_access")
+public class ProjectAccess {
+
+    @Id
+    @JdbcTypeCode(Types.VARCHAR)
+    @Convert(converter = IdConverter.class)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "manage_state")
+    private boolean manageState;
+
+    @Column(name = "manage_job")
+    private boolean manageJob;
+
+    @Column(name = "manage_workspace")
+    private boolean manageWorkspace;
+
+    @Column(name = "plan_job")
+    private boolean planJob;
+
+    @Column(name = "approve_job")
+    private boolean approveJob;
+
+    @Column(name = "role")
+    private String role;
+
+    @ManyToOne
+    private Project project;
+}

--- a/api/src/main/java/io/terrakube/api/rs/project/access/ProjectAccess.java
+++ b/api/src/main/java/io/terrakube/api/rs/project/access/ProjectAccess.java
@@ -15,10 +15,10 @@ import io.terrakube.api.rs.project.Project;
 import java.sql.Types;
 import java.util.UUID;
 
-@ReadPermission(expression = "team manage project access")
-@CreatePermission(expression = "user is a superuser OR team manage project access")
-@UpdatePermission(expression = "user is a superuser OR team manage project access")
-@DeletePermission(expression = "user is a superuser OR team manage project access")
+@ReadPermission(expression = "team manage project access OR team project limited manage project access")
+@CreatePermission(expression = "user is a superuser OR team manage project access OR team project limited manage project access")
+@UpdatePermission(expression = "user is a superuser OR team manage project access OR team project limited manage project access")
+@DeletePermission(expression = "user is a superuser OR team manage project access OR team project limited manage project access")
 @Include(rootLevel = false)
 @Getter
 @Setter

--- a/api/src/main/java/io/terrakube/api/rs/project/access/ProjectAccess.java
+++ b/api/src/main/java/io/terrakube/api/rs/project/access/ProjectAccess.java
@@ -16,9 +16,9 @@ import java.sql.Types;
 import java.util.UUID;
 
 @ReadPermission(expression = "team manage project access")
-@CreatePermission(expression = "user is a superuser")
-@UpdatePermission(expression = "user is a superuser")
-@DeletePermission(expression = "user is a superuser")
+@CreatePermission(expression = "user is a superuser OR team manage project access")
+@UpdatePermission(expression = "user is a superuser OR team manage project access")
+@DeletePermission(expression = "user is a superuser OR team manage project access")
 @Include(rootLevel = false)
 @Getter
 @Setter

--- a/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
@@ -31,9 +31,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-@ReadPermission(expression = "team view workspace OR team limited view workspace")
+@ReadPermission(expression = "team view workspace OR team project limited view workspace OR team limited view workspace")
 @CreatePermission(expression = "team manage workspace")
-@UpdatePermission(expression = "team manage workspace OR team limited manage workspace")
+@UpdatePermission(expression = "team manage workspace OR team project limited manage workspace OR team limited manage workspace")
 @DeletePermission(expression = "team manage workspace")
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE, phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT, hook = WorkspaceManageHook.class)
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT, hook = WorkspaceManageHook.class)
@@ -119,7 +119,7 @@ public class Workspace extends GenericAuditFields {
     private List<Schedule> schedule;
 
     @OneToMany(mappedBy = "workspace")
-    @UpdatePermission(expression = "team view workspace OR team limited view workspace")
+    @UpdatePermission(expression = "team view workspace OR team project limited view workspace OR team limited view workspace")
     private List<Job> job;
 
     @Exclude

--- a/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
@@ -129,6 +129,7 @@ public class Workspace extends GenericAuditFields {
     @OneToMany(mappedBy = "workspace")
     private List<WorkspaceTag> workspaceTag;
 
+    @UpdatePermission(expression = "team manage workspace")
     @OneToOne
     private Project project;
 

--- a/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.UUID;
 
 @ReadPermission(expression = "team view workspace OR team project limited view workspace OR team limited view workspace")
-@CreatePermission(expression = "team manage workspace")
+@CreatePermission(expression = "team manage workspace OR team project limited create workspace")
 @UpdatePermission(expression = "team manage workspace OR team project limited manage workspace OR team limited manage workspace")
 @DeletePermission(expression = "team manage workspace")
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE, phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT, hook = WorkspaceManageHook.class)
@@ -129,7 +129,7 @@ public class Workspace extends GenericAuditFields {
     @OneToMany(mappedBy = "workspace")
     private List<WorkspaceTag> workspaceTag;
 
-    @UpdatePermission(expression = "team manage workspace")
+    @UpdatePermission(expression = "team manage workspace OR team project limited reassign workspace")
     @OneToOne
     private Project project;
 

--- a/api/src/main/resources/db/changelog/changelog-demo.xml
+++ b/api/src/main/resources/db/changelog/changelog-demo.xml
@@ -17,4 +17,5 @@
     <include file="/db/changelog/demo-data/limited-access.xml"/>
     <include file="/db/changelog/demo-data/h2-test-values.xml" />
     <include file="/db/changelog/demo-data/rbac-v2-demo-data.xml" />
+    <include file="/db/changelog/demo-data/project-access-demo-data.xml" />
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -102,4 +102,5 @@
     <include file="/db/changelog/local/changelog-2.31.0-federated-claims.xml" />
     <include file="/db/changelog/local/changelog-2.31.0-variable-incomplete.xml" />
     <include file="db/changelog/local/changelog-2.31.0-repo-webhooks.xml"/>
+    <include file="/db/changelog/local/changelog-2.32.0-project-access.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/demo-data/project-access-demo-data.xml
+++ b/api/src/main/resources/db/changelog/demo-data/project-access-demo-data.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet author="demo-data" id="demo-project-access">
+
+        <!--
+        ***************
+        ***PROJECT***
+        ***************
+        -->
+        <insert tableName="project">
+            <column name="id"              value="a1b2c3d4-e5f6-7890-abcd-ef1234567890" />
+            <column name="name"            value="demo-project" />
+            <column name="description"     value="Demo project showing project-level team access" />
+            <column name="organization_id" value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
+        </insert>
+
+        <!--
+        ********************
+        ***PROJECT ACCESS***
+        ********************
+        -->
+        <insert tableName="project_access">
+            <column name="id"               value="c3d4e5f6-a7b8-9012-cdef-123456789012" />
+            <column name="name"             value="GCP_DEVELOPERS" />
+            <column name="role"             value="write" />
+            <column name="manage_workspace" value="true" />
+            <column name="manage_job"       value="true" />
+            <column name="manage_state"     value="false" />
+            <column name="plan_job"         value="true" />
+            <column name="approve_job"      value="true" />
+            <column name="project_id"       value="a1b2c3d4-e5f6-7890-abcd-ef1234567890" />
+        </insert>
+
+    </changeSet>
+
+    <changeSet author="demo-data" id="demo-project-access-teams">
+
+        <!--
+        *************
+        ***TEAMS***
+        *************
+        -->
+        <insert tableName="team">
+            <column name="id"               value="a1b2c3d4-0001-0000-0000-000000000001" />
+            <column name="name"             value="PROJECT_TEAM_MEMBER" />
+            <column name="manage_workspace" value="false" />
+            <column name="manage_module"    value="false" />
+            <column name="manage_provider"  value="false" />
+            <column name="manage_vcs"       value="false" />
+            <column name="manage_template"  value="false" />
+            <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
+        </insert>
+
+        <insert tableName="team">
+            <column name="id"               value="a1b2c3d4-0001-0000-0000-000000000002" />
+            <column name="name"             value="PROJECT_WRITE_MEMBER" />
+            <column name="manage_workspace" value="false" />
+            <column name="manage_module"    value="false" />
+            <column name="manage_provider"  value="false" />
+            <column name="manage_vcs"       value="false" />
+            <column name="manage_template"  value="false" />
+            <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
+        </insert>
+
+        <insert tableName="team">
+            <column name="id"               value="a1b2c3d4-0001-0000-0000-000000000003" />
+            <column name="name"             value="PROJECT_ADMIN_MEMBER" />
+            <column name="manage_workspace" value="false" />
+            <column name="manage_module"    value="false" />
+            <column name="manage_provider"  value="false" />
+            <column name="manage_vcs"       value="false" />
+            <column name="manage_template"  value="false" />
+            <column name="organization_id"  value="d9b58bd3-f3fc-4056-a026-1163297e80a8" />
+        </insert>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.32.0-project-access.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.32.0-project-access.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-32-0-project-access" author="hirokimatsueda">
+        <createTable tableName="project_access">
+            <column name="id" type="varchar(36)">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="varchar(255)"/>
+            <column name="manage_workspace" type="boolean" defaultValueBoolean="false"/>
+            <column name="manage_state" type="boolean" defaultValueBoolean="false"/>
+            <column name="manage_job" type="boolean" defaultValueBoolean="false"/>
+            <column name="plan_job" type="boolean" defaultValueBoolean="false"/>
+            <column name="approve_job" type="boolean" defaultValueBoolean="false"/>
+            <column name="role" type="varchar(255)"/>
+            <column name="project_id" type="varchar(36)">
+                <constraints nullable="false"
+                             foreignKeyName="fk_project_access_project"
+                             references="project(id)"
+                             deleteCascade="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/ProjectAccessTests.java
+++ b/api/src/test/java/io/terrakube/api/ProjectAccessTests.java
@@ -1,0 +1,610 @@
+package io.terrakube.api;
+
+import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.Mockito.when;
+
+public class ProjectAccessTests extends ServerApplicationTests {
+
+    private static final String ORG_ID = "d9b58bd3-f3fc-4056-a026-1163297e80a8";
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    void searchWorkspacesWithProjectLevelAccess() {
+        String projectId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"searchWorkspacesWithProjectLevelAccess\",\n" +
+                        "      \"description\": \"Integration test project\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project")
+                .then()
+                .assertThat()
+                .body("data.attributes.name", IsEqual.equalTo("searchWorkspacesWithProjectLevelAccess"))
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        String workspaceId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"searchWorkspacesWithProjectLevelAccess\",\n" +
+                        "      \"source\": \"https://github.com/AzBuilder/terraform-azurerm-terrakube-app-registration.git\",\n" +
+                        "      \"branch\": \"main\",\n" +
+                        "      \"terraformVersion\": \"1.0.11\"\n" +
+                        "    },\n" +
+                        "    \"relationships\": {\n" +
+                        "      \"project\": {\n" +
+                        "        \"data\": {\n" +
+                        "          \"type\": \"project\",\n" +
+                        "          \"id\": \"" + projectId + "\"\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/workspace")
+                .then()
+                .assertThat()
+                .body("data.attributes.name", IsEqual.equalTo("searchWorkspacesWithProjectLevelAccess"))
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_TEAM_MEMBER"))
+                .when()
+                .get("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_TEAM_MEMBER"))
+                .when()
+                .get("/api/v1/organization/" + ORG_ID + "/workspace")
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value())
+                .body("data.id", Matchers.not(Matchers.hasItem(workspaceId)));
+
+        String accessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"PROJECT_TEAM_MEMBER\",\n" +
+                        "      \"role\": \"read\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .log()
+                .all()
+                .body("data.attributes.name", IsEqual.equalTo("PROJECT_TEAM_MEMBER"))
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_TEAM_MEMBER"))
+                .when()
+                .get("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_TEAM_MEMBER"))
+                .when()
+                .get("/api/v1/organization/" + ORG_ID + "/workspace")
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value())
+                .body("data.id", Matchers.hasItem(workspaceId));
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + accessId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    void manageWorkspaceWithProjectWriteRole() {
+        String projectId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"manageWorkspaceWithProjectWriteRole\",\n" +
+                        "      \"description\": \"Integration test project for write role\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project")
+                .then()
+                .assertThat()
+                .body("data.attributes.name", IsEqual.equalTo("manageWorkspaceWithProjectWriteRole"))
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        String workspaceId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"manageWorkspaceWithProjectWriteRole\",\n" +
+                        "      \"source\": \"https://github.com/AzBuilder/terraform-azurerm-terrakube-app-registration.git\",\n" +
+                        "      \"branch\": \"main\",\n" +
+                        "      \"terraformVersion\": \"1.0.11\"\n" +
+                        "    },\n" +
+                        "    \"relationships\": {\n" +
+                        "      \"project\": {\n" +
+                        "        \"data\": {\n" +
+                        "          \"type\": \"project\",\n" +
+                        "          \"id\": \"" + projectId + "\"\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/workspace")
+                .then()
+                .assertThat()
+                .body("data.attributes.name", IsEqual.equalTo("manageWorkspaceWithProjectWriteRole"))
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_WRITE_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"id\": \"" + workspaceId + "\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"description\": \"Modified by project write role\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .patch("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+
+        String accessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"PROJECT_WRITE_MEMBER\",\n" +
+                        "      \"role\": \"write\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .log()
+                .all()
+                .body("data.attributes.name", IsEqual.equalTo("PROJECT_WRITE_MEMBER"))
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_WRITE_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"id\": \"" + workspaceId + "\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"description\": \"Modified by project write role\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .patch("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + accessId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    void manageProjectAccessWithProjectAdminRole() {
+        String projectId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"manageProjectAccessWithProjectAdminRole\",\n" +
+                        "      \"description\": \"Integration test project for admin role\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project")
+                .then()
+                .assertThat()
+                .body("data.attributes.name", IsEqual.equalTo("manageProjectAccessWithProjectAdminRole"))
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        // PROJECT_ADMIN_MEMBER cannot manage ProjectAccess before being granted admin role
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_ADMIN_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"SOME_TEAM\",\n" +
+                        "      \"role\": \"read\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+
+        // Org admin grants PROJECT_ADMIN_MEMBER an admin role on the project
+        String adminAccessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"PROJECT_ADMIN_MEMBER\",\n" +
+                        "      \"role\": \"admin\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .log()
+                .all()
+                .body("data.attributes.name", IsEqual.equalTo("PROJECT_ADMIN_MEMBER"))
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        // PROJECT_ADMIN_MEMBER can now create a new ProjectAccess entry
+        String newAccessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_ADMIN_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"SOME_TEAM\",\n" +
+                        "      \"role\": \"read\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .log()
+                .all()
+                .body("data.attributes.name", IsEqual.equalTo("SOME_TEAM"))
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        // PROJECT_ADMIN_MEMBER can delete a ProjectAccess entry
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_ADMIN_MEMBER"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + newAccessId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        // Cleanup
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + adminAccessId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    void manageProjectMetadataWithProjectAdminRole() {
+        String projectId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"manageProjectMetadataWithProjectAdminRole\",\n" +
+                        "      \"description\": \"Integration test project for admin metadata update\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project")
+                .then()
+                .assertThat()
+                .body("data.attributes.name", IsEqual.equalTo("manageProjectMetadataWithProjectAdminRole"))
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        // PROJECT_ADMIN_MEMBER cannot update project metadata before being granted admin role
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_ADMIN_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"id\": \"" + projectId + "\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"shouldBeRejected\",\n" +
+                        "      \"description\": \"Should be rejected\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .patch("/api/v1/organization/" + ORG_ID + "/project/" + projectId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+
+        // Org admin grants PROJECT_ADMIN_MEMBER an admin role on the project
+        String adminAccessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"PROJECT_ADMIN_MEMBER\",\n" +
+                        "      \"role\": \"admin\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .log()
+                .all()
+                .body("data.attributes.name", IsEqual.equalTo("PROJECT_ADMIN_MEMBER"))
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        // PROJECT_ADMIN_MEMBER can now update project name and description
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_ADMIN_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"id\": \"" + projectId + "\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"updatedByProjectAdmin\",\n" +
+                        "      \"description\": \"Updated by project admin\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .patch("/api/v1/organization/" + ORG_ID + "/project/" + projectId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        // Cleanup
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + adminAccessId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    void cannotManageProjectAccessWithProjectWriteRole() {
+        String projectId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"cannotManageProjectAccessWithProjectWriteRole\",\n" +
+                        "      \"description\": \"Integration test project for write role restriction\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project")
+                .then()
+                .assertThat()
+                .body("data.attributes.name", IsEqual.equalTo("cannotManageProjectAccessWithProjectWriteRole"))
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        String writeAccessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"PROJECT_WRITE_MEMBER\",\n" +
+                        "      \"role\": \"write\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .log()
+                .all()
+                .body("data.attributes.name", IsEqual.equalTo("PROJECT_WRITE_MEMBER"))
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        // PROJECT_WRITE_MEMBER cannot create a new ProjectAccess entry
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_WRITE_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"SOME_TEAM\",\n" +
+                        "      \"role\": \"read\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+
+        // PROJECT_WRITE_MEMBER cannot delete a ProjectAccess entry (Elide returns 404 when ReadPermission is denied)
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_WRITE_MEMBER"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + writeAccessId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+
+        // Cleanup
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + writeAccessId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+}

--- a/api/src/test/java/io/terrakube/api/ProjectAccessTests.java
+++ b/api/src/test/java/io/terrakube/api/ProjectAccessTests.java
@@ -607,4 +607,327 @@ public class ProjectAccessTests extends ServerApplicationTests {
                 .all()
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
+
+    @Test
+    void workspaceCreatedWithoutProjectAutoAssignedToDefault() {
+        String workspaceId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"workspaceCreatedWithoutProject\",\n" +
+                        "      \"source\": \"https://github.com/AzBuilder/terraform-azurerm-terrakube-app-registration.git\",\n" +
+                        "      \"branch\": \"main\",\n" +
+                        "      \"terraformVersion\": \"1.0.11\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/workspace")
+                .then()
+                .assertThat()
+                .body("data.attributes.name", IsEqual.equalTo("workspaceCreatedWithoutProject"))
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        // Workspace auto-assigned to Default project — org member can see it
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_TEAM_MEMBER"))
+                .when()
+                .get("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    void orphanedWorkspaceNotVisibleToRegularUser() {
+        String projectId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"orphanedWorkspaceNotVisibleToRegularUser\",\n" +
+                        "      \"description\": \"Integration test project\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        String workspaceId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"orphanedWorkspaceTest\",\n" +
+                        "      \"source\": \"https://github.com/AzBuilder/terraform-azurerm-terrakube-app-registration.git\",\n" +
+                        "      \"branch\": \"main\",\n" +
+                        "      \"terraformVersion\": \"1.0.11\"\n" +
+                        "    },\n" +
+                        "    \"relationships\": {\n" +
+                        "      \"project\": {\n" +
+                        "        \"data\": {\n" +
+                        "          \"type\": \"project\",\n" +
+                        "          \"id\": \"" + projectId + "\"\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/workspace")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        String accessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"PROJECT_TEAM_MEMBER\",\n" +
+                        "      \"role\": \"read\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        // PROJECT_TEAM_MEMBER can see the workspace via project access
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_TEAM_MEMBER"))
+                .when()
+                .get("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value());
+
+        // Admin orphans the workspace by removing the project relationship
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"id\": \"" + workspaceId + "\",\n" +
+                        "    \"relationships\": {\n" +
+                        "      \"project\": {\n" +
+                        "        \"data\": null\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .patch("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        // Orphaned workspace (null project) IS visible to all org members
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_TEAM_MEMBER"))
+                .when()
+                .get("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_TEAM_MEMBER"))
+                .when()
+                .get("/api/v1/organization/" + ORG_ID + "/workspace")
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value())
+                .body("data.id", Matchers.hasItem(workspaceId));
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + accessId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    void projectAdminCannotMoveWorkspaceToAnotherProject() {
+        String projectAId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"projectAdminCannotMove_A\",\n" +
+                        "      \"description\": \"Source project\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project")
+                .then()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        String projectBId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"projectAdminCannotMove_B\",\n" +
+                        "      \"description\": \"Target project\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project")
+                .then()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        String workspaceId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"projectAdminCannotMoveWs\",\n" +
+                        "      \"source\": \"https://github.com/AzBuilder/terraform-azurerm-terrakube-app-registration.git\",\n" +
+                        "      \"branch\": \"main\",\n" +
+                        "      \"terraformVersion\": \"1.0.11\"\n" +
+                        "    },\n" +
+                        "    \"relationships\": {\n" +
+                        "      \"project\": {\n" +
+                        "        \"data\": {\n" +
+                        "          \"type\": \"project\",\n" +
+                        "          \"id\": \"" + projectAId + "\"\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/workspace")
+                .then()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        // Grant PROJECT_ADMIN_MEMBER admin role on Project A
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"PROJECT_ADMIN_MEMBER\",\n" +
+                        "      \"role\": \"admin\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectAId + "/projectAccess")
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+
+        // Project Admin tries to move workspace to Project B — must be forbidden
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_ADMIN_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"id\": \"" + workspaceId + "\",\n" +
+                        "    \"relationships\": {\n" +
+                        "      \"project\": {\n" +
+                        "        \"data\": {\n" +
+                        "          \"type\": \"project\",\n" +
+                        "          \"id\": \"" + projectBId + "\"\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .patch("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+
+        // Project Admin tries to set project to null — must also be forbidden
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_ADMIN_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"id\": \"" + workspaceId + "\",\n" +
+                        "    \"relationships\": {\n" +
+                        "      \"project\": {\n" +
+                        "        \"data\": null\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .patch("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+
+        // Cleanup
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectAId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectBId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
 }

--- a/api/src/test/java/io/terrakube/api/ProjectAccessTests.java
+++ b/api/src/test/java/io/terrakube/api/ProjectAccessTests.java
@@ -1,5 +1,6 @@
 package io.terrakube.api;
 
+import io.terrakube.api.rs.team.Team;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
@@ -7,17 +8,34 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static io.restassured.RestAssured.given;
 import static org.mockito.Mockito.when;
 
 public class ProjectAccessTests extends ServerApplicationTests {
 
     private static final String ORG_ID = "d9b58bd3-f3fc-4056-a026-1163297e80a8";
+    private static final String TEMPLATE_REF = "2db36f7c-f549-4341-a789-315d47eb061d";
+    private static final String DEVS_TEAM_ID = "58529721-425e-44d7-8b0d-1d515043c2f7";
 
     @BeforeEach
     public void setup() {
         MockitoAnnotations.openMocks(this);
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        wireMockServer.resetAll();
+        stubFor(post(urlPathEqualTo("/api/v1/terraform-rs"))
+                .willReturn(aResponse().withStatus(HttpStatus.ACCEPTED.value()).withBody("")));
+    }
+
+    private void setDevsJobPermissions(boolean enabled) {
+        Team team = teamRepository.findById(UUID.fromString(DEVS_TEAM_ID)).get();
+        team.setManageJob(enabled);
+        team.setPlanJob(enabled);
+        team.setApproveJob(enabled);
+        team.setRole("custom");
+        teamRepository.save(team);
     }
 
     @Test
@@ -926,6 +944,483 @@ public class ProjectAccessTests extends ServerApplicationTests {
                 .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
                 .when()
                 .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectBId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    void viewJobWithProjectLevelAccess() {
+        String projectId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"viewJobWithProjectLevelAccess\",\n" +
+                        "      \"description\": \"Integration test project\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().path("data.id");
+
+        String workspaceId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"viewJobWithProjectLevelAccess\",\n" +
+                        "      \"source\": \"https://github.com/AzBuilder/terraform-azurerm-terrakube-app-registration.git\",\n" +
+                        "      \"branch\": \"main\",\n" +
+                        "      \"terraformVersion\": \"1.0.11\"\n" +
+                        "    },\n" +
+                        "    \"relationships\": {\n" +
+                        "      \"project\": {\n" +
+                        "        \"data\": {\n" +
+                        "          \"type\": \"project\",\n" +
+                        "          \"id\": \"" + projectId + "\"\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/workspace")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().path("data.id");
+
+        setDevsJobPermissions(true);
+        String jobId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"job\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"templateReference\": \"" + TEMPLATE_REF + "\"\n" +
+                        "    },\n" +
+                        "    \"relationships\": {\n" +
+                        "      \"workspace\": {\n" +
+                        "        \"data\": {\n" +
+                        "          \"type\": \"workspace\",\n" +
+                        "          \"id\": \"" + workspaceId + "\"\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/job")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().path("data.id");
+
+        // Before project access: PROJECT_PLAN_MEMBER (not an org team member) gets 403
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_PLAN_MEMBER"))
+                .when()
+                .get("/api/v1/organization/" + ORG_ID + "/job/" + jobId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+
+        // Grant PROJECT_PLAN_MEMBER read role on the project
+        String accessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"PROJECT_PLAN_MEMBER\",\n" +
+                        "      \"role\": \"read\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().path("data.id");
+
+        // After project access: PROJECT_PLAN_MEMBER can view the job
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_PLAN_MEMBER"))
+                .when()
+                .get("/api/v1/organization/" + ORG_ID + "/job/" + jobId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value());
+
+        // Cleanup
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + accessId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        // Job has no @DeletePermission; delete steps first to avoid FK_JOB_STEP constraint
+        stepRepository.deleteAll(stepRepository.findByJobId(Integer.parseInt(jobId)));
+        jobRepository.deleteById(Integer.parseInt(jobId));
+        setDevsJobPermissions(false);
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    void planJobWithProjectPlanRole() {
+        String projectId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"planJobWithProjectPlanRole\",\n" +
+                        "      \"description\": \"Integration test project for plan role\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().path("data.id");
+
+        String workspaceId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"planJobWithProjectPlanRole\",\n" +
+                        "      \"source\": \"https://github.com/AzBuilder/terraform-azurerm-terrakube-app-registration.git\",\n" +
+                        "      \"branch\": \"main\",\n" +
+                        "      \"terraformVersion\": \"1.0.11\"\n" +
+                        "    },\n" +
+                        "    \"relationships\": {\n" +
+                        "      \"project\": {\n" +
+                        "        \"data\": {\n" +
+                        "          \"type\": \"project\",\n" +
+                        "          \"id\": \"" + projectId + "\"\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/workspace")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().path("data.id");
+
+        // Grant PROJECT_TEAM_MEMBER read role (canPlanJob=false)
+        String readAccessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"PROJECT_TEAM_MEMBER\",\n" +
+                        "      \"role\": \"read\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().path("data.id");
+
+        String jobPayload = "{\n" +
+                "  \"data\": {\n" +
+                "    \"type\": \"job\",\n" +
+                "    \"attributes\": {\n" +
+                "      \"templateReference\": \"" + TEMPLATE_REF + "\"\n" +
+                "    },\n" +
+                "    \"relationships\": {\n" +
+                "      \"workspace\": {\n" +
+                "        \"data\": {\n" +
+                "          \"type\": \"workspace\",\n" +
+                "          \"id\": \"" + workspaceId + "\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        // Read role cannot create (plan) a job
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_TEAM_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body(jobPayload)
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/job")
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+
+        // Grant PROJECT_PLAN_MEMBER plan role (canPlanJob=true)
+        String planAccessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"PROJECT_PLAN_MEMBER\",\n" +
+                        "      \"role\": \"plan\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().path("data.id");
+
+        // Plan role can create (plan) a job
+        String jobId = given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_PLAN_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body(jobPayload)
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/job")
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().path("data.id");
+
+        // Cleanup
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + planAccessId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + readAccessId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        // Job has no @DeletePermission; delete steps first to avoid FK_JOB_STEP constraint
+        stepRepository.deleteAll(stepRepository.findByJobId(Integer.parseInt(jobId)));
+        jobRepository.deleteById(Integer.parseInt(jobId));
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    void approveJobWithProjectWriteRole() {
+        String projectId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"approveJobWithProjectWriteRole\",\n" +
+                        "      \"description\": \"Integration test project for approve role\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().path("data.id");
+
+        String workspaceId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"approveJobWithProjectWriteRole\",\n" +
+                        "      \"source\": \"https://github.com/AzBuilder/terraform-azurerm-terrakube-app-registration.git\",\n" +
+                        "      \"branch\": \"main\",\n" +
+                        "      \"terraformVersion\": \"1.0.11\"\n" +
+                        "    },\n" +
+                        "    \"relationships\": {\n" +
+                        "      \"project\": {\n" +
+                        "        \"data\": {\n" +
+                        "          \"type\": \"project\",\n" +
+                        "          \"id\": \"" + projectId + "\"\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/workspace")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().path("data.id");
+
+        setDevsJobPermissions(true);
+        String jobId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"job\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"templateReference\": \"" + TEMPLATE_REF + "\"\n" +
+                        "    },\n" +
+                        "    \"relationships\": {\n" +
+                        "      \"workspace\": {\n" +
+                        "        \"data\": {\n" +
+                        "          \"type\": \"workspace\",\n" +
+                        "          \"id\": \"" + workspaceId + "\"\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/job")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().path("data.id");
+        setDevsJobPermissions(false);
+
+        // Grant PROJECT_PLAN_MEMBER plan role (canApproveJob=false)
+        String planAccessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"PROJECT_PLAN_MEMBER\",\n" +
+                        "      \"role\": \"plan\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().path("data.id");
+
+        // Plan role cannot approve a job (canApproveJob=false)
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_PLAN_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body("{\"data\": {\"type\": \"job\", \"id\": \"" + jobId + "\", \"attributes\": {\"status\": \"approved\"}}}")
+                .when()
+                .patch("/api/v1/organization/" + ORG_ID + "/job/" + jobId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+
+        // Grant PROJECT_WRITE_MEMBER write role (canApproveJob=true)
+        String writeAccessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"PROJECT_WRITE_MEMBER\",\n" +
+                        "      \"role\": \"write\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract().path("data.id");
+
+        // Write role can approve a job (canApproveJob=true)
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_WRITE_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body("{\"data\": {\"type\": \"job\", \"id\": \"" + jobId + "\", \"attributes\": {\"status\": \"approved\"}}}")
+                .when()
+                .patch("/api/v1/organization/" + ORG_ID + "/job/" + jobId)
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        // Cleanup
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + writeAccessId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + planAccessId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        // Job has no @DeletePermission; delete steps first to avoid FK_JOB_STEP constraint
+        stepRepository.deleteAll(stepRepository.findByJobId(Integer.parseInt(jobId)));
+        jobRepository.deleteById(Integer.parseInt(jobId));
+        setDevsJobPermissions(false);
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId)
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.NO_CONTENT.value());

--- a/ui/src/domain/Workspaces/Create.tsx
+++ b/ui/src/domain/Workspaces/Create.tsx
@@ -20,14 +20,13 @@ import { IconContext } from "react-icons";
 import { BiBookBookmark, BiTerminal, BiUpload } from "react-icons/bi";
 import { SiBitbucket, SiGit } from "react-icons/si";
 import { VscAzureDevops } from "react-icons/vsc";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { v7 as uuid } from "uuid";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
 import axiosInstance from "../../config/axiosConfig";
 import { ProjectModel, SshKey, Template, TofuRelease, VcsModel, VcsType, VcsTypeExtended } from "../types";
 import { compareVersions } from "./Workspaces";
 import projectService from "@/modules/projects/projectService";
-import workspaceService from "@/modules/workspaces/workspaceService";
 const { Content } = Layout;
 const { Step } = Steps;
 
@@ -146,6 +145,9 @@ export const CreateWorkspace = () => {
     },
   ];
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const preselectedProjectId = searchParams.get("projectId");
+
   useEffect(() => {
     setOrganizationName(sessionStorage.getItem(ORGANIZATION_NAME));
     setLoading(true);
@@ -191,7 +193,12 @@ export const CreateWorkspace = () => {
       setVCS(vcsRes.data.data);
 
       // Set projects
-      if (!projectsRes.isError) setProjectList(projectsRes.data);
+      if (!projectsRes.isError) {
+        setProjectList(projectsRes.data);
+        if (preselectedProjectId) {
+          form.setFieldsValue({ project: preselectedProjectId });
+        }
+      }
 
       setLoading(false);
     });
@@ -357,6 +364,15 @@ export const CreateWorkspace = () => {
       };
     }
 
+    if (values.project && values.project !== "none") {
+      (body["atomic:operations"][0].data.relationships as any)["project"] = {
+        data: {
+          type: "project",
+          id: values.project,
+        },
+      };
+    }
+
     try {
       const response = await axiosInstance.post(`/operations`, body, {
         headers: {
@@ -366,9 +382,6 @@ export const CreateWorkspace = () => {
       });
       if (response.status === 200) {
         const workspaceId = response.data["atomic:results"][0].data.id;
-        if (values.project && values.project !== "none") {
-          await workspaceService.assignWorkspaceToProject(organizationId!, workspaceId, values.project);
-        }
         navigate(`/organizations/${organizationId}/workspaces/${workspaceId}`);
       }
     } catch (error: any) {
@@ -739,7 +752,7 @@ export const CreateWorkspace = () => {
                 extra="Optional. Assigning a project lets you group and filter workspaces."
               >
                 <Select placeholder="(No project)" style={{ width: 250 }}>
-                  <Option key="none">(No project)</Option>
+                  {!preselectedProjectId && <Option key="none">(No project)</Option>}
                   {projectList.map((p) => (
                     <Option key={p.id}>{p.name}</Option>
                   ))}

--- a/ui/src/domain/Workspaces/Settings/General.tsx
+++ b/ui/src/domain/Workspaces/Settings/General.tsx
@@ -353,7 +353,7 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
             extra="Optional. Assigning a project lets you group and filter workspaces."
             style={{ marginTop: 16 }}
           >
-            <Select placeholder="No project" disabled={!orgPermissions.manageWorkspace}>
+            <Select placeholder="No project" disabled={!manageWorkspace}>
               {orgPermissions.manageWorkspace && <Option key="none">(No project)</Option>}
               {projectList.map((p) => (
                 <Option key={p.id}>{p.name}</Option>

--- a/ui/src/domain/Workspaces/Settings/General.tsx
+++ b/ui/src/domain/Workspaces/Settings/General.tsx
@@ -5,6 +5,7 @@ import { Agent, Template, TofuRelease, Workspace } from "../../types";
 import { atomicHeader, compareVersions, genericHeader, getIaCIconById, getIaCNameById, iacTypes } from "../Workspaces";
 import projectService from "@/modules/projects/projectService";
 import { ProjectModel } from "@/domain/types";
+import { useOrgPermissions } from "@/modules/permissions/useOrgPermissions";
 
 const { Text } = Typography;
 
@@ -32,6 +33,7 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
   const id = workspaceData.id;
   const Option = Select;
   const [selectedIac, setSelectedIac] = useState("");
+  const { permissions: orgPermissions } = useOrgPermissions();
   const [terraformVersions, setTerraformVersions] = useState<string[]>([]);
   const [agentList, setAgentList] = useState<Agent[]>([]);
   const [projectList, setProjectList] = useState<ProjectModel[]>([]);
@@ -351,8 +353,8 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
             extra="Optional. Assigning a project lets you group and filter workspaces."
             style={{ marginTop: 16 }}
           >
-            <Select placeholder="No project" disabled={!manageWorkspace}>
-              <Option key="none">(No project)</Option>
+            <Select placeholder="No project" disabled={!orgPermissions.manageWorkspace}>
+              {orgPermissions.manageWorkspace && <Option key="none">(No project)</Option>}
               {projectList.map((p) => (
                 <Option key={p.id}>{p.name}</Option>
               ))}

--- a/ui/src/modules/permissions/useOrgPermissions.ts
+++ b/ui/src/modules/permissions/useOrgPermissions.ts
@@ -41,20 +41,21 @@ const defaultPermissions: OrgPermissionSet = {
  * Returns { permissions, loading } where permissions contains all the
  * granular boolean flags from the backend PermissionSet.
  */
-export function useOrgPermissions() {
+export function useOrgPermissions(orgIdOverride?: string) {
   const { orgid } = useParams<{ orgid: string }>();
+  const orgId = orgIdOverride ?? orgid;
   const [permissions, setPermissions] = useState<OrgPermissionSet>(defaultPermissions);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!orgid) {
+    if (!orgId) {
       setLoading(false);
       return;
     }
 
     const url = `${
       new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
-    }/access-token/v1/teams/permissions/organization/${orgid}`;
+    }/access-token/v1/teams/permissions/organization/${orgId}`;
 
     axiosInstance
       .get(url)
@@ -79,7 +80,7 @@ export function useOrgPermissions() {
       .finally(() => {
         setLoading(false);
       });
-  }, [orgid]);
+  }, [orgId]);
 
   return { permissions, loading };
 }

--- a/ui/src/modules/projects/ProjectAccessTab.tsx
+++ b/ui/src/modules/projects/ProjectAccessTab.tsx
@@ -1,0 +1,192 @@
+import { DeleteOutlined, PlusOutlined } from "@ant-design/icons";
+import { Button, Form, Popconfirm, Select, Spin, Table, Tag, Typography, message } from "antd";
+import { useEffect, useState } from "react";
+import axiosInstance from "@/config/axiosConfig";
+import projectService, { ProjectAccessModel } from "./projectService";
+
+type Props = {
+  orgid: string;
+  projectId: string;
+};
+
+type AddTeamForm = {
+  teamName: string;
+  role: string;
+};
+
+type TeamOption = { id: string; name: string };
+
+const ROLES = [
+  { value: "admin", label: "Admin", color: "red" },
+  { value: "write", label: "Write", color: "orange" },
+  { value: "plan", label: "Plan", color: "blue" },
+  { value: "read", label: "Read", color: "default" },
+];
+
+function roleColor(role: string): string {
+  return ROLES.find((r) => r.value === role)?.color ?? "default";
+}
+
+export default function ProjectAccessTab({ orgid, projectId }: Props) {
+  const [accessList, setAccessList] = useState<ProjectAccessModel[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const [teams, setTeams] = useState<TeamOption[]>([]);
+  const [loadingTeams, setLoadingTeams] = useState(false);
+  const [form] = Form.useForm<AddTeamForm>();
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const result = await projectService.listProjectAccess(orgid, projectId);
+      if (!result.isError) {
+        setAccessList(result.data);
+      } else {
+        message.error("Failed to load team access list");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, [projectId]);
+
+  useEffect(() => {
+    setLoadingTeams(true);
+    axiosInstance
+      .get(`organization/${orgid}/team`)
+      .then((res) => {
+        const list = (res.data?.data ?? []).map((t: any) => ({
+          id: t.id,
+          name: t.attributes.name,
+        }));
+        setTeams(list);
+      })
+      .finally(() => setLoadingTeams(false));
+  }, [orgid]);
+
+  const onAdd = async (values: AddTeamForm) => {
+    setAdding(true);
+    try {
+      await projectService.addProjectAccess(orgid, projectId, values.teamName, values.role);
+      message.success(`Team "${values.teamName}" added to project`);
+      form.resetFields();
+      await load();
+    } catch (err: any) {
+      if (err?.response?.status === 403) {
+        message.error("You are not authorized to manage project team access.");
+      } else {
+        message.error(err?.message ?? "Failed to add team access");
+      }
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const onRemove = async (accessId: string, teamName: string) => {
+    try {
+      await projectService.removeProjectAccess(orgid, projectId, accessId);
+      message.success(`Team "${teamName}" removed from project`);
+      await load();
+    } catch (err: any) {
+      if (err?.response?.status === 403) {
+        message.error("You are not authorized to manage project team access.");
+      } else {
+        message.error(err?.message ?? "Failed to remove team access");
+      }
+    }
+  };
+
+  const columns = [
+    {
+      title: "Team",
+      dataIndex: "name",
+      key: "name",
+      render: (name: string) => <Typography.Text strong>{name}</Typography.Text>,
+    },
+    {
+      title: "Role",
+      dataIndex: "role",
+      key: "role",
+      render: (role: string) => <Tag color={roleColor(role)}>{role ?? "custom"}</Tag>,
+    },
+    {
+      title: "",
+      key: "actions",
+      align: "right" as const,
+      render: (_: any, record: ProjectAccessModel) => (
+        <Popconfirm
+          title={`Remove team "${record.name}" from this project?`}
+          onConfirm={() => onRemove(record.id, record.name)}
+          okText="Yes"
+          cancelText="No"
+          placement="left"
+        >
+          <Button danger icon={<DeleteOutlined />} size="small">
+            Remove
+          </Button>
+        </Popconfirm>
+      ),
+    },
+  ];
+
+  return (
+    <div style={{ width: "100%" }}>
+      <h1>Team Access</h1>
+      <p>Grant teams access to all workspaces within this project.</p>
+
+      <Spin spinning={loading}>
+        <Table
+          dataSource={accessList}
+          columns={columns}
+          rowKey="id"
+          pagination={false}
+          locale={{ emptyText: "No teams have been granted project-level access." }}
+          style={{ marginBottom: 32 }}
+        />
+      </Spin>
+
+      <h2>Add Team</h2>
+      <Form form={form} layout="inline" onFinish={onAdd} style={{ marginBottom: 16 }}>
+        <Form.Item
+          name="teamName"
+          rules={[{ required: true, message: "Team name is required" }]}
+        >
+          <Select
+            showSearch
+            placeholder="Select a team"
+            optionFilterProp="label"
+            loading={loadingTeams}
+            style={{ minWidth: 220 }}
+            options={teams.map((t) => ({
+              label: t.name,
+              value: t.name,
+              disabled: accessList.some((a) => a.name === t.name),
+            }))}
+          />
+        </Form.Item>
+        <Form.Item name="role" initialValue="write" rules={[{ required: true }]}>
+          <Select style={{ width: 140 }}>
+            {ROLES.map((r) => (
+              <Select.Option key={r.value} value={r.value}>
+                <Tag color={r.color}>{r.label}</Tag>
+              </Select.Option>
+            ))}
+          </Select>
+        </Form.Item>
+        <Form.Item>
+          <Button type="primary" htmlType="submit" icon={<PlusOutlined />} loading={adding}>
+            Add Team
+          </Button>
+        </Form.Item>
+      </Form>
+
+      <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+        Teams added here can manage workspaces in this project based on their assigned role.
+        This is additive — existing org-level and workspace-level permissions are not affected.
+      </Typography.Text>
+    </div>
+  );
+}

--- a/ui/src/modules/projects/ProjectAccessTab.tsx
+++ b/ui/src/modules/projects/ProjectAccessTab.tsx
@@ -154,38 +154,41 @@ export default function ProjectAccessTab({ orgid, projectId, canManage }: Props)
         />
       </Spin>
 
-      <h2>Add Team</h2>
-      <Form form={form} layout="inline" onFinish={onAdd} style={{ marginBottom: 16 }}>
-        <Form.Item name="teamName" rules={[{ required: true, message: "Team name is required" }]}>
-          <Select
-            showSearch
-            placeholder="Select a team"
-            optionFilterProp="label"
-            loading={loadingTeams}
-            style={{ minWidth: 220 }}
-            disabled={!canManage}
-            options={teams.map((t) => ({
-              label: t.name,
-              value: t.name,
-              disabled: accessList.some((a) => a.name === t.name),
-            }))}
-          />
-        </Form.Item>
-        <Form.Item name="role" initialValue="write" rules={[{ required: true }]}>
-          <Select style={{ width: 140 }} disabled={!canManage}>
-            {ROLES.map((r) => (
-              <Select.Option key={r.value} value={r.value}>
-                <Tag color={r.color}>{r.label}</Tag>
-              </Select.Option>
-            ))}
-          </Select>
-        </Form.Item>
-        <Form.Item>
-          <Button type="primary" htmlType="submit" icon={<PlusOutlined />} loading={adding} disabled={!canManage}>
-            Add Team
-          </Button>
-        </Form.Item>
-      </Form>
+      {canManage && (
+        <>
+          <h2>Add Team</h2>
+          <Form form={form} layout="inline" onFinish={onAdd} style={{ marginBottom: 16 }}>
+            <Form.Item name="teamName" rules={[{ required: true, message: "Team name is required" }]}>
+              <Select
+                showSearch
+                placeholder="Select a team"
+                optionFilterProp="label"
+                loading={loadingTeams}
+                style={{ minWidth: 220 }}
+                options={teams.map((t) => ({
+                  label: t.name,
+                  value: t.name,
+                  disabled: accessList.some((a) => a.name === t.name),
+                }))}
+              />
+            </Form.Item>
+            <Form.Item name="role" initialValue="write" rules={[{ required: true }]}>
+              <Select style={{ width: 140 }}>
+                {ROLES.map((r) => (
+                  <Select.Option key={r.value} value={r.value}>
+                    <Tag color={r.color}>{r.label}</Tag>
+                  </Select.Option>
+                ))}
+              </Select>
+            </Form.Item>
+            <Form.Item>
+              <Button type="primary" htmlType="submit" icon={<PlusOutlined />} loading={adding}>
+                Add Team
+              </Button>
+            </Form.Item>
+          </Form>
+        </>
+      )}
 
       <Typography.Text type="secondary" style={{ fontSize: 12 }}>
         Teams added here can manage workspaces in this project based on their assigned role.

--- a/ui/src/modules/projects/ProjectAccessTab.tsx
+++ b/ui/src/modules/projects/ProjectAccessTab.tsx
@@ -150,10 +150,7 @@ export default function ProjectAccessTab({ orgid, projectId }: Props) {
 
       <h2>Add Team</h2>
       <Form form={form} layout="inline" onFinish={onAdd} style={{ marginBottom: 16 }}>
-        <Form.Item
-          name="teamName"
-          rules={[{ required: true, message: "Team name is required" }]}
-        >
+        <Form.Item name="teamName" rules={[{ required: true, message: "Team name is required" }]}>
           <Select
             showSearch
             placeholder="Select a team"
@@ -185,6 +182,7 @@ export default function ProjectAccessTab({ orgid, projectId }: Props) {
 
       <Typography.Text type="secondary" style={{ fontSize: 12 }}>
         Teams added here can manage workspaces in this project based on their assigned role.
+        <br />
         This is additive — existing org-level and workspace-level permissions are not affected.
       </Typography.Text>
     </div>

--- a/ui/src/modules/projects/ProjectAccessTab.tsx
+++ b/ui/src/modules/projects/ProjectAccessTab.tsx
@@ -7,6 +7,7 @@ import projectService, { ProjectAccessModel } from "./projectService";
 type Props = {
   orgid: string;
   projectId: string;
+  canManage: boolean;
 };
 
 type AddTeamForm = {
@@ -27,7 +28,7 @@ function roleColor(role: string): string {
   return ROLES.find((r) => r.value === role)?.color ?? "default";
 }
 
-export default function ProjectAccessTab({ orgid, projectId }: Props) {
+export default function ProjectAccessTab({ orgid, projectId, canManage }: Props) {
   const [accessList, setAccessList] = useState<ProjectAccessModel[]>([]);
   const [loading, setLoading] = useState(false);
   const [adding, setAdding] = useState(false);
@@ -123,8 +124,9 @@ export default function ProjectAccessTab({ orgid, projectId }: Props) {
           okText="Yes"
           cancelText="No"
           placement="left"
+          disabled={!canManage}
         >
-          <Button danger icon={<DeleteOutlined />} size="small">
+          <Button danger icon={<DeleteOutlined />} size="small" disabled={!canManage}>
             Remove
           </Button>
         </Popconfirm>
@@ -143,7 +145,11 @@ export default function ProjectAccessTab({ orgid, projectId }: Props) {
           columns={columns}
           rowKey="id"
           pagination={false}
-          locale={{ emptyText: "No teams have been granted project-level access." }}
+          locale={{
+            emptyText: canManage
+              ? "No teams have been granted project-level access."
+              : "You don't have permission to view or manage team assignments for this project.",
+          }}
           style={{ marginBottom: 32 }}
         />
       </Spin>
@@ -157,6 +163,7 @@ export default function ProjectAccessTab({ orgid, projectId }: Props) {
             optionFilterProp="label"
             loading={loadingTeams}
             style={{ minWidth: 220 }}
+            disabled={!canManage}
             options={teams.map((t) => ({
               label: t.name,
               value: t.name,
@@ -165,7 +172,7 @@ export default function ProjectAccessTab({ orgid, projectId }: Props) {
           />
         </Form.Item>
         <Form.Item name="role" initialValue="write" rules={[{ required: true }]}>
-          <Select style={{ width: 140 }}>
+          <Select style={{ width: 140 }} disabled={!canManage}>
             {ROLES.map((r) => (
               <Select.Option key={r.value} value={r.value}>
                 <Tag color={r.color}>{r.label}</Tag>
@@ -174,7 +181,7 @@ export default function ProjectAccessTab({ orgid, projectId }: Props) {
           </Select>
         </Form.Item>
         <Form.Item>
-          <Button type="primary" htmlType="submit" icon={<PlusOutlined />} loading={adding}>
+          <Button type="primary" htmlType="submit" icon={<PlusOutlined />} loading={adding} disabled={!canManage}>
             Add Team
           </Button>
         </Form.Item>

--- a/ui/src/modules/projects/ProjectDetailPage.tsx
+++ b/ui/src/modules/projects/ProjectDetailPage.tsx
@@ -211,11 +211,7 @@ export default function ProjectDetailPage({ organizationName, setOrganizationNam
   }, [orgid, id]);
 
   const isProjectAdmin = projectAccessForPerm.some((a) => userGroups.includes(a.name) && a.role === "admin");
-  const isProjectAdminOrWrite = projectAccessForPerm.some(
-    (a) => userGroups.includes(a.name) && (a.role === "admin" || a.role === "write")
-  );
   const canManageProject = permissions.manageWorkspace || isProjectAdmin;
-  const canRemoveWorkspace = permissions.manageWorkspace || isProjectAdminOrWrite;
 
   const { loading, execute, error } = useApiRequest({
     action: () => projectService.getProject(orgid!, id!),
@@ -278,14 +274,7 @@ export default function ProjectDetailPage({ organizationName, setOrganizationNam
   const renderContent = () => {
     switch (activeKey) {
       case "workspaces":
-        return (
-          <ProjectWorkspaces
-            orgid={orgid!}
-            projectId={id!}
-            manageWorkspace={permissions.manageWorkspace}
-            canRemoveWorkspace={canRemoveWorkspace}
-          />
-        );
+        return <ProjectWorkspaces orgid={orgid!} projectId={id!} />;
       case "teams":
         return <ProjectAccessTab orgid={orgid!} projectId={id!} canManage={canManageProject} />;
       case "general":

--- a/ui/src/modules/projects/ProjectDetailPage.tsx
+++ b/ui/src/modules/projects/ProjectDetailPage.tsx
@@ -3,13 +3,15 @@ import { Button, Form, Input, Layout, Menu, Popconfirm, Space, Spin, Typography,
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import PageWrapper from "@/modules/layout/PageWrapper/PageWrapper";
-import projectService from "./projectService";
+import projectService, { ProjectAccessModel } from "./projectService";
+import { apiGet } from "@/modules/api/apiWrapper";
 import ProjectWorkspaces from "./ProjectWorkspaces";
 import ProjectAccessTab from "./ProjectAccessTab";
 import workspaceService from "@/modules/workspaces/workspaceService";
 import useApiRequest from "@/modules/api/useApiRequest";
 import { ProjectModel } from "@/domain/types";
 import { ORGANIZATION_NAME } from "../../config/actionTypes";
+import { useOrgPermissions } from "@/modules/permissions/useOrgPermissions";
 import type { MenuProps } from "antd";
 
 const { Content, Sider } = Layout;
@@ -30,9 +32,18 @@ type GeneralProps = {
   projectId: string;
   project: ProjectModel | null;
   assignedWorkspacesCount: number;
+  manageWorkspace: boolean;
+  canUpdateProject: boolean;
 };
 
-function ProjectGeneralSettings({ orgid, projectId, project, assignedWorkspacesCount }: GeneralProps) {
+function ProjectGeneralSettings({
+  orgid,
+  projectId,
+  project,
+  assignedWorkspacesCount,
+  manageWorkspace,
+  canUpdateProject,
+}: GeneralProps) {
   const [waiting, setWaiting] = useState(false);
   const [form] = Form.useForm<ProjectForm>();
   const navigate = useNavigate();
@@ -117,7 +128,7 @@ function ProjectGeneralSettings({ orgid, projectId, project, assignedWorkspacesC
             <Input.TextArea rows={5} placeholder="Project description" />
           </Form.Item>
           <Form.Item>
-            <Button type="primary" htmlType="submit">
+            <Button type="primary" htmlType="submit" disabled={!canUpdateProject}>
               Save settings
             </Button>
           </Form.Item>
@@ -156,13 +167,13 @@ function ProjectGeneralSettings({ orgid, projectId, project, assignedWorkspacesC
           okText="Yes"
           cancelText="No"
           placement="bottom"
-          disabled={assignedWorkspacesCount > 0}
+          disabled={assignedWorkspacesCount > 0 || !manageWorkspace}
         >
           <Button
             type="primary"
             danger
             style={{ width: "fit-content", padding: "8px 24px", height: "auto" }}
-            disabled={assignedWorkspacesCount > 0}
+            disabled={assignedWorkspacesCount > 0 || !manageWorkspace}
           >
             <Space>
               <DeleteOutlined />
@@ -181,6 +192,30 @@ export default function ProjectDetailPage({ organizationName, setOrganizationNam
   const [activeKey, setActiveKey] = useState("general");
   const [assignedWorkspacesCount, setAssignedWorkspacesCount] = useState(0);
   const { token } = theme.useToken();
+  const { permissions } = useOrgPermissions();
+  const [userGroups, setUserGroups] = useState<string[]>([]);
+  const [projectAccessForPerm, setProjectAccessForPerm] = useState<ProjectAccessModel[]>([]);
+
+  useEffect(() => {
+    apiGet<{ groups: string[] }>("/access-token/v1/teams/current-teams").then((res) => {
+      if (!res.isError && res.data?.groups) setUserGroups(res.data.groups);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (orgid && id) {
+      projectService.listProjectAccess(orgid, id).then((res) => {
+        if (!res.isError) setProjectAccessForPerm(res.data ?? []);
+      });
+    }
+  }, [orgid, id]);
+
+  const isProjectAdmin = projectAccessForPerm.some((a) => userGroups.includes(a.name) && a.role === "admin");
+  const isProjectAdminOrWrite = projectAccessForPerm.some(
+    (a) => userGroups.includes(a.name) && (a.role === "admin" || a.role === "write")
+  );
+  const canManageProject = permissions.manageWorkspace || isProjectAdmin;
+  const canRemoveWorkspace = permissions.manageWorkspace || isProjectAdminOrWrite;
 
   const { loading, execute, error } = useApiRequest({
     action: () => projectService.getProject(orgid!, id!),
@@ -243,9 +278,16 @@ export default function ProjectDetailPage({ organizationName, setOrganizationNam
   const renderContent = () => {
     switch (activeKey) {
       case "workspaces":
-        return <ProjectWorkspaces orgid={orgid!} projectId={id!} />;
+        return (
+          <ProjectWorkspaces
+            orgid={orgid!}
+            projectId={id!}
+            manageWorkspace={permissions.manageWorkspace}
+            canRemoveWorkspace={canRemoveWorkspace}
+          />
+        );
       case "teams":
-        return <ProjectAccessTab orgid={orgid!} projectId={id!} />;
+        return <ProjectAccessTab orgid={orgid!} projectId={id!} canManage={canManageProject} />;
       case "general":
       default:
         return (
@@ -254,6 +296,8 @@ export default function ProjectDetailPage({ organizationName, setOrganizationNam
             projectId={id!}
             project={project}
             assignedWorkspacesCount={assignedWorkspacesCount}
+            manageWorkspace={permissions.manageWorkspace}
+            canUpdateProject={canManageProject}
           />
         );
     }

--- a/ui/src/modules/projects/ProjectDetailPage.tsx
+++ b/ui/src/modules/projects/ProjectDetailPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import PageWrapper from "@/modules/layout/PageWrapper/PageWrapper";
 import projectService from "./projectService";
 import ProjectWorkspaces from "./ProjectWorkspaces";
+import ProjectAccessTab from "./ProjectAccessTab";
 import workspaceService from "@/modules/workspaces/workspaceService";
 import useApiRequest from "@/modules/api/useApiRequest";
 import { ProjectModel } from "@/domain/types";
@@ -234,6 +235,7 @@ export default function ProjectDetailPage({ organizationName, setOrganizationNam
       children: [
         { key: "general", label: "General" },
         { key: "workspaces", label: "Workspaces" },
+        { key: "teams", label: "Teams" },
       ],
     },
   ];
@@ -242,6 +244,8 @@ export default function ProjectDetailPage({ organizationName, setOrganizationNam
     switch (activeKey) {
       case "workspaces":
         return <ProjectWorkspaces orgid={orgid!} projectId={id!} />;
+      case "teams":
+        return <ProjectAccessTab orgid={orgid!} projectId={id!} />;
       case "general":
       default:
         return (

--- a/ui/src/modules/projects/ProjectDetailPage.tsx
+++ b/ui/src/modules/projects/ProjectDetailPage.tsx
@@ -34,6 +34,7 @@ type GeneralProps = {
   assignedWorkspacesCount: number;
   manageWorkspace: boolean;
   canUpdateProject: boolean;
+  onSaved: () => void;
 };
 
 function ProjectGeneralSettings({
@@ -43,6 +44,7 @@ function ProjectGeneralSettings({
   assignedWorkspacesCount,
   manageWorkspace,
   canUpdateProject,
+  onSaved,
 }: GeneralProps) {
   const [waiting, setWaiting] = useState(false);
   const [form] = Form.useForm<ProjectForm>();
@@ -59,6 +61,7 @@ function ProjectGeneralSettings({
     try {
       await projectService.updateProject(orgid, projectId, values);
       message.success("Project updated successfully");
+      onSaved();
     } catch (err: any) {
       if (err?.response?.status === 403) {
         message.error(
@@ -122,10 +125,10 @@ function ProjectGeneralSettings({
       <Spin spinning={waiting}>
         <Form form={form} layout="vertical" name="project-general-settings" onFinish={onFinish} requiredMark={false}>
           <Form.Item name="name" label="Name" rules={[{ required: true, message: "Name is required" }]}>
-            <Input />
+            <Input disabled={!canUpdateProject} />
           </Form.Item>
           <Form.Item name="description" label="Description" extra="Optional">
-            <Input.TextArea rows={5} placeholder="Project description" />
+            <Input.TextArea rows={5} placeholder="Project description" disabled={!canUpdateProject} />
           </Form.Item>
           <Form.Item>
             <Button type="primary" htmlType="submit" disabled={!canUpdateProject}>
@@ -248,7 +251,7 @@ export default function ProjectDetailPage({ organizationName, setOrganizationNam
   const handleTabChange = (key: string) => {
     setActiveKey(key);
     if (key === "general" && orgid && id) {
-      // Reload workspace count when returning to general tab
+      execute();
       workspaceService.listWorkspaces(orgid).then((result) => {
         if (!result.isError) {
           const assignedCount = result.data.workspaces.filter((ws) => ws.projectId === id).length;
@@ -287,6 +290,7 @@ export default function ProjectDetailPage({ organizationName, setOrganizationNam
             assignedWorkspacesCount={assignedWorkspacesCount}
             manageWorkspace={permissions.manageWorkspace}
             canUpdateProject={canManageProject}
+            onSaved={execute}
           />
         );
     }

--- a/ui/src/modules/projects/ProjectWorkspaces.tsx
+++ b/ui/src/modules/projects/ProjectWorkspaces.tsx
@@ -9,9 +9,11 @@ import workspaceService from "@/modules/workspaces/workspaceService";
 type Props = {
   orgid: string;
   projectId: string;
+  manageWorkspace: boolean;
+  canRemoveWorkspace: boolean;
 };
 
-export default function ProjectWorkspaces({ orgid, projectId }: Props) {
+export default function ProjectWorkspaces({ orgid, projectId, manageWorkspace, canRemoveWorkspace }: Props) {
   const [allWorkspaces, setAllWorkspaces] = useState<WorkspaceListItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
@@ -128,8 +130,9 @@ export default function ProjectWorkspaces({ orgid, projectId }: Props) {
           okText="Yes"
           cancelText="No"
           placement="left"
+          disabled={!canRemoveWorkspace}
         >
-          <Button danger size="small">
+          <Button danger size="small" disabled={!canRemoveWorkspace}>
             Remove
           </Button>
         </Popconfirm>
@@ -146,7 +149,7 @@ export default function ProjectWorkspaces({ orgid, projectId }: Props) {
         icon={<PlusOutlined />}
         style={{ marginBottom: 16 }}
         onClick={() => setModalOpen(true)}
-        disabled={unassignedWorkspaces.length === 0}
+        disabled={unassignedWorkspaces.length === 0 || !manageWorkspace}
       >
         Add Workspace
       </Button>

--- a/ui/src/modules/projects/ProjectWorkspaces.tsx
+++ b/ui/src/modules/projects/ProjectWorkspaces.tsx
@@ -1,5 +1,4 @@
-import { PlusOutlined } from "@ant-design/icons";
-import { Button, Modal, Popconfirm, Select, Table, Typography, message } from "antd";
+import { Table, Typography } from "antd";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import WorkspaceStatusTag from "@/modules/workspaces/components/WorkspaceStatusTag";
@@ -9,19 +8,13 @@ import workspaceService from "@/modules/workspaces/workspaceService";
 type Props = {
   orgid: string;
   projectId: string;
-  manageWorkspace: boolean;
-  canRemoveWorkspace: boolean;
 };
 
-export default function ProjectWorkspaces({ orgid, projectId, manageWorkspace, canRemoveWorkspace }: Props) {
+export default function ProjectWorkspaces({ orgid, projectId }: Props) {
   const [allWorkspaces, setAllWorkspaces] = useState<WorkspaceListItem[]>([]);
   const [loading, setLoading] = useState(false);
-  const [modalOpen, setModalOpen] = useState(false);
-  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | undefined>();
-  const [assigning, setAssigning] = useState(false);
 
   const assignedWorkspaces = allWorkspaces.filter((ws) => ws.projectId === projectId);
-  const unassignedWorkspaces = allWorkspaces.filter((ws) => !ws.projectId);
 
   async function loadWorkspaces() {
     setLoading(true);
@@ -38,66 +31,6 @@ export default function ProjectWorkspaces({ orgid, projectId, manageWorkspace, c
   useEffect(() => {
     loadWorkspaces();
   }, [orgid, projectId]);
-
-  const handleAssign = async () => {
-    if (!selectedWorkspaceId) return;
-    setAssigning(true);
-    try {
-      await workspaceService.assignWorkspaceToProject(orgid, selectedWorkspaceId, projectId);
-      message.success("Workspace added to project");
-      setModalOpen(false);
-      setSelectedWorkspaceId(undefined);
-      await loadWorkspaces();
-    } catch (err: any) {
-      if (err?.response?.status === 403) {
-        message.error(
-          <span>
-            You are not authorized to assign workspaces to projects. <br /> Please contact your administrator and
-            request the <b>Manage Workspaces</b> permission. <br /> For more information, visit the{" "}
-            <a
-              target="_blank"
-              href="https://docs.terrakube.io/user-guide/organizations/team-management"
-              rel="noreferrer"
-            >
-              Terrakube documentation
-            </a>
-            .
-          </span>
-        );
-      } else {
-        message.error("Failed to add workspace to project");
-      }
-    } finally {
-      setAssigning(false);
-    }
-  };
-
-  const handleRemove = async (workspaceId: string) => {
-    try {
-      await workspaceService.removeWorkspaceFromProject(orgid, workspaceId);
-      message.success("Workspace removed from project");
-      await loadWorkspaces();
-    } catch (err: any) {
-      if (err?.response?.status === 403) {
-        message.error(
-          <span>
-            You are not authorized to remove workspaces from projects. <br /> Please contact your administrator and
-            request the <b>Manage Workspaces</b> permission. <br /> For more information, visit the{" "}
-            <a
-              target="_blank"
-              href="https://docs.terrakube.io/user-guide/organizations/team-management"
-              rel="noreferrer"
-            >
-              Terrakube documentation
-            </a>
-            .
-          </span>
-        );
-      } else {
-        message.error("Failed to remove workspace from project");
-      }
-    }
-  };
 
   const columns = [
     {
@@ -120,39 +53,12 @@ export default function ProjectWorkspaces({ orgid, projectId, manageWorkspace, c
       key: "normalizedSource",
       render: (src: string | undefined) => <Typography.Text type="secondary">{src || "—"}</Typography.Text>,
     },
-    {
-      title: "",
-      key: "actions",
-      render: (_: unknown, record: WorkspaceListItem) => (
-        <Popconfirm
-          title="Remove workspace from this project?"
-          onConfirm={() => handleRemove(record.id)}
-          okText="Yes"
-          cancelText="No"
-          placement="left"
-          disabled={!canRemoveWorkspace}
-        >
-          <Button danger size="small" disabled={!canRemoveWorkspace}>
-            Remove
-          </Button>
-        </Popconfirm>
-      ),
-    },
   ];
 
   return (
     <div style={{ width: "100%" }}>
       <h1>Workspaces</h1>
-      <p>Manage which workspaces belong to this project.</p>
-      <Button
-        type="primary"
-        icon={<PlusOutlined />}
-        style={{ marginBottom: 16 }}
-        onClick={() => setModalOpen(true)}
-        disabled={unassignedWorkspaces.length === 0 || !manageWorkspace}
-      >
-        Add Workspace
-      </Button>
+      <p>Workspaces assigned to this project. To change a workspace&apos;s project, go to the workspace settings.</p>
       <Table
         rowKey="id"
         loading={loading}
@@ -161,28 +67,6 @@ export default function ProjectWorkspaces({ orgid, projectId, manageWorkspace, c
         pagination={{ pageSize: 10, showSizeChanger: true }}
         locale={{ emptyText: "No workspaces assigned to this project yet." }}
       />
-      <Modal
-        title="Add workspace to project"
-        open={modalOpen}
-        onOk={handleAssign}
-        onCancel={() => {
-          setModalOpen(false);
-          setSelectedWorkspaceId(undefined);
-        }}
-        confirmLoading={assigning}
-        okText="Add"
-        okButtonProps={{ disabled: !selectedWorkspaceId }}
-      >
-        <Select
-          showSearch
-          placeholder="Search workspaces..."
-          optionFilterProp="label"
-          style={{ width: "100%", marginTop: 8 }}
-          value={selectedWorkspaceId}
-          onChange={setSelectedWorkspaceId}
-          options={unassignedWorkspaces.map((ws) => ({ label: ws.name, value: ws.id }))}
-        />
-      </Modal>
     </div>
   );
 }

--- a/ui/src/modules/projects/ProjectsPage.tsx
+++ b/ui/src/modules/projects/ProjectsPage.tsx
@@ -7,6 +7,7 @@ import projectService from "./projectService";
 import useApiRequest from "@/modules/api/useApiRequest";
 import { ProjectModel } from "@/domain/types";
 import { ORGANIZATION_NAME } from "../../config/actionTypes";
+import { useOrgPermissions } from "@/modules/permissions/useOrgPermissions";
 
 type Props = {
   organizationName: string;
@@ -21,6 +22,7 @@ type ProjectForm = {
 export default function ProjectsPage({ organizationName, setOrganizationName }: Props) {
   const { id } = useParams();
   const navigate = useNavigate();
+  const { permissions } = useOrgPermissions(id);
   const [projects, setProjects] = useState<ProjectModel[]>([]);
   const [modalOpen, setModalOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -112,7 +114,7 @@ export default function ProjectsPage({ organizationName, setOrganizationName }: 
       ]}
       fluid
       actions={
-        <Button icon={<PlusOutlined />} type="primary" onClick={openCreate}>
+        <Button icon={<PlusOutlined />} type="primary" onClick={openCreate} disabled={!permissions.manageWorkspace}>
           New project
         </Button>
       }

--- a/ui/src/modules/projects/projectService.ts
+++ b/ui/src/modules/projects/projectService.ts
@@ -3,6 +3,17 @@ import { apiPost } from "@/modules/api/apiWrapper";
 import { ApiResponse } from "@/modules/api/types";
 import { ProjectModel } from "@/domain/types";
 
+export type ProjectAccessModel = {
+  id: string;
+  name: string;
+  role: string;
+  manageWorkspace: boolean;
+  manageState: boolean;
+  manageJob: boolean;
+  planJob: boolean;
+  approveJob: boolean;
+};
+
 async function listProjects(organizationId: string): Promise<ApiResponse<ProjectModel[]>> {
   const body = {
     query: `{
@@ -140,12 +151,109 @@ async function deleteProject(organizationId: string, projectId: string): Promise
   await axiosInstance.delete(`organization/${organizationId}/project/${projectId}`);
 }
 
+async function listProjectAccess(organizationId: string, projectId: string): Promise<ApiResponse<ProjectAccessModel[]>> {
+  const body = {
+    query: `{
+      project(ids: ["${projectId}"]) {
+        edges {
+          node {
+            projectAccess {
+              edges {
+                node {
+                  id
+                  name
+                  role
+                  manageWorkspace
+                  manageState
+                  manageJob
+                  planJob
+                  approveJob
+                }
+              }
+            }
+          }
+        }
+      }
+    }`,
+  };
+
+  const tempData = await apiPost<unknown, any>("/graphql/api/v1", body, {
+    dataWrapped: true,
+    contentType: "application/json",
+  });
+
+  if (tempData.isError) {
+    return {
+      isError: true,
+      responseCode: tempData.responseCode,
+      error: tempData.error,
+      data: [],
+    };
+  }
+
+  const edges = tempData.data?.project?.edges?.[0]?.node?.projectAccess?.edges ?? [];
+
+  return {
+    isError: false,
+    responseCode: tempData.responseCode,
+    data: edges.map((edge: any) => ({
+      id: edge.node.id,
+      name: edge.node.name,
+      role: edge.node.role ?? "custom",
+      manageWorkspace: edge.node.manageWorkspace ?? false,
+      manageState: edge.node.manageState ?? false,
+      manageJob: edge.node.manageJob ?? false,
+      planJob: edge.node.planJob ?? false,
+      approveJob: edge.node.approveJob ?? false,
+    })),
+  };
+}
+
+async function addProjectAccess(
+  organizationId: string,
+  projectId: string,
+  teamName: string,
+  role: string
+): Promise<void> {
+  const body = {
+    data: {
+      type: "project_access",
+      attributes: {
+        name: teamName,
+        role,
+      },
+      relationships: {
+        project: {
+          data: { type: "project", id: projectId },
+        },
+      },
+    },
+  };
+
+  await axiosInstance.post(`organization/${organizationId}/project/${projectId}/projectAccess`, body, {
+    headers: { "Content-Type": "application/vnd.api+json" },
+  });
+}
+
+async function removeProjectAccess(
+  organizationId: string,
+  projectId: string,
+  accessId: string
+): Promise<void> {
+  await axiosInstance.delete(
+    `organization/${organizationId}/project/${projectId}/projectAccess/${accessId}`
+  );
+}
+
 const methods = {
   listProjects,
   getProject,
   createProject,
   updateProject,
   deleteProject,
+  listProjectAccess,
+  addProjectAccess,
+  removeProjectAccess,
 };
 
 export default methods;

--- a/ui/src/modules/projects/projectService.ts
+++ b/ui/src/modules/projects/projectService.ts
@@ -151,7 +151,10 @@ async function deleteProject(organizationId: string, projectId: string): Promise
   await axiosInstance.delete(`organization/${organizationId}/project/${projectId}`);
 }
 
-async function listProjectAccess(organizationId: string, projectId: string): Promise<ApiResponse<ProjectAccessModel[]>> {
+async function listProjectAccess(
+  organizationId: string,
+  projectId: string
+): Promise<ApiResponse<ProjectAccessModel[]>> {
   const body = {
     query: `{
       project(ids: ["${projectId}"]) {
@@ -235,14 +238,8 @@ async function addProjectAccess(
   });
 }
 
-async function removeProjectAccess(
-  organizationId: string,
-  projectId: string,
-  accessId: string
-): Promise<void> {
-  await axiosInstance.delete(
-    `organization/${organizationId}/project/${projectId}/projectAccess/${accessId}`
-  );
+async function removeProjectAccess(organizationId: string, projectId: string, accessId: string): Promise<void> {
+  await axiosInstance.delete(`organization/${organizationId}/project/${projectId}/projectAccess/${accessId}`);
 }
 
 const methods = {

--- a/ui/src/modules/projects/projectService.ts
+++ b/ui/src/modules/projects/projectService.ts
@@ -225,11 +225,6 @@ async function addProjectAccess(
         name: teamName,
         role,
       },
-      relationships: {
-        project: {
-          data: { type: "project", id: projectId },
-        },
-      },
     },
   };
 


### PR DESCRIPTION
Related #3167

## Overview
This PR introduces project-level permissions, allowing teams to be granted roles at the project level that apply to all workspaces within that project.
This addresses the need to simplify permission management for large organizations with many workspaces grouped under projects.

The API endpoints and the UI are both implemented and have been verified to work as expected.

## Implementation Details

### What's Included
- `ProjectAccess` entity: Stores team permissions at the project level
- Security checks: New permission rules that propagate project-level permissions
  to workspaces and jobs within the project
- API endpoints: Support for creating, reading, and managing project access rules
- UI: A "Team Access" tab on the project detail page for managing team assignments

### How It Works
1. Grant a team a role on a project (e.g., "Write")
2. All workspaces within that project inherit the team's permissions
3. Organization-level permissions take precedence if they are more permissive

### Permission Hierarchy
Organization-level (most permissive wins)
↓
Project-level
↓
Workspace-level

### Supported Project-level Roles

| Role  | Manage Project | Manage Workspace | Create Workspace | Plan Job | Approve Job |
|-------|:---:|:---:|:---:|:---:|:---:|
| Admin | ✅ | ✅ | ✅ | ✅ | ✅ |
| Write | ❌ | ✅ | ✅ | ✅ | ✅ |
| Plan  | ❌ | ❌ | ❌ | ✅ | ❌ |
| Read  | ❌ | ❌ | ❌ | ❌ | ❌ |

"Manage Project" covers editing project settings and managing team access entries for the project.

Note: Reassigning a workspace to a different project requires organization-level Manage Workspace permission,
regardless of project-level roles, to prevent unauthorized workspace moves across projects.

## Screenshots

<img width="931" height="587" alt="image" src="https://github.com/user-attachments/assets/83c150d6-edb5-4934-a0a5-8013b08e4e5f" />

<img width="927" height="645" alt="image" src="https://github.com/user-attachments/assets/d1c14016-202c-4d4a-bb55-eb5737c79d48" />

<img width="1900" height="659" alt="image" src="https://github.com/user-attachments/assets/1ba01c9d-1cfe-4bfd-a05a-6152a30531c8" />

<img width="1898" height="776" alt="image" src="https://github.com/user-attachments/assets/ce7e87d8-3028-4a0f-9cfb-4e97bebea973" />


## Discussion Points

### Q1: Should Project-level permissions include "Manage State"?

Currently, Manage State is only enforced at the organization level — there is no project-scoped security check for state operations.
The permission logic (`canManageState`) is already implemented for `ProjectAccess` in `RbacV2Service`
(Admin and Write both return true, consistent with org-level behavior),
but the corresponding security check class has not been added yet.

**Should we:**
1. Keep State management at Organization level only (current behavior)
2. Add a project-scoped security check to enable Manage State for Admin and Write
   (consistent with organization-level behavior)
3. Something else?