### PR TITLE
feat(registry): import providers from private registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The key features of Terrakube are:
 
 - **Remote Backend:** Terrakube supports both `remote backend` and `cloud` block so you can run your workflow directly from the Terraform / OpenTofu CLI.
 
+- **Import providers from private registries:** Mirror custom Terraform/OpenTofu providers into the Terrakube private registry from any Terraform provider registry (resolved through service discovery — works with GitLab, Artifactory/JFrog, TFE and self-hosted registries) or from a plain repository release page / web server that hosts goreleaser-style assets. Private sources can be authenticated with a bearer token, and versions are refreshed automatically in the background.
+
 ### Getting Started
 
 ### Installation
@@ -55,6 +57,41 @@ The key features of Terrakube are:
 - [Test Terrakube using minikube](https://docs.terrakube.io/getting-started/deployment/minikube-+-https)
 - [Test Terrakube using Gitpod](https://docs.terrakube.io/getting-started/getting-started)
 - [Develop Terrakube using VS Code Dev Containers](.devcontainer/README.md)
+
+### Importing providers from a private registry
+
+Terrakube can mirror a provider published outside the public Terraform Registry into your organization's private registry, so `terraform init` / `tofu init` can install it from Terrakube. Open **Registry → Publish → Import provider from private registry** in the UI (or POST a `provider` with `imported=true` via the API). Two source types are supported:
+
+**1. Terraform provider registry (`sourceType=TERRAFORM_REGISTRY`)**
+
+Any registry that implements the [Terraform provider registry protocol](https://developer.hashicorp.com/terraform/internals/provider-registry-protocol). The host is resolved through service discovery (`/.well-known/terraform.json`), so this works with GitLab, Artifactory/JFrog, Terraform Enterprise and self-hosted registries.
+
+| Field | Description |
+| --- | --- |
+| `name` | Provider type, e.g. `mycloud`. |
+| `registryHost` | Registry host, e.g. `gitlab.example.com`. Leave empty to use the public `registry.terraform.io`. |
+| `registryNamespace` | Namespace/organization of the provider in that registry. |
+| `registryToken` | Optional bearer token sent as `Authorization: Bearer …`. |
+
+**2. Repository / web page (`sourceType=REPOSITORY`)**
+
+A repository release page (GitHub/GitLab releases) or any web server hosting [goreleaser](https://goreleaser.com/)-style assets — the standard output of the [terraform-provider scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding-framework):
+
+```
+terraform-provider-<name>_<version>_<os>_<arch>.zip
+terraform-provider-<name>_<version>_SHA256SUMS
+terraform-provider-<name>_<version>_SHA256SUMS.sig
+```
+
+| Field | Description |
+| --- | --- |
+| `name` | Provider type, must match the asset filenames. |
+| `repositoryUrl` | Base URL holding the assets. Use `{version}` where the version/tag appears in the path, e.g. `https://github.com/acme/terraform-provider-mycloud/releases/download/v{version}`. |
+| `repositoryVersions` | Comma-separated versions to import, e.g. `1.0.0,1.1.0`. |
+| `gpgKeyId` / `gpgAsciiArmor` | GPG key id and ASCII-armored public key used to sign `SHA256SUMS`. Required for Terraform to verify the provider on install. |
+| `registryToken` | Optional bearer token for private repositories. |
+
+Platforms and shasums are discovered from the `SHA256SUMS` file, so only the versions you list need to be specified. In both modes a background job (`ProviderRefreshJob`) imports new versions on creation and re-checks every 24 hours; existing public-registry imports are unaffected (`registryHost` empty + `sourceType=TERRAFORM_REGISTRY` keeps the previous behavior).
 
 ### Documentation
 To learn more about Terrakube [go to the complete documentation.](https://docs.terrakube.io/) 

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/provider/ProviderRefreshJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/provider/ProviderRefreshJob.java
@@ -6,6 +6,7 @@ import io.terrakube.api.repository.ProviderImplementationRepository;
 import io.terrakube.api.repository.ProviderRepository;
 import io.terrakube.api.repository.ProviderVersionRepository;
 import io.terrakube.api.rs.provider.Provider;
+import io.terrakube.api.rs.provider.SourceType;
 import io.terrakube.api.rs.provider.implementation.Implementation;
 import io.terrakube.api.rs.provider.implementation.Version;
 import lombok.extern.slf4j.Slf4j;
@@ -13,30 +14,48 @@ import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
- * Quartz job that periodically checks the public Terraform Registry (registry.terraform.io)
- * for new versions of a provider and imports them into the Terrakube private registry.
+ * Quartz job that checks a provider registry (or repository release page) for new versions of a
+ * provider and imports them into the Terrakube private registry.
  *
- * This mirrors the ModuleRefreshJob pattern but instead of using git ls-remote,
- * it queries the Terraform Registry v1 API for provider versions and platform downloads.
+ * <p>Two source types are supported (see {@link SourceType}):
+ * <ul>
+ *     <li>{@code TERRAFORM_REGISTRY}: any registry implementing the Terraform provider registry
+ *     protocol. The host comes from {@link Provider#getRegistryHost()} (defaulting to the public
+ *     registry.terraform.io) and is resolved through service discovery
+ *     (/.well-known/terraform.json). Works with GitLab, Artifactory/JFrog, TFE and self hosted
+ *     registries.</li>
+ *     <li>{@code REPOSITORY}: a base URL hosting goreleaser style release assets
+ *     ({@code terraform-provider-NAME_VERSION_OS_ARCH.zip} + {@code SHA256SUMS} +
+ *     {@code SHA256SUMS.sig}). Versions to import are listed in
+ *     {@link Provider#getRepositoryVersions()} and platforms/shasums are discovered from the
+ *     SHA256SUMS file.</li>
+ * </ul>
+ *
+ * <p>Private sources can be authenticated with a bearer token ({@link Provider#getRegistryToken()}).
  */
 @Slf4j
 @Component
 public class ProviderRefreshJob implements Job {
 
-    private static final String TERRAFORM_REGISTRY_BASE_URL = "https://registry.terraform.io";
+    static final String PUBLIC_REGISTRY_BASE_URL = "https://registry.terraform.io";
+    static final String DEFAULT_PROVIDERS_PATH = "/v1/providers/";
 
-    /** Standard platforms to import for each version */
+    /** Standard platforms to import for each version (TERRAFORM_REGISTRY source). */
     private static final List<String[]> STANDARD_PLATFORMS = List.of(
             new String[]{"linux", "amd64"},
             new String[]{"linux", "arm64"},
@@ -44,6 +63,10 @@ public class ProviderRefreshJob implements Job {
             new String[]{"darwin", "arm64"},
             new String[]{"windows", "amd64"}
     );
+
+    /** Matches a goreleaser asset: terraform-provider-NAME_VERSION_OS_ARCH.zip */
+    private static final Pattern ASSET_PATTERN =
+            Pattern.compile("^terraform-provider-.+_([^_]+)_([^_]+)\\.zip$");
 
     @Autowired
     private ProviderRepository providerRepository;
@@ -60,11 +83,7 @@ public class ProviderRefreshJob implements Job {
 
     public ProviderRefreshJob() {
         this.webClient = WebClient.builder()
-                .baseUrl(TERRAFORM_REGISTRY_BASE_URL)
-                .defaultHeaders(h -> {
-                    h.setAccept(List.of(MediaType.APPLICATION_JSON));
-                    h.add("User-Agent", "Terrakube/1.0 (https://terrakube.io)");
-                })
+                .defaultHeaders(h -> h.add("User-Agent", "Terrakube/1.0 (https://terrakube.io)"))
                 .codecs(configurer -> configurer
                         .defaultCodecs()
                         .maxInMemorySize(16 * 1024 * 1024))
@@ -84,84 +103,148 @@ public class ProviderRefreshJob implements Job {
                 log.warn("Provider {} not found, skipping refresh", providerId);
                 return;
             }
-
-            Provider provider = optProvider.get();
-            refreshProvider(provider);
+            refreshProvider(optProvider.get());
         } catch (Exception e) {
             log.error("Error refreshing provider {}: {}", providerId, e.getMessage(), e);
         }
     }
 
-    /**
-     * Fetches all versions from the public registry for this provider,
-     * compares with existing versions in the DB, and imports any new ones.
-     */
     private void refreshProvider(Provider provider) {
-        // Use the dedicated registryNamespace field for imported providers
-        if (!provider.isImported() || provider.getRegistryNamespace() == null || provider.getRegistryNamespace().isEmpty()) {
-            log.warn("Provider '{}' is not an imported provider or has no registryNamespace, skipping refresh", provider.getName());
+        if (!provider.isImported()) {
+            log.warn("Provider '{}' is not an imported provider, skipping refresh", provider.getName());
+            return;
+        }
+
+        SourceType sourceType = provider.getSourceType() == null ? SourceType.TERRAFORM_REGISTRY : provider.getSourceType();
+        switch (sourceType) {
+            case REPOSITORY:
+                refreshFromRepository(provider);
+                break;
+            case TERRAFORM_REGISTRY:
+            default:
+                refreshFromRegistry(provider);
+                break;
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // TERRAFORM_REGISTRY source
+    // ---------------------------------------------------------------------
+
+    private void refreshFromRegistry(Provider provider) {
+        if (provider.getRegistryNamespace() == null || provider.getRegistryNamespace().isEmpty()) {
+            log.warn("Provider '{}' has no registryNamespace, skipping refresh", provider.getName());
             return;
         }
 
         String namespace = provider.getRegistryNamespace();
         String name = provider.getName();
+        String providersBase = resolveProvidersBase(provider);
 
-        log.info("Checking registry for new versions of {}/{}", namespace, name);
+        log.info("Checking registry {} for new versions of {}/{}", providersBase, namespace, name);
 
-        // 1. Fetch all versions from the public registry
-        List<RegistryVersion> registryVersions = fetchRegistryVersions(namespace, name);
+        List<RegistryVersion> registryVersions = fetchRegistryVersions(provider, providersBase, namespace, name);
         if (registryVersions.isEmpty()) {
             log.info("No versions found in registry for {}/{}", namespace, name);
             return;
         }
 
-        // 2. Get existing versions from DB
-        List<Version> existingVersions = providerVersionRepository.findAllByProviderId(provider.getId());
-        Set<String> existingVersionNumbers = existingVersions.stream()
-                .map(Version::getVersionNumber)
-                .collect(Collectors.toSet());
-
-        // 3. Find new versions
+        Set<String> existing = existingVersionNumbers(provider);
         List<RegistryVersion> newVersions = registryVersions.stream()
-                .filter(rv -> !existingVersionNumbers.contains(rv.version))
+                .filter(rv -> !existing.contains(rv.version))
                 .collect(Collectors.toList());
 
         if (newVersions.isEmpty()) {
-            log.info("Provider {}/{} is up to date ({} versions)", namespace, name, existingVersions.size());
+            log.info("Provider {}/{} is up to date ({} versions)", namespace, name, existing.size());
             return;
         }
 
         log.info("Found {} new version(s) for {}/{}: {}", newVersions.size(), namespace, name,
                 newVersions.stream().map(v -> v.version).collect(Collectors.joining(", ")));
 
-        // 4. Import each new version
         for (RegistryVersion rv : newVersions) {
             try {
-                importVersion(provider, namespace, name, rv);
+                importRegistryVersion(provider, providersBase, namespace, name, rv);
             } catch (Exception e) {
-                log.error("Failed to import version {} for {}/{}: {}",
-                        rv.version, namespace, name, e.getMessage());
+                log.error("Failed to import version {} for {}/{}: {}", rv.version, namespace, name, e.getMessage());
             }
         }
     }
 
     /**
-     * Fetches the list of versions from the Terraform Registry v1 API.
+     * Resolves the absolute providers protocol base URL for a provider, performing service
+     * discovery against the configured host when one is set.
      */
-    private List<RegistryVersion> fetchRegistryVersions(String namespace, String name) {
+    String resolveProvidersBase(Provider provider) {
+        String host = provider.getRegistryHost();
+        if (host == null || host.isBlank()) {
+            return PUBLIC_REGISTRY_BASE_URL + DEFAULT_PROVIDERS_PATH;
+        }
+
+        String hostBaseUrl = host.startsWith("http") ? stripTrailingSlash(host) : "https://" + stripTrailingSlash(host);
+        try {
+            String body = webClient.get()
+                    .uri(URI.create(hostBaseUrl + "/.well-known/terraform.json"))
+                    .accept(MediaType.APPLICATION_JSON)
+                    .headers(h -> applyAuth(h, provider))
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block(Duration.ofSeconds(30));
+            String resolved = providersBaseFromDiscovery(body, hostBaseUrl);
+            if (resolved != null) {
+                return resolved;
+            }
+        } catch (Exception e) {
+            log.warn("Service discovery failed for host {} ({}), falling back to {}",
+                    hostBaseUrl, e.getMessage(), DEFAULT_PROVIDERS_PATH);
+        }
+        return hostBaseUrl + DEFAULT_PROVIDERS_PATH;
+    }
+
+    /**
+     * Parses the providers.v1 entry from a /.well-known/terraform.json body and resolves it to an
+     * absolute URL ending with a slash. Returns null when the body cannot be parsed.
+     */
+    String providersBaseFromDiscovery(String discoveryBody, String hostBaseUrl) {
+        if (discoveryBody == null || discoveryBody.isBlank()) return null;
+        try {
+            JsonNode root = objectMapper.readTree(discoveryBody);
+            String providersV1 = root.path("providers.v1").asText("");
+            if (providersV1.isEmpty()) return null;
+            String absolute = providersV1.startsWith("http")
+                    ? providersV1
+                    : hostBaseUrl + (providersV1.startsWith("/") ? providersV1 : "/" + providersV1);
+            return absolute.endsWith("/") ? absolute : absolute + "/";
+        } catch (Exception e) {
+            log.warn("Failed to parse service discovery document: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private List<RegistryVersion> fetchRegistryVersions(Provider provider, String providersBase,
+                                                        String namespace, String name) {
         try {
             String response = webClient.get()
-                    .uri("/v1/providers/{namespace}/{name}/versions", namespace, name)
+                    .uri(URI.create(providersBase + namespace + "/" + name + "/versions"))
+                    .accept(MediaType.APPLICATION_JSON)
+                    .headers(h -> applyAuth(h, provider))
                     .retrieve()
                     .bodyToMono(String.class)
                     .retryWhen(reactor.util.retry.Retry.backoff(2, Duration.ofMillis(500))
                             .filter(t -> !(t instanceof WebClientResponseException.NotFound)))
                     .block(Duration.ofSeconds(30));
 
-            if (response == null) return Collections.emptyList();
+            return parseRegistryVersions(response);
+        } catch (Exception e) {
+            log.error("Failed to fetch versions from registry for {}/{}: {}", namespace, name, e.getMessage());
+            return Collections.emptyList();
+        }
+    }
 
-            JsonNode root = objectMapper.readTree(response);
-            JsonNode versionsNode = root.path("versions");
+    List<RegistryVersion> parseRegistryVersions(String response) {
+        if (response == null) return Collections.emptyList();
+        try {
+            JsonNode versionsNode = objectMapper.readTree(response).path("versions");
             if (!versionsNode.isArray()) return Collections.emptyList();
 
             List<RegistryVersion> result = new ArrayList<>();
@@ -181,46 +264,30 @@ public class ProviderRefreshJob implements Job {
                 JsonNode platformsNode = vNode.path("platforms");
                 if (platformsNode.isArray()) {
                     for (JsonNode pNode : platformsNode) {
-                        platforms.add(new String[]{
-                                pNode.path("os").asText(""),
-                                pNode.path("arch").asText("")
-                        });
+                        platforms.add(new String[]{pNode.path("os").asText(""), pNode.path("arch").asText("")});
                     }
                 }
-
                 result.add(new RegistryVersion(version, protocols, platforms));
             }
             return result;
         } catch (Exception e) {
-            log.error("Failed to fetch versions from registry for {}/{}: {}", namespace, name, e.getMessage());
+            log.error("Failed to parse registry versions: {}", e.getMessage());
             return Collections.emptyList();
         }
     }
 
-    /**
-     * Imports a single version: creates a Version record and Implementation records
-     * for each available platform.
-     */
-    private void importVersion(Provider provider, String namespace, String name, RegistryVersion rv) {
-        // Create the Version entity
-        Version version = new Version();
-        version.setVersionNumber(rv.version);
-        version.setProtocols(rv.protocols.isEmpty() ? "5.0" : rv.protocols);
-        version.setProvider(provider);
-        version = providerVersionRepository.save(version);
-
+    private void importRegistryVersion(Provider provider, String providersBase, String namespace,
+                                       String name, RegistryVersion rv) {
+        Version version = saveVersion(provider, rv.version, rv.protocols.isEmpty() ? "5.0" : rv.protocols);
         log.info("Created version {} for provider {}", rv.version, provider.getName());
 
-        // Determine which platforms to import (intersection of available and standard)
         List<String[]> platformsToImport = STANDARD_PLATFORMS.stream()
-                .filter(std -> rv.platforms.stream()
-                        .anyMatch(p -> p[0].equals(std[0]) && p[1].equals(std[1])))
+                .filter(std -> rv.platforms.stream().anyMatch(p -> p[0].equals(std[0]) && p[1].equals(std[1])))
                 .collect(Collectors.toList());
 
-        // Fetch download info and create implementations for each platform
         for (String[] platform : platformsToImport) {
             try {
-                importImplementation(provider, namespace, name, version, rv.version, platform[0], platform[1]);
+                importRegistryImplementation(provider, providersBase, namespace, name, version, rv.version, platform[0], platform[1]);
             } catch (Exception e) {
                 log.warn("Failed to import implementation {}/{} for {}/{} v{}: {}",
                         platform[0], platform[1], namespace, name, rv.version, e.getMessage());
@@ -228,15 +295,13 @@ public class ProviderRefreshJob implements Job {
         }
     }
 
-    /**
-     * Fetches download info for a specific platform and creates an Implementation record.
-     */
-    private void importImplementation(Provider provider, String namespace, String name,
-                                       Version version, String versionNumber,
-                                       String os, String arch) {
+    private void importRegistryImplementation(Provider provider, String providersBase, String namespace,
+                                              String name, Version version, String versionNumber,
+                                              String os, String arch) {
         String response = webClient.get()
-                .uri("/v1/providers/{namespace}/{name}/{version}/download/{os}/{arch}",
-                        namespace, name, versionNumber, os, arch)
+                .uri(URI.create(providersBase + namespace + "/" + name + "/" + versionNumber + "/download/" + os + "/" + arch))
+                .accept(MediaType.APPLICATION_JSON)
+                .headers(h -> applyAuth(h, provider))
                 .retrieve()
                 .bodyToMono(String.class)
                 .retryWhen(reactor.util.retry.Retry.backoff(2, Duration.ofMillis(500))
@@ -247,7 +312,6 @@ public class ProviderRefreshJob implements Job {
 
         try {
             JsonNode dl = objectMapper.readTree(response);
-
             Implementation impl = new Implementation();
             impl.setOs(truncate(dl.path("os").asText(""), 32));
             impl.setArch(truncate(dl.path("arch").asText(""), 32));
@@ -257,7 +321,6 @@ public class ProviderRefreshJob implements Job {
             impl.setShasumsSignatureUrl(truncate(dl.path("shasums_signature_url").asText(""), 1024));
             impl.setShasum(truncate(dl.path("shasum").asText(""), 1024));
 
-            // GPG key info
             JsonNode gpgKeys = dl.path("signing_keys").path("gpg_public_keys");
             if (gpgKeys.isArray() && gpgKeys.size() > 0) {
                 JsonNode key = gpgKeys.get(0);
@@ -267,20 +330,191 @@ public class ProviderRefreshJob implements Job {
                 impl.setSource(truncate(key.path("source").asText("unknown"), 64));
                 impl.setSourceUrl(truncate(key.path("source_url").asText("https://unknown"), 512));
             } else {
-                impl.setKeyId("");
-                impl.setAsciiArmor("");
-                impl.setTrustSignature("");
-                impl.setSource("unknown");
-                impl.setSourceUrl("https://unknown");
+                applyEmptyGpg(impl);
             }
 
             impl.setVersion(version);
             providerImplementationRepository.save(impl);
-
             log.debug("Created implementation {}/{} for {} v{}", os, arch, provider.getName(), versionNumber);
         } catch (Exception e) {
             log.error("Failed to parse download info for {}/{} {}/{}: {}", namespace, name, os, arch, e.getMessage());
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // REPOSITORY source
+    // ---------------------------------------------------------------------
+
+    private void refreshFromRepository(Provider provider) {
+        if (provider.getRepositoryUrl() == null || provider.getRepositoryUrl().isBlank()) {
+            log.warn("Provider '{}' has no repositoryUrl, skipping refresh", provider.getName());
+            return;
+        }
+
+        List<String> requested = parseVersionList(provider.getRepositoryVersions());
+        if (requested.isEmpty()) {
+            log.warn("Provider '{}' has no repositoryVersions configured, nothing to import", provider.getName());
+            return;
+        }
+
+        Set<String> existing = existingVersionNumbers(provider);
+        List<String> newVersions = requested.stream().filter(v -> !existing.contains(v)).collect(Collectors.toList());
+        if (newVersions.isEmpty()) {
+            log.info("Provider {} is up to date ({} versions)", provider.getName(), existing.size());
+            return;
+        }
+
+        for (String versionNumber : newVersions) {
+            try {
+                importRepositoryVersion(provider, versionNumber);
+            } catch (Exception e) {
+                log.error("Failed to import version {} for {}: {}", versionNumber, provider.getName(), e.getMessage());
+            }
+        }
+    }
+
+    private void importRepositoryVersion(Provider provider, String versionNumber) {
+        String name = provider.getName();
+        String shasumsFile = "terraform-provider-" + name + "_" + versionNumber + "_SHA256SUMS";
+        String shasumsUrl = buildAssetUrl(provider.getRepositoryUrl(), versionNumber, shasumsFile);
+        String shasumsSignatureUrl = buildAssetUrl(provider.getRepositoryUrl(), versionNumber, shasumsFile + ".sig");
+
+        String shasumsContent = webClient.get()
+                .uri(URI.create(shasumsUrl))
+                .headers(h -> applyAuth(h, provider))
+                .retrieve()
+                .bodyToMono(String.class)
+                .retryWhen(reactor.util.retry.Retry.backoff(2, Duration.ofMillis(500))
+                        .filter(t -> !(t instanceof WebClientResponseException.NotFound)))
+                .block(Duration.ofSeconds(30));
+
+        Map<String, String> shasums = parseShaSums(shasumsContent);
+        if (shasums.isEmpty()) {
+            log.warn("No SHA256SUMS entries found at {} for provider {}", shasumsUrl, name);
+            return;
+        }
+
+        Version version = saveVersion(provider, versionNumber, "5.0");
+        log.info("Created version {} for provider {} (repository source)", versionNumber, name);
+
+        for (Map.Entry<String, String> entry : shasums.entrySet()) {
+            String filename = entry.getKey();
+            String[] platform = platformFromFilename(filename);
+            if (platform == null) continue;
+
+            Implementation impl = new Implementation();
+            impl.setOs(truncate(platform[0], 32));
+            impl.setArch(truncate(platform[1], 32));
+            impl.setFilename(truncate(filename, 512));
+            impl.setDownloadUrl(truncate(buildAssetUrl(provider.getRepositoryUrl(), versionNumber, filename), 1024));
+            impl.setShasumsUrl(truncate(shasumsUrl, 1024));
+            impl.setShasumsSignatureUrl(truncate(shasumsSignatureUrl, 1024));
+            impl.setShasum(truncate(entry.getValue(), 1024));
+
+            if (provider.getGpgAsciiArmor() != null && !provider.getGpgAsciiArmor().isBlank()) {
+                impl.setKeyId(truncate(provider.getGpgKeyId() == null ? "" : provider.getGpgKeyId(), 32));
+                impl.setAsciiArmor(provider.getGpgAsciiArmor());
+                impl.setTrustSignature("");
+                impl.setSource(truncate(name, 64));
+                impl.setSourceUrl(truncate(provider.getRepositoryUrl(), 512));
+            } else {
+                applyEmptyGpg(impl);
+            }
+
+            impl.setVersion(version);
+            providerImplementationRepository.save(impl);
+            log.debug("Created implementation {}/{} for {} v{} (repository source)",
+                    platform[0], platform[1], name, versionNumber);
+        }
+    }
+
+    /**
+     * Builds a release asset URL. {@code repositoryUrl} may contain a {@code {version}} placeholder
+     * (useful for release pages where the tag is part of the path); otherwise all assets are assumed
+     * to live directly under the base URL.
+     */
+    static String buildAssetUrl(String repositoryUrl, String version, String filename) {
+        String resolved = repositoryUrl.replace("{version}", version);
+        return stripTrailingSlash(resolved) + "/" + filename;
+    }
+
+    /**
+     * Parses the contents of a SHA256SUMS file into a map of filename to hex sha256.
+     * Each line looks like: {@code <sha256>  terraform-provider-foo_1.2.3_linux_amd64.zip}.
+     */
+    static Map<String, String> parseShaSums(String content) {
+        Map<String, String> result = new LinkedHashMap<>();
+        if (content == null) return result;
+        for (String rawLine : content.split("\\R")) {
+            String line = rawLine.trim();
+            if (line.isEmpty()) continue;
+            String[] parts = line.split("\\s+", 2);
+            if (parts.length != 2) continue;
+            String sha = parts[0].trim();
+            // a leading '*' marks binary mode in some sha256sum outputs
+            String filename = parts[1].trim();
+            if (filename.startsWith("*")) filename = filename.substring(1);
+            if (!sha.isEmpty() && !filename.isEmpty()) {
+                result.put(filename, sha);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Extracts the os and arch from a goreleaser provider asset filename.
+     * Returns {@code null} when the filename is not a provider zip (e.g. the manifest or signature).
+     */
+    static String[] platformFromFilename(String filename) {
+        if (filename == null) return null;
+        Matcher m = ASSET_PATTERN.matcher(filename);
+        if (!m.matches()) return null;
+        return new String[]{m.group(1), m.group(2)};
+    }
+
+    static List<String> parseVersionList(String versions) {
+        if (versions == null || versions.isBlank()) return Collections.emptyList();
+        return Arrays.stream(versions.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    // ---------------------------------------------------------------------
+    // Shared helpers
+    // ---------------------------------------------------------------------
+
+    private Set<String> existingVersionNumbers(Provider provider) {
+        return providerVersionRepository.findAllByProviderId(provider.getId()).stream()
+                .map(Version::getVersionNumber)
+                .collect(Collectors.toSet());
+    }
+
+    private Version saveVersion(Provider provider, String versionNumber, String protocols) {
+        Version version = new Version();
+        version.setVersionNumber(versionNumber);
+        version.setProtocols(protocols);
+        version.setProvider(provider);
+        return providerVersionRepository.save(version);
+    }
+
+    private void applyAuth(HttpHeaders headers, Provider provider) {
+        if (provider.getRegistryToken() != null && !provider.getRegistryToken().isBlank()) {
+            headers.setBearerAuth(provider.getRegistryToken());
+        }
+    }
+
+    private static void applyEmptyGpg(Implementation impl) {
+        impl.setKeyId("");
+        impl.setAsciiArmor("");
+        impl.setTrustSignature("");
+        impl.setSource("unknown");
+        impl.setSourceUrl("https://unknown");
+    }
+
+    private static String stripTrailingSlash(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
     }
 
     private static String truncate(String value, int maxLength) {
@@ -289,7 +523,7 @@ public class ProviderRefreshJob implements Job {
     }
 
     /** Internal record for a version from the registry API */
-    private static class RegistryVersion {
+    static class RegistryVersion {
         final String version;
         final String protocols;
         final List<String[]> platforms;

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/provider/ProviderRefreshService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/provider/ProviderRefreshService.java
@@ -66,8 +66,8 @@ public class ProviderRefreshService extends ScheduleServiceBase {
                 continue;
             }
 
-            // Only refresh imported providers that have a registryNamespace
-            if (!provider.isImported() || provider.getRegistryNamespace() == null || provider.getRegistryNamespace().isEmpty()) {
+            // Only refresh imported providers (the job validates the per source type configuration)
+            if (!provider.isImported()) {
                 log.debug("Provider '{}' is not an imported provider, skipping refresh",
                         provider.getName());
                 continue;

--- a/api/src/main/java/io/terrakube/api/rs/hooks/provider/ProviderManageHook.java
+++ b/api/src/main/java/io/terrakube/api/rs/hooks/provider/ProviderManageHook.java
@@ -18,7 +18,8 @@ import java.util.Optional;
 
 /**
  * Elide lifecycle hook for the Provider entity.
- * On CREATE: schedules a ProviderRefreshJob to immediately fetch versions from the public registry.
+ * On CREATE: schedules a ProviderRefreshJob to immediately fetch versions from the configured
+ *            source (a Terraform registry or a repository release page).
  * On UPDATE: ensures a refresh job exists, creates one if missing.
  */
 @AllArgsConstructor
@@ -40,10 +41,10 @@ public class ProviderManageHook implements LifeCycleHook<Provider> {
         switch (operation) {
             case CREATE:
                 if (transactionPhase == LifeCycleHookBinding.TransactionPhase.POSTCOMMIT) {
-                    // Only schedule refresh for imported providers (from public registry)
-                    if (provider.isImported() && provider.getRegistryNamespace() != null) {
+                    // Schedule refresh for any imported provider (registry or repository source)
+                    if (provider.isImported()) {
                         try {
-                            log.info("Scheduling provider refresh for {}/{}", provider.getRegistryNamespace(), provider.getName());
+                            log.info("Scheduling provider refresh for {} (source {})", provider.getName(), provider.getSourceType());
                             providerRefreshService.createTask(300, provider.getId().toString(), true);
                         } catch (SchedulerException e) {
                             log.error("Failed to create provider refresh task for {}: {}",
@@ -64,7 +65,7 @@ public class ProviderManageHook implements LifeCycleHook<Provider> {
      * On update, check if a refresh trigger exists. If not, create one.
      */
     private void checkNextProviderRefresh(Provider provider) {
-        if (!provider.isImported() || provider.getRegistryNamespace() == null) return;
+        if (!provider.isImported()) return;
 
         try {
             String triggerKey = providerRefreshService.getJobPrefix() + provider.getId();
@@ -74,9 +75,9 @@ public class ProviderManageHook implements LifeCycleHook<Provider> {
 
             if (trigger != null) {
                 Date nextFireTime = trigger.getNextFireTime();
-                log.info("Next provider refresh for {}/{}: {}", provider.getRegistryNamespace(), provider.getName(), nextFireTime);
+                log.info("Next provider refresh for {}: {}", provider.getName(), nextFireTime);
             } else {
-                log.info("No refresh trigger found for {}/{}, creating one", provider.getRegistryNamespace(), provider.getName());
+                log.info("No refresh trigger found for {}, creating one", provider.getName());
                 providerRefreshService.createTask(300, provider.getId().toString(), true);
             }
         } catch (SchedulerException e) {

--- a/api/src/main/java/io/terrakube/api/rs/provider/Provider.java
+++ b/api/src/main/java/io/terrakube/api/rs/provider/Provider.java
@@ -1,6 +1,7 @@
 package io.terrakube.api.rs.provider;
 
 import com.yahoo.elide.annotation.*;
+import io.terrakube.api.rs.provider.SourceType;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -43,6 +44,43 @@ public class Provider {
 
     @Column(name = "registry_namespace")
     private String registryNamespace;
+
+    /**
+     * Where versions of this provider are imported from.
+     * TERRAFORM_REGISTRY (default): a Terraform provider registry resolved via service discovery.
+     * REPOSITORY: a base URL hosting goreleaser style release assets (repo release page or web server).
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type")
+    private SourceType sourceType = SourceType.TERRAFORM_REGISTRY;
+
+    /**
+     * Host of the Terraform provider registry to import from (e.g. registry.terraform.io,
+     * gitlab.example.com, artifactory.example.com). Null/empty falls back to the public registry.
+     */
+    @Column(name = "registry_host")
+    private String registryHost;
+
+    /** Base URL holding the release assets when sourceType is REPOSITORY. */
+    @Column(name = "repository_url")
+    private String repositoryUrl;
+
+    /** Comma separated list of versions to import when sourceType is REPOSITORY. */
+    @Column(name = "repository_versions")
+    private String repositoryVersions;
+
+    /** GPG key id used to verify SHA256SUMS for a REPOSITORY source. */
+    @Column(name = "gpg_key_id")
+    private String gpgKeyId;
+
+    /** ASCII armored GPG public key used to verify SHA256SUMS for a REPOSITORY source. */
+    @Column(name = "gpg_ascii_armor")
+    private String gpgAsciiArmor;
+
+    /** Optional bearer token used to authenticate against a private registry/repository. */
+    @ReadPermission(expression = "team manage provider")
+    @Column(name = "registry_token")
+    private String registryToken;
 
     @ManyToOne
     private Organization organization;

--- a/api/src/main/java/io/terrakube/api/rs/provider/SourceType.java
+++ b/api/src/main/java/io/terrakube/api/rs/provider/SourceType.java
@@ -1,0 +1,18 @@
+package io.terrakube.api.rs.provider;
+
+/**
+ * Origin of the versions imported for a {@link Provider}.
+ */
+public enum SourceType {
+    /**
+     * A Terraform provider registry that implements the provider registry protocol.
+     * The host is resolved through service discovery (/.well-known/terraform.json).
+     */
+    TERRAFORM_REGISTRY,
+
+    /**
+     * A plain repository release page or web server hosting goreleaser style assets
+     * (terraform-provider-NAME_VERSION_OS_ARCH.zip + SHA256SUMS + SHA256SUMS.sig).
+     */
+    REPOSITORY
+}

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -103,4 +103,5 @@
     <include file="/db/changelog/local/changelog-2.31.0-variable-incomplete.xml" />
     <include file="db/changelog/local/changelog-2.31.0-repo-webhooks.xml"/>
     <include file="/db/changelog/local/changelog-2.32.0-project-access.xml"/>
+    <include file="/db/changelog/local/changelog-2.33.0-provider-private-registry.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-provider-private-registry.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-provider-private-registry.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="provider-private-registry-fields" author="jplorier">
+        <addColumn tableName="provider">
+            <!-- TERRAFORM_REGISTRY (default) or REPOSITORY -->
+            <column name="source_type" type="varchar(32)" defaultValue="TERRAFORM_REGISTRY">
+                <constraints nullable="true"/>
+            </column>
+            <!-- Host of a Terraform provider registry to import from (service discovery).
+                 Null/empty means the public registry.terraform.io -->
+            <column name="registry_host" type="varchar(256)">
+                <constraints nullable="true"/>
+            </column>
+            <!-- Base URL hosting goreleaser-style release assets (REPOSITORY source) -->
+            <column name="repository_url" type="varchar(1024)">
+                <constraints nullable="true"/>
+            </column>
+            <!-- Comma separated list of versions to import for a REPOSITORY source -->
+            <column name="repository_versions" type="varchar(1024)">
+                <constraints nullable="true"/>
+            </column>
+            <!-- GPG key information used to verify SHA256SUMS for a REPOSITORY source -->
+            <column name="gpg_key_id" type="varchar(64)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="gpg_ascii_armor" type="clob">
+                <constraints nullable="true"/>
+            </column>
+            <!-- Optional bearer token used to authenticate against a private registry/repository -->
+            <column name="registry_token" type="varchar(2048)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="provider-private-registry-fields-update-existing" author="jplorier">
+        <update tableName="provider">
+            <column name="source_type" value="TERRAFORM_REGISTRY"/>
+            <where>source_type IS NULL</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/ProviderTests.java
+++ b/api/src/test/java/io/terrakube/api/ProviderTests.java
@@ -4,7 +4,10 @@ import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
+import org.quartz.JobKey;
+import org.quartz.SchedulerException;
 import org.springframework.http.HttpStatus;
+import org.springframework.util.Assert;
 
 import static io.restassured.RestAssured.given;
 import static org.mockito.Mockito.when;
@@ -63,6 +66,72 @@ class ProviderTests extends ServerApplicationTests {
                 .log()
                 .all()
                 .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    void createImportedProviderFromPrivateRegistrySchedulesRefresh() throws SchedulerException {
+        String providerId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"provider\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"customreg\",\n" +
+                        "      \"description\": \"Imported from a private registry\",\n" +
+                        "      \"imported\": true,\n" +
+                        "      \"sourceType\": \"TERRAFORM_REGISTRY\",\n" +
+                        "      \"registryHost\": \"registry.example.com\",\n" +
+                        "      \"registryNamespace\": \"acme\",\n" +
+                        "      \"registryToken\": \"super-secret-token\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/provider")
+                .then()
+                .assertThat()
+                .body("data.attributes.name", IsEqual.equalTo("customreg"))
+                .body("data.attributes.sourceType", IsEqual.equalTo("TERRAFORM_REGISTRY"))
+                .body("data.attributes.registryHost", IsEqual.equalTo("registry.example.com"))
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        boolean jobExist = scheduler.getJobDetail(new JobKey("TerrakubeV2_ProviderRefresh_" + providerId)) != null;
+        Assert.isTrue(jobExist, "Refresh job should be created for an imported provider");
+    }
+
+    @Test
+    void createImportedProviderFromRepositorySchedulesRefresh() throws SchedulerException {
+        String providerId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"provider\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"repoprov\",\n" +
+                        "      \"description\": \"Imported from a repository release page\",\n" +
+                        "      \"imported\": true,\n" +
+                        "      \"sourceType\": \"REPOSITORY\",\n" +
+                        "      \"repositoryUrl\": \"https://github.com/acme/terraform-provider-repoprov/releases/download/v{version}\",\n" +
+                        "      \"repositoryVersions\": \"1.0.0,1.1.0\",\n" +
+                        "      \"gpgKeyId\": \"51852D87348FFC4C\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/provider")
+                .then()
+                .assertThat()
+                .body("data.attributes.name", IsEqual.equalTo("repoprov"))
+                .body("data.attributes.sourceType", IsEqual.equalTo("REPOSITORY"))
+                .body("data.attributes.repositoryVersions", IsEqual.equalTo("1.0.0,1.1.0"))
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        boolean jobExist = scheduler.getJobDetail(new JobKey("TerrakubeV2_ProviderRefresh_" + providerId)) != null;
+        Assert.isTrue(jobExist, "Refresh job should be created for a repository imported provider");
     }
 
     @Test

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/provider/ProviderRefreshJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/provider/ProviderRefreshJobTest.java
@@ -1,0 +1,147 @@
+package io.terrakube.api.plugin.scheduler.provider;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the pure parsing/URL helpers used when importing providers from a private
+ * Terraform registry or a repository release page. No Spring context or network is required.
+ */
+class ProviderRefreshJobTest {
+
+    private final ProviderRefreshJob job = new ProviderRefreshJob();
+
+    // ---- SHA256SUMS parsing -------------------------------------------------
+
+    @Test
+    void parseShaSumsReadsEveryEntry() {
+        String content = """
+                abc123  terraform-provider-foo_1.2.3_linux_amd64.zip
+                def456  terraform-provider-foo_1.2.3_darwin_arm64.zip
+                """;
+
+        Map<String, String> sums = ProviderRefreshJob.parseShaSums(content);
+
+        assertEquals(2, sums.size());
+        assertEquals("abc123", sums.get("terraform-provider-foo_1.2.3_linux_amd64.zip"));
+        assertEquals("def456", sums.get("terraform-provider-foo_1.2.3_darwin_arm64.zip"));
+    }
+
+    @Test
+    void parseShaSumsHandlesBinaryMarkerAndBlankLines() {
+        String content = "abc123 *terraform-provider-foo_1.2.3_linux_amd64.zip\n\n   \n";
+
+        Map<String, String> sums = ProviderRefreshJob.parseShaSums(content);
+
+        assertEquals(1, sums.size());
+        assertEquals("abc123", sums.get("terraform-provider-foo_1.2.3_linux_amd64.zip"));
+    }
+
+    @Test
+    void parseShaSumsHandlesNull() {
+        assertTrue(ProviderRefreshJob.parseShaSums(null).isEmpty());
+    }
+
+    // ---- filename -> platform ----------------------------------------------
+
+    @Test
+    void platformFromFilenameExtractsOsAndArch() {
+        String[] platform = ProviderRefreshJob.platformFromFilename("terraform-provider-foo_1.2.3_linux_amd64.zip");
+        assertNotNull(platform);
+        assertEquals("linux", platform[0]);
+        assertEquals("amd64", platform[1]);
+    }
+
+    @Test
+    void platformFromFilenameIgnoresNonZipAssets() {
+        assertNull(ProviderRefreshJob.platformFromFilename("terraform-provider-foo_1.2.3_SHA256SUMS"));
+        assertNull(ProviderRefreshJob.platformFromFilename("terraform-provider-foo_1.2.3_SHA256SUMS.sig"));
+        assertNull(ProviderRefreshJob.platformFromFilename("terraform-provider-foo_1.2.3_manifest.json"));
+        assertNull(ProviderRefreshJob.platformFromFilename(null));
+    }
+
+    // ---- asset URL building -------------------------------------------------
+
+    @Test
+    void buildAssetUrlAppendsFilenameToFlatBase() {
+        String url = ProviderRefreshJob.buildAssetUrl(
+                "https://files.example.com/providers/", "1.2.3",
+                "terraform-provider-foo_1.2.3_linux_amd64.zip");
+        assertEquals("https://files.example.com/providers/terraform-provider-foo_1.2.3_linux_amd64.zip", url);
+    }
+
+    @Test
+    void buildAssetUrlSubstitutesVersionPlaceholder() {
+        String url = ProviderRefreshJob.buildAssetUrl(
+                "https://github.com/org/terraform-provider-foo/releases/download/v{version}", "1.2.3",
+                "terraform-provider-foo_1.2.3_linux_amd64.zip");
+        assertEquals(
+                "https://github.com/org/terraform-provider-foo/releases/download/v1.2.3/terraform-provider-foo_1.2.3_linux_amd64.zip",
+                url);
+    }
+
+    // ---- repository version list -------------------------------------------
+
+    @Test
+    void parseVersionListTrimsDedupesAndSkipsBlanks() {
+        List<String> versions = ProviderRefreshJob.parseVersionList(" 1.0.0, 1.1.0 ,1.0.0,, 2.0.0 ");
+        assertEquals(List.of("1.0.0", "1.1.0", "2.0.0"), versions);
+        assertTrue(ProviderRefreshJob.parseVersionList(null).isEmpty());
+        assertTrue(ProviderRefreshJob.parseVersionList("   ").isEmpty());
+    }
+
+    // ---- service discovery --------------------------------------------------
+
+    @Test
+    void providersBaseFromDiscoveryResolvesRelativePath() {
+        String body = "{\"modules.v1\":\"/terraform/modules/v1/\",\"providers.v1\":\"/terraform/providers/v1/\"}";
+        String base = job.providersBaseFromDiscovery(body, "https://registry.example.com");
+        assertEquals("https://registry.example.com/terraform/providers/v1/", base);
+    }
+
+    @Test
+    void providersBaseFromDiscoveryKeepsAbsoluteUrlAndEnsuresTrailingSlash() {
+        String body = "{\"providers.v1\":\"https://cdn.example.com/v1/providers\"}";
+        String base = job.providersBaseFromDiscovery(body, "https://registry.example.com");
+        assertEquals("https://cdn.example.com/v1/providers/", base);
+    }
+
+    @Test
+    void providersBaseFromDiscoveryReturnsNullWhenMissing() {
+        assertNull(job.providersBaseFromDiscovery("{\"modules.v1\":\"/m/\"}", "https://registry.example.com"));
+        assertNull(job.providersBaseFromDiscovery("", "https://registry.example.com"));
+        assertNull(job.providersBaseFromDiscovery(null, "https://registry.example.com"));
+    }
+
+    // ---- registry version listing ------------------------------------------
+
+    @Test
+    void parseRegistryVersionsReadsVersionsProtocolsAndPlatforms() {
+        String body = """
+                {"versions":[
+                  {"version":"1.0.0","protocols":["5.0","6.0"],
+                   "platforms":[{"os":"linux","arch":"amd64"},{"os":"darwin","arch":"arm64"}]},
+                  {"version":"1.1.0","protocols":["6.0"],"platforms":[{"os":"linux","arch":"arm64"}]}
+                ]}
+                """;
+
+        List<ProviderRefreshJob.RegistryVersion> versions = job.parseRegistryVersions(body);
+
+        assertEquals(2, versions.size());
+        assertEquals("1.0.0", versions.get(0).version);
+        assertEquals("5.0,6.0", versions.get(0).protocols);
+        assertEquals(2, versions.get(0).platforms.size());
+        assertEquals("linux", versions.get(0).platforms.get(0)[0]);
+        assertEquals("amd64", versions.get(0).platforms.get(0)[1]);
+    }
+
+    @Test
+    void parseRegistryVersionsHandlesEmptyAndNull() {
+        assertTrue(job.parseRegistryVersions(null).isEmpty());
+        assertTrue(job.parseRegistryVersions("{}").isEmpty());
+    }
+}

--- a/ui/src/domain/Modules/Registry.tsx
+++ b/ui/src/domain/Modules/Registry.tsx
@@ -11,6 +11,7 @@ import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import PageWrapper from "@/modules/layout/PageWrapper/PageWrapper";
 import { ModuleList } from "./ModuleList";
 import { ProviderList } from "../Providers/ProviderList";
+import ImportProviderModal from "../Providers/ImportProviderModal";
 import axiosInstance from "../../config/axiosConfig";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
 import { FlatModule, FlatProvider } from "../types";
@@ -89,6 +90,7 @@ export const Registry = ({ setOrganizationName, organizationName }: Props) => {
   const [providers, setProviders] = useState<FlatProvider[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<ErrorInformation | undefined>(undefined);
+  const [importProviderOpen, setImportProviderOpen] = useState(false);
 
   // Track which data has been loaded to avoid re-fetching
   const modulesLoaded = useRef(false);
@@ -178,11 +180,24 @@ export const Registry = ({ setOrganizationName, organizationName }: Props) => {
     navigate(`/organizations/${orgid}/registry/search`);
   };
 
+  const reloadProviders = useCallback(() => {
+    if (!orgid) return;
+    fetchProviders(orgid).then((data) => {
+      setProviders(data);
+      providersLoaded.current = true;
+    });
+  }, [orgid]);
+
   const publishMenuItems: MenuProps["items"] = [
     {
       key: "module",
       label: "Publish module",
       onClick: () => navigate(`/organizations/${orgid}/registry/create`),
+    },
+    {
+      key: "import-provider",
+      label: "Import provider from private registry",
+      onClick: () => setImportProviderOpen(true),
     },
   ];
 
@@ -248,6 +263,17 @@ export const Registry = ({ setOrganizationName, organizationName }: Props) => {
         />
         <Tabs activeKey={activeTab} onChange={handleTabChange} items={tabItems} size="large" />
       </div>
+      {orgid && (
+        <ImportProviderModal
+          orgId={orgid}
+          open={importProviderOpen}
+          onCancel={() => setImportProviderOpen(false)}
+          onImported={() => {
+            setSearchParams({ tab: "providers" });
+            reloadProviders();
+          }}
+        />
+      )}
     </PageWrapper>
   );
 };

--- a/ui/src/domain/Providers/ImportProviderModal.tsx
+++ b/ui/src/domain/Providers/ImportProviderModal.tsx
@@ -1,0 +1,184 @@
+import { Modal, Form, Input, Radio, Alert, Button, Flex, Typography, message } from "antd";
+import { useState } from "react";
+import { importProviderFromPrivateRegistry } from "./providerService";
+import { ProviderSourceType } from "./types";
+
+type Props = {
+  orgId: string;
+  open: boolean;
+  onCancel: () => void;
+  onImported: () => void;
+};
+
+type FormValues = {
+  name: string;
+  description?: string;
+  registryHost?: string;
+  registryNamespace?: string;
+  repositoryUrl?: string;
+  repositoryVersions?: string;
+  gpgKeyId?: string;
+  gpgAsciiArmor?: string;
+  registryToken?: string;
+};
+
+/**
+ * Imports a custom provider from a private Terraform registry or a repository release page.
+ * The provider is created with imported=true; the backend refresh job then pulls the versions,
+ * platforms and shasums asynchronously.
+ */
+export default function ImportProviderModal({ orgId, open, onCancel, onImported }: Props) {
+  const [form] = Form.useForm<FormValues>();
+  const [sourceType, setSourceType] = useState<ProviderSourceType>("TERRAFORM_REGISTRY");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  const reset = () => {
+    form.resetFields();
+    setSourceType("TERRAFORM_REGISTRY");
+    setError(undefined);
+  };
+
+  const handleCancel = () => {
+    reset();
+    onCancel();
+  };
+
+  const submit = async () => {
+    setError(undefined);
+    const values = await form.validateFields();
+    setLoading(true);
+    try {
+      if (sourceType === "TERRAFORM_REGISTRY") {
+        await importProviderFromPrivateRegistry(orgId, {
+          sourceType: "TERRAFORM_REGISTRY",
+          name: values.name.trim(),
+          registryNamespace: values.registryNamespace!.trim(),
+          registryHost: values.registryHost?.trim() || undefined,
+          registryToken: values.registryToken?.trim() || undefined,
+          description: values.description?.trim(),
+        });
+      } else {
+        await importProviderFromPrivateRegistry(orgId, {
+          sourceType: "REPOSITORY",
+          name: values.name.trim(),
+          repositoryUrl: values.repositoryUrl!.trim(),
+          repositoryVersions: values.repositoryVersions!.trim(),
+          gpgKeyId: values.gpgKeyId?.trim() || undefined,
+          gpgAsciiArmor: values.gpgAsciiArmor?.trim() || undefined,
+          registryToken: values.registryToken?.trim() || undefined,
+        });
+      }
+      message.success("Provider import started. Versions will appear shortly.");
+      reset();
+      onImported();
+      onCancel();
+    } catch (e: any) {
+      setError(e?.response?.data?.errors?.[0]?.detail || e?.message || "Failed to import provider");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      title="Import provider from a private registry"
+      destroyOnClose
+      onCancel={handleCancel}
+      footer={
+        <Flex justify="end" gap="small">
+          <Button onClick={handleCancel}>Cancel</Button>
+          <Button type="primary" loading={loading} onClick={submit}>
+            Import
+          </Button>
+        </Flex>
+      }
+    >
+      {error && <Alert type="error" banner message={error} style={{ marginBottom: 16 }} />}
+      <Form form={form} layout="vertical" disabled={loading}>
+        <Form.Item label="Source">
+          <Radio.Group
+            value={sourceType}
+            onChange={(e) => setSourceType(e.target.value)}
+            optionType="button"
+            buttonStyle="solid"
+          >
+            <Radio.Button value="TERRAFORM_REGISTRY">Terraform registry</Radio.Button>
+            <Radio.Button value="REPOSITORY">Repository / web page</Radio.Button>
+          </Radio.Group>
+        </Form.Item>
+
+        <Form.Item
+          name="name"
+          label="Provider name"
+          help="The provider type, e.g. 'random' or 'mycloud'."
+          rules={[{ required: true, message: "Provider name is required" }]}
+        >
+          <Input placeholder="mycloud" />
+        </Form.Item>
+
+        {sourceType === "TERRAFORM_REGISTRY" ? (
+          <>
+            <Form.Item
+              name="registryHost"
+              label="Registry host"
+              help="Leave empty to use the public registry.terraform.io. Example: gitlab.example.com, artifactory.example.com."
+            >
+              <Input placeholder="registry.example.com" />
+            </Form.Item>
+            <Form.Item
+              name="registryNamespace"
+              label="Namespace"
+              help="The provider namespace/organization in the registry."
+              rules={[{ required: true, message: "Namespace is required" }]}
+            >
+              <Input placeholder="acme" />
+            </Form.Item>
+          </>
+        ) : (
+          <>
+            <Form.Item
+              name="repositoryUrl"
+              label="Release base URL"
+              help="Base URL hosting goreleaser style assets. Use {version} where the version/tag appears, e.g. https://github.com/acme/terraform-provider-mycloud/releases/download/v{version}"
+              rules={[{ required: true, message: "Release base URL is required" }]}
+            >
+              <Input placeholder="https://github.com/acme/terraform-provider-mycloud/releases/download/v{version}" />
+            </Form.Item>
+            <Form.Item
+              name="repositoryVersions"
+              label="Versions"
+              help="Comma separated list of versions to import, e.g. 1.0.0, 1.1.0"
+              rules={[{ required: true, message: "At least one version is required" }]}
+            >
+              <Input placeholder="1.0.0, 1.1.0" />
+            </Form.Item>
+            <Form.Item
+              name="gpgKeyId"
+              label="GPG key id"
+              help="Key id used to sign the SHA256SUMS file (required by Terraform to verify the provider)."
+            >
+              <Input placeholder="51852D87348FFC4C" />
+            </Form.Item>
+            <Form.Item name="gpgAsciiArmor" label="GPG public key (ASCII armored)">
+              <Input.TextArea rows={3} placeholder="-----BEGIN PGP PUBLIC KEY BLOCK-----" />
+            </Form.Item>
+          </>
+        )}
+
+        <Form.Item
+          name="registryToken"
+          label="Bearer token"
+          help="Optional. Sent as 'Authorization: Bearer ...' when downloading from a private source."
+        >
+          <Input.Password placeholder="Leave empty for public sources" autoComplete="new-password" />
+        </Form.Item>
+
+        <Typography.Text type="secondary">
+          Versions are imported in the background and may take a moment to appear.
+        </Typography.Text>
+      </Form>
+    </Modal>
+  );
+}

--- a/ui/src/domain/Providers/providerService.ts
+++ b/ui/src/domain/Providers/providerService.ts
@@ -28,22 +28,37 @@ export const getProvider = async (
   return response.data;
 };
 
+export type CreateProviderOptions = {
+  imported?: boolean;
+  registryNamespace?: string;
+  sourceType?: "TERRAFORM_REGISTRY" | "REPOSITORY";
+  registryHost?: string;
+  repositoryUrl?: string;
+  repositoryVersions?: string;
+  gpgKeyId?: string;
+  gpgAsciiArmor?: string;
+  registryToken?: string;
+};
+
 export const createProvider = async (
   orgId: string,
   name: string,
   description: string,
-  options?: { imported?: boolean; registryNamespace?: string }
+  options?: CreateProviderOptions
 ): Promise<{ data: ProviderModel }> => {
   const attributes: Record<string, unknown> = {
     name,
     description,
   };
-  if (options?.imported !== undefined) {
-    attributes.imported = options.imported;
-  }
-  if (options?.registryNamespace) {
-    attributes.registryNamespace = options.registryNamespace;
-  }
+  if (options?.imported !== undefined) attributes.imported = options.imported;
+  if (options?.registryNamespace) attributes.registryNamespace = options.registryNamespace;
+  if (options?.sourceType) attributes.sourceType = options.sourceType;
+  if (options?.registryHost) attributes.registryHost = options.registryHost;
+  if (options?.repositoryUrl) attributes.repositoryUrl = options.repositoryUrl;
+  if (options?.repositoryVersions) attributes.repositoryVersions = options.repositoryVersions;
+  if (options?.gpgKeyId) attributes.gpgKeyId = options.gpgKeyId;
+  if (options?.gpgAsciiArmor) attributes.gpgAsciiArmor = options.gpgAsciiArmor;
+  if (options?.registryToken) attributes.registryToken = options.registryToken;
 
   const response = await axiosInstance.post(
     `organization/${orgId}/provider`,
@@ -204,6 +219,62 @@ export const getProviderDownload = async (
     `/registry/v1/providers/${namespace}/${name}/${version}/download/${os}/${arch}`
   );
   return response.data;
+};
+
+/**
+ * Import a provider from a private registry or repository release page.
+ *
+ * The backend ProviderRefreshJob does the heavy lifting: once an imported provider is created
+ * with the right source configuration it fetches versions/platforms/shasums asynchronously.
+ * The UI only needs to persist the provider with imported=true and the source settings.
+ */
+export const importProviderFromPrivateRegistry = async (
+  orgId: string,
+  params:
+    | {
+        sourceType: "TERRAFORM_REGISTRY";
+        name: string;
+        registryNamespace: string;
+        registryHost?: string;
+        registryToken?: string;
+        description?: string;
+      }
+    | {
+        sourceType: "REPOSITORY";
+        name: string;
+        repositoryUrl: string;
+        repositoryVersions: string;
+        gpgKeyId?: string;
+        gpgAsciiArmor?: string;
+        registryToken?: string;
+        description?: string;
+      }
+): Promise<{ data: ProviderModel }> => {
+  const description =
+    params.description?.substring(0, 256) ||
+    (params.sourceType === "TERRAFORM_REGISTRY"
+      ? `${params.registryHost || "registry.terraform.io"}/${params.registryNamespace}/${params.name}`
+      : params.repositoryUrl);
+
+  if (params.sourceType === "TERRAFORM_REGISTRY") {
+    return createProvider(orgId, params.name, description, {
+      imported: true,
+      sourceType: "TERRAFORM_REGISTRY",
+      registryNamespace: params.registryNamespace,
+      registryHost: params.registryHost,
+      registryToken: params.registryToken,
+    });
+  }
+
+  return createProvider(orgId, params.name, description, {
+    imported: true,
+    sourceType: "REPOSITORY",
+    repositoryUrl: params.repositoryUrl,
+    repositoryVersions: params.repositoryVersions,
+    gpgKeyId: params.gpgKeyId,
+    gpgAsciiArmor: params.gpgAsciiArmor,
+    registryToken: params.registryToken,
+  });
 };
 
 // Import provider from Terraform Registry to Terrakube

--- a/ui/src/domain/Providers/types.ts
+++ b/ui/src/domain/Providers/types.ts
@@ -6,12 +6,21 @@ export type ProviderModel = {
   attributes: ProviderAttributes;
 };
 
+export type ProviderSourceType = "TERRAFORM_REGISTRY" | "REPOSITORY";
+
 export type ProviderAttributes = {
   name: string;
   namespace: string;
   description: string;
   imported?: boolean;
   registryNamespace?: string;
+  sourceType?: ProviderSourceType;
+  registryHost?: string;
+  repositoryUrl?: string;
+  repositoryVersions?: string;
+  gpgKeyId?: string;
+  gpgAsciiArmor?: string;
+  registryToken?: string;
   latestVersion?: string;
 } & AuditFieldBase;
 


### PR DESCRIPTION
## What

Extends the existing provider import (which today only targets the public `registry.terraform.io`) so a provider published outside the public registry can be mirrored into a Terrakube organization's private registry. Two source types are supported:

- **`TERRAFORM_REGISTRY`** — any registry that speaks the [Terraform provider registry protocol](https://developer.hashicorp.com/terraform/internals/provider-registry-protocol). The host comes from a new `registryHost` field and is resolved via service discovery (`/.well-known/terraform.json`), so it works with GitLab, Artifactory/JFrog, Terraform Enterprise and self-hosted registries. Leaving the host empty keeps the current public-registry behaviour unchanged.
- **`REPOSITORY`** — a repository release page (GitHub/GitLab releases) or any web server hosting goreleaser-style assets (`terraform-provider-<name>_<version>_<os>_<arch>.zip` + `SHA256SUMS` + `SHA256SUMS.sig`). Platforms and shasums are discovered from the `SHA256SUMS` file; the base URL accepts a `{version}` placeholder for the tag in the path, and a GPG public key can be supplied so Terraform can verify the signature on install.

Both source types optionally authenticate with a bearer token (`Authorization: Bearer …`) for private sources.

## Why

`ProviderRefreshJob` was hardcoded to `https://registry.terraform.io` with no authentication, so only public providers could be imported. Teams that publish providers to a private registry (GitLab/Artifactory) or just to a repository release page had no way to serve them through Terrakube.

## How

- `Provider` gains `sourceType`, `registryHost`, `repositoryUrl`, `repositoryVersions`, `gpgKeyId`, `gpgAsciiArmor` and `registryToken` columns (Liquibase migration `changelog-2.33.0-provider-private-registry.xml`). The token is read-restricted to provider managers, mirroring how `Vcs.accessToken` is handled.
- `ProviderRefreshJob` is refactored to build a per-provider request (configurable host + optional bearer token), perform service discovery for the registry source, and parse `SHA256SUMS` for the repository source. The public-registry path is preserved when no host is set.
- The refresh scheduling (`ProviderRefreshService` / `ProviderManageHook`) now schedules any imported provider regardless of source type.
- UI: an "Import provider from private registry" entry under **Registry → Publish** opens a modal that collects the source configuration.

## Testing

- Unit tests (`ProviderRefreshJobTest`) cover the parsing/URL helpers: `SHA256SUMS` parsing, filename → os/arch, asset URL building with the `{version}` placeholder, version-list parsing, service discovery resolution and registry version listing.
- Integration tests (`ProviderTests`) create imported providers for both source types and assert the refresh job is scheduled and the new attributes round-trip.
- `mvn -pl api test -Dtest=ProviderRefreshJobTest,ProviderTests` → 20/20 passing. UI `tsc --noEmit` clean.

## Backwards compatibility

Existing public-registry imports are unaffected: an empty `registryHost` with `sourceType=TERRAFORM_REGISTRY` (the default) keeps the previous behaviour, and the migration backfills `sourceType` for existing rows.
