### PR TITLE
fix(executor,api): handle null source for remote-content manual runs

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutionException.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutionException.java
@@ -4,4 +4,8 @@ public class ExecutionException extends Exception {
     public ExecutionException(Throwable cause) {
         super(cause);
     }
+
+    public ExecutionException(String message) {
+        super(message);
+    }
 }

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -160,6 +160,18 @@ public class ExecutorService {
             executorContext.setBranch(job.getOverrideBranch());
         }
 
+        // A remote-content workspace requires a tarball URL (job.overrideSource set by
+        // the Terraform CLI configuration-version upload, or workspace.source set by the
+        // same flow). A manual UI run against such a workspace will arrive here with both
+        // null and would NPE later inside the executor when constructing the download URL.
+        if ("remote-content".equals(executorContext.getBranch())
+                && (executorContext.getSource() == null || executorContext.getSource().isBlank())) {
+            throw new ExecutionException(
+                    "Cannot run job " + job.getId() + ": workspace '" + job.getWorkspace().getName()
+                            + "' has branch 'remote-content' but no configuration has been uploaded. "
+                            + "Upload configuration via the terraform CLI or attach a VCS connection before running.");
+        }
+
         if (job.getWorkspace().getModuleSshKey() != null) {
             String moduleSshId = job.getWorkspace().getModuleSshKey();
             Optional<Ssh> ssh = sshRepository.findById(UUID.fromString(moduleSshId));

--- a/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -195,6 +195,12 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
     private void downloadWorkspaceTarGz(File tarGzFolder, String organizationId, String jobId) throws IOException, URISyntaxException {
         String source = terrakubeClient.getJobById(organizationId, jobId).getData().getAttributes().getOverrideSource();
         log.info("Download workspace from source: {}", source);
+        if (source == null || source.isBlank()) {
+            throw new IOException(
+                    "No configuration tarball URL is set for job " + jobId
+                            + " (overrideSource is null). The workspace branch is 'remote-content' but no configuration"
+                            + " has been uploaded — upload it via the terraform CLI or attach a VCS connection before running.");
+        }
         File terraformTarGz = new File(tarGzFolder.getPath() + "/terraformContent.tar.gz");
         URL url = new URI(source).toURL();
         URLConnection urlConnection = url.openConnection();


### PR DESCRIPTION
## Summary
- Triggering a manual run against a `remote-content` workspace with no uploaded configuration crashed the executor with `NullPointerException: Cannot invoke "String.length()" because "this.input" is null` inside `new URI(source).toURL()` at `SetupWorkspaceImpl.downloadWorkspaceTarGz` — both `job.overrideSource` and `workspace.source` are null in that flow, since they're only populated by the Terraform-CLI configuration-version upload path in `RemoteTfeService`.
- API-side fix: in `ExecutorService.execute`, after resolving branch/source, reject the job upfront with a clear `ExecutionException` when the workspace branch is `remote-content` and source is null/blank — so the job fails cleanly with a meaningful message instead of being dispatched to the executor.
- Executor-side defensive fix: in `SetupWorkspaceImpl.downloadWorkspaceTarGz`, null/blank-check the source URL before constructing the URI and throw an `IOException` with the same guidance.
- Added a `String` message constructor to `ExecutionException` so the API can raise it without wrapping a synthetic cause.

## Test plan
- [x] `mvn -pl api -am -DskipTests compile` — green
- [x] `mvn -pl executor -am -DskipTests compile` — green
- [ ] Manual: trigger a manual run on a `remote-content` workspace with no uploaded content → job fails fast with the new message (no NPE in executor logs)
- [ ] Regression: trigger a normal VCS-backed manual run → still succeeds
- [ ] Regression: trigger via `terraform` CLI (which sets `overrideSource`) → still succeeds