### PR TITLE
feat: support for semantic version

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
@@ -32,6 +32,8 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Builder
@@ -68,10 +70,32 @@ public class AwsTerraformStateImpl implements TerraformState {
     @NonNull
     TerraformStatePathService terraformStatePathService;
 
+    // Matches X-Range wildcards: * or major.wildcard (e.g. 1.x, 1.*, 1.X).
+    // Bare x/X are intentionally excluded: TerraformDownloader rejects them as invalid.
+    // Major.minor.wildcard (1.6.x) is also excluded: the version regex extracts the concrete prefix correctly.
+    private static final Pattern X_RANGE_PATTERN = Pattern.compile("^\\*$|^\\d+\\.[*xX]$");
+
     @Override
     public String getBackendStateFile(String organizationId, String workspaceId, File workingDirectory, String terraformVersion) {
         log.info("Generating backend override file for terraform {}", terraformVersion);
-        ComparableVersion version = new ComparableVersion(terraformVersion);
+        ComparableVersion version;
+        if (X_RANGE_PATTERN.matcher(terraformVersion.trim()).matches()) {
+            // X-Range wildcards (*, x, 1.x, …) resolve to the latest terraform release,
+            // which is always >= 1.6.0, so use the new-style endpoints block.
+            log.info("X-Range wildcard detected for \"{}\", treating as latest version", terraformVersion);
+            version = new ComparableVersion("9999.9999.9999");
+        } else {
+            Matcher versionMatcher = Pattern.compile("(\\d+\\.\\d+(?:\\.\\d+)*)").matcher(terraformVersion);
+            ComparableVersion maxVersion = null;
+            while (versionMatcher.find()) {
+                ComparableVersion found = new ComparableVersion(versionMatcher.group(1));
+                if (maxVersion == null || found.compareTo(maxVersion) > 0) {
+                    maxVersion = found;
+                }
+            }
+            version = maxVersion != null ? maxVersion : new ComparableVersion(terraformVersion);
+        }
+        log.info("Terraform version resolved to \"{}\" from constraint \"{}\"", version, terraformVersion);
 
         String awsBackend = BACKEND_FILE_NAME;
         try {

--- a/executor/src/test/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImplTest.java
@@ -9,6 +9,8 @@ import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Answers;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -78,6 +80,32 @@ class AwsTerraformStateImplTest {
     }
 
     @Test
+    void testGetBackendStateFile_PessimisticConstraintWithEndpoint(@TempDir Path tempDir) throws IOException {
+        awsTerraformState.setEndpoint("http://minio:9000");
+
+        String result = awsTerraformState.getBackendStateFile("org1", "ws1", tempDir.toFile(), "~>1.13.0");
+
+        assertEquals("aws_backend_override.tf", result);
+        String content = FileUtils.readFileToString(new File(tempDir.toFile(), "aws_backend_override.tf"), Charset.defaultCharset());
+        assertTrue(content.contains("endpoints = {"), "Should use new-style endpoints block for ~>1.13.0");
+        assertTrue(content.contains("skip_requesting_account_id = true"), "Should include skip_requesting_account_id for ~>1.13.0");
+        assertFalse(content.contains("endpoint  ="), "Should not use deprecated endpoint parameter for ~>1.13.0");
+    }
+
+    @Test
+    void testGetBackendStateFile_IvyRangeWithEndpoint(@TempDir Path tempDir) throws IOException {
+        awsTerraformState.setEndpoint("http://minio:9000");
+
+        String result = awsTerraformState.getBackendStateFile("org1", "ws1", tempDir.toFile(), "[1.13.0,1.14.0]");
+
+        assertEquals("aws_backend_override.tf", result);
+        String content = FileUtils.readFileToString(new File(tempDir.toFile(), "aws_backend_override.tf"), Charset.defaultCharset());
+        assertTrue(content.contains("endpoints = {"), "Should use new-style endpoints block for [1.13.0,1.14.0]");
+        assertTrue(content.contains("skip_requesting_account_id = true"), "Should include skip_requesting_account_id for [1.13.0,1.14.0]");
+        assertFalse(content.contains("endpoint  ="), "Should not use deprecated endpoint parameter for [1.13.0,1.14.0]");
+    }
+
+    @Test
     void testGetBackendStateFile_NewVersionWithEndpoint(@TempDir Path tempDir) throws IOException {
         awsTerraformState.setEndpoint("http://localhost:4566");
         awsTerraformState.setIncludeBackendKeys(true);
@@ -97,6 +125,49 @@ class AwsTerraformStateImplTest {
         assertTrue(content.contains("s3 = \"http://localhost:4566\""));
         assertTrue(content.contains("access_key = \"access\""));
         assertTrue(content.contains("secret_key = \"secret\""));
+    }
+
+    @ParameterizedTest(name = "version constraint \"{0}\" uses new endpoints block")
+    @ValueSource(strings = {
+        "~1.13.0",           // npm tilde
+        "^1.13.0",           // npm caret
+        ">=1.7.0 <1.14.0",   // primitive range (lower >= 1.6.0)
+        ">=1.5.7 <1.9.0",    // primitive range straddling 1.6.0 boundary
+        "[1.7.0,)",           // ivy open upper (inclusive)
+        "]1.7.0,)",           // ivy open upper (exclusive)
+        "(,1.14.0]",          // ivy open lower
+        "1.13.0 - 1.14.0",   // npm hyphen
+        "*",                  // X-Range: any version
+        "1.x",                // X-Range: any 1.y version
+        "1.*",                // X-Range: any 1.y version (alternative)
+    })
+    void testGetBackendStateFile_NewStyleConstraintUsesEndpointsBlock(String version, @TempDir Path tempDir) throws IOException {
+        awsTerraformState.setEndpoint("http://minio:9000");
+
+        awsTerraformState.getBackendStateFile("org1", "ws1", tempDir.toFile(), version);
+
+        String content = FileUtils.readFileToString(new File(tempDir.toFile(), "aws_backend_override.tf"), Charset.defaultCharset());
+        assertTrue(content.contains("endpoints = {"), "Should use new-style endpoints for: " + version);
+        assertTrue(content.contains("skip_requesting_account_id = true"), "Should include skip_requesting_account_id for: " + version);
+        assertFalse(content.contains("endpoint  ="), "Should not use deprecated endpoint for: " + version);
+    }
+
+    @ParameterizedTest(name = "legacy version constraint \"{0}\" uses deprecated endpoint param")
+    @ValueSource(strings = {
+        "~>1.5.0",           // cocoapods pessimistic (< 1.6.0)
+        "[1.4.0,1.5.9]",     // ivy bounded (< 1.6.0)
+        "~1.5",              // npm tilde (< 1.6.0)
+        "^1.5.3",            // npm caret (< 1.6.0)
+        ">=1.4.0 <1.5.9",    // primitive range (< 1.6.0)
+    })
+    void testGetBackendStateFile_LegacyConstraintUsesOldEndpoint(String version, @TempDir Path tempDir) throws IOException {
+        awsTerraformState.setEndpoint("http://minio:9000");
+
+        awsTerraformState.getBackendStateFile("org1", "ws1", tempDir.toFile(), version);
+
+        String content = FileUtils.readFileToString(new File(tempDir.toFile(), "aws_backend_override.tf"), Charset.defaultCharset());
+        assertTrue(content.contains("endpoint  ="), "Should use deprecated endpoint for legacy: " + version);
+        assertFalse(content.contains("endpoints = {"), "Should not use new-style endpoints for legacy: " + version);
     }
 
     @Test

--- a/ui/src/domain/Workspaces/Create.tsx
+++ b/ui/src/domain/Workspaces/Create.tsx
@@ -1,5 +1,6 @@
 import { DownOutlined, GithubOutlined, GitlabOutlined } from "@ant-design/icons";
 import {
+  AutoComplete,
   Breadcrumb,
   Button,
   Card,
@@ -25,7 +26,7 @@ import { v7 as uuid } from "uuid";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
 import axiosInstance from "../../config/axiosConfig";
 import { ProjectModel, SshKey, Template, TofuRelease, VcsModel, VcsType, VcsTypeExtended } from "../types";
-import { compareVersions } from "./Workspaces";
+import { compareVersions, validateTerraformVersion } from "./Workspaces";
 import projectService from "@/modules/projects/projectService";
 import { withBasePath } from "../../config/basePath";
 const { Content } = Layout;
@@ -722,16 +723,19 @@ export const CreateWorkspace = () => {
               <Form.Item
                 name="terraformVersion"
                 label={iacType?.name + " Version"}
-                rules={[{ required: true }]}
+                rules={[{ required: true }, { validator: validateTerraformVersion(terraformVersions) }]}
                 extra={
-                  "The version of " + iacType?.name + " to use for this workspace. It will not upgrade automatically."
+                  "The version of " +
+                  iacType?.name +
+                  " to use for this workspace. It will not upgrade automatically. Version constraints are also supported (e.g. ~>1.11.0, >=1.5.7 <1.9.0)."
                 }
               >
-                <Select placeholder="select version" style={{ width: 250 }}>
-                  {terraformVersions.map(function (name) {
-                    return <Option key={name}>{name}</Option>;
-                  })}
-                </Select>
+                <AutoComplete
+                  placeholder="e.g. 1.11.0 or ~>1.11.0"
+                  options={terraformVersions.map((v) => ({ value: v }))}
+                  filterOption={(input, option) => (option?.value ?? "").includes(input)}
+                  style={{ width: 250 }}
+                />
               </Form.Item>
               <Form.Item
                 hidden={!sshKeysVisible}

--- a/ui/src/domain/Workspaces/Settings/General.tsx
+++ b/ui/src/domain/Workspaces/Settings/General.tsx
@@ -1,8 +1,16 @@
-import { Button, Divider, Form, Input, Select, Spin, Typography, message } from "antd";
+import { AutoComplete, Button, Divider, Form, Input, Select, Spin, Typography, message } from "antd";
 import { useEffect, useState } from "react";
 import axiosInstance from "../../../config/axiosConfig";
 import { Agent, Template, TofuRelease, Workspace } from "../../types";
-import { atomicHeader, compareVersions, genericHeader, getIaCIconById, getIaCNameById, iacTypes } from "../Workspaces";
+import {
+  atomicHeader,
+  compareVersions,
+  genericHeader,
+  getIaCIconById,
+  getIaCNameById,
+  iacTypes,
+  validateTerraformVersion,
+} from "../Workspaces";
 import projectService from "@/modules/projects/projectService";
 import { ProjectModel } from "@/domain/types";
 import { useOrgPermissions } from "@/modules/permissions/useOrgPermissions";
@@ -187,6 +195,7 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace,
             description: workspaceData.attributes?.description,
             folder: workspaceData.attributes?.folder,
             executionMode: workspaceData.attributes?.executionMode,
+            terraformVersion: workspaceData.attributes?.terraformVersion,
             iacType: workspaceData.attributes?.iacType,
             branch: workspaceData.attributes?.branch,
             defaultTemplate: workspaceData.attributes?.defaultTemplate,
@@ -288,17 +297,19 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace,
           <Form.Item
             name="terraformVersion"
             label={getIaCNameById(selectedIac || workspaceData.attributes?.iacType) + " Version"}
+            rules={[{ validator: validateTerraformVersion(terraformVersions) }]}
             extra={
               "The version of " +
               getIaCNameById(selectedIac || workspaceData.attributes?.iacType) +
-              " to use for this workspace. Upon creating this workspace, the latest version was selected and will be used until it is changed manually. It will not upgrade automatically."
+              " to use for this workspace. It will not upgrade automatically. Version constraints are also supported (e.g. ~>1.11.0, >=1.5.7 <1.9.0)."
             }
           >
-            <Select defaultValue={workspaceData.attributes?.terraformVersion} disabled={!manageWorkspace}>
-              {terraformVersions.map(function (name) {
-                return <Option key={name}>{name}</Option>;
-              })}
-            </Select>
+            <AutoComplete
+              disabled={!manageWorkspace}
+              options={terraformVersions.map((v) => ({ value: v }))}
+              filterOption={(input, option) => (option?.value ?? "").includes(input)}
+              placeholder="e.g. 1.11.0 or ~>1.11.0"
+            />
           </Form.Item>
           <Form.Item
             name="folder"

--- a/ui/src/domain/Workspaces/Workspaces.tsx
+++ b/ui/src/domain/Workspaces/Workspaces.tsx
@@ -13,6 +13,8 @@ export const genericHeader = {
   },
 };
 
+export { validateTerraformVersion } from "@/modules/workspaces/utils/versionValidation";
+
 export function compareVersions(a: string, b: string) {
   if (a === b) {
     return 0;

--- a/ui/src/modules/workspaces/utils/versionValidation.spec.ts
+++ b/ui/src/modules/workspaces/utils/versionValidation.spec.ts
@@ -62,8 +62,10 @@ describe("validateTerraformVersion", () => {
     const check = (v: string) => validateTerraformVersion(versions)(null, v);
 
     it("accepts a version that exists in the list", () => expect(check("1.11.0")).resolves.toBeUndefined());
-    it("rejects a version that does not exist in the list", () => expect(check("1.99.99")).rejects.toThrow("not available"));
-    it("accepts a constraint string even if it is not in the list", () => expect(check("~>1.11.0")).resolves.toBeUndefined());
+    it("rejects a version that does not exist in the list", () =>
+      expect(check("1.99.99")).rejects.toThrow("not available"));
+    it("accepts a constraint string even if it is not in the list", () =>
+      expect(check("~>1.11.0")).resolves.toBeUndefined());
     it("skips the existence check when the list is empty", () =>
       expect(validateTerraformVersion([])(null, "1.99.99")).resolves.toBeUndefined());
   });

--- a/ui/src/modules/workspaces/utils/versionValidation.spec.ts
+++ b/ui/src/modules/workspaces/utils/versionValidation.spec.ts
@@ -1,0 +1,70 @@
+import { validateTerraformVersion } from "./versionValidation";
+
+const valid = async (value: string) => expect(validateTerraformVersion()(null, value)).resolves.toBeUndefined();
+
+const invalid = async (value: string) =>
+  expect(validateTerraformVersion()(null, value)).rejects.toThrow("Invalid version format");
+
+describe("validateTerraformVersion", () => {
+  describe("empty / absent values are allowed (optional field)", () => {
+    it("accepts undefined", () => expect(validateTerraformVersion()(null, undefined)).resolves.toBeUndefined());
+    it("accepts empty string", () => expect(validateTerraformVersion()(null, "")).resolves.toBeUndefined());
+  });
+
+  describe("plain semantic versions", () => {
+    it.each(["1.11.0", "1.11", "1", "0.15.0", "1.2.3.4"])("accepts %s", valid);
+  });
+
+  describe("NPM x-range", () => {
+    it.each(["*", "1.x", "1.X", "1.2.x", "1.2.*", "1.2.X"])("accepts %s", valid);
+  });
+
+  describe("NPM tilde range", () => {
+    it.each(["~1", "~1.2", "~1.2.3"])("accepts %s", valid);
+  });
+
+  describe("NPM caret range", () => {
+    it.each(["^1.2.3", "^0.2.5", "^0.0.4", "^1"])("accepts %s", valid);
+  });
+
+  describe("NPM hyphen range", () => {
+    it.each(["1.2.3 - 2.3.4", "1.0 - 2.0"])("accepts %s", valid);
+  });
+
+  describe("primitive operators and CocoaPods ~>", () => {
+    it.each([
+      ">=1.5.7",
+      ">1.5.7",
+      "<=1.9.0",
+      "<1.9.0",
+      "=1.9.0",
+      "!=1.5.7",
+      "~>1.11.0",
+      "~> 1.0",
+      ">=1.5.7 <1.9.0",
+      ">=1.5.7 <=1.9.0",
+    ])("accepts %s", valid);
+  });
+
+  describe("Ivy version ranges", () => {
+    it.each(["[1.0,2.0]", "[1.0,2.0[", "]1.0,2.0]", "]1.0,2.0[", "[1.0,)", "]1.0,)", "(,2.0]", "(,2.0["])(
+      "accepts %s",
+      valid
+    );
+  });
+
+  describe("invalid formats are rejected", () => {
+    it.each(["latest", "v1.11.0", "1.11.0-rc1", "abc", ">=", "~>", "[]", "1..0", "x", "X"])("rejects %s", invalid);
+  });
+
+  describe("existence check when availableVersions is specified", () => {
+    const versions = ["1.11.0", "1.12.0"];
+    const check = (v: string) => validateTerraformVersion(versions)(null, v);
+
+    it("accepts a version that exists in the list", () => expect(check("1.11.0")).resolves.toBeUndefined());
+    it("rejects a version that does not exist in the list", () => expect(check("1.99.99")).rejects.toThrow("not available"));
+    it("accepts a constraint string even if it is not in the list", () => expect(check("~>1.11.0")).resolves.toBeUndefined());
+    it("skips the existence check when the list is empty", () =>
+      expect(validateTerraformVersion([])(null, "1.99.99")).resolves.toBeUndefined());
+  });
+});

--- a/ui/src/modules/workspaces/utils/versionValidation.ts
+++ b/ui/src/modules/workspaces/utils/versionValidation.ts
@@ -1,0 +1,28 @@
+const VERSION_CONSTRAINT_PATTERNS = [
+  /^\d+(\.\d+)*$/, // plain: 1.2.3
+  /^(\d+|\*)(\.((\d+)|[xX*])(\.((\d+)|[xX*]))?)?$/, // npm x-range: 1.2.x, * (bare x/X unsupported by terraform-spring-boot-starter)
+  /^~\d+(\.\d+(\.\d+)?)?$/, // npm tilde: ~1.2.3
+  /^\^\d+(\.\d+(\.\d+)?)?$/, // npm caret: ^1.2.3
+  /^\d+(\.\d+)*\s+-\s+\d+(\.\d+)*$/, // npm hyphen: 1.2.3 - 2.3.4
+  /^(~>|>=?|<=?|!=|=)\s*\d+(\.\d+)*(\s+(~>|>=?|<=?|!=|=)\s*\d+(\.\d+)*)*$/, // primitive / cocoapods ~>
+  /^[[\]]\d+(\.\d+)*,\d+(\.\d+)*[[\]]$/, // ivy bounded: [1.0,2.0]
+  /^[[\]]\d+(\.\d+)*,\)$/, // ivy open upper: [1.0,)
+  /^\(,\d+(\.\d+)*[[\]]$/, // ivy open lower: (,2.0]
+];
+
+export const validateTerraformVersion =
+  (availableVersions?: string[]) =>
+  (_: unknown, value: string | undefined): Promise<void> => {
+    if (!value) return Promise.resolve();
+    const trimmed = value.trim();
+    if (!VERSION_CONSTRAINT_PATTERNS.some((p) => p.test(trimmed))) {
+      return Promise.reject(new Error("Invalid version format"));
+    }
+    const isExactVersion = /^\d+(\.\d+)*$/.test(trimmed);
+    if (isExactVersion && availableVersions && availableVersions.length > 0) {
+      if (!availableVersions.includes(trimmed)) {
+        return Promise.reject(new Error(`Version ${trimmed} is not available. Select a version from the list.`));
+      }
+    }
+    return Promise.resolve();
+  };

--- a/ui/tsconfig.test.json
+++ b/ui/tsconfig.test.json
@@ -25,7 +25,8 @@
     "baseUrl": "./src",
     "paths": {
       "@/*": ["./*"]
-    }
+    },
+    "ignoreDeprecations": "6.0"
   },
 
 }


### PR DESCRIPTION
## Summary

Closes #2449

Adds support for Terraform/OpenTofu semantic version constraints in workspace settings. Previously, users were forced to select an exact version from a fixed dropdown. This PR replaces the dropdown with a free-text `AutoComplete` input that validates the entered value and still surfaces available versions as suggestions.

## Changes

### UI

- Replaced the `<Select>` dropdown for Terraform version in **Create Workspace** and **Workspace Settings → General** with `<AutoComplete>`, allowing users to type a constraint while browsing available versions as suggestions.
- Added `validateTerraformVersion` (versionValidation.ts) — a curried validator factory `validateTerraformVersion(availableVersions?)` that applies two layers of checks:
    1. **Format check** — accepts any of the following:
        - Plain semver: `1.11.0`, `1.11`, `1`
        - NPM x-range: `*`, `1.x`, `1.2.*` *(bare `x`/`X` are not accepted — see Known Limitations)*
        - NPM tilde/caret/hyphen: `~1.2.3`, `^1.2.3`, `1.2.3 - 2.3.4`
        - Primitive operators and CocoaPods pessimistic: `>=1.5.7 <1.9.0`, `~>1.11.0`
        - Ivy notation: `[1.0,2.0]`, `[1.7.0,)`, `(,1.14.0]`
    2. **Existence check** — when an exact version (e.g. `1.11.0`) is entered and `availableVersions` is non-empty, validates that the version is actually present in the available releases list. Constraint strings (non-exact) skip this check intentionally.
- Updated help text to inform users that version constraints are supported.

### Executor (AWS S3 backend)

- Fixed `AwsTerraformStateImpl.getBackendStateFile()` to correctly select the S3 backend HCL format when a version constraint is used. Terraform 1.6.0 changed the S3 backend configuration syntax — the `endpoint` attribute was replaced with an `endpoints` block, and `force_path_style` was renamed to `use_path_style` — so Terrakube generates different HCL depending on which syntax the target version requires. Previously this selection only worked with an exact version string; this fix extends it to handle constraints:
    - For range constraints, the **largest version number found literally in the constraint string** is used as a reference for backend selection (e.g. `~>1.11.0` → `1.11.0`, `>=1.5.7 <1.9.0` → `1.9.0` as the upper boundary marker). This is a best-effort heuristic: the code does not resolve the constraint to an actual release, but the highest number in the string is a reliable indicator of the target version range.
    - For X-Range wildcards (`*`, `1.x`, `1.*`), the constraint is treated as "latest" and the new-style backend block is used.

## Tests

- **UI:** Vitest unit test suite covering all supported formats, invalid inputs, and the existence-check behavior with and without an `availableVersions` list (versionValidation.spec.ts).
- **Executor:** JUnit 5 parameterized tests verifying that each constraint style produces the correct backend block, including boundary cases around the 1.6.0 threshold (AwsTerraformStateImplTest.java).

## Known Limitations

- **Bare `x` and `X` wildcards are not supported.** Using `x` or `X` alone as the Terraform version (e.g. entering `x` to mean "any version") results in a validation error in the UI. This is a limitation of `terraform-spring-boot-starter` v1.4.0: `TerraformDownloader` rejects these as an invalid version range at runtime. Use `*` for "any version", or specify a major prefix (e.g. `1.x`, `1.10.x`).
