### PR TITLE
fix(ui): fix IaC type card clipping on workspace creation page

### DIFF
--- a/ui/src/domain/Workspaces/Create.tsx
+++ b/ui/src/domain/Workspaces/Create.tsx
@@ -486,12 +486,12 @@ export const CreateWorkspace = () => {
             <Space className="chooseType" direction="vertical">
               <h3>Choose your IaC type </h3>
               <List
-                grid={{ gutter: 5, column: 5 }}
+                grid={{ gutter: 16, column: 4 }}
                 dataSource={iacTypes}
                 renderItem={(item) => (
                   <List.Item>
                     <Card
-                      style={{ width: "150px", textAlign: "center" }}
+                      style={{ textAlign: "center" }}
                       hoverable
                       onClick={() => handleIacTypeClick(item)}
                     >


### PR DESCRIPTION
## Summary

- Reduces the `List` grid from `column: 5` to `column: 4` on the "Choose your IaC type" step of workspace creation
- Removes the hardcoded `width: "150px"` from the IaC type cards so they fill their columns proportionally

## Root cause

The 5-column grid produced cells ~20% wide each. With the nested container paddings (`Content: 0 50px`, `site-layout-content: 24px`, `createWorkspace: 65% width`), those cells were narrower than the hardcoded 150px card width. In Ant Design v6, grid cells constrain their items, causing the Terraform card to be clipped and only partially visible.

## Test plan

- [x] Navigate to **Create Workspace** in any organization
- [x] Verify both the **Terraform** and **OpenTofu** cards are fully visible on step 1 ("Choose your IaC type")
- [x] Verify clicking each card proceeds to the next step correctly
- [x] Check at different viewport widths (desktop, narrow window)