### PR TITLE
fix: show imported resources in structured plan view

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/service/terraform/PlanStructuredOutputService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/PlanStructuredOutputService.java
@@ -114,8 +114,13 @@ public class PlanStructuredOutputService {
 
             List<String> actions = (List<String>) changeBlock.getOrDefault("actions", List.of());
             String action = normalizeAction(actions);
-            if ("no-op".equals(action)) {
+            Object importingValue = changeBlock.get("importing");
+            boolean isImporting = importingValue != null;
+            if ("no-op".equals(action) && !isImporting) {
                 continue;
+            }
+            if ("no-op".equals(action) && isImporting) {
+                action = "import";
             }
 
             Map<String, Object> entry = new HashMap<>();
@@ -125,6 +130,9 @@ public class PlanStructuredOutputService {
             entry.put("resourceName", change.get("name"));
             entry.put("actions", actions);
             entry.put("action", action);
+            if (isImporting) {
+                entry.put("importing", importingValue);
+            }
             Object beforeValue = changeBlock.get("before");
             Object afterValue = changeBlock.get("after");
             Object beforeSensitive = changeBlock.get("before_sensitive");

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/PlanStructuredOutputServiceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/PlanStructuredOutputServiceTest.java
@@ -223,6 +223,37 @@ class PlanStructuredOutputServiceTest {
     }
 
     @Test
+    void includesNoOpChangesWithImportingFieldAsImportAction() throws Exception {
+        String json = """
+                {
+                  "resource_changes": [
+                    {
+                      "address": "aws_instance.example",
+                      "type": "aws_instance",
+                      "name": "example",
+                      "change": {
+                        "actions": ["no-op"],
+                        "before": {"id": "i-abc123", "ami": "ami-12345"},
+                        "after": {"id": "i-abc123", "ami": "ami-12345"},
+                        "after_unknown": {},
+                        "before_sensitive": {},
+                        "after_sensitive": {},
+                        "importing": {"id": "i-abc123"}
+                      }
+                    }
+                  ]
+                }
+                """;
+
+        List<Map<String, Object>> changes = subject().buildChangesFromPlanJson(json);
+
+        assertEquals(1, changes.size());
+        assertEquals("import", changes.get(0).get("action"));
+        assertEquals("aws_instance.example", changes.get(0).get("address"));
+        assertEquals(Map.of("id", "i-abc123"), changes.get(0).get("importing"));
+    }
+
+    @Test
     void mergesStructuredPlanDataWithoutDroppingExistingContext() {
         Map<String, Object> context = new HashMap<>();
         context.put("custom", "value");

--- a/ui/src/domain/Jobs/StructuredPlanOutput.css
+++ b/ui/src/domain/Jobs/StructuredPlanOutput.css
@@ -47,6 +47,10 @@
   background: #cf3d38;
 }
 
+.structured-plan-summarySegment--import {
+  background: #6d28d9;
+}
+
 .structured-plan-summarySymbol {
   display: inline-flex;
   align-items: center;
@@ -298,6 +302,12 @@
   color: #64748b;
 }
 
+.structured-plan-actionIcon--import {
+  background: #f3eeff;
+  border-color: #d4b8ff;
+  color: #6d28d9;
+}
+
 .structured-plan-providerBadge {
   align-items: center;
   background: #f4f6f9;
@@ -419,6 +429,19 @@
   background: #f8fafc;
   border-color: #dce3eb;
   color: #64748b;
+}
+
+.structured-plan-actionPill--import {
+  background: #f3eeff;
+  border-color: #d4b8ff;
+  color: #6d28d9;
+}
+
+.structured-plan-metaPill--import {
+  background: #f3eeff;
+  border-color: #d4b8ff;
+  color: #6d28d9;
+  font-weight: 600;
 }
 
 .structured-plan-metaPill {
@@ -781,6 +804,12 @@
   color: var(--tk-text-tertiary);
 }
 
+[data-theme="dark"] .structured-plan-actionIcon--import {
+  background: rgba(163, 113, 247, 0.15);
+  border-color: rgba(163, 113, 247, 0.3);
+  color: #d2a8ff;
+}
+
 [data-theme="dark"] .structured-plan-providerBadge {
   background: var(--tk-fill-primary);
   border-color: var(--tk-border-primary);
@@ -952,6 +981,18 @@
   background: var(--tk-fill-primary);
   border-color: var(--tk-border-primary);
   color: var(--tk-text-tertiary);
+}
+
+[data-theme="dark"] .structured-plan-actionPill--import {
+  background: rgba(163, 113, 247, 0.15);
+  border-color: rgba(163, 113, 247, 0.3);
+  color: #d2a8ff;
+}
+
+[data-theme="dark"] .structured-plan-metaPill--import {
+  background: rgba(163, 113, 247, 0.15);
+  border-color: rgba(163, 113, 247, 0.3);
+  color: #d2a8ff;
 }
 
 [data-theme="dark"] .structured-plan-metaPill {

--- a/ui/src/domain/Jobs/StructuredPlanOutput.tsx
+++ b/ui/src/domain/Jobs/StructuredPlanOutput.tsx
@@ -12,8 +12,8 @@ type Props = {
   outputLog?: string;
 };
 
-type ActionName = "create" | "update" | "replace" | "delete" | "read" | "unknown" | "no-op";
-type ActionFilter = "all" | "create" | "update" | "replace" | "delete" | "read";
+type ActionName = "create" | "update" | "replace" | "delete" | "read" | "import" | "unknown" | "no-op";
+type ActionFilter = "all" | "create" | "update" | "replace" | "delete" | "read" | "import";
 
 type DiffRow = {
   key: string;
@@ -52,6 +52,7 @@ type SummaryCounts = {
   update: number;
   delete: number;
   read: number;
+  import: number;
   unknown: number;
 };
 
@@ -70,7 +71,7 @@ type PreparedChangeRow = {
 };
 
 type SummarySegment = {
-  key: "create" | "update" | "delete";
+  key: "create" | "update" | "delete" | "import";
   label: string;
   count: number;
   symbol: string;
@@ -114,6 +115,12 @@ const actionMeta: Record<
     filterLabel: "Read",
     symbol: "?",
     className: "read",
+  },
+  import: {
+    displayLabel: "import",
+    filterLabel: "Import",
+    symbol: "i",
+    className: "import",
   },
   unknown: {
     displayLabel: "unknown",
@@ -715,6 +722,7 @@ const normalizeActionName = (value: string): ActionName => {
     value === "replace" ||
     value === "delete" ||
     value === "read" ||
+    value === "import" ||
     value === "unknown" ||
     value === "no-op"
   ) {
@@ -858,6 +866,11 @@ const buildSummary = (rows: PreparedChangeRow[]): SummaryCounts => {
         return summary;
       }
 
+      if (row.action === "import") {
+        summary.import += 1;
+        return summary;
+      }
+
       summary.unknown += 1;
       return summary;
     },
@@ -866,6 +879,7 @@ const buildSummary = (rows: PreparedChangeRow[]): SummaryCounts => {
       update: 0,
       delete: 0,
       read: 0,
+      import: 0,
       unknown: 0,
     }
   );
@@ -901,6 +915,15 @@ const buildSummarySegments = (summary: SummaryCounts): SummarySegment[] => {
     });
   }
 
+  if (summary.import > 0) {
+    segments.push({
+      key: "import",
+      label: `${summary.import} to import`,
+      count: summary.import,
+      symbol: "i",
+    });
+  }
+
   return segments;
 };
 
@@ -917,6 +940,10 @@ const formatResourceSummary = (summary: SummaryCounts) => {
 
   if (summary.delete > 0) {
     parts.push(`${summary.delete} to destroy`);
+  }
+
+  if (summary.import > 0) {
+    parts.push(`${summary.import} to import`);
   }
 
   if (parts.length === 0) {
@@ -1167,6 +1194,7 @@ export const StructuredPlanOutput = ({ changes, outputLog }: Props) => {
                 <option value="replace">{actionMeta.replace.filterLabel}</option>
                 <option value="delete">{actionMeta.delete.filterLabel}</option>
                 <option value="read">{actionMeta.read.filterLabel}</option>
+                <option value="import">{actionMeta.import.filterLabel}</option>
               </select>
               <DownOutlined className="structured-plan-selectChevron" />
             </label>
@@ -1266,6 +1294,11 @@ export const StructuredPlanOutput = ({ changes, outputLog }: Props) => {
                               <span className="structured-plan-metaPill">{row.change.moduleAddress}</span>
                             ) : null}
                             {row.isDataSource ? <span className="structured-plan-metaPill">data source</span> : null}
+                            {row.change.importing?.id ? (
+                              <span className="structured-plan-metaPill structured-plan-metaPill--import">
+                                imported: {row.change.importing.id}
+                              </span>
+                            ) : null}
                           </div>
 
                           <div className="structured-plan-rowCounts">

--- a/ui/src/domain/Jobs/structuredPlan.ts
+++ b/ui/src/domain/Jobs/structuredPlan.ts
@@ -11,6 +11,7 @@ export type PlanChange = {
   after?: unknown;
   afterSensitive?: unknown;
   afterUnknown?: unknown;
+  importing?: { id?: string };
 };
 
 export type StructuredPlanOutputByStep = Record<string, PlanChange[]>;
@@ -74,6 +75,10 @@ export const getPlanChangeActionLabel = (actions: string[] = [], fallback?: stri
     return "no-op";
   }
 
+  if (normalizedActions.includes("import")) {
+    return "import";
+  }
+
   const fallbackValue = toOptionalString(fallback);
   if (fallbackValue) {
     return fallbackValue;
@@ -112,6 +117,12 @@ const normalizePlanChange = (value: unknown): PlanChange | null => {
   const actions = toStringArray(value.actions);
   const action = getPlanChangeActionLabel(actions, toOptionalString(value.action));
 
+  const rawImporting = value.importing;
+  const importing =
+    isRecord(rawImporting)
+      ? { id: typeof rawImporting.id === "string" ? rawImporting.id : undefined }
+      : undefined;
+
   return {
     address: toOptionalString(value.address),
     resourceType: toOptionalString(value.resourceType),
@@ -125,6 +136,7 @@ const normalizePlanChange = (value: unknown): PlanChange | null => {
     after: value.after,
     afterSensitive: value.afterSensitive,
     afterUnknown: value.afterUnknown,
+    importing,
   };
 };
 


### PR DESCRIPTION
## Summary

- Fixes #3216 — imported resources were invisible in the new plan view
- Root cause: `PlanStructuredOutputService` skipped all `no-op` resource changes, but Terraform represents imports as `no-op` + `importing: { id: "..." }` in the plan JSON
- No-op changes that carry an `importing` field are now kept and surfaced as action `"import"` so they reach the UI

## Changes

**Executor (Java)**
- `PlanStructuredOutputService.buildChangesFromPlanJson`: skip no-op only when `importing` is absent; reclassify matching entries as action `"import"` and forward the `importing` object
- `PlanStructuredOutputServiceTest`: new test verifying imported resources are included with action `"import"` and the import ID

**UI (TypeScript)**
- `structuredPlan.ts`: added `importing?: { id?: string }` to `PlanChange`; `normalizePlanChange` extracts the field; `getPlanChangeActionLabel` handles `"import"` action string
- `StructuredPlanOutput.tsx`: `"import"` added to `ActionName`, `ActionFilter`, `actionMeta`, `SummaryCounts`, `SummarySegment`, `buildSummary`, `buildSummarySegments`, `formatResourceSummary`, `normalizeActionName`, and the operation filter dropdown; expanded resource panel shows an `imported: <id>` badge when present
- `StructuredPlanOutput.css`: purple styles for import summary strip segment, action icon, action pill, and import ID badge (light and dark mode)

## Test plan

- [ ] Run a Terraform plan that includes an `import` block — the imported resource should now appear in the structured plan view with a purple `i` badge and `imported: <id>` pill
- [ ] Plans with no imports are unaffected — no-op resources without `importing` continue to be filtered out
- [ ] Java unit test `includesNoOpChangesWithImportingFieldAsImportAction` passes
- [ ] Operation filter includes "Import" as a selectable option

🤖 Generated with [Claude Code](https://claude.com/claude-code)