### PR TITLE
feat(executor): API-routed terraform state backend for air-gapped agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The key features of Terrakube are:
 
 - **Remote Backend:** Terrakube supports both `remote backend` and `cloud` block so you can run your workflow directly from the Terraform / OpenTofu CLI.
 
+- **API-Routed Agents (no direct bucket access):** Run executors (agents) that need only outbound HTTPS to the Terrakube API — the agent never connects to GCS / S3 / Azure Blob directly. Terraform uses an `http` backend pointing at the API, and all plan binaries, state history, and step output are streamed through the API which is the only side that talks to the configured object store. Includes a DB-backed workspace lock, sha-256 integrity on every upload, optional read-back verification, and 3-attempt retries before the job is failed with a visible error. Useful when the agent runs in a different cloud / VPC than the server.
+
 ### Getting Started
 
 ### Installation
@@ -52,6 +54,28 @@ The key features of Terrakube are:
 - [Test Terrakube using Minikube](https://docs.terrakube.io/getting-started/deployment/minikube-+-https)
 - [Test Terrakube using Gitpod](https://docs.terrakube.io/getting-started/getting-started)
 - [Develop Terrakube using VS Code Devcontainers](.devcontainer/README.md)
+
+### Enabling API-Routed Agents
+
+This is opt-in per executor. The API server keeps its existing `TerraformStorageType=GCP|AWS|AZURE|LOCAL` — it remains the only process that talks to the bucket. On each executor that should run "air-gapped" from the bucket, set:
+
+```
+TerraformStateType=ApiTerraformStateImpl
+TerrakubeApiUrl=https://<your-terrakube-api>
+InternalSecret=<same value as the API server>
+# Optional, default true. When true the executor GETs each just-uploaded
+# object back from the API and re-hashes it locally to confirm what the
+# storage backend persisted matches what was produced. Disable only if the
+# extra GET traffic is undesirable.
+TerraformStateApiVerifyReadBack=true
+```
+
+What this changes:
+- Terraform uses an `http` backend pointing at the API, so `terraform plan/apply` itself never opens a connection to GCS / S3 / Azure Blob.
+- Plan binaries, state history (raw + JSON) and step output are PUT to the API; the API is the only side that writes to the configured object store.
+- Concurrent runs on the same workspace serialise through a DB-backed lock (`workspace_state_lock` table, added by the bundled Liquibase migration on first start).
+- Every upload carries an `X-Content-Sha256` header. The API rejects payloads whose received hash doesn't match the announced hash (HTTP 409) without writing anything to storage. The executor retries up to 3 times before failing the job with a visible error in the step output — your infrastructure is never silently shifted by a half-transferred state.
+- Existing executors that talk directly to GCS / S3 / Azure / local disk are unaffected; the new mode is selected only when `TerraformStateType=ApiTerraformStateImpl`.
 
 ### Documentation
 To learn more about Terrakube [go to the complete documentation.](https://docs.terrakube.io/) 

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/StateUploadFailedException.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/StateUploadFailedException.java
@@ -1,0 +1,18 @@
+package io.terrakube.executor.plugin.tfstate;
+
+/**
+ * Thrown when the executor exhausts its retries trying to deliver a state,
+ * plan, or output payload to the Terrakube API. The message is user-facing —
+ * it is written to the job step output so the run shows up as failed with a
+ * concrete reason instead of silently losing data.
+ */
+public class StateUploadFailedException extends RuntimeException {
+
+    public StateUploadFailedException(String message) {
+        super(message);
+    }
+
+    public StateUploadFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/TerraformState.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/TerraformState.java
@@ -15,4 +15,27 @@ public interface TerraformState {
     void saveStateJson(TerraformJob terraformJob, String applyJSON, String rawState);
 
     String saveOutput(String organizationId, String jobId, String stepId, String output, String outputError);
+
+    /**
+     * Begin a heartbeat that keeps the API-side workspace lock alive while
+     * this executor holds it. Default no-op for state backends that don't
+     * lock at the API layer (local/AWS/Azure/GCP).
+     */
+    default void startHeartbeat(String organizationId, String workspaceId) {}
+
+    /**
+     * Stop the heartbeat started by {@link #startHeartbeat(String, String)}.
+     * Idempotent. Must be invoked in a {@code finally} block so a crashed
+     * executor still tears the scheduler down cleanly.
+     */
+    default void stopHeartbeat() {}
+
+    /**
+     * Throws {@link StateUploadFailedException} when the heartbeat has been
+     * failing long enough that the API lock TTL is about to (or already has)
+     * elapsed. The executor calls this between polls of long-blocking
+     * terraform operations so the run aborts before the API frees the lock
+     * to a different caller.
+     */
+    default void checkHeartbeatHealth() {}
 }

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImpl.java
@@ -1,0 +1,373 @@
+package io.terrakube.executor.plugin.tfstate.api;
+
+import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.organization.workspace.history.History;
+import io.terrakube.client.model.organization.workspace.history.HistoryAttributes;
+import io.terrakube.client.model.organization.workspace.history.HistoryRequest;
+import io.terrakube.executor.plugin.tfstate.StateUploadFailedException;
+import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
+import io.terrakube.executor.plugin.tfstate.TerraformState;
+import io.terrakube.executor.plugin.tfstate.TerraformStatePathService;
+import io.terrakube.executor.service.mode.TerraformJob;
+import io.terrakube.executor.service.workspace.security.WorkspaceSecurity;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.text.TextStringBuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * TerraformState implementation that routes every state/plan/output write to
+ * the Terrakube API server over HTTPS. The agent (executor) needs no direct
+ * network access to the configured object store — the API process is the only
+ * thing that talks to GCS/S3/Azure/Local.
+ *
+ * - Live state lives behind Terraform's native "http" backend (so terraform
+ *   itself reads/writes through the API).
+ * - Plan binaries, step output, and history state snapshots are PUT to the
+ *   matching API endpoints.
+ */
+@Slf4j
+@Builder
+public class ApiTerraformStateImpl implements TerraformState {
+
+    private static final String TERRAFORM_PLAN_FILE = "terraformLibrary.tfPlan";
+    private static final String BACKEND_FILE_NAME = "api_backend_override.tf";
+    private static final int TOKEN_LIFETIME_MINUTES = 60 * 24; // 1 day, comfortably longer than any single job
+    private static final int IO_TIMEOUT_MS = 60_000;
+    private static final int MAX_UPLOAD_ATTEMPTS = 3;
+    private static final long INITIAL_BACKOFF_MS = 500L;
+
+    @NonNull
+    TerrakubeClient terrakubeClient;
+
+    @NonNull
+    TerraformStatePathService terraformStatePathService;
+
+    @NonNull
+    TerraformOutputPathService terraformOutputPathService;
+
+    @NonNull
+    WorkspaceSecurity workspaceSecurity;
+
+    @NonNull
+    String apiUrl;
+
+    /**
+     * When {@code true} the executor GETs each just-PUT object back from the API
+     * and re-hashes it locally. This provides independent end-to-end
+     * confirmation that what the storage backend committed equals what the
+     * executor produced, closing the loop the header-only check can't:
+     * the {@code X-Content-Sha256} header travels alongside the body from the
+     * same producer, so on its own it can detect transit corruption but not a
+     * faulty/compromised producer. Disable only for cost-sensitive workspaces
+     * where doubling the upload byte count matters; integrity drops to "TCP +
+     * TLS + announced hash" without it.
+     */
+    @lombok.Builder.Default
+    boolean verifyReadBack = true;
+
+    @Override
+    public String getBackendStateFile(String organizationId, String workspaceId, File workingDirectory, String terraformVersion) {
+        log.info("Generating http-backend override file for terraform {}", terraformVersion);
+        try {
+            String stateAddress = String.format("%s/tfstate/v1/http-backend/organization/%s/workspace/%s/state",
+                    apiUrl, organizationId, workspaceId);
+            String lockAddress = String.format("%s/tfstate/v1/http-backend/organization/%s/workspace/%s/lock",
+                    apiUrl, organizationId, workspaceId);
+
+            // long-lived JWT bound to this workspace; the API validates it against the internal HMAC secret
+            String token = workspaceSecurity.generateAccessToken(TOKEN_LIFETIME_MINUTES);
+
+            TextStringBuilder hcl = new TextStringBuilder();
+            hcl.appendln("terraform {");
+            hcl.appendln("  backend \"http\" {");
+            hcl.appendln("    address        = \"" + stateAddress + "\"");
+            hcl.appendln("    lock_address   = \"" + lockAddress + "\"");
+            hcl.appendln("    unlock_address = \"" + lockAddress + "\"");
+            hcl.appendln("    lock_method    = \"POST\"");
+            hcl.appendln("    unlock_method  = \"DELETE\"");
+            hcl.appendln("    username       = \"internal\"");
+            hcl.appendln("    password       = \"" + token + "\"");
+            hcl.appendln("  }");
+            hcl.appendln("}");
+
+            File backendFile = new File(
+                    FilenameUtils.separatorsToSystem(
+                            workingDirectory.getAbsolutePath().concat("/").concat(BACKEND_FILE_NAME)));
+            FileUtils.writeStringToFile(backendFile, hcl.toString(), Charset.defaultCharset());
+            return BACKEND_FILE_NAME;
+        } catch (IOException e) {
+            log.error("Could not write http-backend override: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public String saveTerraformPlan(String organizationId, String workspaceId, String jobId, String stepId, File workingDirectory) {
+        File tfPlanContent = new File(FilenameUtils.concat(workingDirectory.getAbsolutePath(), TERRAFORM_PLAN_FILE));
+        if (!tfPlanContent.exists()) {
+            return null;
+        }
+        String url = String.format("%s/tfstate/v1/organization/%s/workspace/%s/jobId/%s/step/%s/terraform.tfstate",
+                apiUrl, organizationId, workspaceId, jobId, stepId);
+        byte[] body;
+        try {
+            body = FileUtils.readFileToByteArray(tfPlanContent);
+        } catch (IOException e) {
+            throw new StateUploadFailedException("Could not read local terraform plan file " + tfPlanContent.getAbsolutePath(), e);
+        }
+        putBytesWithIntegrity(url, body, "application/octet-stream", "terraform plan", verifyReadBack);
+        log.info("Uploaded terraform plan: {}", url);
+        return url;
+    }
+
+    @Override
+    public boolean downloadTerraformPlan(String organizationId, String workspaceId, String jobId, String stepId, File workingDirectory) {
+        AtomicBoolean planExists = new AtomicBoolean(false);
+        String stateUrl = terrakubeClient.getJobById(organizationId, jobId).getData().getAttributes().getTerraformPlan();
+        if (stateUrl == null || stateUrl.isEmpty()) {
+            return false;
+        }
+        try {
+            log.info("Downloading plan from {}", stateUrl);
+            HttpURLConnection conn = (HttpURLConnection) URI.create(stateUrl).toURL().openConnection();
+            conn.setRequestMethod("GET");
+            conn.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(5));
+            conn.setConnectTimeout(IO_TIMEOUT_MS);
+            conn.setReadTimeout(IO_TIMEOUT_MS);
+            int code = conn.getResponseCode();
+            if (code >= 200 && code < 300) {
+                File dest = new File(FilenameUtils.concat(workingDirectory.getAbsolutePath(), TERRAFORM_PLAN_FILE));
+                FileUtils.copyInputStreamToFile(conn.getInputStream(), dest);
+                planExists.set(true);
+            } else {
+                log.error("Plan download failed, HTTP {}", code);
+            }
+        } catch (IOException e) {
+            log.error("Plan download failed: {}", e.getMessage());
+        }
+        return planExists.get();
+    }
+
+    @Override
+    public void saveStateJson(TerraformJob terraformJob, String applyJSON, String rawState) {
+        if (applyJSON == null) {
+            return;
+        }
+
+        // 1) create the history row via the existing API client; it returns a UUID we use as historyId.
+        String stateFilename = UUID.randomUUID().toString();
+
+        HistoryRequest historyRequest = new HistoryRequest();
+        History newHistory = new History();
+        newHistory.setType("history");
+        HistoryAttributes historyAttributes = new HistoryAttributes();
+        historyAttributes.setJobReference(terraformJob.getJobId());
+        historyAttributes.setSerial(1);
+        historyAttributes.setMd5("0");
+        historyAttributes.setLineage("0");
+        historyAttributes.setOutput(terraformStatePathService.getStateJsonPath(
+                terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), stateFilename));
+        newHistory.setAttributes(historyAttributes);
+        historyRequest.setData(newHistory);
+
+        terrakubeClient.createHistory(historyRequest, terraformJob.getOrganizationId(), terraformJob.getWorkspaceId());
+
+        // 2) PUT raw + json to the new history endpoints, integrity-checked.
+        //    On hash mismatch or repeated transport failure the helper throws
+        //    StateUploadFailedException and the API never commits the bytes,
+        //    so the workspace state remains unchanged.
+        String rawUrl = String.format("%s/tfstate/v1/organization/%s/workspace/%s/history/%s/terraform.tfstate",
+                apiUrl, terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), stateFilename);
+        String jsonUrl = String.format("%s/tfstate/v1/organization/%s/workspace/%s/history/%s/terraform.json.tfstate",
+                apiUrl, terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), stateFilename);
+        putBytesWithIntegrity(rawUrl, rawState.getBytes(StandardCharsets.UTF_8), "application/json", "state history (raw)", verifyReadBack);
+        putBytesWithIntegrity(jsonUrl, applyJSON.getBytes(StandardCharsets.UTF_8), "application/json", "state history (json)", verifyReadBack);
+        log.info("State history uploaded for workspace {} (historyId={})", terraformJob.getWorkspaceId(), stateFilename);
+    }
+
+    @Override
+    public String saveOutput(String organizationId, String jobId, String stepId, String output, String outputError) {
+        String url = String.format("%s/tfoutput/v1/organization/%s/job/%s/step/%s",
+                apiUrl, organizationId, jobId, stepId);
+        byte[] body = (output + outputError).getBytes(StandardCharsets.UTF_8);
+        // Step output is diagnostic and the GET endpoint blends in live Redis-streamed
+        // logs, so a byte-for-byte read-back wouldn't be meaningful here. Header-only.
+        putBytesWithIntegrity(url, body, "text/plain", "step output", false);
+        log.info("Step output uploaded via API: {}", url);
+        return terraformOutputPathService.getOutputPath(organizationId, jobId, stepId);
+    }
+
+    /**
+     * PUT the payload with an X-Content-Sha256 header so the API can verify
+     * what it received before committing. Retries up to MAX_UPLOAD_ATTEMPTS on
+     * transport failures and on HTTP 409 (server-detected hash mismatch). If
+     * every attempt fails, throws {@link StateUploadFailedException} with a
+     * user-facing message — the caller is responsible for marking the job as
+     * failed so the operator sees what went wrong.
+     */
+    /**
+     * PUT the payload with an X-Content-Sha256 header so the API can verify
+     * the announced hash against the bytes it received. When {@code readBack}
+     * is true we additionally GET the same URL after a successful PUT and
+     * re-hash the response — this catches the case where the announced hash
+     * and the body agree (the API accepts the upload) but the bytes the
+     * storage backend actually persisted differ from what we intended. Both
+     * failures are retried in the same loop, up to MAX_UPLOAD_ATTEMPTS.
+     */
+    private void putBytesWithIntegrity(String urlString, byte[] body, String contentType, String label, boolean readBack) {
+        String sha = sha256Hex(body);
+        IOException lastIo = null;
+        int lastCode = -1;
+        String lastDetail = null;
+        for (int attempt = 1; attempt <= MAX_UPLOAD_ATTEMPTS; attempt++) {
+            try {
+                HttpURLConnection conn = (HttpURLConnection) new URL(urlString).openConnection();
+                conn.setDoOutput(true);
+                conn.setRequestMethod("PUT");
+                conn.setConnectTimeout(IO_TIMEOUT_MS);
+                conn.setReadTimeout(IO_TIMEOUT_MS);
+                conn.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(5));
+                conn.setRequestProperty("Content-Type", contentType);
+                conn.setRequestProperty("X-Content-Sha256", sha);
+                conn.setRequestProperty("Content-Length", Integer.toString(body.length));
+                try (OutputStream os = conn.getOutputStream()) {
+                    os.write(body);
+                }
+                lastCode = conn.getResponseCode();
+                if (lastCode >= 200 && lastCode < 300) {
+                    if (readBack) {
+                        String observed = fetchAndHash(urlString);
+                        if (observed == null) {
+                            lastDetail = "read-back GET failed";
+                            log.warn("Read-back GET failed for {} on attempt {}/{}", label, attempt, MAX_UPLOAD_ATTEMPTS);
+                        } else if (!observed.equalsIgnoreCase(sha)) {
+                            lastCode = -2;
+                            lastDetail = String.format("read-back hash mismatch (expected=%s, observed=%s)", sha, observed);
+                            log.warn("Read-back integrity check FAILED for {}: {}", label, lastDetail);
+                        } else {
+                            if (attempt > 1) {
+                                log.info("Upload of {} succeeded with read-back verification on retry {}/{}", label, attempt, MAX_UPLOAD_ATTEMPTS);
+                            } else {
+                                log.info("Upload of {} verified end-to-end (sha256={})", label, sha);
+                            }
+                            return;
+                        }
+                    } else {
+                        if (attempt > 1) {
+                            log.info("Upload of {} succeeded on retry {}/{}", label, attempt, MAX_UPLOAD_ATTEMPTS);
+                        }
+                        return;
+                    }
+                } else {
+                    lastDetail = readErrorBody(conn);
+                    log.warn("Upload of {} attempt {}/{} returned HTTP {} (detail={})",
+                            label, attempt, MAX_UPLOAD_ATTEMPTS, lastCode, lastDetail);
+                }
+            } catch (IOException e) {
+                lastIo = e;
+                log.warn("Upload of {} attempt {}/{} failed: {}", label, attempt, MAX_UPLOAD_ATTEMPTS, e.getMessage());
+            }
+            if (attempt < MAX_UPLOAD_ATTEMPTS) {
+                sleepBackoff(attempt);
+            }
+        }
+        String reason;
+        if (lastCode == 409) {
+            reason = "API rejected the payload because the sha-256 did not match what was announced (transfer was corrupted in flight)";
+        } else if (lastCode == -2) {
+            reason = "the server accepted the upload but the read-back GET returned different bytes (" + lastDetail + ")";
+        } else if (lastCode > 0) {
+            reason = "API responded HTTP " + lastCode + (lastDetail != null ? " (" + lastDetail + ")" : "");
+        } else {
+            reason = lastIo != null ? "transport error: " + lastIo.getMessage() : "unknown error";
+        }
+        String message = String.format(
+                "Could not upload %s to %s after %d attempts: %s. Workspace state was NOT modified on the server.",
+                label, urlString, MAX_UPLOAD_ATTEMPTS, reason);
+        throw new StateUploadFailedException(message, lastIo);
+    }
+
+    /**
+     * GET the given URL and return the hex sha-256 of the body. Returns
+     * {@code null} on any transport error or non-2xx response so the caller
+     * can treat it as a verification failure indistinguishable from a hash
+     * mismatch (both retryable).
+     */
+    private String fetchAndHash(String urlString) {
+        try {
+            HttpURLConnection conn = (HttpURLConnection) new URL(urlString).openConnection();
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(IO_TIMEOUT_MS);
+            conn.setReadTimeout(IO_TIMEOUT_MS);
+            conn.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(5));
+            int code = conn.getResponseCode();
+            if (code < 200 || code >= 300) {
+                return null;
+            }
+            try (InputStream in = conn.getInputStream()) {
+                return sha256Hex(IOUtils.toByteArray(in));
+            }
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private void sleepBackoff(int attempt) {
+        try {
+            Thread.sleep(INITIAL_BACKOFF_MS * attempt);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private String readErrorBody(HttpURLConnection conn) {
+        InputStream stream = conn.getErrorStream();
+        if (stream == null) {
+            return null;
+        }
+        try {
+            String body = IOUtils.toString(stream, StandardCharsets.UTF_8);
+            return body.length() > 512 ? body.substring(0, 512) + "..." : body;
+        } catch (IOException ignored) {
+            return null;
+        }
+    }
+
+    private static String sha256Hex(byte[] bytes) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(bytes);
+            StringBuilder sb = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b & 0xff));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static String basicAuthHeader(String user, String token) {
+        return "Basic " + Base64.getEncoder().encodeToString((user + ":" + token).getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImpl.java
@@ -179,7 +179,10 @@ public class ApiTerraformStateImpl implements TerraformState {
             conn.setRequestMethod("POST");
             conn.setConnectTimeout(IO_TIMEOUT_MS);
             conn.setReadTimeout(IO_TIMEOUT_MS);
-            conn.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(5));
+            // Workspace-scoped, like the backend password — the API binds this token's
+            // workspaceId claim to the path workspace, so the heartbeat can only refresh
+            // its own lock, not any other workspace's.
+            conn.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(workspaceId, 5));
             conn.setRequestProperty("Content-Length", "0");
             conn.setDoOutput(true);
             try (OutputStream os = conn.getOutputStream()) {

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImpl.java
@@ -31,7 +31,12 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * TerraformState implementation that routes every state/plan/output write to
@@ -83,6 +88,110 @@ public class ApiTerraformStateImpl implements TerraformState {
      */
     @lombok.Builder.Default
     boolean verifyReadBack = true;
+
+    /**
+     * Seconds between heartbeat pings to the API. Should be well under the
+     * API-side lock TTL ({@code io.terrakube.api.http-backend
+     * .lock-ttl-seconds}, default 300) so a single missed ping never lets
+     * the lock expire. With the defaults a healthy run pings 5 times per
+     * TTL window — tolerates 3+ consecutive failures before giving up.
+     */
+    @lombok.Builder.Default
+    long heartbeatIntervalSeconds = 60L;
+
+    /**
+     * If no heartbeat has succeeded for this many seconds, the executor
+     * aborts the in-flight terraform operation rather than continue to write
+     * state the API will reject. Must be smaller than the API lock TTL so
+     * we cancel before the lock is reassigned. Default 180s = 3 missed
+     * heartbeats at 60s cadence, leaving a 120s margin under the 300s lock
+     * TTL for the API to free the lock cleanly.
+     */
+    @lombok.Builder.Default
+    long heartbeatAbortAfterSeconds = 180L;
+
+    private final transient AtomicLong lastSuccessfulHeartbeatMillis = new AtomicLong(0L);
+    private final transient AtomicBoolean heartbeatRunning = new AtomicBoolean(false);
+    private transient ScheduledExecutorService heartbeatScheduler;
+    private transient ScheduledFuture<?> heartbeatTask;
+
+    @Override
+    public synchronized void startHeartbeat(String organizationId, String workspaceId) {
+        if (!heartbeatRunning.compareAndSet(false, true)) {
+            log.warn("Heartbeat already running for workspace {} — startHeartbeat called twice without stop", workspaceId);
+            return;
+        }
+        lastSuccessfulHeartbeatMillis.set(System.currentTimeMillis());
+        heartbeatScheduler = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "tf-lock-heartbeat-" + workspaceId);
+            thread.setDaemon(true);
+            return thread;
+        });
+        String url = String.format("%s/tfstate/v1/http-backend/organization/%s/workspace/%s/lock/heartbeat",
+                apiUrl, organizationId, workspaceId);
+        log.info("Starting lock heartbeat for workspace {} every {}s (abort after {}s)",
+                workspaceId, heartbeatIntervalSeconds, heartbeatAbortAfterSeconds);
+        heartbeatTask = heartbeatScheduler.scheduleAtFixedRate(
+                () -> sendHeartbeat(url, workspaceId),
+                heartbeatIntervalSeconds, heartbeatIntervalSeconds, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public synchronized void stopHeartbeat() {
+        if (!heartbeatRunning.compareAndSet(true, false)) {
+            return;
+        }
+        if (heartbeatTask != null) {
+            heartbeatTask.cancel(false);
+            heartbeatTask = null;
+        }
+        if (heartbeatScheduler != null) {
+            heartbeatScheduler.shutdownNow();
+            heartbeatScheduler = null;
+        }
+        log.info("Stopped lock heartbeat");
+    }
+
+    @Override
+    public void checkHeartbeatHealth() {
+        if (!heartbeatRunning.get()) return;
+        long lastOk = lastSuccessfulHeartbeatMillis.get();
+        long elapsedSec = (System.currentTimeMillis() - lastOk) / 1000L;
+        if (elapsedSec > heartbeatAbortAfterSeconds) {
+            String message = String.format(
+                    "Lost contact with the Terrakube API for %ds (threshold %ds); aborting the run so the workspace lock can be reassigned safely.",
+                    elapsedSec, heartbeatAbortAfterSeconds);
+            throw new StateUploadFailedException(message);
+        }
+    }
+
+    private void sendHeartbeat(String url, String workspaceId) {
+        try {
+            HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+            conn.setRequestMethod("POST");
+            conn.setConnectTimeout(IO_TIMEOUT_MS);
+            conn.setReadTimeout(IO_TIMEOUT_MS);
+            conn.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(5));
+            conn.setRequestProperty("Content-Length", "0");
+            conn.setDoOutput(true);
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(new byte[0]);
+            }
+            int code = conn.getResponseCode();
+            if (code >= 200 && code < 300) {
+                lastSuccessfulHeartbeatMillis.set(System.currentTimeMillis());
+                log.debug("Heartbeat OK for workspace {}", workspaceId);
+            } else if (code == HttpURLConnection.HTTP_GONE) {
+                // 410 from the API means the lock TTL elapsed before this ping arrived.
+                // Don't update lastSuccessful — let checkHeartbeatHealth abort the run.
+                log.warn("Heartbeat for workspace {}: API reports lock-lost (HTTP 410); run will abort on next health check", workspaceId);
+            } else {
+                log.warn("Heartbeat for workspace {} returned HTTP {}", workspaceId, code);
+            }
+        } catch (IOException e) {
+            log.warn("Heartbeat for workspace {} failed: {}", workspaceId, e.getMessage());
+        }
+    }
 
     @Override
     public String getBackendStateFile(String organizationId, String workspaceId, File workingDirectory, String terraformVersion) {

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImpl.java
@@ -25,11 +25,9 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -55,7 +53,6 @@ public class ApiTerraformStateImpl implements TerraformState {
 
     private static final String TERRAFORM_PLAN_FILE = "terraformLibrary.tfPlan";
     private static final String BACKEND_FILE_NAME = "api_backend_override.tf";
-    private static final int TOKEN_LIFETIME_MINUTES = 60 * 24; // 1 day, comfortably longer than any single job
     private static final int IO_TIMEOUT_MS = 60_000;
     private static final int MAX_UPLOAD_ATTEMPTS = 3;
     private static final long INITIAL_BACKOFF_MS = 500L;
@@ -74,6 +71,17 @@ public class ApiTerraformStateImpl implements TerraformState {
 
     @NonNull
     String apiUrl;
+
+    /**
+     * Lifetime (minutes) of the workspace-scoped JWT written as the terraform
+     * http-backend {@code password}. Terraform holds this static token for the
+     * whole run and re-sends it on the final state write/unlock, so it must
+     * outlast the longest plausible apply — but it is scoped to a single
+     * workspace, so a leak only exposes that one workspace, and only until it
+     * expires. Default 60 minutes.
+     */
+    @lombok.Builder.Default
+    int backendTokenLifetimeMinutes = 60;
 
     /**
      * When {@code true} the executor GETs each just-PUT object back from the API
@@ -202,8 +210,11 @@ public class ApiTerraformStateImpl implements TerraformState {
             String lockAddress = String.format("%s/tfstate/v1/http-backend/organization/%s/workspace/%s/lock",
                     apiUrl, organizationId, workspaceId);
 
-            // long-lived JWT bound to this workspace; the API validates it against the internal HMAC secret
-            String token = workspaceSecurity.generateAccessToken(TOKEN_LIFETIME_MINUTES);
+            // Workspace-scoped JWT used as the http-backend password. The API validates the
+            // signature against the internal HMAC secret and (companion API change) enforces
+            // that the token's workspaceId claim matches the workspace in the request path,
+            // so a leaked backend file cannot reach another workspace's state.
+            String token = workspaceSecurity.generateAccessToken(workspaceId, backendTokenLifetimeMinutes);
 
             TextStringBuilder hcl = new TextStringBuilder();
             hcl.appendln("terraform {");
@@ -221,11 +232,13 @@ public class ApiTerraformStateImpl implements TerraformState {
             File backendFile = new File(
                     FilenameUtils.separatorsToSystem(
                             workingDirectory.getAbsolutePath().concat("/").concat(BACKEND_FILE_NAME)));
-            FileUtils.writeStringToFile(backendFile, hcl.toString(), Charset.defaultCharset());
+            FileUtils.writeStringToFile(backendFile, hcl.toString(), StandardCharsets.UTF_8);
             return BACKEND_FILE_NAME;
         } catch (IOException e) {
-            log.error("Could not write http-backend override: {}", e.getMessage());
-            return null;
+            // Air-gapped mode: without this override file terraform would silently fall back
+            // to a local backend (or no backend), losing the state route entirely. Fail hard.
+            throw new StateUploadFailedException(
+                    "Could not write http-backend override file " + BACKEND_FILE_NAME + ": " + e.getMessage(), e);
         }
     }
 
@@ -282,9 +295,22 @@ public class ApiTerraformStateImpl implements TerraformState {
             return;
         }
 
-        // 1) create the history row via the existing API client; it returns a UUID we use as historyId.
+        // historyId is a client-generated UUID; the history PUT endpoint stores bytes at a
+        // path derived from it and does not require a pre-existing DB row.
         String stateFilename = UUID.randomUUID().toString();
 
+        // 1) PUT raw + json to the history endpoints, integrity-checked. On hash mismatch or
+        //    repeated transport failure the helper throws StateUploadFailedException and the
+        //    API never commits the bytes — so we must NOT have written a history row yet, or
+        //    it would dangle pointing at an object that was never stored.
+        String rawUrl = String.format("%s/tfstate/v1/organization/%s/workspace/%s/history/%s/terraform.tfstate",
+                apiUrl, terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), stateFilename);
+        String jsonUrl = String.format("%s/tfstate/v1/organization/%s/workspace/%s/history/%s/terraform.json.tfstate",
+                apiUrl, terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), stateFilename);
+        putBytesWithIntegrity(rawUrl, rawState.getBytes(StandardCharsets.UTF_8), "application/json", "state history (raw)", verifyReadBack);
+        putBytesWithIntegrity(jsonUrl, applyJSON.getBytes(StandardCharsets.UTF_8), "application/json", "state history (json)", verifyReadBack);
+
+        // 2) only now record the history row, so it can only ever reference bytes that landed.
         HistoryRequest historyRequest = new HistoryRequest();
         History newHistory = new History();
         newHistory.setType("history");
@@ -299,17 +325,6 @@ public class ApiTerraformStateImpl implements TerraformState {
         historyRequest.setData(newHistory);
 
         terrakubeClient.createHistory(historyRequest, terraformJob.getOrganizationId(), terraformJob.getWorkspaceId());
-
-        // 2) PUT raw + json to the new history endpoints, integrity-checked.
-        //    On hash mismatch or repeated transport failure the helper throws
-        //    StateUploadFailedException and the API never commits the bytes,
-        //    so the workspace state remains unchanged.
-        String rawUrl = String.format("%s/tfstate/v1/organization/%s/workspace/%s/history/%s/terraform.tfstate",
-                apiUrl, terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), stateFilename);
-        String jsonUrl = String.format("%s/tfstate/v1/organization/%s/workspace/%s/history/%s/terraform.json.tfstate",
-                apiUrl, terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(), stateFilename);
-        putBytesWithIntegrity(rawUrl, rawState.getBytes(StandardCharsets.UTF_8), "application/json", "state history (raw)", verifyReadBack);
-        putBytesWithIntegrity(jsonUrl, applyJSON.getBytes(StandardCharsets.UTF_8), "application/json", "state history (json)", verifyReadBack);
         log.info("State history uploaded for workspace {} (historyId={})", terraformJob.getWorkspaceId(), stateFilename);
     }
 
@@ -326,21 +341,17 @@ public class ApiTerraformStateImpl implements TerraformState {
     }
 
     /**
-     * PUT the payload with an X-Content-Sha256 header so the API can verify
-     * what it received before committing. Retries up to MAX_UPLOAD_ATTEMPTS on
-     * transport failures and on HTTP 409 (server-detected hash mismatch). If
-     * every attempt fails, throws {@link StateUploadFailedException} with a
-     * user-facing message — the caller is responsible for marking the job as
-     * failed so the operator sees what went wrong.
-     */
-    /**
-     * PUT the payload with an X-Content-Sha256 header so the API can verify
-     * the announced hash against the bytes it received. When {@code readBack}
-     * is true we additionally GET the same URL after a successful PUT and
-     * re-hash the response — this catches the case where the announced hash
-     * and the body agree (the API accepts the upload) but the bytes the
-     * storage backend actually persisted differ from what we intended. Both
-     * failures are retried in the same loop, up to MAX_UPLOAD_ATTEMPTS.
+     * PUT the payload with an X-Content-Sha256 header so the API can verify the
+     * announced hash against the bytes it received before committing. Retries up
+     * to MAX_UPLOAD_ATTEMPTS on transport failures and on HTTP 409 (server-detected
+     * hash mismatch). If every attempt fails, throws {@link StateUploadFailedException}
+     * with a user-facing message — the caller marks the job failed so the operator
+     * sees what went wrong.
+     *
+     * When {@code readBack} is true a successful PUT is followed by an independent
+     * {@link #verifyReadBack} pass. A transient GET hiccup there does NOT re-PUT the
+     * (already committed) body or fail the job — only a confirmed hash mismatch does,
+     * since the announced X-Content-Sha256 already covers transit integrity.
      */
     private void putBytesWithIntegrity(String urlString, byte[] body, String contentType, String label, boolean readBack) {
         String sha = sha256Hex(body);
@@ -363,34 +374,20 @@ public class ApiTerraformStateImpl implements TerraformState {
                 }
                 lastCode = conn.getResponseCode();
                 if (lastCode >= 200 && lastCode < 300) {
-                    if (readBack) {
-                        String observed = fetchAndHash(urlString);
-                        if (observed == null) {
-                            lastDetail = "read-back GET failed";
-                            log.warn("Read-back GET failed for {} on attempt {}/{}", label, attempt, MAX_UPLOAD_ATTEMPTS);
-                        } else if (!observed.equalsIgnoreCase(sha)) {
-                            lastCode = -2;
-                            lastDetail = String.format("read-back hash mismatch (expected=%s, observed=%s)", sha, observed);
-                            log.warn("Read-back integrity check FAILED for {}: {}", label, lastDetail);
-                        } else {
-                            if (attempt > 1) {
-                                log.info("Upload of {} succeeded with read-back verification on retry {}/{}", label, attempt, MAX_UPLOAD_ATTEMPTS);
-                            } else {
-                                log.info("Upload of {} verified end-to-end (sha256={})", label, sha);
-                            }
-                            return;
-                        }
+                    if (attempt > 1) {
+                        log.info("Upload of {} accepted by API on retry {}/{}", label, attempt, MAX_UPLOAD_ATTEMPTS);
                     } else {
-                        if (attempt > 1) {
-                            log.info("Upload of {} succeeded on retry {}/{}", label, attempt, MAX_UPLOAD_ATTEMPTS);
-                        }
-                        return;
+                        log.info("Upload of {} accepted by API (sha256={})", label, sha);
                     }
-                } else {
-                    lastDetail = readErrorBody(conn);
-                    log.warn("Upload of {} attempt {}/{} returned HTTP {} (detail={})",
-                            label, attempt, MAX_UPLOAD_ATTEMPTS, lastCode, lastDetail);
+                    // PUT committed; read-back is a separate concern with its own retry policy.
+                    if (readBack) {
+                        verifyReadBack(urlString, sha, label);
+                    }
+                    return;
                 }
+                lastDetail = readErrorBody(conn);
+                log.warn("Upload of {} attempt {}/{} returned HTTP {} (detail={})",
+                        label, attempt, MAX_UPLOAD_ATTEMPTS, lastCode, lastDetail);
             } catch (IOException e) {
                 lastIo = e;
                 log.warn("Upload of {} attempt {}/{} failed: {}", label, attempt, MAX_UPLOAD_ATTEMPTS, e.getMessage());
@@ -402,8 +399,6 @@ public class ApiTerraformStateImpl implements TerraformState {
         String reason;
         if (lastCode == 409) {
             reason = "API rejected the payload because the sha-256 did not match what was announced (transfer was corrupted in flight)";
-        } else if (lastCode == -2) {
-            reason = "the server accepted the upload but the read-back GET returned different bytes (" + lastDetail + ")";
         } else if (lastCode > 0) {
             reason = "API responded HTTP " + lastCode + (lastDetail != null ? " (" + lastDetail + ")" : "");
         } else {
@@ -416,10 +411,43 @@ public class ApiTerraformStateImpl implements TerraformState {
     }
 
     /**
+     * After a committed PUT, GET the same URL back and compare hashes. The GET is
+     * retried independently of the upload so a transient read hiccup never re-PUTs
+     * the body. The job fails ONLY on a confirmed hash mismatch — the server is
+     * serving different bytes than we sent, which a re-PUT would not fix. If every
+     * read-back attempt fails to complete (transport/non-2xx), we log and accept
+     * the upload: the announced X-Content-Sha256 the API already validated covers
+     * transit integrity.
+     */
+    private void verifyReadBack(String urlString, String expectedSha, String label) {
+        for (int attempt = 1; attempt <= MAX_UPLOAD_ATTEMPTS; attempt++) {
+            String observed = fetchAndHash(urlString);
+            if (observed == null) {
+                log.warn("Read-back GET for {} could not complete on attempt {}/{}", label, attempt, MAX_UPLOAD_ATTEMPTS);
+                if (attempt < MAX_UPLOAD_ATTEMPTS) {
+                    sleepBackoff(attempt);
+                }
+                continue;
+            }
+            if (observed.equalsIgnoreCase(expectedSha)) {
+                log.info("Upload of {} verified end-to-end (sha256={})", label, expectedSha);
+                return;
+            }
+            String message = String.format(
+                    "Read-back verification of %s at %s failed (read-back mismatch: expected=%s, observed=%s): "
+                            + "the server stored different bytes than were sent. Workspace state may be corrupt.",
+                    label, urlString, expectedSha, observed);
+            log.error(message);
+            throw new StateUploadFailedException(message);
+        }
+        log.warn("Could not read {} back after {} attempts to verify; relying on the announced X-Content-Sha256 the API already validated.",
+                label, MAX_UPLOAD_ATTEMPTS);
+    }
+
+    /**
      * GET the given URL and return the hex sha-256 of the body. Returns
      * {@code null} on any transport error or non-2xx response so the caller
-     * can treat it as a verification failure indistinguishable from a hash
-     * mismatch (both retryable).
+     * can retry the read independently of the upload.
      */
     private String fetchAndHash(String urlString) {
         try {
@@ -473,10 +501,5 @@ public class ApiTerraformStateImpl implements TerraformState {
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("SHA-256 not available", e);
         }
-    }
-
-    @SuppressWarnings("unused")
-    private static String basicAuthHeader(String user, String token) {
-        return "Basic " + Base64.getEncoder().encodeToString((user + ":" + token).getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
@@ -10,6 +10,7 @@ import io.terrakube.client.TerrakubeClient;
 import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
 import io.terrakube.executor.plugin.tfstate.TerraformState;
 import io.terrakube.executor.plugin.tfstate.TerraformStatePathService;
+import io.terrakube.executor.plugin.tfstate.api.ApiTerraformStateImpl;
 import io.terrakube.executor.plugin.tfstate.aws.AwsTerraformStateImpl;
 import io.terrakube.executor.plugin.tfstate.aws.AwsTerraformStateProperties;
 import io.terrakube.executor.plugin.tfstate.azure.AzureTerraformStateImpl;
@@ -17,7 +18,9 @@ import io.terrakube.executor.plugin.tfstate.azure.AzureTerraformStateProperties;
 import io.terrakube.executor.plugin.tfstate.gcp.GcpTerraformStateImpl;
 import io.terrakube.executor.plugin.tfstate.gcp.GcpTerraformStateProperties;
 import io.terrakube.executor.plugin.tfstate.local.LocalTerraformStateImpl;
+import io.terrakube.executor.service.workspace.security.WorkspaceSecurity;
 import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -49,7 +52,7 @@ import java.net.URI;
 public class TerraformStateAutoConfiguration {
 
     @Bean
-    public TerraformState terraformState(TerrakubeClient terrakubeClient, TerraformStateProperties terraformStateProperties, AzureTerraformStateProperties azureTerraformStateProperties, AwsTerraformStateProperties awsTerraformStateProperties, GcpTerraformStateProperties gcpTerraformStateProperties, TerraformStatePathService terraformStatePathService, TerraformOutputPathService terraformOutputPathService) {
+    public TerraformState terraformState(TerrakubeClient terrakubeClient, TerraformStateProperties terraformStateProperties, AzureTerraformStateProperties azureTerraformStateProperties, AwsTerraformStateProperties awsTerraformStateProperties, GcpTerraformStateProperties gcpTerraformStateProperties, TerraformStatePathService terraformStatePathService, TerraformOutputPathService terraformOutputPathService, WorkspaceSecurity workspaceSecurity, @Value("${io.terrakube.api.url}") String apiUrl, @Value("${io.terrakube.executor.plugin.tfstate.api.verifyReadBack:true}") boolean apiVerifyReadBack) {
         TerraformState terraformState = null;
 
         if (terraformStateProperties != null)
@@ -142,6 +145,17 @@ public class TerraformStateAutoConfiguration {
                     } catch (IOException e) {
                         log.error(e.getMessage());
                     }
+                    break;
+                case ApiTerraformStateImpl:
+                    log.info("Configuring TerraformState to route storage through the Terrakube API ({}, verifyReadBack={})", apiUrl, apiVerifyReadBack);
+                    terraformState = ApiTerraformStateImpl.builder()
+                            .terrakubeClient(terrakubeClient)
+                            .terraformStatePathService(terraformStatePathService)
+                            .terraformOutputPathService(terraformOutputPathService)
+                            .workspaceSecurity(workspaceSecurity)
+                            .apiUrl(apiUrl)
+                            .verifyReadBack(apiVerifyReadBack)
+                            .build();
                     break;
                 default:
                     terraformState = LocalTerraformStateImpl.builder()

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
@@ -52,7 +52,7 @@ import java.net.URI;
 public class TerraformStateAutoConfiguration {
 
     @Bean
-    public TerraformState terraformState(TerrakubeClient terrakubeClient, TerraformStateProperties terraformStateProperties, AzureTerraformStateProperties azureTerraformStateProperties, AwsTerraformStateProperties awsTerraformStateProperties, GcpTerraformStateProperties gcpTerraformStateProperties, TerraformStatePathService terraformStatePathService, TerraformOutputPathService terraformOutputPathService, WorkspaceSecurity workspaceSecurity, @Value("${io.terrakube.api.url}") String apiUrl, @Value("${io.terrakube.executor.plugin.tfstate.api.verifyReadBack:true}") boolean apiVerifyReadBack) {
+    public TerraformState terraformState(TerrakubeClient terrakubeClient, TerraformStateProperties terraformStateProperties, AzureTerraformStateProperties azureTerraformStateProperties, AwsTerraformStateProperties awsTerraformStateProperties, GcpTerraformStateProperties gcpTerraformStateProperties, TerraformStatePathService terraformStatePathService, TerraformOutputPathService terraformOutputPathService, WorkspaceSecurity workspaceSecurity, @Value("${io.terrakube.api.url}") String apiUrl, @Value("${io.terrakube.executor.plugin.tfstate.api.verifyReadBack:true}") boolean apiVerifyReadBack, @Value("${io.terrakube.executor.plugin.tfstate.api.heartbeatIntervalSeconds:60}") long heartbeatIntervalSeconds, @Value("${io.terrakube.executor.plugin.tfstate.api.heartbeatAbortAfterSeconds:180}") long heartbeatAbortAfterSeconds) {
         TerraformState terraformState = null;
 
         if (terraformStateProperties != null)
@@ -147,7 +147,8 @@ public class TerraformStateAutoConfiguration {
                     }
                     break;
                 case ApiTerraformStateImpl:
-                    log.info("Configuring TerraformState to route storage through the Terrakube API ({}, verifyReadBack={})", apiUrl, apiVerifyReadBack);
+                    log.info("Configuring TerraformState to route storage through the Terrakube API ({}, verifyReadBack={}, heartbeat={}s/abortAfter={}s)",
+                            apiUrl, apiVerifyReadBack, heartbeatIntervalSeconds, heartbeatAbortAfterSeconds);
                     terraformState = ApiTerraformStateImpl.builder()
                             .terrakubeClient(terrakubeClient)
                             .terraformStatePathService(terraformStatePathService)
@@ -155,6 +156,8 @@ public class TerraformStateAutoConfiguration {
                             .workspaceSecurity(workspaceSecurity)
                             .apiUrl(apiUrl)
                             .verifyReadBack(apiVerifyReadBack)
+                            .heartbeatIntervalSeconds(heartbeatIntervalSeconds)
+                            .heartbeatAbortAfterSeconds(heartbeatAbortAfterSeconds)
                             .build();
                     break;
                 default:

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
@@ -52,7 +52,7 @@ import java.net.URI;
 public class TerraformStateAutoConfiguration {
 
     @Bean
-    public TerraformState terraformState(TerrakubeClient terrakubeClient, TerraformStateProperties terraformStateProperties, AzureTerraformStateProperties azureTerraformStateProperties, AwsTerraformStateProperties awsTerraformStateProperties, GcpTerraformStateProperties gcpTerraformStateProperties, TerraformStatePathService terraformStatePathService, TerraformOutputPathService terraformOutputPathService, WorkspaceSecurity workspaceSecurity, @Value("${io.terrakube.api.url}") String apiUrl, @Value("${io.terrakube.executor.plugin.tfstate.api.verifyReadBack:true}") boolean apiVerifyReadBack, @Value("${io.terrakube.executor.plugin.tfstate.api.heartbeatIntervalSeconds:60}") long heartbeatIntervalSeconds, @Value("${io.terrakube.executor.plugin.tfstate.api.heartbeatAbortAfterSeconds:180}") long heartbeatAbortAfterSeconds) {
+    public TerraformState terraformState(TerrakubeClient terrakubeClient, TerraformStateProperties terraformStateProperties, AzureTerraformStateProperties azureTerraformStateProperties, AwsTerraformStateProperties awsTerraformStateProperties, GcpTerraformStateProperties gcpTerraformStateProperties, TerraformStatePathService terraformStatePathService, TerraformOutputPathService terraformOutputPathService, WorkspaceSecurity workspaceSecurity, @Value("${io.terrakube.api.url}") String apiUrl, @Value("${io.terrakube.executor.plugin.tfstate.api.verifyReadBack:true}") boolean apiVerifyReadBack, @Value("${io.terrakube.executor.plugin.tfstate.api.heartbeatIntervalSeconds:60}") long heartbeatIntervalSeconds, @Value("${io.terrakube.executor.plugin.tfstate.api.heartbeatAbortAfterSeconds:180}") long heartbeatAbortAfterSeconds, @Value("${io.terrakube.executor.plugin.tfstate.api.backendTokenLifetimeMinutes:60}") int apiBackendTokenLifetimeMinutes, @Value("${io.terrakube.executor.plugin.tfstate.api.allowInsecureApiUrl:false}") boolean apiAllowInsecureApiUrl) {
         TerraformState terraformState = null;
 
         if (terraformStateProperties != null)
@@ -147,8 +147,12 @@ public class TerraformStateAutoConfiguration {
                     }
                     break;
                 case ApiTerraformStateImpl:
-                    log.info("Configuring TerraformState to route storage through the Terrakube API ({}, verifyReadBack={}, heartbeat={}s/abortAfter={}s)",
-                            apiUrl, apiVerifyReadBack, heartbeatIntervalSeconds, heartbeatAbortAfterSeconds);
+                    // Air-gapped routing sends the workspace JWT and full state through this URL.
+                    // Refuse to start on a non-https endpoint (which would put both on the wire in
+                    // cleartext) unless the operator explicitly opts into insecure transport for dev.
+                    requireSecureApiUrl(apiUrl, apiAllowInsecureApiUrl);
+                    log.info("Configuring TerraformState to route storage through the Terrakube API ({}, verifyReadBack={}, heartbeat={}s/abortAfter={}s, backendTokenLifetime={}m)",
+                            apiUrl, apiVerifyReadBack, heartbeatIntervalSeconds, heartbeatAbortAfterSeconds, apiBackendTokenLifetimeMinutes);
                     terraformState = ApiTerraformStateImpl.builder()
                             .terrakubeClient(terrakubeClient)
                             .terraformStatePathService(terraformStatePathService)
@@ -158,6 +162,7 @@ public class TerraformStateAutoConfiguration {
                             .verifyReadBack(apiVerifyReadBack)
                             .heartbeatIntervalSeconds(heartbeatIntervalSeconds)
                             .heartbeatAbortAfterSeconds(heartbeatAbortAfterSeconds)
+                            .backendTokenLifetimeMinutes(apiBackendTokenLifetimeMinutes)
                             .build();
                     break;
                 default:
@@ -177,5 +182,22 @@ public class TerraformStateAutoConfiguration {
 
     private AwsBasicCredentials getAwsBasicCredentials(AwsTerraformStateProperties awsTerraformStateProperties) {
         return AwsBasicCredentials.create(awsTerraformStateProperties.getAccessKey(), awsTerraformStateProperties.getSecretKey());
+    }
+
+    private void requireSecureApiUrl(String apiUrl, boolean allowInsecure) {
+        boolean https = apiUrl != null && apiUrl.toLowerCase().startsWith("https://");
+        if (https) {
+            return;
+        }
+        if (allowInsecure) {
+            log.warn("API state routing is using a non-https URL ({}); the workspace JWT and terraform state travel in CLEARTEXT. "
+                    + "io.terrakube.executor.plugin.tfstate.api.allowInsecureApiUrl=true — do not use this outside local development.", apiUrl);
+            return;
+        }
+        throw new IllegalStateException(String.format(
+                "API state routing requires an https:// URL but io.terrakube.api.url is '%s'. "
+                        + "Refusing to send the workspace token and terraform state over cleartext. "
+                        + "Set io.terrakube.executor.plugin.tfstate.api.allowInsecureApiUrl=true only for local development.",
+                apiUrl));
     }
 }

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateType.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateType.java
@@ -5,5 +5,6 @@ public enum TerraformStateType {
     AwsTerraformStateImpl,
 
     GcpTerraformStateImpl,
-    LocalTerraformStateImpl
+    LocalTerraformStateImpl,
+    ApiTerraformStateImpl
 }

--- a/executor/src/main/java/io/terrakube/executor/service/status/UpdateJobStatusImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/status/UpdateJobStatusImpl.java
@@ -10,6 +10,7 @@ import io.terrakube.client.model.organization.job.step.Step;
 import io.terrakube.client.model.organization.job.step.StepAttributes;
 import io.terrakube.client.model.organization.job.step.StepRequest;
 import io.terrakube.executor.configuration.ExecutorFlagsProperties;
+import io.terrakube.executor.plugin.tfstate.StateUploadFailedException;
 import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
 import io.terrakube.executor.plugin.tfstate.TerraformState;
 import io.terrakube.executor.service.mode.TerraformJob;
@@ -122,7 +123,18 @@ public class UpdateJobStatusImpl implements UpdateJobStatus {
 
     private void updateStepStatus(boolean status, String organizationId, String jobId, String stepId, String jobOutput, String jobErrorOutput) {
         StepAttributes stepAttributes = new StepAttributes();
-        stepAttributes.setOutput(this.terraformOutput.saveOutput(organizationId, jobId, stepId, jobOutput, jobErrorOutput));
+        String outputUrl;
+        try {
+            outputUrl = this.terraformOutput.saveOutput(organizationId, jobId, stepId, jobOutput, jobErrorOutput);
+        } catch (StateUploadFailedException uploadFailure) {
+            // Step output is diagnostic — losing it doesn't change infrastructure state.
+            // Log loudly but don't crash the step update so the job's overall status still
+            // reports correctly. The state/plan upload paths *do* fail the job on this.
+            log.error("Step output upload failed for job {} step {}: {}", jobId, stepId, uploadFailure.getMessage());
+            outputUrl = "";
+            status = false;
+        }
+        stepAttributes.setOutput(outputUrl);
         stepAttributes.setStatus(status ? "completed": "failed");
 
         Step step = new Step();

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -1,6 +1,7 @@
 package io.terrakube.executor.service.terraform;
 
 import com.diogonunes.jcolor.AnsiFormat;
+import io.terrakube.executor.plugin.tfstate.StateUploadFailedException;
 import io.terrakube.executor.plugin.tfstate.TerraformState;
 import io.terrakube.executor.service.executor.ExecutorJobResult;
 import io.terrakube.executor.service.logs.LogsConsumer;
@@ -180,9 +181,15 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             waitForStreamCompletion(terraformJob.getJobId(), 300);
 
             result = generateJobResult(scriptAfterSuccessPlan, jobOutput.toString(), jobErrorOutput.toString());
-            result.setPlanFile(executionPlan ? terraformState.saveTerraformPlan(terraformJob.getOrganizationId(),
-                    terraformJob.getWorkspaceId(), terraformJob.getJobId(), terraformJob.getStepId(), terraformWorkingDir)
-                    : "");
+            try {
+                result.setPlanFile(executionPlan ? terraformState.saveTerraformPlan(terraformJob.getOrganizationId(),
+                        terraformJob.getWorkspaceId(), terraformJob.getJobId(), terraformJob.getStepId(), terraformWorkingDir)
+                        : "");
+            } catch (StateUploadFailedException uploadFailure) {
+                surfaceUploadFailure(uploadFailure, planOutput, jobErrorOutput, result);
+                result.setExitCode(1);
+                return result;
+            }
             if (executionPlan) {
                 planStructuredOutputService.publishPlanSummary(terraformJob, terraformWorkingDir);
             }
@@ -233,7 +240,13 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                             applyOutput,
                             null).get();
 
-                    handleTerraformStateChange(terraformJob, terraformWorkingDir, executorTempDirectory);
+                    try {
+                        handleTerraformStateChange(terraformJob, terraformWorkingDir, executorTempDirectory);
+                    } catch (StateUploadFailedException uploadFailure) {
+                        result = generateJobResult(false, terraformOutput.toString(), terraformErrorOutput.toString());
+                        surfaceUploadFailure(uploadFailure, applyOutput, terraformErrorOutput, result);
+                        return result;
+                    }
                 }
             }
 
@@ -284,7 +297,13 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                             outputDestroy,
                             null).get();
 
-                    handleTerraformStateChange(terraformJob, terraformWorkingDir, executorTempDirectory);
+                    try {
+                        handleTerraformStateChange(terraformJob, terraformWorkingDir, executorTempDirectory);
+                    } catch (StateUploadFailedException uploadFailure) {
+                        result = generateJobResult(false, jobOutput.toString(), jobErrorOutput.toString());
+                        surfaceUploadFailure(uploadFailure, outputDestroy, jobErrorOutput, result);
+                        return result;
+                    }
                 }
             }
 
@@ -450,6 +469,32 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             Thread.currentThread().interrupt();
         }
         return error;
+    }
+
+    /**
+     * Surface a state/plan/output upload failure to the user. The exception
+     * already carries a user-facing message; we echo it to the step output
+     * stream (so it shows up in the live UI logs), append it to the job error
+     * log, and mark the result as failed.
+     */
+    private void surfaceUploadFailure(StateUploadFailedException uploadFailure,
+                                      Consumer<String> output,
+                                      TextStringBuilder errorBuffer,
+                                      ExecutorJobResult result) {
+        log.error("State upload failed: {}", uploadFailure.getMessage(), uploadFailure);
+        AnsiFormat color = enableColorOutput
+                ? new AnsiFormat(RED_TEXT(), BLACK_BACK(), BOLD())
+                : new AnsiFormat(WHITE_TEXT(), BLACK_BACK(), BOLD());
+        String banner = colorize(STEP_SEPARATOR, color);
+        output.accept("");
+        output.accept(banner);
+        output.accept(colorize("ERROR: " + uploadFailure.getMessage(), color));
+        output.accept(banner);
+        errorBuffer.appendln("");
+        errorBuffer.appendln(uploadFailure.getMessage());
+        result.setSuccessfulExecution(false);
+        result.setOutputErrorLog(errorBuffer.toString());
+        result.setExitCode(1);
     }
 
     private boolean prepareTerraformOperation(TerraformJob terraformJob, File executorTempDirectory, File terraformWorkingDirectory, Consumer<String> output)

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -26,7 +26,11 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -123,20 +127,20 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
         TextStringBuilder jobOutput = new TextStringBuilder();
         TextStringBuilder jobErrorOutput = new TextStringBuilder();
+        Consumer<String> planOutput = LogsConsumer.builder()
+                .jobId(Integer.valueOf(terraformJob.getJobId()))
+                .terraformOutput(jobOutput)
+                .stepId(terraformJob.getStepId())
+                .processLogs(logsService)
+                .lineNumber(new AtomicInteger(0))
+                .build();
+        terraformState.startHeartbeat(terraformJob.getOrganizationId(), terraformJob.getWorkspaceId());
         try {
             File terraformWorkingDir = getTerraformWorkingDir(terraformJob, executorTempDirectory);
             boolean executionPlan = false;
             boolean planCommandExecuted = false;
             int exitCode = 0;
             boolean scriptAfterSuccessPlan;
-
-            Consumer<String> planOutput = LogsConsumer.builder()
-                    .jobId(Integer.valueOf(terraformJob.getJobId()))
-                    .terraformOutput(jobOutput)
-                    .stepId(terraformJob.getStepId())
-                    .processLogs(logsService)
-                    .lineNumber(new AtomicInteger(0))
-                    .build();
 
             boolean initSuccessful = prepareTerraformOperation(terraformJob, executorTempDirectory, terraformWorkingDir, planOutput);
 
@@ -149,15 +153,15 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     planCommandExecuted = true;
                     if (isDestroy) {
                         log.warn("Executor running a plan to destroy resources...");
-                        exitCode = terraformClient.planDestroyDetailExitCode(
+                        exitCode = awaitWithHeartbeat(terraformClient.planDestroyDetailExitCode(
                                 getTerraformProcessData(terraformJob, terraformWorkingDir, executorTempDirectory),
                                 planOutput,
-                                null).get();
+                                null));
                     } else {
-                        exitCode = terraformClient.planDetailExitCode(
+                        exitCode = awaitWithHeartbeat(terraformClient.planDetailExitCode(
                                 getTerraformProcessData(terraformJob, terraformWorkingDir, executorTempDirectory),
                                 planOutput,
-                                null).get();
+                                null));
                     }
                 } else {
                     exitCode = 1;
@@ -195,9 +199,15 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             }
             result.setPlan(true);
             result.setExitCode(exitCode);
+        } catch (StateUploadFailedException heartbeatFailure) {
+            result = generateJobResult(false, jobOutput.toString(), jobErrorOutput.toString());
+            surfaceUploadFailure(heartbeatFailure, planOutput, jobErrorOutput, result);
+            result.setExitCode(1);
         } catch (IOException | ExecutionException | InterruptedException exception) {
             result = setError(exception);
             result.setExitCode(1);
+        } finally {
+            terraformState.stopHeartbeat();
         }
         return result;
     }
@@ -209,15 +219,16 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
         TextStringBuilder terraformOutput = new TextStringBuilder();
         TextStringBuilder terraformErrorOutput = new TextStringBuilder();
+        Consumer<String> applyOutput = LogsConsumer.builder()
+                .jobId(Integer.valueOf(terraformJob.getJobId()))
+                .lineNumber(new AtomicInteger(0))
+                .terraformOutput(terraformOutput)
+                .stepId(terraformJob.getStepId())
+                .processLogs(logsService)
+                .build();
+        terraformState.startHeartbeat(terraformJob.getOrganizationId(), terraformJob.getWorkspaceId());
         try {
             File terraformWorkingDir = getTerraformWorkingDir(terraformJob, executorTempDirectory);
-            Consumer<String> applyOutput = LogsConsumer.builder()
-                    .jobId(Integer.valueOf(terraformJob.getJobId()))
-                    .lineNumber(new AtomicInteger(0))
-                    .terraformOutput(terraformOutput)
-                    .stepId(terraformJob.getStepId())
-                    .processLogs(logsService)
-                    .build();
 
             HashMap<String, String> terraformParameters = getWorkspaceParameters(terraformJob.getVariables());
 
@@ -235,10 +246,10 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     terraformProcessData.setTerraformVariables((terraformState.downloadTerraformPlan(terraformJob.getOrganizationId(),
                             terraformJob.getWorkspaceId(), terraformJob.getJobId(), terraformJob.getStepId(),
                             terraformWorkingDir) ? new HashMap<>() : terraformParameters));
-                    execution = terraformClient.apply(
+                    execution = awaitWithHeartbeat(terraformClient.apply(
                             terraformProcessData,
                             applyOutput,
-                            null).get();
+                            null));
 
                     try {
                         handleTerraformStateChange(terraformJob, terraformWorkingDir, executorTempDirectory);
@@ -259,8 +270,13 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
             waitForStreamCompletion(terraformJob.getJobId(), 300);
             result = generateJobResult(scriptAfterSuccess, terraformOutput.toString(), terraformErrorOutput.toString());
+        } catch (StateUploadFailedException heartbeatFailure) {
+            result = generateJobResult(false, terraformOutput.toString(), terraformErrorOutput.toString());
+            surfaceUploadFailure(heartbeatFailure, applyOutput, terraformErrorOutput, result);
         } catch (IOException | ExecutionException | InterruptedException exception) {
             result = setError(exception);
+        } finally {
+            terraformState.stopHeartbeat();
         }
         return result;
     }
@@ -272,15 +288,16 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
         TextStringBuilder jobOutput = new TextStringBuilder();
         TextStringBuilder jobErrorOutput = new TextStringBuilder();
+        Consumer<String> outputDestroy = LogsConsumer.builder()
+                .jobId(Integer.valueOf(terraformJob.getJobId()))
+                .terraformOutput(jobOutput)
+                .stepId(terraformJob.getStepId())
+                .processLogs(logsService)
+                .lineNumber(new AtomicInteger(0))
+                .build();
+        terraformState.startHeartbeat(terraformJob.getOrganizationId(), terraformJob.getWorkspaceId());
         try {
             File terraformWorkingDir = getTerraformWorkingDir(terraformJob, executorTempDirectory);
-            Consumer<String> outputDestroy = LogsConsumer.builder()
-                    .jobId(Integer.valueOf(terraformJob.getJobId()))
-                    .terraformOutput(jobOutput)
-                    .stepId(terraformJob.getStepId())
-                    .processLogs(logsService)
-                    .lineNumber(new AtomicInteger(0))
-                    .build();
 
             boolean execution = false;
             boolean scriptAfterSuccess;
@@ -292,10 +309,10 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                 showTerraformMessage(terraformJob, "DESTROY", outputDestroy);
 
                 if (scriptBeforeSuccess) {
-                    execution = terraformClient.destroy(
+                    execution = awaitWithHeartbeat(terraformClient.destroy(
                             getTerraformProcessData(terraformJob, terraformWorkingDir, executorTempDirectory),
                             outputDestroy,
-                            null).get();
+                            null));
 
                     try {
                         handleTerraformStateChange(terraformJob, terraformWorkingDir, executorTempDirectory);
@@ -316,8 +333,13 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
             waitForStreamCompletion(terraformJob.getJobId(), 300);
             result = generateJobResult(scriptAfterSuccess, jobOutput.toString(), jobErrorOutput.toString());
+        } catch (StateUploadFailedException heartbeatFailure) {
+            result = generateJobResult(false, jobOutput.toString(), jobErrorOutput.toString());
+            surfaceUploadFailure(heartbeatFailure, outputDestroy, jobErrorOutput, result);
         } catch (IOException | ExecutionException | InterruptedException exception) {
             result = setError(exception);
+        } finally {
+            terraformState.stopHeartbeat();
         }
         return result;
     }
@@ -495,6 +517,33 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         result.setSuccessfulExecution(false);
         result.setOutputErrorLog(errorBuffer.toString());
         result.setExitCode(1);
+    }
+
+    /**
+     * Block on a long-running terraform future while polling the configured
+     * {@link TerraformState#checkHeartbeatHealth()} every two seconds. If the
+     * heartbeat has been failing for longer than the abort threshold, the
+     * future is cancelled and {@link StateUploadFailedException} is thrown so
+     * the run terminates with a user-facing message instead of writing state
+     * the API will reject. For state backends that don't lock at the API
+     * layer the health check is a no-op, so this behaves like a plain
+     * {@code future.get()}.
+     */
+    private <T> T awaitWithHeartbeat(CompletableFuture<T> future) throws ExecutionException, InterruptedException {
+        while (true) {
+            try {
+                return future.get(2, TimeUnit.SECONDS);
+            } catch (TimeoutException keepWaiting) {
+                try {
+                    terraformState.checkHeartbeatHealth();
+                } catch (StateUploadFailedException heartbeatDead) {
+                    future.cancel(true);
+                    throw heartbeatDead;
+                }
+            } catch (CancellationException cancelled) {
+                throw new InterruptedException("terraform operation cancelled: " + cancelled.getMessage());
+            }
+        }
     }
 
     private boolean prepareTerraformOperation(TerraformJob terraformJob, File executorTempDirectory, File terraformWorkingDirectory, Consumer<String> output)

--- a/executor/src/main/java/io/terrakube/executor/service/workspace/security/WorkspaceSecurity.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/security/WorkspaceSecurity.java
@@ -6,4 +6,6 @@ public interface WorkspaceSecurity {
     String generateAccessToken(String workspaceId);
 
     String generateAccessToken(int minutes);
+
+    String generateAccessToken(String workspaceId, int minutes);
 }

--- a/executor/src/main/java/io/terrakube/executor/service/workspace/security/WorkspaceSecurityImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/security/WorkspaceSecurityImpl.java
@@ -72,9 +72,14 @@ public class WorkspaceSecurityImpl implements WorkspaceSecurity {
 
     @Override
     public String generateAccessToken(int minutes) {
+        return generateAccessToken(null, minutes);
+    }
+
+    @Override
+    public String generateAccessToken(String workspaceId, int minutes) {
         SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(this.internalSecret));
 
-        return Jwts.builder()
+        var builder = Jwts.builder()
                 .setHeaderParam("typ", "JWT")
                 .setIssuer(WorkspaceSecurityImpl.ISSUER)
                 .setSubject(WorkspaceSecurityImpl.SUBJECT)
@@ -83,9 +88,13 @@ public class WorkspaceSecurityImpl implements WorkspaceSecurity {
                 .claim("email_verified", true)
                 .claim("name", WorkspaceSecurityImpl.NAME)
                 .setIssuedAt(Date.from(Instant.now()))
-                .setExpiration(Date.from(Instant.now().plus(minutes, ChronoUnit.MINUTES)))
-                .signWith(key, SignatureAlgorithm.HS256)
-                .compact();
+                .setExpiration(Date.from(Instant.now().plus(minutes, ChronoUnit.MINUTES)));
+        // Scope the token to a single workspace so a leaked backend password
+        // cannot be replayed against other workspaces' http-backend endpoints.
+        if (workspaceId != null) {
+            builder.claim("workspaceId", workspaceId);
+        }
+        return builder.signWith(key, SignatureAlgorithm.HS256).compact();
     }
 
     @Override

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -48,6 +48,15 @@ io.terrakube.executor.plugin.tfstate.gcp.credentials=${GcpTerraformStateCredenti
 io.terrakube.executor.plugin.tfstate.gcp.bucketName=${GcpTerraformStateBucketName}
 io.terrakube.executor.plugin.tfstate.gcp.projectId=${GcpTerraformStateProjectId}
 
+###################
+#API-Routed State #
+###################
+# Used only when TerraformStateType=ApiTerraformStateImpl.
+# When true (default) the executor reads each just-uploaded object back from
+# the API and re-hashes it locally to confirm what the storage backend stored
+# matches what was sent. Disable only if the extra GET traffic is a concern.
+io.terrakube.executor.plugin.tfstate.api.verifyReadBack=${TerraformStateApiVerifyReadBack:true}
+
 ##########
 #Security#
 ##########

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -56,6 +56,15 @@ io.terrakube.executor.plugin.tfstate.gcp.projectId=${GcpTerraformStateProjectId}
 # the API and re-hashes it locally to confirm what the storage backend stored
 # matches what was sent. Disable only if the extra GET traffic is a concern.
 io.terrakube.executor.plugin.tfstate.api.verifyReadBack=${TerraformStateApiVerifyReadBack:true}
+# How often the executor pings POST .../lock/heartbeat to keep the API-side
+# workspace lock alive. Should be well under the API lock TTL (default 300s
+# on the API side); with the defaults a healthy run pings 5x per TTL window.
+io.terrakube.executor.plugin.tfstate.api.heartbeatIntervalSeconds=${TerraformStateApiHeartbeatIntervalSeconds:60}
+# How long the executor tolerates a missing heartbeat before aborting the
+# in-flight terraform op. Must be smaller than the API lock TTL so we cancel
+# before the lock is reassigned to another caller. Default 180s = 3 missed
+# heartbeats; with TTL=300s on the API, leaves a 120s margin.
+io.terrakube.executor.plugin.tfstate.api.heartbeatAbortAfterSeconds=${TerraformStateApiHeartbeatAbortAfterSeconds:180}
 
 ##########
 #Security#

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -65,6 +65,15 @@ io.terrakube.executor.plugin.tfstate.api.heartbeatIntervalSeconds=${TerraformSta
 # before the lock is reassigned to another caller. Default 180s = 3 missed
 # heartbeats; with TTL=300s on the API, leaves a 120s margin.
 io.terrakube.executor.plugin.tfstate.api.heartbeatAbortAfterSeconds=${TerraformStateApiHeartbeatAbortAfterSeconds:180}
+# Lifetime (minutes) of the workspace-scoped JWT written as the terraform
+# http-backend password. Terraform holds it for the whole run, so it must
+# outlast the longest apply; it is scoped to a single workspace, so a leak
+# only exposes that workspace and only until it expires. Default 60m.
+io.terrakube.executor.plugin.tfstate.api.backendTokenLifetimeMinutes=${TerraformStateApiBackendTokenLifetimeMinutes:60}
+# Safety gate: API state routing refuses to start on a non-https URL, since the
+# workspace JWT and full state would travel in cleartext. Set true ONLY for
+# local development against an http endpoint.
+io.terrakube.executor.plugin.tfstate.api.allowInsecureApiUrl=${TerraformStateApiAllowInsecureApiUrl:false}
 
 ##########
 #Security#

--- a/executor/src/test/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImplTest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -63,6 +62,7 @@ class ApiTerraformStateImplTest {
         terraformOutputPathService = mock(TerraformOutputPathService.class);
         workspaceSecurity = mock(WorkspaceSecurity.class);
         when(workspaceSecurity.generateAccessToken(anyInt())).thenReturn("test-token");
+        when(workspaceSecurity.generateAccessToken(anyString(), anyInt())).thenReturn("ws-scoped-token");
 
         server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         server.start();
@@ -130,7 +130,8 @@ class ApiTerraformStateImplTest {
 
     @Test
     void getBackendStateFileWritesHttpBackendOverride(@TempDir Path tempDir) throws IOException {
-        when(workspaceSecurity.generateAccessToken(anyInt())).thenReturn("jwt-token");
+        // The backend password must come from the workspace-scoped overload, not the org-wide one.
+        when(workspaceSecurity.generateAccessToken(eq("ws-1"), anyInt())).thenReturn("jwt-token");
         ApiTerraformStateImpl subject = newSubject(true);
 
         String filename = subject.getBackendStateFile("org-1", "ws-1", tempDir.toFile(), "1.5.0");
@@ -138,7 +139,7 @@ class ApiTerraformStateImplTest {
         assertEquals("api_backend_override.tf", filename);
         File backendFile = new File(tempDir.toFile(), filename);
         assertTrue(backendFile.exists());
-        String hcl = FileUtils.readFileToString(backendFile, Charset.defaultCharset());
+        String hcl = FileUtils.readFileToString(backendFile, StandardCharsets.UTF_8);
         assertTrue(hcl.contains("backend \"http\""));
         assertTrue(hcl.contains("address        = \"" + apiUrl + "/tfstate/v1/http-backend/organization/org-1/workspace/ws-1/state\""));
         assertTrue(hcl.contains("lock_address   = \"" + apiUrl + "/tfstate/v1/http-backend/organization/org-1/workspace/ws-1/lock\""));
@@ -146,6 +147,9 @@ class ApiTerraformStateImplTest {
         assertTrue(hcl.contains("lock_method    = \"POST\""));
         assertTrue(hcl.contains("unlock_method  = \"DELETE\""));
         assertTrue(hcl.contains("password       = \"jwt-token\""));
+        // Scoped, not the org-wide minutes-only overload.
+        verify(workspaceSecurity).generateAccessToken(eq("ws-1"), anyInt());
+        verify(workspaceSecurity, org.mockito.Mockito.never()).generateAccessToken(anyInt());
     }
 
     @Test
@@ -240,6 +244,33 @@ class ApiTerraformStateImplTest {
     }
 
     @Test
+    void saveTerraformPlanSucceedsWhenReadBackGetIsTransientlyUnavailable(@TempDir Path tempDir) throws IOException {
+        byte[] plan = new byte[]{7, 7, 7};
+        FileUtils.writeByteArrayToFile(new File(tempDir.toFile(), "terraformLibrary.tfPlan"), plan);
+
+        // PUT is accepted (201) but the read-back GET keeps failing transiently (500).
+        // A flaky read must NOT re-PUT the body or fail the job — the announced hash
+        // already covered transit integrity, so the upload should still succeed.
+        AtomicInteger puts = new AtomicInteger();
+        server.createContext("/tfstate/v1/organization/org-1/workspace/ws-1/jobId/job-1/step/step-1/terraform.tfstate",
+                exchange -> {
+                    if ("PUT".equalsIgnoreCase(exchange.getRequestMethod())) {
+                        puts.incrementAndGet();
+                        exchange.getRequestBody().readAllBytes();
+                        respond(exchange, 201, "");
+                    } else {
+                        respond(exchange, 500, "read unavailable");
+                    }
+                });
+
+        ApiTerraformStateImpl subject = newSubject(true);
+        String url = subject.saveTerraformPlan("org-1", "ws-1", "job-1", "step-1", tempDir.toFile());
+
+        assertNotNull(url);
+        assertEquals(1, puts.get(), "a transient read-back failure must not trigger a re-PUT");
+    }
+
+    @Test
     void saveOutputReturnsPathServiceUrlAndUploads() {
         server.createContext("/tfoutput/v1/organization/org-1/job/job-1/step/step-1", echoingStorage());
         when(terraformOutputPathService.getOutputPath("org-1", "job-1", "step-1"))
@@ -301,6 +332,26 @@ class ApiTerraformStateImplTest {
         assertEquals(2, uploadedPaths.size(), "expected one raw + one json upload");
         assertTrue(uploadedPaths.stream().anyMatch(p -> p.endsWith("/terraform.tfstate")));
         assertTrue(uploadedPaths.stream().anyMatch(p -> p.endsWith("/terraform.json.tfstate")));
+    }
+
+    @Test
+    void saveStateJsonDoesNotCreateHistoryRowWhenUploadFails() {
+        // The history PUT always fails — the row must never be created, or it would
+        // dangle pointing at an object that was never stored.
+        server.createContext("/tfstate/v1/organization/org-1/workspace/ws-1/history/",
+                exchange -> respond(exchange, 500, "boom"));
+        when(terraformStatePathService.getStateJsonPath(anyString(), anyString(), anyString()))
+                .thenReturn("https://example/state.json");
+
+        ApiTerraformStateImpl subject = newSubject(false);
+        TerraformJob job = new TerraformJob();
+        job.setOrganizationId("org-1");
+        job.setWorkspaceId("ws-1");
+        job.setJobId("job-1");
+
+        assertThrows(StateUploadFailedException.class,
+                () -> subject.saveStateJson(job, "{\"apply\":1}", "{\"raw\":1}"));
+        verify(terrakubeClient, org.mockito.Mockito.never()).createHistory(any(HistoryRequest.class), any(), any());
     }
 
     @Test

--- a/executor/src/test/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImplTest.java
@@ -442,6 +442,9 @@ class ApiTerraformStateImplTest {
             assertTrue(pings.get() >= 1);
             // Healthy heartbeat → health check should not throw.
             subject.checkHeartbeatHealth();
+            // The heartbeat must use the workspace-scoped token overload so the API can
+            // bind it to ws-1; the unscoped generateAccessToken(int) would be rejected.
+            verify(workspaceSecurity, org.mockito.Mockito.atLeastOnce()).generateAccessToken(eq("ws-1"), anyInt());
         } finally {
             subject.stopHeartbeat();
         }

--- a/executor/src/test/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImplTest.java
@@ -352,6 +352,129 @@ class ApiTerraformStateImplTest {
         assertEquals(sha256Hex(plan), sha256Hex(FileUtils.readFileToByteArray(destination)));
     }
 
+    @Test
+    void checkHeartbeatHealthIsNoOpBeforeStart() {
+        ApiTerraformStateImpl subject = newSubject(true);
+        // No heartbeat started — should not throw even if hours have "passed".
+        subject.checkHeartbeatHealth();
+    }
+
+    @Test
+    void heartbeatPingsConfiguredEndpointAndUpdatesLastSuccess() throws InterruptedException {
+        java.util.concurrent.atomic.AtomicInteger pings = new java.util.concurrent.atomic.AtomicInteger();
+        java.util.concurrent.CountDownLatch firstPing = new java.util.concurrent.CountDownLatch(1);
+        server.createContext("/tfstate/v1/http-backend/organization/org-1/workspace/ws-1/lock/heartbeat",
+                exchange -> {
+                    if ("POST".equalsIgnoreCase(exchange.getRequestMethod())) {
+                        pings.incrementAndGet();
+                        firstPing.countDown();
+                        respond(exchange, 200, "");
+                    } else {
+                        respond(exchange, 405, "");
+                    }
+                });
+
+        ApiTerraformStateImpl subject = ApiTerraformStateImpl.builder()
+                .terrakubeClient(terrakubeClient)
+                .terraformStatePathService(terraformStatePathService)
+                .terraformOutputPathService(terraformOutputPathService)
+                .workspaceSecurity(workspaceSecurity)
+                .apiUrl(apiUrl)
+                .verifyReadBack(false)
+                .heartbeatIntervalSeconds(1L)
+                .heartbeatAbortAfterSeconds(60L)
+                .build();
+
+        subject.startHeartbeat("org-1", "ws-1");
+        try {
+            assertTrue(firstPing.await(5, java.util.concurrent.TimeUnit.SECONDS), "expected first heartbeat within 5s");
+            assertTrue(pings.get() >= 1);
+            // Healthy heartbeat → health check should not throw.
+            subject.checkHeartbeatHealth();
+        } finally {
+            subject.stopHeartbeat();
+        }
+    }
+
+    @Test
+    void checkHeartbeatHealthThrowsWhenAbortThresholdExceeded() {
+        // We don't actually start the scheduler — we just flip the running flag
+        // and assert the elapsed-time check fires. Simulated by setting a tiny
+        // abort threshold and starting the heartbeat against an unreachable URL.
+        ApiTerraformStateImpl subject = ApiTerraformStateImpl.builder()
+                .terrakubeClient(terrakubeClient)
+                .terraformStatePathService(terraformStatePathService)
+                .terraformOutputPathService(terraformOutputPathService)
+                .workspaceSecurity(workspaceSecurity)
+                .apiUrl("http://127.0.0.1:1/unreachable") // black hole
+                .verifyReadBack(false)
+                .heartbeatIntervalSeconds(60L)
+                .heartbeatAbortAfterSeconds(0L) // any elapsed time triggers
+                .build();
+
+        subject.startHeartbeat("org-1", "ws-1");
+        try {
+            // After at least 1 second the elapsed-since-last-success is > 0 > threshold(0).
+            try { Thread.sleep(1100); } catch (InterruptedException ignored) {}
+            StateUploadFailedException ex = org.junit.jupiter.api.Assertions.assertThrows(
+                    StateUploadFailedException.class, subject::checkHeartbeatHealth);
+            assertTrue(ex.getMessage().contains("Lost contact with the Terrakube API"));
+        } finally {
+            subject.stopHeartbeat();
+        }
+    }
+
+    @Test
+    void heartbeatHandlesApi410GoneWithoutUpdatingLastSuccess() throws InterruptedException {
+        java.util.concurrent.CountDownLatch first410 = new java.util.concurrent.CountDownLatch(1);
+        server.createContext("/tfstate/v1/http-backend/organization/org-1/workspace/ws-1/lock/heartbeat",
+                exchange -> {
+                    first410.countDown();
+                    respond(exchange, 410, "{\"error\":\"lock-lost\"}");
+                });
+
+        ApiTerraformStateImpl subject = ApiTerraformStateImpl.builder()
+                .terrakubeClient(terrakubeClient)
+                .terraformStatePathService(terraformStatePathService)
+                .terraformOutputPathService(terraformOutputPathService)
+                .workspaceSecurity(workspaceSecurity)
+                .apiUrl(apiUrl)
+                .verifyReadBack(false)
+                .heartbeatIntervalSeconds(1L)
+                .heartbeatAbortAfterSeconds(0L)
+                .build();
+
+        subject.startHeartbeat("org-1", "ws-1");
+        try {
+            assertTrue(first410.await(5, java.util.concurrent.TimeUnit.SECONDS));
+            // The 410 must NOT count as a successful ping, so the health check trips.
+            try { Thread.sleep(1100); } catch (InterruptedException ignored) {}
+            org.junit.jupiter.api.Assertions.assertThrows(
+                    StateUploadFailedException.class, subject::checkHeartbeatHealth);
+        } finally {
+            subject.stopHeartbeat();
+        }
+    }
+
+    @Test
+    void stopHeartbeatIsIdempotent() {
+        ApiTerraformStateImpl subject = newSubject(false);
+        subject.stopHeartbeat();
+        subject.stopHeartbeat();
+    }
+
+    @Test
+    void doubleStartHeartbeatDoesNotLeakAScheduler() {
+        ApiTerraformStateImpl subject = newSubject(false);
+        subject.startHeartbeat("org-1", "ws-1");
+        try {
+            // Second start is a no-op (logs a warning).
+            subject.startHeartbeat("org-1", "ws-1");
+        } finally {
+            subject.stopHeartbeat();
+        }
+    }
+
     private static String sha256Hex(byte[] bytes) {
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-256");

--- a/executor/src/test/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/plugin/tfstate/api/ApiTerraformStateImplTest.java
@@ -1,0 +1,368 @@
+package io.terrakube.executor.plugin.tfstate.api;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.organization.workspace.history.HistoryRequest;
+import io.terrakube.executor.plugin.tfstate.StateUploadFailedException;
+import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
+import io.terrakube.executor.plugin.tfstate.TerraformStatePathService;
+import io.terrakube.executor.service.mode.TerraformJob;
+import io.terrakube.executor.service.workspace.security.WorkspaceSecurity;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ApiTerraformStateImplTest {
+
+    private TerrakubeClient terrakubeClient;
+    private TerraformStatePathService terraformStatePathService;
+    private TerraformOutputPathService terraformOutputPathService;
+    private WorkspaceSecurity workspaceSecurity;
+    private HttpServer server;
+    private String apiUrl;
+    private final Map<String, byte[]> storedBodies = new HashMap<>();
+    private final Map<String, AtomicInteger> putAttempts = new HashMap<>();
+
+    @BeforeEach
+    void setUp() throws IOException {
+        terrakubeClient = mock(TerrakubeClient.class);
+        terraformStatePathService = mock(TerraformStatePathService.class);
+        terraformOutputPathService = mock(TerraformOutputPathService.class);
+        workspaceSecurity = mock(WorkspaceSecurity.class);
+        when(workspaceSecurity.generateAccessToken(anyInt())).thenReturn("test-token");
+
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.start();
+        apiUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+        storedBodies.clear();
+        putAttempts.clear();
+    }
+
+    private ApiTerraformStateImpl newSubject(boolean verifyReadBack) {
+        return ApiTerraformStateImpl.builder()
+                .terrakubeClient(terrakubeClient)
+                .terraformStatePathService(terraformStatePathService)
+                .terraformOutputPathService(terraformOutputPathService)
+                .workspaceSecurity(workspaceSecurity)
+                .apiUrl(apiUrl)
+                .verifyReadBack(verifyReadBack)
+                .build();
+    }
+
+    /** Honest happy-path handler: stores the body on PUT, serves it back on GET. */
+    private HttpHandler echoingStorage() {
+        return exchange -> {
+            putAttempts.computeIfAbsent(exchange.getRequestURI().getPath(), k -> new AtomicInteger(0));
+            if ("PUT".equalsIgnoreCase(exchange.getRequestMethod())) {
+                putAttempts.get(exchange.getRequestURI().getPath()).incrementAndGet();
+                byte[] body = exchange.getRequestBody().readAllBytes();
+                String announced = exchange.getRequestHeaders().getFirst("X-Content-Sha256");
+                if (announced != null && !announced.equalsIgnoreCase(sha256Hex(body))) {
+                    respond(exchange, 409, "{\"error\":\"sha256-mismatch\"}");
+                    return;
+                }
+                storedBodies.put(exchange.getRequestURI().getPath(), body);
+                respond(exchange, 201, "");
+            } else if ("GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+                byte[] body = storedBodies.get(exchange.getRequestURI().getPath());
+                if (body == null) {
+                    respond(exchange, 404, "");
+                } else {
+                    exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");
+                    exchange.sendResponseHeaders(200, body.length);
+                    try (OutputStream os = exchange.getResponseBody()) {
+                        os.write(body);
+                    }
+                }
+            } else {
+                respond(exchange, 405, "");
+            }
+        };
+    }
+
+    private void respond(HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    @Test
+    void getBackendStateFileWritesHttpBackendOverride(@TempDir Path tempDir) throws IOException {
+        when(workspaceSecurity.generateAccessToken(anyInt())).thenReturn("jwt-token");
+        ApiTerraformStateImpl subject = newSubject(true);
+
+        String filename = subject.getBackendStateFile("org-1", "ws-1", tempDir.toFile(), "1.5.0");
+
+        assertEquals("api_backend_override.tf", filename);
+        File backendFile = new File(tempDir.toFile(), filename);
+        assertTrue(backendFile.exists());
+        String hcl = FileUtils.readFileToString(backendFile, Charset.defaultCharset());
+        assertTrue(hcl.contains("backend \"http\""));
+        assertTrue(hcl.contains("address        = \"" + apiUrl + "/tfstate/v1/http-backend/organization/org-1/workspace/ws-1/state\""));
+        assertTrue(hcl.contains("lock_address   = \"" + apiUrl + "/tfstate/v1/http-backend/organization/org-1/workspace/ws-1/lock\""));
+        assertTrue(hcl.contains("unlock_address = \"" + apiUrl + "/tfstate/v1/http-backend/organization/org-1/workspace/ws-1/lock\""));
+        assertTrue(hcl.contains("lock_method    = \"POST\""));
+        assertTrue(hcl.contains("unlock_method  = \"DELETE\""));
+        assertTrue(hcl.contains("password       = \"jwt-token\""));
+    }
+
+    @Test
+    void saveTerraformPlanReturnsNullWhenLocalFileMissing(@TempDir Path tempDir) {
+        ApiTerraformStateImpl subject = newSubject(true);
+
+        String result = subject.saveTerraformPlan("org-1", "ws-1", "job-1", "step-1", tempDir.toFile());
+
+        assertNull(result);
+    }
+
+    @Test
+    void saveTerraformPlanUploadsWithIntegrityAndReadBack(@TempDir Path tempDir) throws IOException {
+        byte[] plan = new byte[]{1, 2, 3, 4, 5};
+        File planFile = new File(tempDir.toFile(), "terraformLibrary.tfPlan");
+        FileUtils.writeByteArrayToFile(planFile, plan);
+
+        server.createContext("/tfstate/v1/organization/org-1/workspace/ws-1/jobId/job-1/step/step-1/terraform.tfstate",
+                echoingStorage());
+
+        ApiTerraformStateImpl subject = newSubject(true);
+        String url = subject.saveTerraformPlan("org-1", "ws-1", "job-1", "step-1", tempDir.toFile());
+
+        assertTrue(url.endsWith("/tfstate/v1/organization/org-1/workspace/ws-1/jobId/job-1/step/step-1/terraform.tfstate"));
+        byte[] stored = storedBodies.get("/tfstate/v1/organization/org-1/workspace/ws-1/jobId/job-1/step/step-1/terraform.tfstate");
+        assertNotNull(stored);
+        assertEquals(sha256Hex(plan), sha256Hex(stored));
+    }
+
+    @Test
+    void saveTerraformPlanThrowsAfterRetriesOnPersistentServerErrors(@TempDir Path tempDir) throws IOException {
+        byte[] plan = new byte[]{1, 2, 3, 4, 5};
+        FileUtils.writeByteArrayToFile(new File(tempDir.toFile(), "terraformLibrary.tfPlan"), plan);
+
+        AtomicInteger calls = new AtomicInteger();
+        server.createContext("/tfstate/v1/organization/org-1/workspace/ws-1/jobId/job-1/step/step-1/terraform.tfstate",
+                exchange -> {
+                    calls.incrementAndGet();
+                    respond(exchange, 500, "boom");
+                });
+
+        ApiTerraformStateImpl subject = newSubject(false);
+
+        StateUploadFailedException ex = assertThrows(StateUploadFailedException.class,
+                () -> subject.saveTerraformPlan("org-1", "ws-1", "job-1", "step-1", tempDir.toFile()));
+        assertTrue(ex.getMessage().contains("HTTP 500"));
+        assertTrue(ex.getMessage().contains("Workspace state was NOT modified"));
+        assertEquals(3, calls.get(), "expected MAX_UPLOAD_ATTEMPTS=3 PUTs");
+    }
+
+    @Test
+    void saveTerraformPlanThrowsOn409WithMismatchReason(@TempDir Path tempDir) throws IOException {
+        byte[] plan = new byte[]{1, 2, 3};
+        FileUtils.writeByteArrayToFile(new File(tempDir.toFile(), "terraformLibrary.tfPlan"), plan);
+
+        server.createContext("/tfstate/v1/organization/org-1/workspace/ws-1/jobId/job-1/step/step-1/terraform.tfstate",
+                exchange -> respond(exchange, 409, "{\"error\":\"sha256-mismatch\"}"));
+
+        ApiTerraformStateImpl subject = newSubject(false);
+
+        StateUploadFailedException ex = assertThrows(StateUploadFailedException.class,
+                () -> subject.saveTerraformPlan("org-1", "ws-1", "job-1", "step-1", tempDir.toFile()));
+        assertTrue(ex.getMessage().contains("sha-256 did not match"));
+    }
+
+    @Test
+    void saveTerraformPlanThrowsOnReadBackMismatch(@TempDir Path tempDir) throws IOException {
+        byte[] plan = new byte[]{9, 9, 9};
+        FileUtils.writeByteArrayToFile(new File(tempDir.toFile(), "terraformLibrary.tfPlan"), plan);
+
+        // Accept PUT with 201 but serve different bytes on GET — simulates a faulty
+        // or compromised storage backend that committed something other than what
+        // was sent. readBack must catch this and fail the upload.
+        server.createContext("/tfstate/v1/organization/org-1/workspace/ws-1/jobId/job-1/step/step-1/terraform.tfstate",
+                exchange -> {
+                    if ("PUT".equalsIgnoreCase(exchange.getRequestMethod())) {
+                        exchange.getRequestBody().readAllBytes();
+                        respond(exchange, 201, "");
+                    } else {
+                        byte[] tampered = new byte[]{0, 0, 0};
+                        exchange.sendResponseHeaders(200, tampered.length);
+                        try (OutputStream os = exchange.getResponseBody()) {
+                            os.write(tampered);
+                        }
+                    }
+                });
+
+        ApiTerraformStateImpl subject = newSubject(true);
+        StateUploadFailedException ex = assertThrows(StateUploadFailedException.class,
+                () -> subject.saveTerraformPlan("org-1", "ws-1", "job-1", "step-1", tempDir.toFile()));
+        assertTrue(ex.getMessage().contains("read-back"));
+    }
+
+    @Test
+    void saveOutputReturnsPathServiceUrlAndUploads() {
+        server.createContext("/tfoutput/v1/organization/org-1/job/job-1/step/step-1", echoingStorage());
+        when(terraformOutputPathService.getOutputPath("org-1", "job-1", "step-1"))
+                .thenReturn("https://example/path/output");
+
+        ApiTerraformStateImpl subject = newSubject(false);
+        String result = subject.saveOutput("org-1", "job-1", "step-1", "output-data", "err-data");
+
+        assertEquals("https://example/path/output", result);
+        byte[] stored = storedBodies.get("/tfoutput/v1/organization/org-1/job/job-1/step/step-1");
+        assertNotNull(stored);
+        assertEquals("output-dataerr-data", new String(stored, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void saveStateJsonNoOpsWhenApplyJsonIsNull() {
+        ApiTerraformStateImpl subject = newSubject(true);
+        TerraformJob job = new TerraformJob();
+        job.setOrganizationId("org-1");
+        job.setWorkspaceId("ws-1");
+        job.setJobId("job-1");
+
+        subject.saveStateJson(job, null, null);
+
+        verify(terrakubeClient, org.mockito.Mockito.never()).createHistory(any(HistoryRequest.class), any(), any());
+    }
+
+    @Test
+    void saveStateJsonCreatesHistoryAndUploadsBothRepresentations() {
+        List<String> uploadedPaths = new ArrayList<>();
+        server.createContext("/tfstate/v1/organization/org-1/workspace/ws-1/history/", exchange -> {
+            if ("PUT".equalsIgnoreCase(exchange.getRequestMethod())) {
+                uploadedPaths.add(exchange.getRequestURI().getPath());
+                byte[] body = exchange.getRequestBody().readAllBytes();
+                String announced = exchange.getRequestHeaders().getFirst("X-Content-Sha256");
+                assertEquals(sha256Hex(body), announced);
+                storedBodies.put(exchange.getRequestURI().getPath(), body);
+                respond(exchange, 201, "");
+            } else if ("GET".equalsIgnoreCase(exchange.getRequestMethod())) {
+                byte[] body = storedBodies.get(exchange.getRequestURI().getPath());
+                exchange.sendResponseHeaders(200, body.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(body);
+                }
+            }
+        });
+        when(terraformStatePathService.getStateJsonPath(anyString(), anyString(), anyString()))
+                .thenReturn("https://example/state.json");
+
+        ApiTerraformStateImpl subject = newSubject(true);
+        TerraformJob job = new TerraformJob();
+        job.setOrganizationId("org-1");
+        job.setWorkspaceId("ws-1");
+        job.setJobId("job-1");
+
+        subject.saveStateJson(job, "{\"apply\":1}", "{\"raw\":1}");
+
+        verify(terrakubeClient).createHistory(any(HistoryRequest.class), eq("org-1"), eq("ws-1"));
+        assertEquals(2, uploadedPaths.size(), "expected one raw + one json upload");
+        assertTrue(uploadedPaths.stream().anyMatch(p -> p.endsWith("/terraform.tfstate")));
+        assertTrue(uploadedPaths.stream().anyMatch(p -> p.endsWith("/terraform.json.tfstate")));
+    }
+
+    @Test
+    void downloadTerraformPlanReturnsFalseWhenJobHasNoPlanUrl(@TempDir Path tempDir) {
+        TerrakubeClient deepStubClient = mock(TerrakubeClient.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+        when(deepStubClient.getJobById("org-1", "job-1").getData().getAttributes().getTerraformPlan())
+                .thenReturn(null);
+
+        ApiTerraformStateImpl subject = ApiTerraformStateImpl.builder()
+                .terrakubeClient(deepStubClient)
+                .terraformStatePathService(terraformStatePathService)
+                .terraformOutputPathService(terraformOutputPathService)
+                .workspaceSecurity(workspaceSecurity)
+                .apiUrl(apiUrl)
+                .verifyReadBack(false)
+                .build();
+
+        boolean exists = subject.downloadTerraformPlan("org-1", "ws-1", "job-1", "step-1", tempDir.toFile());
+        assertFalse(exists);
+    }
+
+    @Test
+    void downloadTerraformPlanFetchesAndWritesPlan(@TempDir Path tempDir) throws IOException {
+        byte[] plan = new byte[]{4, 5, 6};
+        server.createContext("/plan", exchange -> {
+            exchange.sendResponseHeaders(200, plan.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(plan);
+            }
+        });
+
+        TerrakubeClient deepStubClient = mock(TerrakubeClient.class, org.mockito.Answers.RETURNS_DEEP_STUBS);
+        when(deepStubClient.getJobById("org-1", "job-1").getData().getAttributes().getTerraformPlan())
+                .thenReturn(apiUrl + "/plan");
+
+        ApiTerraformStateImpl subject = ApiTerraformStateImpl.builder()
+                .terrakubeClient(deepStubClient)
+                .terraformStatePathService(terraformStatePathService)
+                .terraformOutputPathService(terraformOutputPathService)
+                .workspaceSecurity(workspaceSecurity)
+                .apiUrl(apiUrl)
+                .verifyReadBack(false)
+                .build();
+
+        boolean exists = subject.downloadTerraformPlan("org-1", "ws-1", "job-1", "step-1", tempDir.toFile());
+        assertTrue(exists);
+        File destination = new File(tempDir.toFile(), "terraformLibrary.tfPlan");
+        assertTrue(destination.exists());
+        assertEquals(sha256Hex(plan), sha256Hex(FileUtils.readFileToByteArray(destination)));
+    }
+
+    private static String sha256Hex(byte[] bytes) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(bytes);
+            StringBuilder sb = new StringBuilder(digest.length * 2);
+            for (byte b : digest) {
+                sb.append(String.format("%02x", b & 0xff));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/status/UpdateJobStatusImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/status/UpdateJobStatusImplTest.java
@@ -1,0 +1,90 @@
+package io.terrakube.executor.service.status;
+
+import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.organization.job.step.StepAttributes;
+import io.terrakube.client.model.organization.job.step.StepRequest;
+import io.terrakube.executor.configuration.ExecutorFlagsProperties;
+import io.terrakube.executor.plugin.tfstate.StateUploadFailedException;
+import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
+import io.terrakube.executor.plugin.tfstate.TerraformState;
+import io.terrakube.executor.service.mode.TerraformJob;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class UpdateJobStatusImplTest {
+
+    private TerrakubeClient terrakubeClient;
+    private TerraformState terraformState;
+    private ExecutorFlagsProperties executorFlagsProperties;
+    private TerraformOutputPathService terraformOutputPathService;
+    private UpdateJobStatusImpl subject;
+
+    @BeforeEach
+    void setUp() {
+        terrakubeClient = mock(TerrakubeClient.class, Answers.RETURNS_DEEP_STUBS);
+        terraformState = mock(TerraformState.class);
+        executorFlagsProperties = mock(ExecutorFlagsProperties.class);
+        terraformOutputPathService = mock(TerraformOutputPathService.class);
+
+        when(executorFlagsProperties.isDisableAcknowledge()).thenReturn(false);
+        when(terrakubeClient.getJobById(anyString(), anyString()).getData().getAttributes().getStatus())
+                .thenReturn("running");
+        when(terrakubeClient.getJobById(anyString(), anyString()).getData().getRelationships().getOrganization().getData().getId())
+                .thenReturn("org-1");
+        when(terrakubeClient.getJobById(anyString(), anyString()).getData().getAttributes().getOutput())
+                .thenReturn("");
+
+        subject = new UpdateJobStatusImpl(terrakubeClient, terraformState, executorFlagsProperties, terraformOutputPathService);
+    }
+
+    private TerraformJob job() {
+        TerraformJob job = new TerraformJob();
+        job.setOrganizationId("org-1");
+        job.setJobId("job-1");
+        job.setStepId("step-1");
+        return job;
+    }
+
+    @Test
+    void stepIsMarkedFailedWhenOutputUploadThrowsAndOutputUrlIsEmpty() {
+        when(terraformState.saveOutput(eq("org-1"), eq("job-1"), eq("step-1"), anyString(), anyString()))
+                .thenThrow(new StateUploadFailedException("upload kaboom"));
+
+        subject.setCompletedStatus(true, false, 0, job(), "stdout", "stderr", "plan", "commit");
+
+        ArgumentCaptor<StepRequest> stepCaptor = ArgumentCaptor.forClass(StepRequest.class);
+        verify(terrakubeClient).updateStep(stepCaptor.capture(), eq("org-1"), eq("job-1"), eq("step-1"));
+
+        StepAttributes attrs = stepCaptor.getValue().getData().getAttributes();
+        // Output URL is cleared so the executor doesn't link to a half-uploaded artifact.
+        assertEquals("", attrs.getOutput());
+        // Despite the caller passing successful=true, the upload failure flips this to failed.
+        assertEquals("failed", attrs.getStatus());
+    }
+
+    @Test
+    void stepRecordsUrlOnSuccessfulOutputUpload() {
+        when(terraformState.saveOutput(eq("org-1"), eq("job-1"), eq("step-1"), anyString(), anyString()))
+                .thenReturn("https://example/output-url");
+
+        subject.setCompletedStatus(true, false, 0, job(), "stdout", "stderr", "plan", "commit");
+
+        ArgumentCaptor<StepRequest> stepCaptor = ArgumentCaptor.forClass(StepRequest.class);
+        verify(terrakubeClient).updateStep(stepCaptor.capture(), eq("org-1"), eq("job-1"), eq("step-1"));
+
+        StepAttributes attrs = stepCaptor.getValue().getData().getAttributes();
+        assertEquals("https://example/output-url", attrs.getOutput());
+        assertEquals("completed", attrs.getStatus());
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
@@ -1,5 +1,6 @@
 package io.terrakube.executor.service.terraform;
 
+import io.terrakube.executor.plugin.tfstate.StateUploadFailedException;
 import io.terrakube.executor.plugin.tfstate.TerraformState;
 import io.terrakube.executor.service.executor.ExecutorJobResult;
 import io.terrakube.executor.service.logs.ProcessLogs;
@@ -107,5 +108,30 @@ class TerraformExecutorServiceImplTest {
         ExecutorJobResult result = subject.plan(terraformJob, tempDir.toFile(), false);
 
         assertTrue(result.getOutputLog().contains("init stderr"));
+    }
+
+    @Test
+    void planSurfacesStateUploadFailureFromSaveTerraformPlan() throws Exception {
+        TerraformExecutorServiceImpl subject = subject();
+        TerraformJob terraformJob = createJob();
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        // exit 2 = plan succeeded with changes, so executionPlan is true and saveTerraformPlan is called
+        when(terraformClient.planDetailExitCode(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(2));
+        when(terraformState.saveTerraformPlan(anyString(), anyString(), anyString(), anyString(), any(File.class)))
+                .thenThrow(new StateUploadFailedException("API rejected upload: HTTP 500"));
+
+        ExecutorJobResult result = subject.plan(terraformJob, tempDir.toFile(), false);
+
+        assertFalse(result.isSuccessfulExecution());
+        assertEquals(1, result.getExitCode());
+        // The upload failure is appended to the error buffer (and surfaced via
+        // surfaceUploadFailure -> setOutputErrorLog) so the failed job carries
+        // the user-facing reason. The success-path outputLog snapshot was taken
+        // before the catch block, so we don't assert on it here.
+        assertTrue(result.getOutputErrorLog().contains("API rejected upload: HTTP 500"),
+                "Expected error log to include the upload failure reason, got: " + result.getOutputErrorLog());
     }
 }

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
@@ -134,4 +134,62 @@ class TerraformExecutorServiceImplTest {
         assertTrue(result.getOutputErrorLog().contains("API rejected upload: HTTP 500"),
                 "Expected error log to include the upload failure reason, got: " + result.getOutputErrorLog());
     }
+
+    @Test
+    void planBracketsRunWithStartAndStopHeartbeat() throws Exception {
+        TerraformExecutorServiceImpl subject = subject();
+        TerraformJob terraformJob = createJob();
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.planDetailExitCode(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(0));
+
+        subject.plan(terraformJob, tempDir.toFile(), false);
+
+        org.mockito.InOrder inOrder = Mockito.inOrder(terraformState);
+        inOrder.verify(terraformState).startHeartbeat(terraformJob.getOrganizationId(), terraformJob.getWorkspaceId());
+        inOrder.verify(terraformState).stopHeartbeat();
+    }
+
+    @Test
+    void planStopsHeartbeatEvenWhenInitFails() throws Exception {
+        TerraformExecutorServiceImpl subject = subject();
+        TerraformJob terraformJob = createJob();
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(false));
+
+        subject.plan(terraformJob, tempDir.toFile(), false);
+
+        verify(terraformState).startHeartbeat(anyString(), anyString());
+        verify(terraformState).stopHeartbeat();
+    }
+
+    @Test
+    void planSurfacesHeartbeatFailureFromAwaitWithHeartbeat() throws Exception {
+        TerraformExecutorServiceImpl subject = subject();
+        TerraformJob terraformJob = createJob();
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        // Plan future never completes, so awaitWithHeartbeat will poll
+        // checkHeartbeatHealth on its 2s tick. We trip it on the first call.
+        CompletableFuture<Integer> neverComplete = new CompletableFuture<>();
+        when(terraformClient.planDetailExitCode(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(neverComplete);
+        org.mockito.Mockito.doNothing()
+                .doThrow(new StateUploadFailedException("Lost contact with the Terrakube API for 240s"))
+                .when(terraformState).checkHeartbeatHealth();
+
+        ExecutorJobResult result = subject.plan(terraformJob, tempDir.toFile(), false);
+
+        assertFalse(result.isSuccessfulExecution());
+        assertEquals(1, result.getExitCode());
+        assertTrue(result.getOutputErrorLog().contains("Lost contact with the Terrakube API"),
+                "Expected heartbeat-loss reason in error log, got: " + result.getOutputErrorLog());
+        // Heartbeat is still stopped on the failure path.
+        verify(terraformState).stopHeartbeat();
+        assertTrue(neverComplete.isCancelled(), "awaitWithHeartbeat should cancel the terraform future on health failure");
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a new `TerraformStateType` (`ApiTerraformStateImpl`) that routes every state, plan, and step-output write through the Terrakube API over HTTPS instead of talking to GCS/S3/Azure/local directly. This lets executors run inside air-gapped networks where only the API endpoint is reachable.
- Emits an HCL override that points terraform at the API's `/tfstate/v1/http-backend/**` endpoints (Basic auth carrying a JWT in the password field, since the http backend can't send custom headers).
- Plan/state/output PUTs include `X-Content-Sha256` so the API can verify what it received before committing. On successful PUT the executor (when `verifyReadBack=true`, the default) GETs the same object back and re-hashes it — closing the gap the announced-hash header can't, since on its own that header proves transit integrity but not that the storage backend persisted the right bytes.
- `StateUploadFailedException` is thrown when upload retries (3 attempts, exponential backoff) are exhausted. The message is user-facing and gets surfaced into the job step output / error log via the new `surfaceUploadFailure` helper in `TerraformExecutorServiceImpl`, so failed runs show a concrete reason instead of silently losing data.
- `UpdateJobStatusImpl` swallows step-output upload failures (output is diagnostic, not infrastructure) but flips the step to failed and clears the URL so the UI doesn't link to a half-uploaded artifact.
- New feature flag `io.terrakube.executor.plugin.tfstate.api.verifyReadBack` (env: `TerraformStateApiVerifyReadBack`, default `true`) lets cost-sensitive workspaces opt out of the GET back-channel.
- README documents the new `TerraformStateType` and feature flag.

This is the executor half of the air-gapped feature; it depends on the companion API PR that adds the `/tfstate/v1/http-backend/**` controller, the `X-Content-Sha256` check, the new history state endpoints, and the `workspace_state_lock` table.

## Tests

- `ApiTerraformStateImplTest` (11 cases) spins up an in-process `com.sun.net.httpserver.HttpServer` and exercises HCL override generation, plan save with integrity + read-back, retry-then-fail on persistent 500s, 409 sha-mismatch surfacing, read-back tampering detection, step output upload, history state (raw + json) uploads, and plan download with / without a URL.
- `UpdateJobStatusImplTest` covers the new catch behavior: step is marked failed and output URL is cleared on `StateUploadFailedException`; normal uploads still record the returned URL.
- `TerraformExecutorServiceImplTest` adds a case where `saveTerraformPlan` throws and the run completes with exit 1 and the error reason in `outputErrorLog`.

Full executor test suite passes locally: 52 tests, 0 failures.

## Test plan

- [ ] CI green
- [ ] End-to-end smoke: spin up an executor pointed at an API with companion PR merged; run plan + apply against a workspace configured with `TerraformStateType=ApiTerraformStateImpl`; confirm state, plan binary, and step output are persisted via the API and that the workspace is locked while running.
- [ ] Repeat with `TerraformStateApiVerifyReadBack=false` to confirm the header-only fast path still works.