### PR TITLE
fix(ui): add headers to webhook migration calls

### DIFF
--- a/ui/src/domain/Workspaces/Settings/Webhook.tsx
+++ b/ui/src/domain/Workspaces/Settings/Webhook.tsx
@@ -301,9 +301,11 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
             migratedV2: true,
           },
         },
+      }, {
+        headers: { "Content-Type": "application/vnd.api+json" },
       })
       .then((response) => {
-        if (response.status === 200) {
+        if (response.status === 200 || response.status === 204) {
           setMigratedV2(true);
           message.success("Migrated to shared webhook successfully");
         } else {
@@ -329,9 +331,11 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
             migratedV2: false,
           },
         },
+      }, {
+        headers: { "Content-Type": "application/vnd.api+json" },
       })
       .then((response) => {
-        if (response.status === 200) {
+        if (response.status === 200 || response.status === 204) {
           setMigratedV2(false);
           message.success("Reverted to per-workspace webhook");
         } else {


### PR DESCRIPTION
# Context

I am getting an error when trying to click the Shared Webhook Migration button: 
```
org.springframework.web.HttpMediaTypeNotSupportedException: Content-Type 'application/json' is not supported
```

It comes from the fact that the `Content-Type: application/vnd.api+json` is not set for this specific call.

# Solution

Set the header.
Also accept returned code (204).