### PR TITLE
fix(ui): fix run list status tag icons and colors for dark mode

### DIFF
--- a/ui/src/modules/workspaces/components/RunList.tsx
+++ b/ui/src/modules/workspaces/components/RunList.tsx
@@ -3,9 +3,10 @@ import {
   UserOutlined,
   CheckCircleOutlined,
   ClockCircleOutlined,
-  ExclamationCircleOutlined,
+  CloseSquareOutlined,
   StopOutlined,
   SyncOutlined,
+  WarningOutlined,
 } from "@ant-design/icons";
 import { FlatJob, JobStatus } from "../../../domain/types";
 import { useState, useEffect, useCallback } from "react";
@@ -115,7 +116,28 @@ export default function RunList({ jobs, onRunClick }: Props) {
     return "Terraform";
   };
 
-  const renderStatusTag = (status: JobStatus, statusColor: string) => (
+  const getStatusTagColor = (status: JobStatus): string => {
+    switch (status) {
+      case JobStatus.Completed:
+        return "success";
+      case JobStatus.NoChanges:
+        return "purple";
+      case JobStatus.Running:
+        return "processing";
+      case JobStatus.WaitingApproval:
+        return "warning";
+      case JobStatus.Failed:
+        return "error";
+      case JobStatus.Cancelled:
+        return "error";
+      case JobStatus.Rejected:
+        return "error";
+      default:
+        return "default";
+    }
+  };
+
+  const renderStatusTag = (status: JobStatus) => (
     <Tag
       icon={
         status === JobStatus.Completed ? (
@@ -125,16 +147,18 @@ export default function RunList({ jobs, onRunClick }: Props) {
         ) : status === JobStatus.Running ? (
           <SyncOutlined spin />
         ) : status === JobStatus.WaitingApproval ? (
-          <ExclamationCircleOutlined />
+          <WarningOutlined />
+        ) : status === JobStatus.Failed ? (
+          <CloseSquareOutlined />
         ) : status === JobStatus.Cancelled ? (
           <StopOutlined />
-        ) : status === JobStatus.Failed ? (
-          <StopOutlined />
+        ) : status === JobStatus.Rejected ? (
+          <CloseSquareOutlined />
         ) : (
           <ClockCircleOutlined />
         )
       }
-      color={statusColor}
+      color={getStatusTagColor(status)}
     >
       {status.toLowerCase()}
     </Tag>
@@ -170,7 +194,7 @@ export default function RunList({ jobs, onRunClick }: Props) {
           <List.Item
             actions={[
               <div key="status" style={{ textAlign: "right" }}>
-                {renderStatusTag(item.status, item.statusColor)}
+                {renderStatusTag(item.status)}
                 <div>
                   <Tooltip title={formatDate((item as any).createdDate)}>
                     <span className="metadata">{item.latestChange}</span>


### PR DESCRIPTION
## Problem

Status tags in the Run List were using hardcoded hex color values
(e.g. `#2eb039`, `#FB0136`). Ant Design's `darkAlgorithm` does not
apply to custom hex colors, only to preset color tokens — so tags
appeared the same in both light and dark mode, and statuses like
`cancelled`, `pending`, and `notExecuted` rendered with no background
color at all in dark mode.

Additionally, `failed` and `cancelled` used `StopOutlined` which does
not clearly communicate the nature of each status.

## Changes

- Replaced hardcoded hex `statusColor` values with Ant Design preset
  color names (`success`, `error`, `warning`, `processing`, `purple`,
  `default`) so tags properly adapt to dark mode via the design token system
- Updated icons to align with Terraform Cloud conventions:
  - `WaitingApproval` → `WarningOutlined` (diamond ◇)
  - `Failed` / `Rejected` → `CloseSquareOutlined` (☒)
  - `Cancelled` → `StopOutlined` (⏹)
  - `Completed` / `NoChanges` → `CheckCircleOutlined` (✓)
- Added explicit handling for `Rejected` status (previously falling to default)
- Fixed missing colors for `cancelled`, `notExecuted`, `pending`

## File changed

`ui/src/modules/workspaces/components/RunList.tsx`

cc: @alfespa17