### PR TITLE
fix(ui): refresh workspace state after settings save without page reload

### DIFF
--- a/ui/src/domain/Jobs/Create.tsx
+++ b/ui/src/domain/Jobs/Create.tsx
@@ -45,6 +45,7 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
       const { branch, defaultTemplate } = response.data.data.attributes;
       setDefaultTemplate(defaultTemplate);
       setBranchName(branch);
+      form.setFieldsValue({ templateId: defaultTemplate, branchName: branch });
     });
   };
 
@@ -112,6 +113,7 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
         type="primary"
         htmlType="button"
         onClick={() => {
+          loadBranch();
           setVisible(true);
         }}
         icon={<PlayCircleOutlined />}

--- a/ui/src/domain/Workspaces/Settings/General.tsx
+++ b/ui/src/domain/Workspaces/Settings/General.tsx
@@ -13,6 +13,7 @@ type Props = {
   workspaceData: Workspace;
   orgTemplates: Template[];
   manageWorkspace: boolean;
+  onWorkspaceUpdate?: () => void;
 };
 
 type UpdateWorkspaceForm = {
@@ -28,7 +29,7 @@ type UpdateWorkspaceForm = {
   project?: string;
 };
 
-export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace }: Props) => {
+export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace, onWorkspaceUpdate }: Props) => {
   const organizationId = workspaceData.relationships.organization.data.id;
   const id = workspaceData.id;
   const Option = Select;
@@ -117,6 +118,7 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace 
       axiosInstance.post("/operations", body, atomicHeader).then((response) => {
         if (response.status === 200) {
           message.success("workspace updated successfully");
+          onWorkspaceUpdate?.();
         } else {
           message.error("workspace update failed");
         }

--- a/ui/src/domain/Workspaces/Settings/SSHKey.tsx
+++ b/ui/src/domain/Workspaces/Settings/SSHKey.tsx
@@ -10,9 +10,10 @@ const { Text } = Typography;
 type Props = {
   workspace: Workspace;
   manageWorkspace: boolean;
+  onWorkspaceUpdate?: () => void;
 };
 
-export const WorkspaceSSHKey = ({ workspace, manageWorkspace }: Props) => {
+export const WorkspaceSSHKey = ({ workspace, manageWorkspace, onWorkspaceUpdate }: Props) => {
   const organizationId = workspace.relationships.organization.data.id;
   const id = workspace.id;
   const Option = Select;
@@ -52,6 +53,7 @@ export const WorkspaceSSHKey = ({ workspace, manageWorkspace }: Props) => {
       .then((response) => {
         if (response.status === 200) {
           message.success("SSH key updated successfully");
+          onWorkspaceUpdate?.();
         } else {
           message.error("SSH key update failed");
         }

--- a/ui/src/domain/Workspaces/Settings/StateShared.tsx
+++ b/ui/src/domain/Workspaces/Settings/StateShared.tsx
@@ -10,6 +10,7 @@ const { Text } = Typography;
 type Props = {
   workspace: Workspace;
   manageWorkspace: boolean;
+  onWorkspaceUpdate?: () => void;
 };
 
 type UpdateStateSharedForm = {
@@ -21,7 +22,7 @@ interface SharedWorkspace {
   name: string;
 }
 
-export const WorkspaceStateShared = ({ workspace, manageWorkspace }: Props) => {
+export const WorkspaceStateShared = ({ workspace, manageWorkspace, onWorkspaceUpdate }: Props) => {
   const [form] = Form.useForm();
   const globalRemoteState = Form.useWatch("globalRemoteState", form);
   const organizationId = workspace.relationships.organization.data.id;
@@ -139,6 +140,7 @@ export const WorkspaceStateShared = ({ workspace, manageWorkspace }: Props) => {
     if (response.status === 200) {
       setSharedWorkspaces(updatedWorkspaces);
       message.success("Shared workspaces updated successfully");
+      onWorkspaceUpdate?.();
     } else {
       throw new Error("Update failed");
     }
@@ -167,6 +169,7 @@ export const WorkspaceStateShared = ({ workspace, manageWorkspace }: Props) => {
       .then((response) => {
         if (response.status === 200) {
           message.success("Workspace updated successfully");
+          onWorkspaceUpdate?.();
         } else {
           message.error("Workspace update failed");
         }

--- a/ui/src/domain/Workspaces/Settings/Webhook.tsx
+++ b/ui/src/domain/Workspaces/Settings/Webhook.tsx
@@ -59,9 +59,10 @@ type Props = {
   manageWorkspace: boolean;
   orgTemplates: Template[];
   vcsProvider?: VcsType;
+  onWorkspaceUpdate?: () => void;
 };
 
-export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageWorkspace }: Props) => {
+export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageWorkspace, onWorkspaceUpdate }: Props) => {
   const screens = Grid.useBreakpoint();
   const isMobile = !screens.md;
   const [waiting, setWaiting] = useState(true);
@@ -170,6 +171,7 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
       message.success("Webhook disabled successfully");
       setWebhookEvents([]);
       setWaiting(false);
+      onWorkspaceUpdate?.();
       return;
     }
     if (webhookEnabled && webhookEvents.length === 0) {
@@ -287,6 +289,7 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
       setWebhookEvents([...webhookEvents]);
       setWaiting(false);
       message.success("Webhook saved successfully");
+      onWorkspaceUpdate?.();
     });
   };
   const handleMigrateV2 = () => {

--- a/ui/src/domain/Workspaces/Settings/WorkspaceSettings.tsx
+++ b/ui/src/domain/Workspaces/Settings/WorkspaceSettings.tsx
@@ -44,7 +44,7 @@ export const WorkspaceSettings = ({
     switch (activeKey) {
       case "general":
         return (
-          <WorkspaceGeneral workspaceData={workspace} orgTemplates={orgTemplates} manageWorkspace={manageWorkspace} />
+          <WorkspaceGeneral workspaceData={workspace} orgTemplates={orgTemplates} manageWorkspace={manageWorkspace} onWorkspaceUpdate={handleWorkspaceUpdate} />
         );
       case "locking":
         return (
@@ -55,7 +55,7 @@ export const WorkspaceSettings = ({
           />
         );
       case "sshkey":
-        return <WorkspaceSSHKey workspace={workspace} manageWorkspace={manageWorkspace} />;
+        return <WorkspaceSSHKey workspace={workspace} manageWorkspace={manageWorkspace} onWorkspaceUpdate={handleWorkspaceUpdate} />;
       case "webhook":
         return (
           <WorkspaceWebhook
@@ -63,15 +63,16 @@ export const WorkspaceSettings = ({
             vcsProvider={vcsProvider}
             orgTemplates={orgTemplates}
             manageWorkspace={manageWorkspace}
+            onWorkspaceUpdate={handleWorkspaceUpdate}
           />
         );
       case "advanced":
         return <WorkspaceAdvanced workspace={workspace} manageWorkspace={manageWorkspace} />;
       case "state-shared":
-        return <WorkspaceStateShared workspace={workspace} manageWorkspace={manageWorkspace} />;
+        return <WorkspaceStateShared workspace={workspace} manageWorkspace={manageWorkspace} onWorkspaceUpdate={handleWorkspaceUpdate} />;
       default:
         return (
-          <WorkspaceGeneral workspaceData={workspace} orgTemplates={orgTemplates} manageWorkspace={manageWorkspace} />
+          <WorkspaceGeneral workspaceData={workspace} orgTemplates={orgTemplates} manageWorkspace={manageWorkspace} onWorkspaceUpdate={handleWorkspaceUpdate} />
         );
     }
   };


### PR DESCRIPTION
## Summary

Closes #2900

- Workspace settings (General, SSH Key, Webhook, State Shared) now call `onWorkspaceUpdate` after a successful save, triggering `loadWorkspace` in the parent and refreshing React state immediately
- The "Run now" modal (`CreateJob`) now re-fetches `defaultTemplate` and `branch` each time it opens, and applies them via `form.setFieldsValue()` so stale mount-time values are no longer shown

## Root cause

`WorkspaceGeneral` (and other settings tabs) were never wired to the `onWorkspaceUpdate` callback that `Details.tsx` provides. As a result, the parent workspace state was never refreshed after a save — stale values persisted until a full page reload.

Separately, `Create.tsx` fetched workspace defaults only once on mount and relied on `Form.Item initialValue`, which Ant Design only applies at form initialization. Opening the modal after a settings change always showed the original values.

---
Note: The build-jammy CI failure is unrelated to this PR. These tests are in the Java API module. This PR only touches TypeScript/React files under ui/src/.
