### PR TITLE
fix(api): add missing indexes on foreign-key columns

### DIFF
--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -104,4 +104,5 @@
     <include file="db/changelog/local/changelog-2.31.0-repo-webhooks.xml"/>
     <include file="/db/changelog/local/changelog-2.32.0-project-access.xml"/>
     <include file="/db/changelog/local/changelog-2.32.0-job-step-cascade.xml"/>
+    <include file="/db/changelog/local/changelog-2.32.0-performance-fk-indexes.xml" />
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.32.0-performance-fk-indexes.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.32.0-performance-fk-indexes.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <!--
+      Indexes on foreign-key columns that are filtered on every request but were
+      never indexed. Listing a workspace triggers per-job lookups on step/address
+      and per-workspace lookups on job/history/webhook, all running as sequential
+      table scans. On busy instances this pins the database CPU and makes the
+      workspace screen very slow. Each index is guarded by a precondition so the
+      changeset is idempotent on databases where the index was already added by hand.
+    -->
+
+    <changeSet id="2-32-0-idx-step-job-id" author="kleber.rocha@cora.com.br">
+        <preConditions onFail="MARK_RAN">
+            <not><indexExists indexName="idx_step_job_id" tableName="step"/></not>
+        </preConditions>
+        <createIndex tableName="step" indexName="idx_step_job_id">
+            <column name="job_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2-32-0-idx-job-workspace-id" author="kleber.rocha@cora.com.br">
+        <preConditions onFail="MARK_RAN">
+            <not><indexExists indexName="idx_job_workspace_id" tableName="job"/></not>
+        </preConditions>
+        <createIndex tableName="job" indexName="idx_job_workspace_id">
+            <column name="workspace_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2-32-0-idx-address-job-id" author="kleber.rocha@cora.com.br">
+        <preConditions onFail="MARK_RAN">
+            <not><indexExists indexName="idx_address_job_id" tableName="address"/></not>
+        </preConditions>
+        <createIndex tableName="address" indexName="idx_address_job_id">
+            <column name="job_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2-32-0-idx-webhook-workspace-id" author="kleber.rocha@cora.com.br">
+        <preConditions onFail="MARK_RAN">
+            <not><indexExists indexName="idx_webhook_workspace_id" tableName="webhook"/></not>
+        </preConditions>
+        <createIndex tableName="webhook" indexName="idx_webhook_workspace_id">
+            <column name="workspace_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2-32-0-idx-history-workspace-id" author="kleber.rocha@cora.com.br">
+        <preConditions onFail="MARK_RAN">
+            <not><indexExists indexName="idx_history_workspace_id" tableName="history"/></not>
+        </preConditions>
+        <createIndex tableName="history" indexName="idx_history_workspace_id">
+            <column name="workspace_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2-32-0-idx-workspacetag-workspace-id" author="kleber.rocha@cora.com.br">
+        <preConditions onFail="MARK_RAN">
+            <not><indexExists indexName="idx_workspacetag_workspace_id" tableName="workspacetag"/></not>
+        </preConditions>
+        <createIndex tableName="workspacetag" indexName="idx_workspacetag_workspace_id">
+            <column name="workspace_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="2-32-0-idx-module-version-module-id" author="kleber.rocha@cora.com.br">
+        <preConditions onFail="MARK_RAN">
+            <not><indexExists indexName="idx_module_version_module_id" tableName="module_version"/></not>
+        </preConditions>
+        <createIndex tableName="module_version" indexName="idx_module_version_module_id">
+            <column name="module_id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Problem

Several foreign-key columns that are filtered on every request have no index, so the lookups run as **sequential scans**. Opening a workspace loads its jobs, each of which lazily loads `step`/`address` (N+1), and also looks up `history`/`webhook` by workspace. On a workspace with ~1000 jobs this produces **thousands of sequential scans per page load**, pinning the database CPU at 100% even though the tables are small.

Confirmed with `EXPLAIN ANALYZE` on a real instance:

```
step  WHERE job_id=?       -> Seq Scan, Rows Removed by Filter: 10196
job   WHERE workspace_id=? -> Seq Scan, Rows Removed by Filter: 6045
```

## Changes

Add a Liquibase changeset creating indexes on the FK columns:

- `step.job_id`
- `address.job_id`
- `job.workspace_id`
- `history.workspace_id`
- `webhook.workspace_id`
- `workspacetag.workspace_id`
- `module_version.module_id`

Each `createIndex` is guarded by a `not indexExists` precondition with `onFail="MARK_RAN"`, so the changeset is idempotent on databases where the index was already created by hand.

## Impact (measured on a production instance)

After adding these indexes, the per-query cost dropped from a full table scan (e.g. ~6–22 ms) to an index scan (~0.2 ms), and the database CPU went from saturated back to idle.

## Notes / scope

- This PR is intentionally **indexes only**. Enabling API pagination on `Job`/`History` (to stop clients fetching the full history) is a separate, larger change because the bundled UI currently fetches those collections without pagination or sort, and a small default page size would silently truncate the Runs/States tabs and the computed "current state". That belongs in a follow-up that updates the API **and** the UI together.
- The indexes use plain `createIndex` (Liquibase runs it in a transaction). The affected tables are small, so the lock is momentary. Instances with very large tables that need a zero-lock build can create the indexes out of band first — the preconditions will then skip them.
