### PR TITLE
fix: speed up TFC-compatible workspace list endpoint (N+1 in RemoteTfeService.listWorkspace)

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
@@ -425,35 +425,38 @@ public class RemoteTfeService {
 
     WorkspaceData getWorkspace(String organizationName, String workspaceName, Map<String, Object> otherAttributes,
                                JwtAuthenticationToken currentUser) {
-        Optional<Workspace> workspace = Optional
-                .ofNullable(workspaceRepository.getByOrganizationNameAndName(organizationName, workspaceName));
+        Workspace workspace = workspaceRepository.getByOrganizationNameAndName(organizationName, workspaceName);
+        return getWorkspace(workspace, otherAttributes, currentUser);
+    }
 
-        if (workspace.isPresent()) {
-            log.info("Found Workspace Id: {} Terraform: {} Global Remote State: {}", workspace.get().getId().toString(),
-                    workspace.get().getTerraformVersion(), workspace.get().isGlobalRemoteState());
+    WorkspaceData getWorkspace(Workspace workspace, Map<String, Object> otherAttributes,
+                               JwtAuthenticationToken currentUser) {
+        if (workspace != null) {
+            log.info("Found Workspace Id: {} Terraform: {} Global Remote State: {}", workspace.getId().toString(),
+                    workspace.getTerraformVersion(), workspace.isGlobalRemoteState());
             WorkspaceData workspaceData = new WorkspaceData();
 
             WorkspaceModel workspaceModel = new WorkspaceModel();
-            workspaceModel.setId(workspace.get().getId().toString());
+            workspaceModel.setId(workspace.getId().toString());
             workspaceModel.setType("workspaces");
             Map<String, Object> attributes = new HashMap<>();
-            attributes.put("name", workspaceName);
-            attributes.put("terraform-version", workspace.get().getTerraformVersion());
-            attributes.put("locked", workspace.get().isLocked());
+            attributes.put("name", workspace.getName());
+            attributes.put("terraform-version", workspace.getTerraformVersion());
+            attributes.put("locked", workspace.isLocked());
             attributes.put("auto-apply", false);
-            attributes.put("execution-mode", workspace.get().getExecutionMode());
+            attributes.put("execution-mode", workspace.getExecutionMode());
 
-            attributes.put("global-remote-state", workspace.get().isGlobalRemoteState());
+            attributes.put("global-remote-state", workspace.isGlobalRemoteState());
 
-            if (workspace.get().getFolder() != null
-                    && (workspace.get().getVcs() != null || workspace.get().getSsh() != null)
-                    && !workspace.get().getFolder().split(",")[0].equals("/")) {
-                attributes.put("working-directory", workspace.get().getFolder().split(",")[0]);
+            if (workspace.getFolder() != null
+                    && (workspace.getVcs() != null || workspace.getSsh() != null)
+                    && !workspace.getFolder().split(",")[0].equals("/")) {
+                attributes.put("working-directory", workspace.getFolder().split(",")[0]);
             }
 
-            boolean isManageWorkspace = validateUserManageWorkspace(workspace.get().getOrganization(), currentUser) || validateLimitedManageWorkspace(workspace.get(), currentUser);
-            boolean isManageJob = validateUserManageJob(workspace.get(), currentUser);
-            boolean isApproveJob = validateUserApproveJob(workspace.get(), currentUser);
+            boolean isManageWorkspace = validateUserManageWorkspace(workspace.getOrganization(), currentUser) || validateLimitedManageWorkspace(workspace, currentUser);
+            boolean isManageJob = validateUserManageJob(workspace, currentUser);
+            boolean isApproveJob = validateUserApproveJob(workspace, currentUser);
 
             Map<String, Boolean> defaultAttributes = new HashMap<>();
             defaultAttributes.put("can-create-state-versions", isManageWorkspace);
@@ -477,10 +480,10 @@ public class RemoteTfeService {
 
             attributes.put("permissions", defaultAttributes);
 
-            if (workspace.get().getVcs() != null && !workspace.get().isAllowRemoteApply()) {
+            if (workspace.getVcs() != null && !workspace.isAllowRemoteApply()) {
                 VcsRepo vcsRepo = new VcsRepo();
-                vcsRepo.setBranch(workspace.get().getBranch());
-                vcsRepo.setRepositoryHttpUrl(workspace.get().getSource());
+                vcsRepo.setBranch(workspace.getBranch());
+                vcsRepo.setRepositoryHttpUrl(workspace.getSource());
                 attributes.put("vcs-repo", vcsRepo);
             }
 
@@ -489,7 +492,7 @@ public class RemoteTfeService {
             workspaceModel.setAttributes(attributes);
             workspaceData.setData(workspaceModel);
 
-            Optional<Job> currentJob = jobRepository.findFirstByWorkspaceAndStatusInOrderByIdAsc(workspace.get(),
+            Optional<Job> currentJob = jobRepository.findFirstByWorkspaceAndStatusInOrderByIdAsc(workspace,
                     Arrays.asList(JobStatus.pending, JobStatus.running, JobStatus.queue, JobStatus.waitingApproval));
             if (currentJob.isPresent()) {
                 log.info("Adding current job id: {}", currentJob.get().getId());
@@ -501,8 +504,8 @@ public class RemoteTfeService {
                 workspaceModel.getRelationships().setCurrentRun(currentRunRelationship);
             }
 
-            if (workspace.get().getProject() != null) {
-                Project project = workspace.get().getProject();
+            if (workspace.getProject() != null) {
+                Project project = workspace.getProject();
                 log.info("Adding project information: {}", project.getId());
                 if (workspaceModel.getRelationships() == null) {
                     workspaceModel.setRelationships(new io.terrakube.api.plugin.state.model.workspace.Relationships());
@@ -513,7 +516,7 @@ public class RemoteTfeService {
                 workspaceModel.getRelationships().getProject().getData().setType("projects");
             }
 
-            if (!workspace.get().isGlobalRemoteState()) {
+            if (!workspace.isGlobalRemoteState()) {
                 log.info("Adding workspace remote state consumer relationship information");
                 if (workspaceModel.getRelationships() == null) {
                     workspaceModel.setRelationships(new io.terrakube.api.plugin.state.model.workspace.Relationships());
@@ -521,7 +524,7 @@ public class RemoteTfeService {
                 workspaceModel.getRelationships().setRemoteStateConsumer(new RemoteStateConsumer());
                 workspaceModel.getRelationships().getRemoteStateConsumer().setLinks(new LinksStateConsumer());
                 workspaceModel.getRelationships().getRemoteStateConsumer().getLinks().setRelated(
-                        String.format("/remote/tfe/v2/workspaces/%s/relationships/remote-state-consumers", workspace.get().getId()));
+                        String.format("/remote/tfe/v2/workspaces/%s/relationships/remote-state-consumers", workspace.getId()));
                 log.info("Workspace remote state consumer relationship URL: {}", workspaceModel.getRelationships().getRemoteStateConsumer().getLinks().getRelated());
             }
 
@@ -584,13 +587,19 @@ public class RemoteTfeService {
             String searchTagData = searchTags.get();
             List<String> listTags = Arrays.stream(searchTagData.split(",")).toList();
             log.info("Searching workspaces with tags: {}", searchTags);
-            for (Workspace workspace : organizationRepository.getOrganizationByName(organizationName).getWorkspace()) {
+            Organization organization = organizationRepository.getOrganizationByName(organizationName);
+            Map<String, String> organizationTagNames = new HashMap<>();
+            for (Tag tag : tagRepository.findByOrganizationName(organizationName)) {
+                if (tag.getId() != null) {
+                    organizationTagNames.put(tag.getId().toString(), tag.getName());
+                }
+            }
+            for (Workspace workspace : organization.getWorkspace()) {
                 List<WorkspaceTag> workspaceTagList = workspace.getWorkspaceTag();
                 int matchingTags = 0;
 
                 for (WorkspaceTag workspaceTag : workspaceTagList) {
-                    Tag tag = tagRepository.getReferenceById(UUID.fromString(workspaceTag.getTagId()));
-                    if (listTags.indexOf(tag.getName()) > -1) {
+                    if (listTags.indexOf(organizationTagNames.get(workspaceTag.getTagId())) > -1) {
                         matchingTags++;
                     }
                 }
@@ -598,7 +607,7 @@ public class RemoteTfeService {
                         workspaceTagList.size(), listTags.size(), matchingTags);
                 if (matchingTags == listTags.size()) {
                     workspaceList.getData().add(
-                            getWorkspace(organizationName, workspace.getName(), new HashMap(), currentUser).getData());
+                            getWorkspace(workspace, new HashMap<>(), currentUser).getData());
                 }
             }
         }
@@ -611,7 +620,7 @@ public class RemoteTfeService {
             if (workspaceListByName.isPresent())
                 for (Workspace workspace : workspaceListByName.get()) {
                     workspaceList.getData().add(
-                            getWorkspace(organizationName, workspace.getName(), new HashMap(), currentUser).getData());
+                            getWorkspace(workspace, new HashMap<>(), currentUser).getData());
                 }
         }
         return workspaceList;

--- a/api/src/main/java/io/terrakube/api/repository/TagRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/TagRepository.java
@@ -3,8 +3,11 @@ package io.terrakube.api.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import io.terrakube.api.rs.tag.Tag;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface TagRepository extends JpaRepository<Tag, UUID> {
     Tag getByOrganizationNameAndName(String organizationName, String name);
+
+    List<Tag> findByOrganizationName(String organizationName);
 }

--- a/api/src/test/java/io/terrakube/api/plugin/state/RemoteTfeServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/state/RemoteTfeServiceTest.java
@@ -1,0 +1,228 @@
+package io.terrakube.api.plugin.state;
+
+import io.terrakube.api.plugin.scheduler.ScheduleJobService;
+import io.terrakube.api.plugin.security.encryption.EncryptionService;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.plugin.state.model.workspace.WorkspaceList;
+import io.terrakube.api.plugin.state.model.workspace.WorkspaceModel;
+import io.terrakube.api.plugin.storage.StorageTypeService;
+import io.terrakube.api.plugin.token.team.TeamTokenService;
+import io.terrakube.api.repository.AccessRepository;
+import io.terrakube.api.repository.AddressRepository;
+import io.terrakube.api.repository.ArchiveRepository;
+import io.terrakube.api.repository.ContentRepository;
+import io.terrakube.api.repository.GlobalVarRepository;
+import io.terrakube.api.repository.HistoryRepository;
+import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.repository.ProjectRepository;
+import io.terrakube.api.repository.StepRepository;
+import io.terrakube.api.repository.TagRepository;
+import io.terrakube.api.repository.TemplateRepository;
+import io.terrakube.api.repository.VariableRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.repository.WorkspaceTagRepository;
+import io.terrakube.api.rs.ExecutionMode;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.tag.Tag;
+import io.terrakube.api.rs.team.Team;
+import io.terrakube.api.rs.workspace.Workspace;
+import io.terrakube.api.rs.workspace.tag.WorkspaceTag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RemoteTfeServiceTest {
+
+    private final JobRepository jobRepository = Mockito.mock(JobRepository.class);
+    private final ContentRepository contentRepository = Mockito.mock(ContentRepository.class);
+    private final OrganizationRepository organizationRepository = Mockito.mock(OrganizationRepository.class);
+    private final WorkspaceRepository workspaceRepository = Mockito.mock(WorkspaceRepository.class);
+    private final HistoryRepository historyRepository = Mockito.mock(HistoryRepository.class);
+    private final TemplateRepository templateRepository = Mockito.mock(TemplateRepository.class);
+    private final ScheduleJobService scheduleJobService = Mockito.mock(ScheduleJobService.class);
+    private final StorageTypeService storageTypeService = Mockito.mock(StorageTypeService.class);
+    private final StepRepository stepRepository = Mockito.mock(StepRepository.class);
+    @SuppressWarnings("rawtypes")
+    private final RedisTemplate redisTemplate = Mockito.mock(RedisTemplate.class);
+    private final TagRepository tagRepository = Mockito.mock(TagRepository.class);
+    private final WorkspaceTagRepository workspaceTagRepository = Mockito.mock(WorkspaceTagRepository.class);
+    private final TeamTokenService teamTokenService = Mockito.mock(TeamTokenService.class);
+    private final ArchiveRepository archiveRepository = Mockito.mock(ArchiveRepository.class);
+    private final AccessRepository accessRepository = Mockito.mock(AccessRepository.class);
+    private final EncryptionService encryptionService = Mockito.mock(EncryptionService.class);
+    private final AddressRepository addressRepository = Mockito.mock(AddressRepository.class);
+    private final ProjectRepository projectRepository = Mockito.mock(ProjectRepository.class);
+    private final VariableRepository variableRepository = Mockito.mock(VariableRepository.class);
+    private final GlobalVarRepository globalVarRepository = Mockito.mock(GlobalVarRepository.class);
+    private final RbacService rbacService = Mockito.mock(RbacService.class);
+
+    @Test
+    void listWorkspaceWithSearchNameUsesLoadedWorkspaceEntities() {
+        RemoteTfeService service = remoteTfeService();
+        JwtAuthenticationToken currentUser = currentUser();
+        Organization organization = organization("sample-org");
+        Workspace alpha = workspace("alpha", organization);
+        Workspace alphaTools = workspace("alpha-tools", organization);
+        when(teamTokenService.getCurrentGroups(currentUser)).thenReturn(Collections.emptyList());
+        when(workspaceRepository.findWorkspacesByOrganizationNameAndNameStartingWith("sample-org", "alpha"))
+                .thenReturn(Optional.of(List.of(alpha, alphaTools)));
+        when(jobRepository.findFirstByWorkspaceAndStatusInOrderByIdAsc(any(), anyList()))
+                .thenReturn(Optional.empty());
+
+        WorkspaceList result = service.listWorkspace("sample-org", Optional.empty(), Optional.of("alpha"), currentUser);
+
+        assertEquals(2, result.getData().size());
+        assertEquals("alpha", result.getData().get(0).getAttributes().get("name"));
+        assertEquals("alpha-tools", result.getData().get(1).getAttributes().get("name"));
+        verify(workspaceRepository, never()).getByOrganizationNameAndName(anyString(), anyString());
+        verify(tagRepository, never()).getReferenceById(any());
+    }
+
+    @Test
+    void listWorkspaceWithSearchTagsMatchesAllTagsWithoutPerWorkspaceTagLookups() {
+        RemoteTfeService service = remoteTfeService();
+        JwtAuthenticationToken currentUser = currentUser();
+        Organization organization = organization("sample-org");
+        Workspace prodAws = workspace("prod-aws", organization);
+        Workspace prodOnly = workspace("prod-only", organization);
+        Workspace devAws = workspace("dev-aws", organization);
+        organization.setWorkspace(List.of(prodAws, prodOnly, devAws));
+
+        Tag prod = tag("prod", organization);
+        Tag aws = tag("aws", organization);
+        Tag dev = tag("dev", organization);
+        prodAws.setWorkspaceTag(List.of(workspaceTag(prod), workspaceTag(aws)));
+        prodOnly.setWorkspaceTag(List.of(workspaceTag(prod)));
+        devAws.setWorkspaceTag(List.of(workspaceTag(dev), workspaceTag(aws)));
+
+        when(teamTokenService.getCurrentGroups(currentUser)).thenReturn(Collections.emptyList());
+        when(organizationRepository.getOrganizationByName("sample-org")).thenReturn(organization);
+        when(tagRepository.findByOrganizationName("sample-org")).thenReturn(List.of(prod, aws, dev));
+        when(jobRepository.findFirstByWorkspaceAndStatusInOrderByIdAsc(any(), anyList()))
+                .thenReturn(Optional.empty());
+
+        WorkspaceList result = service.listWorkspace("sample-org", Optional.of("prod,aws"), Optional.empty(), currentUser);
+
+        assertEquals(1, result.getData().size());
+        assertEquals("prod-aws", result.getData().get(0).getAttributes().get("name"));
+        verify(tagRepository).findByOrganizationName("sample-org");
+        verify(tagRepository, never()).getReferenceById(any());
+        verify(workspaceRepository, never()).getByOrganizationNameAndName(anyString(), anyString());
+    }
+
+    @Test
+    void listWorkspaceKeepsWorkspaceSpecificPermissionChecks() {
+        RemoteTfeService service = remoteTfeService();
+        JwtAuthenticationToken currentUser = currentUser();
+        Organization organization = organization("sample-org");
+        Team team = team("developers");
+        organization.setTeam(List.of(team));
+        Workspace workspace = workspace("restricted", organization);
+        when(teamTokenService.getCurrentGroups(currentUser)).thenReturn(List.of("developers"));
+        when(workspaceRepository.findWorkspacesByOrganizationNameAndNameStartingWith("sample-org", "restricted"))
+                .thenReturn(Optional.of(List.of(workspace)));
+        when(jobRepository.findFirstByWorkspaceAndStatusInOrderByIdAsc(any(), anyList()))
+                .thenReturn(Optional.empty());
+        when(rbacService.canManageWorkspace(team)).thenReturn(false);
+        when(rbacService.canManageJob(team)).thenReturn(false);
+        when(rbacService.canApproveJob(team)).thenReturn(false);
+
+        WorkspaceList result = service.listWorkspace("sample-org", Optional.empty(), Optional.of("restricted"), currentUser);
+
+        Map<String, Boolean> permissions = permissions(result.getData().get(0));
+        assertFalse(permissions.get("can-update"));
+        assertFalse(permissions.get("can-manage-tags"));
+        assertFalse(permissions.get("can-queue-run"));
+        assertFalse(permissions.get("can-queue-apply"));
+        assertTrue(permissions.get("can-read-settings"));
+        verify(rbacService).canManageWorkspace(team);
+        verify(rbacService).canManageJob(team);
+        verify(rbacService).canApproveJob(team);
+    }
+
+    private RemoteTfeService remoteTfeService() {
+        return new RemoteTfeService(jobRepository, contentRepository, organizationRepository, workspaceRepository,
+                historyRepository, templateRepository, scheduleJobService, "localhost", storageTypeService,
+                stepRepository, redisTemplate, 1, tagRepository, workspaceTagRepository, teamTokenService,
+                archiveRepository, accessRepository, encryptionService, addressRepository, projectRepository,
+                variableRepository, globalVarRepository, rbacService);
+    }
+
+    private JwtAuthenticationToken currentUser() {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .claim("iss", "issuer")
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(60))
+                .build();
+        return new JwtAuthenticationToken(jwt);
+    }
+
+    private Organization organization(String name) {
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+        organization.setName(name);
+        organization.setTeam(Collections.emptyList());
+        organization.setWorkspace(Collections.emptyList());
+        return organization;
+    }
+
+    private Workspace workspace(String name, Organization organization) {
+        Workspace workspace = new Workspace();
+        workspace.setId(UUID.randomUUID());
+        workspace.setName(name);
+        workspace.setOrganization(organization);
+        workspace.setTerraformVersion("1.6.0");
+        workspace.setExecutionMode(ExecutionMode.remote);
+        workspace.setAccess(Collections.emptyList());
+        workspace.setWorkspaceTag(Collections.emptyList());
+        return workspace;
+    }
+
+    private Tag tag(String name, Organization organization) {
+        Tag tag = new Tag();
+        tag.setId(UUID.randomUUID());
+        tag.setName(name);
+        tag.setOrganization(organization);
+        return tag;
+    }
+
+    private WorkspaceTag workspaceTag(Tag tag) {
+        WorkspaceTag workspaceTag = new WorkspaceTag();
+        workspaceTag.setId(UUID.randomUUID());
+        workspaceTag.setTagId(tag.getId().toString());
+        return workspaceTag;
+    }
+
+    private Team team(String name) {
+        Team team = new Team();
+        team.setId(UUID.randomUUID());
+        team.setName(name);
+        return team;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Boolean> permissions(WorkspaceModel workspaceModel) {
+        return (Map<String, Boolean>) workspaceModel.getAttributes().get("permissions");
+    }
+}


### PR DESCRIPTION
## Summary

Speeds up `GET /remote/tfe/v2/organizations/{org}/workspaces` (used by `terraform workspace list`) on organizations with many workspaces by removing two N+1 database patterns in `RemoteTfeService.listWorkspace()`. The JSON:API response is unchanged.

## Why this matters

On large orgs this endpoint took 16s+ to respond (#3091). The hot path re-fetched data the loop already had:

1. For every matched workspace, `getWorkspace(orgName, name, ...)` re-loaded the same workspace from the database by name, even though `listWorkspace()` already held the loaded `Workspace` entity.
2. In the tag-filtered search, `tagRepository.getReferenceById(...)` ran once per workspace tag inside a nested loop.

## Changes

- Added a `getWorkspace(Workspace, Map, JwtAuthenticationToken)` overload that builds the `WorkspaceData` from an already-loaded entity. The existing String-based `getWorkspace(orgName, name, ...)` now resolves the workspace once and delegates to it, so the produced attributes, permissions, and relationships are identical.
- `listWorkspace()` calls the new overload with the workspace it already has, removing the per-workspace re-fetch.
- Replaced the per-tag `getReferenceById` calls with a single org-scoped lookup into a `tagId -> tagName` map, via a new `TagRepository.findByOrganizationName(String)` derived query (org-scoped so it does not scan tags from other organizations).
- Permission checks still run per workspace; nothing is cached across workspaces, so authorization behavior is unchanged.

## Testing

Added `RemoteTfeServiceTest` (Mockito unit tests) covering:
- name-prefix search returns the matching workspaces and does not re-fetch each by name (`getByOrganizationNameAndName` not called per workspace),
- tag-filtered search returns only workspaces matching all requested tags and builds the tag map without per-tag `getReferenceById`,
- a caller without permission still sees the workspaces listed but with the `can-*` permission flags false.

```
cd api && mvn -Dtest=RemoteTfeServiceTest test
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Fixes #3091
