### PR TITLE
fix(ui): render actions that use optional chaining or nullish coalescing

### DIFF
--- a/ui/src/ActionLoader.tsx
+++ b/ui/src/ActionLoader.tsx
@@ -211,15 +211,15 @@ const ActionLoader = ({ action, context }: { action: any; context: any }) => {
         const importedIcons = resolveAntdIcons(requiredAntdIcons);
         const importedReactIcons = pickReactIcons(requiredReactIcons);
 
-        let transpiledCode = transform(componentString, {
+        // Bind the component before transpiling. Sucrase prepends helper
+        // functions when the action uses optional chaining or nullish
+        // coalescing, so the transpiled output is no longer a single
+        // expression and can't be wrapped in `return (...)` afterwards.
+        const componentExpression = componentString.trim().replace(/;+\s*$/, "");
+        const transpiledCode = transform(`const __ActionComponent = (${componentExpression}\n);`, {
           transforms: ["jsx"],
           production: true,
         }).code;
-
-        const lastSemicolonIndex = transpiledCode!.lastIndexOf(";");
-        if (lastSemicolonIndex !== -1) {
-          transpiledCode = transpiledCode!.slice(0, lastSemicolonIndex);
-        }
 
         const scopeContext: Record<string, any> = {
           React,
@@ -249,7 +249,7 @@ const ActionLoader = ({ action, context }: { action: any; context: any }) => {
         const functionParams = Object.keys(scopeContext);
         const functionArgs = functionParams.map((key) => scopeContext[key]);
 
-        const createComponent = new Function(...functionParams, `return (${transpiledCode})`);
+        const createComponent = new Function(...functionParams, `${transpiledCode}\nreturn __ActionComponent;`);
         const component = createComponent(...functionArgs);
 
         compiledComponentCache.set(action, component);


### PR DESCRIPTION
### Problem

A custom action whose component uses optional chaining (`?.`) or nullish coalescing (`??`) fails to render and shows:

```
Error loading component: Error: Unexpected token 'function'
```

### Cause

`ActionLoader` transpiles the action with sucrase and evaluates it with:

```js
new Function(..., `return (${transpiledCode})`)
```

That assumes the transpiled output is a single expression. When the action source uses `?.` or `??`, sucrase emits helper functions (`_optionalChain`, `_nullishCoalesce`, ...) at the top of the output, so the result looks like `function _x(){} (props) => {...}`, which is not valid inside `return (...)`. The `lastIndexOf(";")` trim doesn't help, and on some inputs it also strips the component's closing brace.

### Fix

Bind the component to a variable before transpiling and return that binding, so the injected helpers stay valid statements:

```js
const __ActionComponent = (<action code>);
// ... sucrase helpers above are fine as statements ...
return __ActionComponent;
```

Trailing semicolons in the action source are stripped first so the wrap stays a single expression.

Tested with actions that use `?.`/`??` (previously broken) and with plain actions (still work).
