### PR TITLE
fix: propagate org/workspace labels to ephemeral executor pod template

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
@@ -326,6 +326,12 @@ public class EphemeralExecutorService {
                     .endMetadata().endTemplate().endSpec();
         }
 
+        if (!labels.isEmpty()) {
+            jobBuilder.editSpec().editTemplate().editOrNewMetadata()
+                    .addToLabels(labels)
+                    .endMetadata().endTemplate().endSpec();
+        }
+
         io.fabric8.kubernetes.api.model.batch.v1.Job k8sJob = jobBuilder.build();
 
         try {

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorServiceTest.java
@@ -1,7 +1,7 @@
 package io.terrakube.api.plugin.scheduler.job.tcl.executor.ephemeral;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
@@ -188,11 +189,15 @@ public class EphemeralExecutorServiceTest {
     }
 
     @Test
-    public void omitsPodTemplateMetadataWhenNoAnnotations() throws ExecutionException {
+    public void setsPodTemplateMetadataWithLabelsWhenNoAnnotations() throws ExecutionException {
         subject().send(job(), context());
 
         verify(namespaced, times(1)).resource(job.capture());
-        assertNull(job.getValue().getSpec().getTemplate().getMetadata());
+        ObjectMeta metadata = job.getValue().getSpec().getTemplate().getMetadata();
+        assertNotNull(metadata);
+        assertEquals("ze-org", metadata.getLabels().get("terrakube.io/organization"));
+        assertEquals("ze-workspace", metadata.getLabels().get("terrakube.io/workspace"));
+        assertTrue(metadata.getAnnotations() == null || metadata.getAnnotations().isEmpty());
     }
 
     @Test
@@ -203,6 +208,32 @@ public class EphemeralExecutorServiceTest {
         Map<String, String> labels = job.getValue().getMetadata().getLabels();
         assertEquals("ze-org", labels.get("terrakube.io/organization"));
         assertEquals("ze-workspace", labels.get("terrakube.io/workspace"));
+    }
+
+    @Test
+    public void setsLabelsOnPodTemplate() throws ExecutionException {
+        subject().send(job(), context());
+
+        verify(namespaced, times(1)).resource(job.capture());
+        Map<String, String> labels = job.getValue().getSpec().getTemplate().getMetadata().getLabels();
+        assertEquals("ze-org", labels.get("terrakube.io/organization"));
+        assertEquals("ze-workspace", labels.get("terrakube.io/workspace"));
+    }
+
+    @Test
+    public void propagatesCustomLabelsToPodTemplate() throws ExecutionException {
+        ExecutorContext context = context();
+        context.getEnvironmentVariables().put("EPHEMERAL_CONFIG_LABELS", "team=platform;env=prod");
+
+        subject().send(job(), context);
+
+        verify(namespaced, times(1)).resource(job.capture());
+        Map<String, String> jobLabels = job.getValue().getMetadata().getLabels();
+        Map<String, String> podLabels = job.getValue().getSpec().getTemplate().getMetadata().getLabels();
+        assertEquals("platform", jobLabels.get("team"));
+        assertEquals("prod", jobLabels.get("env"));
+        assertEquals("platform", podLabels.get("team"));
+        assertEquals("prod", podLabels.get("env"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
Propagate the org/workspace (and any custom `EPHEMERAL_CONFIG_LABELS`) labels onto the ephemeral job's **pod template** metadata, so the spawned Pod inherits them instead of only the Job object carrying them.

## Why this matters
Fixes #3140. When an ephemeral job runs, Terrakube creates a `batch/v1` Job which spawns a Pod. The Job metadata correctly carries `terrakube.io/organization`, `terrakube.io/workspace`, and any custom labels, but those labels were never forwarded to the pod template, so the spawned Pod only showed the Kubernetes-injected `controller-uid` / `job-name` labels. Without the org/workspace labels on the Pod, label-based selectors, network policies, and cost-attribution tooling that target Pods cannot identify the workload.

## Changes
- `EphemeralExecutorService`: after the existing `podAnnotations` block, add a parallel block that copies the already-assembled `labels` map onto the pod template metadata via `jobBuilder.editSpec().editTemplate().editOrNewMetadata().addToLabels(labels)...`. This mirrors the existing pod-annotations precedent and uses `editOrNewMetadata` so it merges cleanly with metadata created by the annotations block. The labels map is always populated (org + workspace), so propagation is unconditional.

## Testing
- `mvn -pl api test -Dtest=EphemeralExecutorServiceTest` -> `Tests run: 23, Failures: 0, Errors: 0` (BUILD SUCCESS).
- Added `setsLabelsOnPodTemplate` asserting the pod template inherits `terrakube.io/organization` and `terrakube.io/workspace`.
- Added `propagatesCustomLabelsToPodTemplate` asserting custom `EPHEMERAL_CONFIG_LABELS` (`team=platform;env=prod`) appear on both the Job metadata and the pod template metadata.
- Updated the former `omitsPodTemplateMetadataWhenNoAnnotations` regression test: since labels are now always set on the pod template, it now asserts the template metadata exists with the org/workspace labels while annotations remain empty.
- Existing `setsLabelsOnJob` and `setsPodTemplateAnnotations` assertions still pass (Job labels and pod annotations unchanged; labels are additive on the template).

Fixes #3140
