### PR TITLE
fix: cascade delete steps and addresses when deleting a job

### DIFF
--- a/api/src/main/java/io/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/Job.java
@@ -16,6 +16,7 @@ import com.yahoo.elide.annotation.LifeCycleHookBinding;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -109,10 +110,10 @@ public class Job extends GenericAuditFields {
     private Workspace workspace;
 
     @UpdatePermission(expression = "user is a super service")
-    @OneToMany(mappedBy = "job")
+    @OneToMany(mappedBy = "job", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Step> step;
 
-    @OneToMany(mappedBy = "job")
+    @OneToMany(mappedBy = "job", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Address> address;
 
 }

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -103,4 +103,5 @@
     <include file="/db/changelog/local/changelog-2.31.0-variable-incomplete.xml" />
     <include file="db/changelog/local/changelog-2.31.0-repo-webhooks.xml"/>
     <include file="/db/changelog/local/changelog-2.32.0-project-access.xml"/>
+    <include file="/db/changelog/local/changelog-2.32.0-job-step-cascade.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.32.0-job-step-cascade.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.32.0-job-step-cascade.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <!--
+        When a job is deleted, its related step and address rows must be removed first.
+        Without ON DELETE CASCADE the database raises a NOT NULL violation because
+        Hibernate tries to null out the job_id FK before deleting the parent row.
+        See: https://github.com/AzBuilder/terrakube/issues/3016
+    -->
+    <changeSet id="2-32-0-job-step-cascade" author="qubeena7@gmail.com">
+        <dropForeignKeyConstraint baseTableName="step" constraintName="fk_job_step"/>
+        <addForeignKeyConstraint
+            baseTableName="step"
+            baseColumnNames="job_id"
+            constraintName="fk_job_step"
+            referencedTableName="job"
+            referencedColumnNames="id"
+            onDelete="CASCADE"/>
+
+        <dropForeignKeyConstraint baseTableName="address" constraintName="fk_job_address"/>
+        <addForeignKeyConstraint
+            baseTableName="address"
+            baseColumnNames="job_id"
+            constraintName="fk_job_address"
+            referencedTableName="job"
+            referencedColumnNames="id"
+            onDelete="CASCADE"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Problem

Deleting a job via `DELETE /api/v1/organization/{orgId}/job/{jobId}` fails with:

```
ERROR: null value in column "job_id" of relation "step" violates not-null constraint
```

Hibernate's default behaviour for `@OneToMany` without cascade options is to null out child FK columns before removing the parent row. Since `step.job_id` and `address.job_id` are `NOT NULL`, the update fails before the delete even runs.

## Fix

**JPA (`Job.java`)** — added `cascade = CascadeType.REMOVE` and `orphanRemoval = true` to the `step` and `address` relationships. Hibernate now deletes child rows instead of nullifying their FK.

**Liquibase migration** — drops and recreates `fk_job_step` and `fk_job_address` with `ON DELETE CASCADE` so that direct SQL deletes behave consistently too.

## Test plan

- [ ] `DELETE /api/v1/organization/{orgId}/job/{jobId}` returns 204 with no errors
- [ ] Verify `step` rows for that job are removed from the database
- [ ] Verify `address` rows for that job are removed from the database
- [ ] Deleting a job with no steps/addresses still works

Fixes #3016