### PR TITLE
fix: use correct casing for third party project and service names

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,6 +1,6 @@
 # Terrakube Development Container
 
-This directory contains the configuration for a development container that provides a consistent environment for working with Terrakube. The devcontainer includes all the necessary tools and dependencies to develop both the Java backend, TypeScript frontend components and includes terraform CLI.
+This directory contains the configuration for a development container that provides a consistent environment for working with Terrakube. The Dev Containers setup includes all the necessary tools and dependencies to develop both the Java backend, TypeScript frontend components and includes terraform CLI.
 
 > **Note:** This setup has been tested on Ubuntu-based distributions and macOS (including Apple Silicon). Windows and GitHub Codespaces support may vary.
 
@@ -20,7 +20,7 @@ This directory contains the configuration for a development container that provi
 
 #### Local Development Domains
 
-To use the devcontainer we need to setup the following domains in our local computer:
+To use the Dev Containers setup we need to setup the following domains in our local computer:
 
 ```shell
 terrakube.platform.local
@@ -42,7 +42,7 @@ The local CA is now installed in the system trust store! ⚡️
 The local CA is now installed in the Firefox trust store (requires browser restart)! 🦊
 ```
 
-#### Create Docker Network for the devcontainer
+#### Create Docker Network for the Dev Containers environment
 
 ```bash
 docker network create terrakube-network -d bridge --subnet 10.25.25.0/24 --gateway 10.25.25.254
@@ -61,7 +61,7 @@ Update the /etc/hosts file adding the following entries:
 10.25.25.253 terrakube-dex.platform.local
 ```
 
-### Opening the Project in a Dev Container
+### Opening the Project in Dev Containers
 
 1. Clone the Terrakube repository and run the project:
    ```bash
@@ -90,7 +90,7 @@ Update the /etc/hosts file adding the following entries:
 
 ## Ports
 
-The devcontainer forwards the following ports:
+The Dev Containers environment forwards the following ports:
 - 8080: Terrakube API 
 - 8075: Terrakube Registry
 - 8090: Terrakube Executor
@@ -99,6 +99,6 @@ The devcontainer forwards the following ports:
 
 ## Customization
 
-You can customize the devcontainer by modifying:
+You can customize the Dev Containers setup by modifying:
 - `.devcontainer/devcontainer.json`: VS Code settings and extensions
 - `.devcontainer/Dockerfile`: Container image configuration

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The key features of Terrakube are:
 
 <img src="https://github.com/terrakube-io/terrakube/assets/27365102/f36953f7-0dbd-4877-be8d-ba2bf7704f2b" width="1080"/>  <br/>
 
-- **Version Control Integration:** Terrakube integrates with Github (Cloud and  Enterprise), GitLab (EE and CE), Bitbucket and Azure DevOps to retrieve your terraform/opentofu code. <br/>
+- **Version Control Integration:** Terrakube integrates with GitHub (Cloud and  Enterprise), GitLab (EE and CE), Bitbucket and Azure DevOps to retrieve your terraform/opentofu code. <br/>
 
 <img src="https://github.com/terrakube-io/terrakube/assets/27365102/d9102910-41af-42be-b154-1257108f688b" width="1080"/>  <br/>
 
@@ -42,7 +42,7 @@ The key features of Terrakube are:
 
 - **Custom Workflows:** Enhance your IaC workflow with OPA, Infracost, or any other tool of your choice. You can use Terrakube extensions to integrate them seamlessly, or create your own custom integration using the Terrakube API. This way, you can automate compliance checks, cost estimates, security scans, and more for your Terraform projects.
 
-- **Access Control:** You can use [DEX](https://github.com/dexidp/dex) to authenticate in Terrakube with various identity providers, such as Azure Active Directory, Amazon Cognito, Github, SAML, and more. You can also leverage your existing groups to assign granular permissions to Workspaces, Modules, VCS, and other resources.
+- **Access Control:** You can use [Dex](https://github.com/dexidp/dex) to authenticate in Terrakube with various identity providers, such as Azure Active Directory, Amazon Cognito, GitHub, SAML, and more. You can also leverage your existing groups to assign granular permissions to Workspaces, Modules, VCS, and other resources.
 
 - **Remote Backend:** Terrakube supports both `remote backend` and `cloud` block so you can run your workflow directly from the Terraform / OpenTofu CLI.
 
@@ -52,9 +52,9 @@ The key features of Terrakube are:
 
 - [Install Terrakube using Helm](https://docs.terrakube.io/getting-started/deployment/docker-compose)
 - [Install Terrakube using Docker Compose](https://docs.terrakube.io/getting-started/docker-compose)
-- [Test Terrakube using Minikube](https://docs.terrakube.io/getting-started/deployment/minikube-+-https)
+- [Test Terrakube using minikube](https://docs.terrakube.io/getting-started/deployment/minikube-+-https)
 - [Test Terrakube using Gitpod](https://docs.terrakube.io/getting-started/getting-started)
-- [Develop Terrakube using VS Code Devcontainers](.devcontainer/README.md)
+- [Develop Terrakube using VS Code Dev Containers](.devcontainer/README.md)
 
 ### Documentation
 To learn more about Terrakube [go to the complete documentation.](https://docs.terrakube.io/) 
@@ -67,7 +67,7 @@ Terrakube welcomes any idea or feedback from the community. If you want to contr
 | Sponsor  | Thanks |
 | ------------- | ------------- |
 | [<img src="https://resources.jetbrains.com/storage/products/company/brand/logos/jb_beam.svg" alt="JetBrains" width="32"> JetBrains](https://jb.gg/OpenSource)  | For providing with free licenses to their great tools.   |
-| [<img src="https://uploads-ssl.webflow.com/5c349f90a3cd4515d0564552/5c66e5b48238e30e170da3be_logo.svg" alt="Gitbook" width="32"> Gitbook](https://www.gitbook.com/)   | For providing us with free OSS Plan. |
+| [<img src="https://uploads-ssl.webflow.com/5c349f90a3cd4515d0564552/5c66e5b48238e30e170da3be_logo.svg" alt="GitBook" width="32"> GitBook](https://www.gitbook.com/)   | For providing us with free OSS Plan. |
 | [<img src="https://github.com/terrakube-io/terrakube/assets/27365102/e5977550-eb4f-4519-9aa8-293e5660f873" width="32"> Docker](https://www.docker.com/) | For providing us with free OSS Plan.|
 | [<img src="https://github.com/user-attachments/assets/c094496d-ff2d-4501-8416-8185b1abe45a" width="32"> Tuta](https://tuta.com/) | For providing us with free email service.|
 

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/TokenService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/TokenService.java
@@ -173,7 +173,7 @@ public class TokenService {
         // If the token is already set, return it, normally this is oAuth token
         if (token!=null && !token.isEmpty()) return token;
         
-        // Otherwise, get the token from other table, currently only Github is supported.
+        // Otherwise, get the token from other table, currently only GitHub is supported.
         return  gitHubTokenService.getAccessToken(vcs, ownerAndRepo);
     }
 
@@ -195,7 +195,7 @@ public class TokenService {
 
         URI uri = new URI(gitPath);
         String[] ownerAndRepo = Arrays.copyOfRange(uri.getPath().replaceAll("\\.git$", "").split("/"), 1, 3);
-        // Otherwise, get the token from other table, currently only Github is supported.
+        // Otherwise, get the token from other table, currently only GitHub is supported.
         return  gitHubTokenService.getAccessToken(vcs, ownerAndRepo);
     }
 }

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookServiceBase.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookServiceBase.java
@@ -40,7 +40,7 @@ public class WebhookServiceBase {
     }
 
     /*
-    Gitlab is a special case, the repos URL could be
+    GitLab is a special case, the repos URL could be
     https://gitlab.com/myuser/simple-terraform -> Normal repo
     https://gitlab.com/terraform2745926/simple-terraform -> Repo inside project
     https://gitlab.com/terraform2745926/test/simple-terraform -> Repo inside project and subgroup

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenService.java
@@ -84,7 +84,7 @@ public class GitHubTokenService implements GetAccessToken<GitHubToken> {
         }
 
 
-        log.info("Calling Github API");
+        log.info("Calling GitHub API");
 
         GitHubToken gitHubToken = client.post().uri(uriBuilder -> uriBuilder.path("/login/oauth/access_token")
                         .queryParam("client_id", clientId)

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -255,7 +255,7 @@ public class GitHubWebhookService extends WebhookServiceBase {
         if (response.getStatusCode().value() == 201) {
             log.info("Job status sent successfully to GitHub");
         } else {
-            log.error(String.format("Failed to send job status to Github, message %s", response.getBody()));
+            log.error(String.format("Failed to send job status to GitHub, message %s", response.getBody()));
         }
 
         // Optional: Check if the commit is part of a PR and send status to the PR as

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabTokenService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabTokenService.java
@@ -62,7 +62,7 @@ public class GitLabTokenService {
         if(gitLabToken != null) {
             return gitLabToken;
         } else {
-            throw new TokenException("500","Unable to get Gitlab Token");
+            throw new TokenException("500","Unable to get GitLab Token");
         }
     }
 }

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -101,16 +101,16 @@ public class GitLabWebhookService extends WebhookServiceBase {
 
                         for (String gitlabmodified : commitData.getModified()) {
                             finalResult.getFileChanges().add(gitlabmodified);
-                            log.info("Modified Gitlab Object: {}", gitlabmodified);
+                            log.info("Modified GitLab Object: {}", gitlabmodified);
                         }
 
                         for (String gitlabRemoved : commitData.getRemoved()) {
                             finalResult.getFileChanges().add(gitlabRemoved);
-                            log.info("Removed Gitlab Object: {}", gitlabRemoved);
+                            log.info("Removed GitLab Object: {}", gitlabRemoved);
                         }
 
                         for (String gitlabAdded : commitData.getAdded()) {
-                            log.info("New Gitlab Object: {}", gitlabAdded);
+                            log.info("New GitLab Object: {}", gitlabAdded);
                             finalResult.getFileChanges().add(gitlabAdded);
                         }
                     });
@@ -446,13 +446,13 @@ public class GitLabWebhookService extends WebhookServiceBase {
                     log.error("Error parsing JSON response", e);
                 }
 
-                log.info("Gitlab Hook created successfully for workspace {}/{} with id {}", workspace.getOrganization().getName(), workspace.getName(), remoteHookId);
+                log.info("GitLab Hook created successfully for workspace {}/{} with id {}", workspace.getOrganization().getName(), workspace.getName(), remoteHookId);
             }
         } else {
             URI gitlabUri = UriComponentsBuilder.fromHttpUrl(workspace.getVcs().getApiUrl() + "/projects/" + projectId + "/hooks/" + webhook.getRemoteHookId()).build(true).toUri();
             response = restTemplate.exchange(
                     gitlabUri, HttpMethod.PUT, entity, String.class);
-            log.info("Gitlab Hook updating Status {} for workspace {}/{} with id {}", response.getStatusCode(), workspace.getOrganization().getName(), workspace.getName(), remoteHookId);
+            log.info("GitLab Hook updating Status {} for workspace {}/{} with id {}", response.getStatusCode(), workspace.getOrganization().getName(), workspace.getName(), remoteHookId);
         }
 
         return remoteHookId;

--- a/api/src/test/java/io/terrakube/api/VcsGitlabTests.java
+++ b/api/src/test/java/io/terrakube/api/VcsGitlabTests.java
@@ -57,7 +57,7 @@ public class VcsGitlabTests extends ServerApplicationTests {
 
         GitLabWebhookService gitLabWebhookService = new GitLabWebhookService(new ObjectMapper(), "localhost", "http://localhost", WebClient.builder(), 30, 25);
 
-        Assert.isTrue("5397249".equals(gitLabWebhookService.getGitlabProjectId("alfespa17/simple-terraform", "12345", "http://localhost:"+ wireMockServer.port())), "Gitlab project id not found");
+        Assert.isTrue("5397249".equals(gitLabWebhookService.getGitlabProjectId("alfespa17/simple-terraform", "12345", "http://localhost:"+ wireMockServer.port())), "GitLab project id not found");
 
         String projectSearch="[\n" +
                 "    {\n" +
@@ -84,7 +84,7 @@ public class VcsGitlabTests extends ServerApplicationTests {
                         .withStatus(HttpStatus.OK.value())
                         .withBody(projectSearch)));
 
-        Assert.isTrue(("7107040".equals(gitLabWebhookService.getGitlabProjectId("terraform2745926/test/simple-terraform", "12345", "http://localhost:" + wireMockServer.port()))), "Gitlab project id not found");
+        Assert.isTrue(("7107040".equals(gitLabWebhookService.getGitlabProjectId("terraform2745926/test/simple-terraform", "12345", "http://localhost:" + wireMockServer.port()))), "GitLab project id not found");
 
         // Stub for direct lookup that returns 404
         stubFor(get(urlPathEqualTo("/projects/terraform2745926%2Fsimple-terraform"))
@@ -99,7 +99,7 @@ public class VcsGitlabTests extends ServerApplicationTests {
                         .withStatus(HttpStatus.OK.value())
                         .withBody(projectSearch)));
 
-        Assert.isTrue("7138024".equals(gitLabWebhookService.getGitlabProjectId("terraform2745926/simple-terraform", "12345", "http://localhost:" + wireMockServer.port())), "Gitlab project id not found");
+        Assert.isTrue("7138024".equals(gitLabWebhookService.getGitlabProjectId("terraform2745926/simple-terraform", "12345", "http://localhost:" + wireMockServer.port())), "GitLab project id not found");
 
     }
 
@@ -119,7 +119,7 @@ public class VcsGitlabTests extends ServerApplicationTests {
 
                 GitLabWebhookService gitLabWebhookService = new GitLabWebhookService(new ObjectMapper(), "localhost", "http://localhost", WebClient.builder(), 30, 25);
 
-                Assert.isTrue("5397249".equals(gitLabWebhookService.getGitlabProjectId("alfespa17/simple-terraform", "12345", "http://localhost:" + wireMockServer.port())), "Direct Gitlab project id not found");
+                Assert.isTrue("5397249".equals(gitLabWebhookService.getGitlabProjectId("alfespa17/simple-terraform", "12345", "http://localhost:" + wireMockServer.port())), "Direct GitLab project id not found");
         }
 
     @Test

--- a/development.md
+++ b/development.md
@@ -4,7 +4,7 @@ GitHub Codespaces
 
 This page contains the configuration for a development container using GitHub Codespaces that provides a consistent environment for working with Terrakube.
 
-The devcontainer includes all the necessary tools and dependencies to develop both the Java backend, TypeScript frontend components and includes terraform CLI.
+The Dev Containers setup includes all the necessary tools and dependencies to develop both the Java backend, TypeScript frontend components and includes terraform CLI.
 Features
 
 * Java 25 (Liberica)
@@ -34,7 +34,7 @@ Select a 4 CPU configuration like the following.
 
 <img width="709" height="434" alt="image" src="https://github.com/user-attachments/assets/254799e9-fc67-4f41-ac86-b3d3982762e1" />
 
-Dev container setup will take a couple of minutes.
+Dev Containers setup will take a couple of minutes.
 
 <img width="1488" height="466" alt="image" src="https://github.com/user-attachments/assets/82b18842-2655-4e6a-842a-2fc4b165d821" />
 
@@ -50,7 +50,7 @@ You need to accept using the Java "Standard Mode".
 
 <img width="468" height="134" alt="image" src="https://github.com/user-attachments/assets/55959647-fb84-4480-bc9d-d5dfc8acabd6" />
 
-The dev container will download all the maven dependencies, this could take a couple of minutes
+The Dev Containers environment will download all the maven dependencies, this could take a couple of minutes
 
 <img width="501" height="156" alt="image" src="https://github.com/user-attachments/assets/269031b2-7469-459d-af39-04172b9ebff6" />
 
@@ -62,7 +62,7 @@ If not you can simply start the ui, api, registry and executor one by one using 
 
 <img width="403" height="188" alt="image" src="https://github.com/user-attachments/assets/50d7e2f7-8112-4ab8-88fb-9bcdd6eaa9b2" />
 
-After we have the components running, we need to change the port configuration, we need to make sure DEX, the api, registry and ui are using public ports.
+After we have the components running, we need to change the port configuration, we need to make sure Dex, the api, registry and ui are using public ports.
 
 <img width="1341" height="314" alt="image" src="https://github.com/user-attachments/assets/eba70773-6a70-41bf-b0da-f7857b8a3f27" />
 
@@ -102,7 +102,7 @@ This will redirect you to dex where you can use "admin@example.com" and "admin" 
 
 <img width="741" height="269" alt="image" src="https://github.com/user-attachments/assets/dee55756-9c1f-4e68-95fa-c675cceb15dd" />
 
-Grant DEX access
+Grant Dex access
 
 <img width="1205" height="500" alt="image" src="https://github.com/user-attachments/assets/fd2e033d-8375-4bf6-a8c7-22631bc60e7b" />
 

--- a/scripts/template/DEVCONTAINER_TEMPLATE.md
+++ b/scripts/template/DEVCONTAINER_TEMPLATE.md
@@ -1,4 +1,4 @@
-# Devcontainer Workspace Information
+# Dev Containers Workspace Information
 
 Endpoints:
 
@@ -17,10 +17,10 @@ Executor:
 Dex Authentication:
 - DEVCONTAINER_WORKSPACE_DEX
 
-Minio Endpoint:
+MinIO Endpoint:
 - DEVCONTAINER_WORKSPACE_MINIO
 
-Minio Console:
+MinIO Console:
 - DEVCONTAINER_WORKSPACE_CONSOLE_MINIO
 
 Terraform Protocols

--- a/ui/src/domain/Modules/Create.tsx
+++ b/ui/src/domain/Modules/Create.tsx
@@ -330,7 +330,7 @@ export const CreateModule = () => {
                       }}
                       size="large"
                     >
-                      Github
+                      GitHub
                     </Button>
                     <Button
                       icon={<GitlabOutlined />}
@@ -339,7 +339,7 @@ export const CreateModule = () => {
                       }}
                       size="large"
                     >
-                      Gitlab
+                      GitLab
                     </Button>
                     <Button
                       icon={<SiBitbucket />}

--- a/ui/src/domain/Settings/AddVCS.tsx
+++ b/ui/src/domain/Settings/AddVCS.tsx
@@ -114,28 +114,28 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
       case "GITHUB_ENTERPRISE":
         return "GitHub Enterprise";
       case "GITHUB_APP":
-        return "Github App";
+        return "GitHub App";
       default:
         return "GitHub";
     }
   };
   const gitlabItems = [
     {
-      label: "Gitlab.com",
+      label: "GitLab.com",
       key: "1",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITLAB);
       },
     },
     {
-      label: "Gitlab Community Edition",
+      label: "GitLab Community Edition",
       key: "2",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITLAB_COMMUNITY);
       },
     },
     {
-      label: "Gitlab Enterprise Edition",
+      label: "GitLab Enterprise Edition",
       key: "3",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITLAB_ENTERPRISE);
@@ -145,14 +145,14 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
 
   const githubItems = [
     {
-      label: "Github.com (GitHub App)",
+      label: "GitHub.com (GitHub App)",
       key: "1",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITHUB_APP, VcsConnectionType.STANDALONE);
       },
     },
     {
-      label: "Github.com (oAuth App)",
+      label: "GitHub.com (oAuth App)",
       key: "2",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITHUB);
@@ -804,7 +804,7 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
             <Dropdown menu={{ items: githubItems }}>
               <Button size="large">
                 <Space>
-                  <GithubOutlined /> Github <DownOutlined />
+                  <GithubOutlined /> GitHub <DownOutlined />
                 </Space>
               </Button>
             </Dropdown>
@@ -812,7 +812,7 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
               <Button size="large">
                 <Space>
                   <GitlabOutlined />
-                  Gitlab <DownOutlined />
+                  GitLab <DownOutlined />
                 </Space>
               </Button>
             </Dropdown>

--- a/ui/src/domain/Settings/EditVCS.tsx
+++ b/ui/src/domain/Settings/EditVCS.tsx
@@ -74,7 +74,7 @@ const renderVCSType = (vcs: VcsTypeExtended): string => {
     case "GITHUB_ENTERPRISE":
       return "GitHub Enterprise";
     case "GITHUB_APP":
-      return "Github App";
+      return "GitHub App";
     default:
       return "GitHub";
   }

--- a/ui/src/domain/Workspaces/Create.tsx
+++ b/ui/src/domain/Workspaces/Create.tsx
@@ -87,21 +87,21 @@ export const CreateWorkspace = () => {
   const [projectList, setProjectList] = useState<ProjectModel[]>([]);
   const gitlabItems = [
     {
-      label: "Gitlab.com",
+      label: "GitLab.com",
       key: "1",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITLAB);
       },
     },
     {
-      label: "Gitlab Community Edition",
+      label: "GitLab Community Edition",
       key: "2",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITLAB_COMMUNITY);
       },
     },
     {
-      label: "Gitlab Enterprise Edition",
+      label: "GitLab Enterprise Edition",
       key: "3",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITLAB_ENTERPRISE);
@@ -111,14 +111,14 @@ export const CreateWorkspace = () => {
 
   const githubItems = [
     {
-      label: "Github.com",
+      label: "GitHub.com",
       key: "1",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITHUB);
       },
     },
     {
-      label: "Github Enterprise",
+      label: "GitHub Enterprise",
       key: "2",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITHUB_ENTERPRISE);
@@ -600,7 +600,7 @@ export const CreateWorkspace = () => {
                     <Dropdown menu={{ items: githubItems }}>
                       <Button size="large">
                         <Space>
-                          <GithubOutlined /> Github <DownOutlined />
+                          <GithubOutlined /> GitHub <DownOutlined />
                         </Space>
                       </Button>
                     </Dropdown>
@@ -608,7 +608,7 @@ export const CreateWorkspace = () => {
                       <Button size="large">
                         <Space>
                           <GitlabOutlined />
-                          Gitlab <DownOutlined />
+                          GitLab <DownOutlined />
                         </Space>
                       </Button>
                     </Dropdown>

--- a/ui/src/domain/Workspaces/Import.tsx
+++ b/ui/src/domain/Workspaces/Import.tsx
@@ -197,7 +197,7 @@ export const ImportWorkspace = () => {
       },
     },
     {
-      title: "Vcs Provider",
+      title: "VCS Provider",
       dataIndex: ["attributes", "vcs-repo", "service-provider"],
       sorter: {
         compare: (a: WorkspaceRecord, b: WorkspaceRecord) => {
@@ -211,7 +211,7 @@ export const ImportWorkspace = () => {
       },
     },
     {
-      title: "Vcs Identifier",
+      title: "VCS Identifier",
       dataIndex: ["attributes", "vcs-repo", "identifier"],
     },
   ];
@@ -232,21 +232,21 @@ export const ImportWorkspace = () => {
   ];
   const gitlabItems = [
     {
-      label: "Gitlab.com",
+      label: "GitLab.com",
       key: "1",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITLAB);
       },
     },
     {
-      label: "Gitlab Community Edition",
+      label: "GitLab Community Edition",
       key: "2",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITLAB_COMMUNITY);
       },
     },
     {
-      label: "Gitlab Enterprise Edition",
+      label: "GitLab Enterprise Edition",
       key: "3",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITLAB_ENTERPRISE);
@@ -256,14 +256,14 @@ export const ImportWorkspace = () => {
 
   const githubItems = [
     {
-      label: "Github.com",
+      label: "GitHub.com",
       key: "1",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITHUB);
       },
     },
     {
-      label: "Github Enterprise",
+      label: "GitHub Enterprise",
       key: "2",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITHUB_ENTERPRISE);
@@ -1011,7 +1011,7 @@ export const ImportWorkspace = () => {
                       <Dropdown menu={{ items: githubItems }}>
                         <Button size="large">
                           <Space>
-                            <GithubOutlined /> Github <DownOutlined />
+                            <GithubOutlined /> GitHub <DownOutlined />
                           </Space>
                         </Button>
                       </Dropdown>
@@ -1019,7 +1019,7 @@ export const ImportWorkspace = () => {
                         <Button size="large">
                           <Space>
                             <GitlabOutlined />
-                            Gitlab <DownOutlined />
+                            GitLab <DownOutlined />
                           </Space>
                         </Button>
                       </Dropdown>


### PR DESCRIPTION
## Summary

Fixes inconsistent casing of third party product names across the UI, documentation and backend code as reported in #3233.

Changes made:
- `Github` → `GitHub` in UI labels, buttons, dropdowns, README and Java log messages
- `Gitlab` → `GitLab` in the same areas
- `Minio` → `MinIO` in docs
- `DEX` → `Dex` in prose (README and development.md)
- `Gitbook` → `GitBook` in README sponsors section
- `Minikube` → `minikube` in README
- `devcontainer` / `Dev container` → `Dev Containers` in docs
- `Vcs Provider` / `Vcs Identifier` → `VCS Provider` / `VCS Identifier` in workspace import table

The `JobVia` enum values (`Github`, `Gitlab`) in both Java and TypeScript are intentionally left unchanged since they are stored as database records and changing them would require a data migration.

## Test plan

- [ ] Open the VCS settings page and verify GitHub and GitLab button labels display correctly
- [ ] Create a workspace and confirm GitHub and GitLab dropdown options show correct casing
- [ ] Create a module and confirm GitHub and GitLab button text is correct
- [ ] Check README renders correctly on GitHub
- [ ] Check workspace import table shows VCS Provider and VCS Identifier column headings

Closes #3233