### PR TITLE
fix(webhook): align v2 matcher with stored regex/pathType semantics

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookEventMatcher.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookEventMatcher.java
@@ -5,6 +5,7 @@ import java.util.List;
 import io.terrakube.api.repository.WebhookEventRepository;
 import io.terrakube.api.rs.webhook.Webhook;
 import io.terrakube.api.rs.webhook.WebhookEvent;
+import io.terrakube.api.rs.webhook.WebhookEventPathType;
 import io.terrakube.api.rs.webhook.WebhookEventType;
 
 import lombok.extern.slf4j.Slf4j;
@@ -19,25 +20,45 @@ public final class WebhookEventMatcher {
         String[] branchList = webhookEvent.getBranch().split(",");
         for (String branch : branchList) {
             branch = branch.trim();
-            if (globMatch(webhookBranch, branch)) {
-                return true;
+            try {
+                if (webhookBranch.matches(branch)) {
+                    return true;
+                }
+            } catch (Exception e) {
+                log.warn("Invalid branch pattern '{}': {}", branch, e.getMessage());
             }
         }
         return false;
     }
 
     public static boolean checkFileChanges(List<String> files, WebhookEvent webhookEvent) {
+        WebhookEventPathType pathType = webhookEvent.getPathType() != null
+                ? webhookEvent.getPathType()
+                : WebhookEventPathType.REGEX;
         String[] triggeredPath = webhookEvent.getPath().split(",");
         for (String file : files) {
             for (int i = 0; i < triggeredPath.length; i++) {
-                if (globMatch(file, triggeredPath[i].trim())) {
-                    log.info("Changed file {} matches set trigger pattern {}", file, triggeredPath[i]);
+                String pattern = triggeredPath[i].trim();
+                if (matchPath(file, pattern, pathType)) {
+                    log.info("Changed file {} matches set trigger pattern {}", file, pattern);
                     return true;
                 }
             }
         }
         log.info("Changed files {} doesn't match any of the trigger path pattern {}", files, triggeredPath);
         return false;
+    }
+
+    static boolean matchPath(String file, String pattern, WebhookEventPathType pathType) {
+        if (pathType == WebhookEventPathType.REGEX) {
+            try {
+                return file.matches(pattern);
+            } catch (Exception e) {
+                log.warn("Invalid regex pattern '{}': {}", pattern, e.getMessage());
+                return false;
+            }
+        }
+        return globMatch(file, pattern);
     }
 
     static boolean globMatch(String input, String globPattern) {

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
@@ -43,6 +43,7 @@ import io.terrakube.api.rs.vcs.VcsType;
 import io.terrakube.api.rs.webhook.RepoWebhook;
 import io.terrakube.api.rs.webhook.Webhook;
 import io.terrakube.api.rs.webhook.WebhookEvent;
+import io.terrakube.api.rs.webhook.WebhookEventPathType;
 import io.terrakube.api.rs.webhook.WebhookEventType;
 import io.terrakube.api.rs.workspace.Workspace;
 
@@ -329,6 +330,7 @@ class RepoWebhookServiceTest {
             event1.setEvent(WebhookEventType.PUSH);
             event1.setBranch("main");
             event1.setPath("*");
+            event1.setPathType(WebhookEventPathType.PATTERN);
             event1.setTemplateId("template-1");
             wh1.setEvents(List.of(event1));
 
@@ -336,6 +338,7 @@ class RepoWebhookServiceTest {
             event2.setEvent(WebhookEventType.PUSH);
             event2.setBranch("main");
             event2.setPath("*");
+            event2.setPathType(WebhookEventPathType.PATTERN);
             event2.setTemplateId("template-2");
             wh2.setEvents(List.of(event2));
 
@@ -431,6 +434,7 @@ class RepoWebhookServiceTest {
             event1.setEvent(WebhookEventType.PULL_REQUEST);
             event1.setBranch("feature-branch");
             event1.setPath("*.tf");
+            event1.setPathType(WebhookEventPathType.PATTERN);
             event1.setTemplateId("pr-template-1");
             wh1.setEvents(List.of(event1));
 
@@ -438,6 +442,7 @@ class RepoWebhookServiceTest {
             event2.setEvent(WebhookEventType.PULL_REQUEST);
             event2.setBranch("feature-branch");
             event2.setPath("*.tf");
+            event2.setPathType(WebhookEventPathType.PATTERN);
             event2.setTemplateId("pr-template-2");
             wh2.setEvents(List.of(event2));
 
@@ -530,13 +535,13 @@ class RepoWebhookServiceTest {
 
             WebhookEvent event1 = new WebhookEvent();
             event1.setEvent(WebhookEventType.RELEASE);
-            event1.setBranch("v1.*"); // Test glob matching
+            event1.setBranch("v1.*"); // Test regex matching
             event1.setTemplateId("release-template-1");
             wh1.setEvents(List.of(event1));
 
             WebhookEvent event2 = new WebhookEvent();
             event2.setEvent(WebhookEventType.RELEASE);
-            event2.setBranch("*");
+            event2.setBranch(".*");
             event2.setTemplateId("release-template-2");
             wh2.setEvents(List.of(event2));
 
@@ -718,6 +723,7 @@ class RepoWebhookServiceTest {
             event1.setEvent(WebhookEventType.PUSH);
             event1.setBranch("main");
             event1.setPath("*");
+            event1.setPathType(WebhookEventPathType.PATTERN);
             event1.setTemplateId("template-1");
             wh1.setEvents(List.of(event1));
             ws1.setWebhook(wh1);
@@ -729,6 +735,7 @@ class RepoWebhookServiceTest {
             event2.setEvent(WebhookEventType.PUSH);
             event2.setBranch("main");
             event2.setPath("*");
+            event2.setPathType(WebhookEventPathType.PATTERN);
             event2.setTemplateId("template-2");
             wh2.setEvents(List.of(event2));
             ws2.setWebhook(wh2);
@@ -780,6 +787,7 @@ class RepoWebhookServiceTest {
             event2.setEvent(WebhookEventType.PUSH);
             event2.setBranch("main");
             event2.setPath("*");
+            event2.setPathType(WebhookEventPathType.PATTERN);
             event2.setTemplateId("template-2");
             wh2.setEvents(List.of(event2));
             ws2.setWebhook(wh2);

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookEventMatcherTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookEventMatcherTest.java
@@ -3,6 +3,7 @@ package io.terrakube.api.plugin.vcs;
 import java.util.List;
 
 import io.terrakube.api.rs.webhook.WebhookEvent;
+import io.terrakube.api.rs.webhook.WebhookEventPathType;
 
 import org.junit.jupiter.api.Test;
 
@@ -17,8 +18,13 @@ class WebhookEventMatcherTest {
     }
 
     private WebhookEvent eventWithPath(String path) {
+        return eventWithPath(path, WebhookEventPathType.REGEX);
+    }
+
+    private WebhookEvent eventWithPath(String path, WebhookEventPathType pathType) {
         WebhookEvent event = new WebhookEvent();
         event.setPath(path);
+        event.setPathType(pathType);
         return event;
     }
 
@@ -30,8 +36,8 @@ class WebhookEventMatcherTest {
     }
 
     @Test
-    void checkBranch_globMatch_returnsTrue() {
-        assertThat(WebhookEventMatcher.checkBranch("main-branch", eventWithBranch("main*"))).isTrue();
+    void checkBranch_regexMatch_returnsTrue() {
+        assertThat(WebhookEventMatcher.checkBranch("main-branch", eventWithBranch("main.*"))).isTrue();
     }
 
     @Test
@@ -41,7 +47,7 @@ class WebhookEventMatcherTest {
 
     @Test
     void checkBranch_commaSeparatedList_matchesAny() {
-        WebhookEvent event = eventWithBranch("main, develop, release/*");
+        WebhookEvent event = eventWithBranch("main, develop, release/.*");
         assertThat(WebhookEventMatcher.checkBranch("develop", event)).isTrue();
         assertThat(WebhookEventMatcher.checkBranch("release/1.0", event)).isTrue();
         assertThat(WebhookEventMatcher.checkBranch("feature/foo", event)).isFalse();
@@ -52,19 +58,37 @@ class WebhookEventMatcherTest {
     @Test
     void checkFileChanges_fileMatchesPattern_returnsTrue() {
         assertThat(WebhookEventMatcher.checkFileChanges(
-                List.of("src/main/App.java"), eventWithPath("src/main/*"))).isTrue();
+                List.of("src/main/App.java"), eventWithPath("src/main/*", WebhookEventPathType.PATTERN))).isTrue();
     }
 
     @Test
     void checkFileChanges_noFileMatches_returnsFalse() {
         assertThat(WebhookEventMatcher.checkFileChanges(
-                List.of("docs/README.md"), eventWithPath("src/*"))).isFalse();
+                List.of("docs/README.md"), eventWithPath("src/*", WebhookEventPathType.PATTERN))).isFalse();
     }
 
     @Test
     void checkFileChanges_multiplePatterns_oneMatches_returnsTrue() {
         assertThat(WebhookEventMatcher.checkFileChanges(
-                List.of("terraform/main.tf"), eventWithPath("src/*,terraform/*"))).isTrue();
+                List.of("terraform/main.tf"), eventWithPath("src/*,terraform/*", WebhookEventPathType.PATTERN))).isTrue();
+    }
+
+    @Test
+    void checkFileChanges_regexFileMatchesPattern_returnsTrue() {
+        assertThat(WebhookEventMatcher.checkFileChanges(
+                List.of("src/main/App.java"), eventWithPath("src/main/.*"))).isTrue();
+    }
+
+    @Test
+    void checkFileChanges_regexNoFileMatches_returnsFalse() {
+        assertThat(WebhookEventMatcher.checkFileChanges(
+                List.of("docs/README.md"), eventWithPath("src/.*"))).isFalse();
+    }
+
+    @Test
+    void checkFileChanges_regexMultiplePatterns_oneMatches_returnsTrue() {
+        assertThat(WebhookEventMatcher.checkFileChanges(
+                List.of("terraform/main.tf"), eventWithPath("src/.*,terraform/.*"))).isTrue();
     }
 
     // --- glob matching tests ---


### PR DESCRIPTION
## Description

The v2 (shared repo-level) webhook matcher in `WebhookEventMatcher` treated `WebhookEvent.branch` and `WebhookEvent.path` as glob patterns via the `globToSafeRegex` converter. The schema and the v1 matcher (`WebhookService` / `WebhookPathMatcher`) both treat those fields as regex by default (`WebhookEventPathType.REGEX`), so any pre-existing webhook event configured normally would silently fail to match on the v2 path — every PR/push routed through a shared webhook hit `IllegalArgumentException: No valid template found…` and no job was created.

Fixes #3203  

## Fix

* `checkBranch` now uses `String.matches` (regex), matching v1 and the rest of the codebase. Wrapped in try/catch so a bad pattern doesn't blow up the whole webhook.
* `checkFileChanges` honors `WebhookEvent.pathType: REGEX` (the default) uses regex; otherwise falls back to the existing `globMatch` / `globToSafeRegex` — preserving the ReDoS-safe glob path for events that explicitly opt in via PATTERN.

## Tests

* `WebhookEventMatcherTest`: existing glob-mode path tests opt into `pathType=PATTERN` (one-line change each) so they keep exercising the safe-glob path; new `_regex_*` tests lock in the new default. Branch tests had to flip to regex semantics (branches have no `pathType` column).
* `RepoWebhookServiceTest`: fan-out fixtures opt into `pathType=PATTERN` to keep their glob strings working; only the release scenario's `setBranch("*")` had to become `.*` since branches are regex-only.