### PR TITLE
perf: replace hcl2-parser with inline parser to eliminate 3.1 MB bundle chunk

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,6 @@
     "cron-to-quartz": "^1.4.13",
     "cronstrue": "^3.14.0",
     "github-markdown-css": "^5.9.0",
-    "hcl2-parser": "^1.0.3",
     "html-react-parser": "^6.1.3",
     "html-to-image": "^1.11.13",
     "luxon": "^3.7.2",

--- a/ui/src/domain/Modules/Details.tsx
+++ b/ui/src/domain/Modules/Details.tsx
@@ -57,6 +57,58 @@ const Markdown = lazy(async () => {
   return { default: MarkdownWithPlugins };
 });
 
+type HclAttrs = Record<string, unknown>;
+type HclObject = Record<string, Record<string, unknown>>;
+
+function parseHcl(input: string): [HclObject] {
+  const result: HclObject = {};
+
+  const text = input
+    .replace(/\/\/[^\n]*/g, "")
+    .replace(/#[^\n]*/g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "");
+
+  const blockRe = /\b(variable|output|resource)\s+"([^"]+)"(?:\s+"([^"]+)")?\s*\{/g;
+  let m: RegExpExecArray | null;
+
+  while ((m = blockRe.exec(text)) !== null) {
+    const [, type, label1, label2] = m;
+    const bodyStart = m.index + m[0].length;
+    let depth = 1, pos = bodyStart;
+    while (pos < text.length && depth > 0) {
+      if (text[pos] === "{") depth++;
+      else if (text[pos] === "}") depth--;
+      pos++;
+    }
+    const body = text.slice(bodyStart, pos - 1);
+    const attrs: HclAttrs = {};
+
+    for (const a of body.matchAll(/^\s*(\w+)\s*=\s*"((?:[^"\\]|\\.)*)"/gm)) {
+      attrs[a[1]] = a[2];
+    }
+    for (const a of body.matchAll(/^\s*(\w+)\s*=\s*([^"\n{[\s#][^\n#]*)/gm)) {
+      if (a[1] in attrs) continue;
+      const v = a[2].trim();
+      if (v === "true") attrs[a[1]] = true;
+      else if (v === "false") attrs[a[1]] = false;
+      else if (v === "null") attrs[a[1]] = null;
+      else if (v !== "" && !isNaN(Number(v))) attrs[a[1]] = Number(v);
+      else attrs[a[1]] = v;
+    }
+
+    if (type === "resource" && label2) {
+      if (!result.resource) result.resource = {};
+      if (!result.resource[label1]) result.resource[label1] = {};
+      (result.resource[label1] as Record<string, HclAttrs[]>)[label2] = [attrs];
+    } else {
+      if (!result[type]) result[type] = {};
+      result[type][label1] = [attrs];
+    }
+  }
+
+  return [result];
+}
+
 type Props = {
   organizationName: string;
 };
@@ -175,8 +227,7 @@ export const ModuleDetails = ({ organizationName }: Props) => {
       }
     }
 
-    const hcl = await import("hcl2-parser");
-    const hclResult = hcl.parseToObject(hclString);
+    const hclResult = parseHcl(hclString);
     if (hclResult) {
       setHclObject(hclResult[0]);
       if (hclResult[0]?.variable) {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3486,7 +3486,6 @@ __metadata:
     eslint-plugin-react-refresh: "npm:^0.5.3"
     github-markdown-css: "npm:^5.9.0"
     globals: "npm:^17.6.0"
-    hcl2-parser: "npm:^1.0.3"
     html-react-parser: "npm:^6.1.3"
     html-to-image: "npm:^1.11.13"
     identity-obj-proxy: "npm:^3.0.0"
@@ -5777,13 +5776,6 @@ __metadata:
     property-information: "npm:^7.0.0"
     space-separated-tokens: "npm:^2.0.0"
   checksum: 10c0/18dc8064e5c3a7a2ae862978e626b97a254e1c8a67ee9d0c9f06d373bba155ed805fc5b5ce21b990fb7bc174624889e5e1ce1cade264f1b1d58b48f994bc85ce
-  languageName: node
-  linkType: hard
-
-"hcl2-parser@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "hcl2-parser@npm:1.0.3"
-  checksum: 10c0/5c5d9b12ec7f84864122e387af41df183666d9d01da6a922631fa0e5f4530b5856fdfb156346b3c23519f2bfc9bb051e8c520d4614d9935c6539d70bce1bb521
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Closes #3212

hcl2-parser was the largest single chunk in the UI bundle at 3118 KB minified / 753 KB gzipped, larger than antd. It was only used in one place: Modules/Details.tsx, to extract variable, output and resource blocks from Terraform HCL files for display in the module details tabs.

This PR replaces it with a small inline parseHcl function (~50 lines) that handles the three block types and attribute patterns the component actually uses. The hcl-parser chunk no longer appears in the build output at all.

### What the parser handles

variable, output and resource block headers with their labels
Single line string values (key = "value")
Bare values including booleans, null, numbers and type expressions like string and list(string)
Strips //, # and block comments before parsing

### What it does not handle (acceptable tradeoffs)

Heredoc descriptions will be blank rather than shown
Multi line default values such as lists or maps spanning multiple lines will not be parsed; the cell will be empty

These edge cases affect display only and are far less common than the straightforward patterns above.

## Test plan

Open a module in the registry and check the Inputs tab shows variable names, types, descriptions and defaults
Check the Outputs tab shows output names and descriptions
Check the Resources tab shows resource type and name pairs
Confirm no hcl-parser chunk appears in the network tab when loading the module details page
Run yarn build and confirm no hcl-parser file in build/assets/