### PR TITLE
feat: shallow git clone (--depth 1) for VCS workspace checkout

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import com.azure.core.credential.AccessToken;
 import com.azure.core.credential.TokenRequestContext;
@@ -25,10 +26,15 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.api.CloneCommand;
+import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.MissingObjectException;
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.eclipse.jgit.transport.sshd.JGitKeyCache;
@@ -53,6 +59,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
     public static final String SSH_DIRECTORY_FILE_MODULE = "%s/.sshModule/%s";
     public static final String SSH_DIRECTORY = "%s/.ssh";
     public static final String SSH_DIRECTORY_MODULE = "%s/.sshModule";
+    private static final Pattern COMMIT_ID_PATTERN = Pattern.compile("^[a-fA-F0-9]{40}$");
 
     WorkspaceSecurity workspaceSecurity;
     boolean enableRegistrySecurity;
@@ -155,7 +162,6 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
 
     private void downloadWorkspaceGit(File gitCloneFolder, TerraformJob terraformJob)
             throws GitAPIException, IOException {
-        boolean shallowClone = terraformJob.getCommitId() == null || terraformJob.getCommitId().isBlank();
         if (terraformJob.getVcsType().startsWith("SSH")) {
             CloneCommand cloneCommand = Git.cloneRepository()
                     .setURI(terraformJob.getSource())
@@ -171,10 +177,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
                     })
                     .setCloneSubmodules(true);
 
-            if (shallowClone) {
-                cloneCommand.setDepth(1);
-            }
-
+            cloneCommand.setDepth(1);
             cloneCommand.call();
         } else {
             CloneCommand cloneCommand = Git.cloneRepository()
@@ -185,23 +188,93 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
                     .setBranch(terraformJob.getBranch())
                     .setCloneSubmodules(true);
 
-            if (shallowClone) {
-                cloneCommand.setDepth(1);
-            }
-
+            cloneCommand.setDepth(1);
             cloneCommand.call();
+        }
 
-            if (terraformJob.getCommitId() != null && !terraformJob.getCommitId().isBlank()) {
-                log.info("Checkout commit id {}", terraformJob.getCommitId());
-                Git.open(gitCloneFolder).checkout().setName(terraformJob.getCommitId()).call();
-                getCommitId(gitCloneFolder, terraformJob.getCommitId());
-            } else {
-                getCommitId(gitCloneFolder, null);
-            }
+        if (terraformJob.getCommitId() != null && !terraformJob.getCommitId().isBlank()) {
+            checkoutCommitId(gitCloneFolder, terraformJob);
+            getCommitId(gitCloneFolder, terraformJob.getCommitId());
+        } else {
+            getCommitId(gitCloneFolder, null);
         }
 
         log.info("Git clone: {} Branch: {} Folder {}", terraformJob.getSource(), terraformJob.getBranch(),
                 gitCloneFolder.getPath());
+    }
+
+    private void checkoutCommitId(File gitCloneFolder, TerraformJob terraformJob) throws GitAPIException, IOException {
+        String commitId = terraformJob.getCommitId();
+        try (Git git = Git.open(gitCloneFolder)) {
+            if (COMMIT_ID_PATTERN.matcher(commitId).matches() && !commitExists(git, commitId)) {
+                fetchMissingCommit(git, gitCloneFolder, terraformJob, commitId);
+            }
+            log.info("Checkout commit id {}", commitId);
+            git.checkout().setName(commitId).call();
+        }
+    }
+
+    private boolean commitExists(Git git, String commitId) throws IOException {
+        ObjectId objectId = git.getRepository().resolve(commitId);
+        if (objectId == null) {
+            return false;
+        }
+
+        try (RevWalk revWalk = new RevWalk(git.getRepository())) {
+            revWalk.parseCommit(objectId);
+            return true;
+        } catch (MissingObjectException e) {
+            return false;
+        }
+    }
+
+    private void fetchMissingCommit(Git git, File gitCloneFolder, TerraformJob terraformJob, String commitId)
+            throws GitAPIException, IOException {
+        try {
+            fetchCommitById(git, gitCloneFolder, terraformJob, commitId);
+        } catch (GitAPIException e) {
+            log.warn("Unable to fetch commit id {} directly. Unshallowing branch {}: {}", commitId,
+                    terraformJob.getBranch(), e.getMessage());
+            unshallowRepository(git, gitCloneFolder, terraformJob);
+        }
+    }
+
+    void fetchCommitById(Git git, File gitCloneFolder, TerraformJob terraformJob, String commitId)
+            throws GitAPIException, IOException {
+        log.info("Fetching missing commit id {} with depth 1", commitId);
+        configureFetchCommand(git.fetch(), gitCloneFolder, terraformJob)
+                .setRefSpecs(new RefSpec(commitId))
+                .setDepth(1)
+                .call();
+    }
+
+    void unshallowRepository(Git git, File gitCloneFolder, TerraformJob terraformJob)
+            throws GitAPIException, IOException {
+        configureFetchCommand(git.fetch(), gitCloneFolder, terraformJob)
+                .setUnshallow(true)
+                .call();
+    }
+
+    private FetchCommand configureFetchCommand(FetchCommand fetchCommand, File gitCloneFolder,
+            TerraformJob terraformJob) throws IOException {
+        fetchCommand.setRemote("origin");
+        if (terraformJob.getVcsType().startsWith("SSH")) {
+            fetchCommand.setTransportConfigCallback(transport -> {
+                try {
+                    ((SshTransport) transport).setSshSessionFactory(
+                            getSshdSessionFactory(gitCloneFolder, terraformJob.getAccessToken()));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } else {
+            CredentialsProvider credentialsProvider = setupCredentials(terraformJob.getVcsType(),
+                    terraformJob.getConnectionType(), terraformJob.getAccessToken());
+            if (credentialsProvider != null) {
+                fetchCommand.setCredentialsProvider(credentialsProvider);
+            }
+        }
+        return fetchCommand;
     }
 
     private void downloadWorkspaceTarGz(File tarGzFolder, String organizationId, String jobId) throws IOException, URISyntaxException {

--- a/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -24,6 +24,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -154,8 +155,9 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
 
     private void downloadWorkspaceGit(File gitCloneFolder, TerraformJob terraformJob)
             throws GitAPIException, IOException {
+        boolean shallowClone = terraformJob.getCommitId() == null || terraformJob.getCommitId().isBlank();
         if (terraformJob.getVcsType().startsWith("SSH")) {
-            Git.cloneRepository()
+            CloneCommand cloneCommand = Git.cloneRepository()
                     .setURI(terraformJob.getSource())
                     .setDirectory(gitCloneFolder)
                     .setBranch(terraformJob.getBranch())
@@ -167,17 +169,27 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
                             throw new RuntimeException(e);
                         }
                     })
-                    .setCloneSubmodules(true)
-                    .call();
+                    .setCloneSubmodules(true);
+
+            if (shallowClone) {
+                cloneCommand.setDepth(1);
+            }
+
+            cloneCommand.call();
         } else {
-            Git.cloneRepository()
+            CloneCommand cloneCommand = Git.cloneRepository()
                     .setURI(terraformJob.getSource())
                     .setDirectory(gitCloneFolder)
                     .setCredentialsProvider(setupCredentials(terraformJob.getVcsType(),
                             terraformJob.getConnectionType(), terraformJob.getAccessToken()))
                     .setBranch(terraformJob.getBranch())
-                    .setCloneSubmodules(true)
-                    .call();
+                    .setCloneSubmodules(true);
+
+            if (shallowClone) {
+                cloneCommand.setDepth(1);
+            }
+
+            cloneCommand.call();
 
             if (terraformJob.getCommitId() != null && !terraformJob.getCommitId().isBlank()) {
                 log.info("Checkout commit id {}", terraformJob.getCommitId());

--- a/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
@@ -94,6 +94,15 @@ public class SetupWorkspaceTest {
     }
 
     @Test
+    public void performsShallowCloneWhenNoCommitIdRequested() throws Exception {
+        TerraformJob job = successfulGitJob();
+        SetupWorkspace setup = standardSetupWorkspaceImpl(job);
+        File workspaceDir = setup.prepareWorkspace(job);
+        File shallowMarker = FileUtils.getFile(workspaceDir, ".git", "shallow");
+        Assert.assertTrue(shallowMarker.exists());
+    }
+
+    @Test
     public void injectsCommitHashInfo() throws Exception {
         TerraformJob job = successfulGitJob();
         SetupWorkspace setup = standardSetupWorkspaceImpl(job);

--- a/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
@@ -4,41 +4,77 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Proxy;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 
 import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.organization.job.Job;
+import io.terrakube.client.model.organization.job.JobAttributes;
+import io.terrakube.client.model.organization.job.step.Step;
+import io.terrakube.client.model.response.ResponseWithInclude;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.tools.tar.TarEntry;
 import org.apache.tools.tar.TarOutputStream;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.InvalidRemoteException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
+import org.eclipse.jgit.api.errors.TransportException;
+import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Answers;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.io.TempDir;
 
+import io.terrakube.executor.service.executor.ExecutorJobResult;
 import io.terrakube.executor.service.mode.TerraformJob;
 import io.terrakube.executor.service.terraform.TerraformExecutor;
 import io.terrakube.executor.service.workspace.security.WorkspaceSecurity;
 
 public class SetupWorkspaceTest {
-    private TerraformJob successfulGitJob() {
+    @TempDir
+    Path testHome;
+    private String userHome;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        userHome = System.getProperty("user.home");
+        System.setProperty("user.home", testHome.toFile().getCanonicalPath());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        System.setProperty("user.home", userHome);
+    }
+
+    private TerraformJob baseGitJob() {
         TerraformJob job = new TerraformJob();
         job.setOrganizationId("ze-org");
         job.setWorkspaceId("ze-ws");
-        // TODO Restore actual values
-        job.setSource("https://github.com/terrakube-io/terrakube");
-        job.setBranch("main");
         job.setFolder("executor/src/test/resources/terraform/hello-world");
-        job.setVcsType("GITHUB");
-        job.setConnectionType("OAUTH");
-        job.setAccessToken("ze-token");
+        job.setVcsType("LOCAL");
+        job.setConnectionType("");
+        job.setAccessToken("");
         job.setEnvironmentVariables(new HashMap<String, String>());
+        return job;
+    }
+
+    private TerraformJob successfulGitJob() throws Exception {
+        TerraformJob job = baseGitJob();
+        File sourceRepository = Files.createTempDirectory(testHome, "terrakube-source").toFile();
+        try (Git sourceGit = Git.init().setDirectory(sourceRepository).call()) {
+            commitFile(sourceGit, job.getFolder() + "/main.tf", "terraform");
+            job.setSource(sourceRepository.toURI().toString());
+            job.setBranch(sourceGit.getRepository().getBranch());
+        }
         return job;
     }
 
@@ -72,16 +108,112 @@ public class SetupWorkspaceTest {
     }
 
     private SetupWorkspace standardSetupWorkspaceImpl(TerraformJob job) {
-        WorkspaceSecurity security = Mockito.mock(WorkspaceSecurity.class);
-        TerraformExecutor executor = Mockito.mock(TerraformExecutor.class);
-        TerrakubeClient client = Mockito.mock(TerrakubeClient.class, Answers.RETURNS_DEEP_STUBS);
+        String overrideSource = job != null && "remote-content".equals(job.getBranch()) ? job.getSource() : null;
+        return new SetupWorkspaceImpl(new NoopWorkspaceSecurity(), false, new NoopTerraformExecutor(),
+                "https://terrakube-api.example.com", terrakubeClient(overrideSource));
+    }
 
-        if (job != null && "remote-content".equals(job.getBranch())) {
-            Mockito.when(client.getJobById(job.getOrganizationId(), job.getJobId()).getData().getAttributes().getOverrideSource())
-                    .thenReturn(job.getSource());
+    private static TerrakubeClient terrakubeClient(String overrideSource) {
+        return (TerrakubeClient) Proxy.newProxyInstance(TerrakubeClient.class.getClassLoader(),
+                new Class[] { TerrakubeClient.class }, (proxy, method, args) -> {
+                    if (method.getDeclaringClass().equals(Object.class)) {
+                        return switch (method.getName()) {
+                            case "equals" -> proxy == args[0];
+                            case "hashCode" -> System.identityHashCode(proxy);
+                            case "toString" -> "TerrakubeClient test proxy";
+                            default -> null;
+                        };
+                    }
+                    if ("getJobById".equals(method.getName())) {
+                        JobAttributes attributes = new JobAttributes();
+                        attributes.setOverrideSource(overrideSource);
+                        Job job = new Job();
+                        job.setAttributes(attributes);
+                        ResponseWithInclude<Job, Step> response = new ResponseWithInclude<>();
+                        response.setData(job);
+                        return response;
+                    }
+                    return null;
+                });
+    }
+
+    private static class NoopWorkspaceSecurity implements WorkspaceSecurity {
+        @Override
+        public void addTerraformCredentials(String workspaceId) {
         }
 
-        return new SetupWorkspaceImpl(security, false, executor, "https://terrakube-api.example.com", client);
+        @Override
+        public String generateAccessToken(String workspaceId) {
+            return "test-token";
+        }
+
+        @Override
+        public String generateAccessToken(int minutes) {
+            return "test-token";
+        }
+    }
+
+    private static class NoopTerraformExecutor implements TerraformExecutor {
+        @Override
+        public ExecutorJobResult plan(TerraformJob terraformJob, File workingDirectory, boolean isDestroy) {
+            return null;
+        }
+
+        @Override
+        public ExecutorJobResult apply(TerraformJob terraformJob, File workingDirectory) {
+            return null;
+        }
+
+        @Override
+        public ExecutorJobResult destroy(TerraformJob terraformJob, File workingDirectory) {
+            return null;
+        }
+
+        @Override
+        public String version() {
+            return "";
+        }
+    }
+
+    private TerraformJob localGitJob(File sourceRepository, String branch) {
+        TerraformJob job = baseGitJob();
+        job.setSource(sourceRepository.toURI().toString());
+        job.setBranch(branch);
+        return job;
+    }
+
+    private RevCommit commitFile(Git git, String fileName, String fileContent) throws Exception {
+        File file = FileUtils.getFile(git.getRepository().getWorkTree(), fileName);
+        FileUtils.forceMkdirParent(file);
+        FileUtils.writeStringToFile(file, fileContent, StandardCharsets.UTF_8);
+        git.add().addFilepattern(fileName).call();
+        return git.commit()
+                .setMessage(fileContent)
+                .setAuthor("Terrakube Test", "test@example.com")
+                .setCommitter("Terrakube Test", "test@example.com")
+                .call();
+    }
+
+    private static class RejectingShaFetchSetupWorkspace extends SetupWorkspaceImpl {
+        boolean unshallowRepositoryCalled;
+
+        RejectingShaFetchSetupWorkspace() {
+            super(new NoopWorkspaceSecurity(), false, new NoopTerraformExecutor(),
+                    "https://terrakube-api.example.com", terrakubeClient(null));
+        }
+
+        @Override
+        void fetchCommitById(Git git, File gitCloneFolder, TerraformJob terraformJob, String commitId)
+                throws GitAPIException {
+            throw new TransportException("SHA-in-want rejected");
+        }
+
+        @Override
+        void unshallowRepository(Git git, File gitCloneFolder, TerraformJob terraformJob)
+                throws GitAPIException, IOException {
+            unshallowRepositoryCalled = true;
+            super.unshallowRepository(git, gitCloneFolder, terraformJob);
+        }
     }
 
     @Test
@@ -103,6 +235,63 @@ public class SetupWorkspaceTest {
     }
 
     @Test
+    public void checksOutRecordedCommitAfterSourceBranchAdvancesFromShallowClone() throws Exception {
+        File sourceRepository = Files.createTempDirectory("terrakube-source").toFile();
+        try (Git sourceGit = Git.init().setDirectory(sourceRepository).call()) {
+            RevCommit plannedCommit = commitFile(sourceGit, "main.tf", "planned");
+            String branch = sourceGit.getRepository().getBranch();
+
+            TerraformJob planJob = localGitJob(sourceRepository, branch);
+            SetupWorkspace setup = standardSetupWorkspaceImpl(planJob);
+            File planWorkspaceDir = setup.prepareWorkspace(planJob);
+
+            Assertions.assertTrue(FileUtils.getFile(planWorkspaceDir, ".git", "shallow").exists());
+            Assertions.assertEquals(plannedCommit.getName(), FileUtils.readFileToString(
+                    FileUtils.getFile(planWorkspaceDir, "commitHash.info"), Charset.defaultCharset()));
+
+            commitFile(sourceGit, "main.tf", "advanced");
+
+            TerraformJob applyJob = localGitJob(sourceRepository, branch);
+            applyJob.setCommitId(plannedCommit.getName());
+            RejectingShaFetchSetupWorkspace applySetup = new RejectingShaFetchSetupWorkspace();
+            File applyWorkspaceDir = applySetup.prepareWorkspace(applyJob);
+
+            Assertions.assertTrue(applySetup.unshallowRepositoryCalled);
+            try (Git applyGit = Git.open(applyWorkspaceDir)) {
+                Assertions.assertEquals(plannedCommit.getName(),
+                        applyGit.getRepository().resolve("HEAD").getName());
+            }
+            Assertions.assertEquals("planned", FileUtils.readFileToString(
+                    FileUtils.getFile(applyWorkspaceDir, "main.tf"), StandardCharsets.UTF_8));
+            Assertions.assertEquals(plannedCommit.getName(), FileUtils.readFileToString(
+                    FileUtils.getFile(applyWorkspaceDir, "commitHash.info"), Charset.defaultCharset()));
+        } finally {
+            FileUtils.deleteDirectory(sourceRepository);
+        }
+    }
+
+    @Test
+    public void keepsShallowCloneWhenRequestedCommitIsBranchTip() throws Exception {
+        File sourceRepository = Files.createTempDirectory("terrakube-source").toFile();
+        try (Git sourceGit = Git.init().setDirectory(sourceRepository).call()) {
+            RevCommit branchTip = commitFile(sourceGit, "main.tf", "branch-tip");
+            TerraformJob job = localGitJob(sourceRepository, sourceGit.getRepository().getBranch());
+            job.setCommitId(branchTip.getName());
+
+            RejectingShaFetchSetupWorkspace setup = new RejectingShaFetchSetupWorkspace();
+            File workspaceDir = setup.prepareWorkspace(job);
+
+            Assertions.assertFalse(setup.unshallowRepositoryCalled);
+            Assertions.assertTrue(FileUtils.getFile(workspaceDir, ".git", "shallow").exists());
+            try (Git workspaceGit = Git.open(workspaceDir)) {
+                Assertions.assertEquals(branchTip.getName(), workspaceGit.getRepository().resolve("HEAD").getName());
+            }
+        } finally {
+            FileUtils.deleteDirectory(sourceRepository);
+        }
+    }
+
+    @Test
     public void injectsCommitHashInfo() throws Exception {
         TerraformJob job = successfulGitJob();
         SetupWorkspace setup = standardSetupWorkspaceImpl(job);
@@ -121,7 +310,7 @@ public class SetupWorkspaceTest {
     }
 
     @Test
-    public void reportsFailureOnBadRepository() {
+    public void reportsFailureOnBadRepository() throws Exception {
         TerraformJob job = successfulGitJob();
         SetupWorkspace setup = standardSetupWorkspaceImpl(job);
         job.setSource("nonsense");


### PR DESCRIPTION
## Why

Cloning a workspace repository takes a long time for large monorepos because the executor performs a full clone of the entire repository history on every job (reported in #3238). For a normal plan/apply only the requested branch tip is needed, so the full-history transfer is wasted work. The reporter noted that `git clone --depth 1` should be relatively easy, and the maintainer agreed it was worth trying.

## What

Performs a shallow git clone (`--depth 1`) of the requested branch tip when checking out a workspace's VCS repository, instead of always cloning the entire repository history.

jgit's `CloneCommand` supports `setDepth(int)`, so the change is small and contained to the executor clone helper.

## How

In `SetupWorkspaceImpl.downloadWorkspaceGit(...)`:

- A depth-1 shallow clone cannot check out an arbitrary historical commit, so the optimization is applied **only when `terraformJob.getCommitId()` is null or blank**.
- When a specific `commitId` is requested, the clone falls back to a full clone (no `setDepth`) so the subsequent `Git.open(...).checkout().setName(commitId)` still resolves the historical commit. The existing checkout block is unchanged.
- The gating is applied to both the SSH clone path and the credentials clone path. `setBranch(...)` and `setCloneSubmodules(true)` are unchanged, so the branch tip (and submodules) are still fetched.

## Testing

- Added `performsShallowCloneWhenNoCommitIdRequested` to `SetupWorkspaceTest`, which asserts the clone is shallow (the jgit `.git/shallow` marker file is present) for the no-`commitId` happy path.
- The existing `failsWhenAskedToCheckoutABadCommit` test continues to cover the full-clone fallback: a bad commit id still throws `RefNotFoundException`, which only succeeds because a `commitId` job performs a full clone.
- `mvn -Dtest=SetupWorkspaceTest test` passes.

Fixes #3238
