### PR TITLE
Emit AWS session tags in the dynamic-credentials JWT for ABAC

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -121,11 +121,15 @@ public class DynamicCredentialsService {
     }
 
     private String generateJwt(String organizationName, String workspaceName, String tokenAudience, String organizationId, String workspaceId, int jobId) {
+        return generateJwt(organizationName, workspaceName, tokenAudience, organizationId, workspaceId, jobId, null);
+    }
+
+    private String generateJwt(String organizationName, String workspaceName, String tokenAudience, String organizationId, String workspaceId, int jobId, Map<String, Object> extraClaims) {
         String jwtToken = "";
         if (privateKeyPath != null && !privateKeyPath.isEmpty()) {
             try {
                 Instant now = Instant.now();
-                jwtToken = Jwts.builder()
+                var builder = Jwts.builder()
                         .subject(String.format("organization:%s:workspace:%s", organizationName, workspaceName))
                         .audience().add(tokenAudience).and()
                         .id(UUID.randomUUID().toString())
@@ -137,7 +141,9 @@ public class DynamicCredentialsService {
                         .claim("terrakube_job_id", String.valueOf(jobId))
                         .issuedAt(Date.from(now))
                         .issuer(String.format("https://%s", overrideHostname.isEmpty() ? hostname : overrideHostname))
-                        .expiration(Date.from(now.plus(dynamicCredentialTtl, ChronoUnit.MINUTES)))
+                        .expiration(Date.from(now.plus(dynamicCredentialTtl, ChronoUnit.MINUTES)));
+                if (extraClaims != null) extraClaims.forEach(builder::claim);
+                jwtToken = builder
                         .signWith(getPrivateKey(), Jwts.SIG.RS512)
                         .compact();
             } catch (Exception e) {
@@ -158,7 +164,8 @@ public class DynamicCredentialsService {
                 workspaceEnvVariables.get("WORKLOAD_IDENTITY_AUDIENCE_AWS"),
                 job.getOrganization().getId().toString(),
                 job.getWorkspace().getId().toString(),
-                job.getId()
+                job.getId(),
+                Map.of("https://aws.amazon.com/tags", buildAwsSessionTags(job))
         );
 
         log.debug("TERRAKUBE_AWS_CREDENTIALS_FILE: {}", awsWebIdentityToken);
@@ -219,6 +226,27 @@ public class DynamicCredentialsService {
         // path of the file it wrote (the workspace clone dir is only known there).
 
         return workspaceEnvVariables;
+    }
+
+    private Map<String, Object> buildAwsSessionTags(Job job) {
+        Map<String, List<String>> principalTags = new LinkedHashMap<>();
+        principalTags.put("terrakube:org",       List.of(sanitizeTag(job.getOrganization().getName())));
+        principalTags.put("terrakube:workspace", List.of(sanitizeTag(job.getWorkspace().getName())));
+        var project = job.getWorkspace().getProject();
+        if (project != null) {
+            principalTags.put("terrakube:project", List.of(sanitizeTag(project.getName())));
+        }
+        return Map.of(
+                "principal_tags",      principalTags,
+                "transitive_tag_keys", new ArrayList<>(principalTags.keySet()));
+    }
+
+    private String sanitizeTag(String value) {
+        if (value == null) {
+            return "";
+        }
+        String sanitized = value.replaceAll("[^A-Za-z0-9 _.:/=+@-]", "_");
+        return sanitized.length() > 256 ? sanitized.substring(0, 256) : sanitized;
     }
 
     private PrivateKey getPrivateKey() throws Exception {

--- a/api/src/main/java/io/terrakube/api/plugin/token/dynamic/OpenIdConfigurationController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/token/dynamic/OpenIdConfigurationController.java
@@ -60,6 +60,7 @@ public class OpenIdConfigurationController {
         openIdData.getClaimsSupported().add("terrakube_job_id");
         openIdData.getClaimsSupported().add("terrakube_workspace_name");
         openIdData.getClaimsSupported().add("terrakube_organization_name");
+        openIdData.getClaimsSupported().add("https://aws.amazon.com/tags");
 
         openIdData.setIdTokenSigningAlgValuesSupported(new ArrayList<>());
         openIdData.getIdTokenSigningAlgValuesSupported().add("RS512");

--- a/api/src/test/java/io/terrakube/api/DynamicCredentialsTests.java
+++ b/api/src/test/java/io/terrakube/api/DynamicCredentialsTests.java
@@ -1,9 +1,12 @@
 package io.terrakube.api;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.terrakube.api.plugin.token.dynamic.DynamicCredentialsService;
 import io.terrakube.api.plugin.token.dynamic.JwksController;
 import io.terrakube.api.plugin.token.dynamic.OpenIdConfigurationController;
 import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.project.Project;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -141,6 +144,7 @@ public class DynamicCredentialsTests extends ServerApplicationTests {
     private Job createMockJob() {
         var organization = organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).orElseThrow();
         var workspace = workspaceRepository.findById(UUID.fromString("5ed411ca-7ab8-4d2f-b591-02d0d5788afc")).orElseThrow();
+        workspace.setProject(null);
 
         Job job = new Job();
         job.setId(999);
@@ -148,6 +152,106 @@ public class DynamicCredentialsTests extends ServerApplicationTests {
         job.setWorkspace(workspace);
 
         return job;
+    }
+
+    private JsonNode decodeJwtClaims(String jwt) throws IOException {
+        String payload = jwt.split("\\.")[1];
+        byte[] decoded = Base64.getUrlDecoder().decode(payload);
+        return new ObjectMapper().readTree(decoded);
+    }
+
+    @Test
+    void testAwsTokenContainsSessionTags() throws IOException {
+        Job job = createMockJob();
+
+        HashMap<String, String> envVariables = new HashMap<>();
+        envVariables.put("WORKLOAD_IDENTITY_AUDIENCE_AWS", "sts.amazonaws.com");
+        envVariables.put("WORKLOAD_IDENTITY_ROLE_AWS", "arn:aws:iam::123456789012:role/test-role");
+
+        HashMap<String, String> result = dynamicCredentialsService.generateDynamicCredentialsAws(job, envVariables);
+
+        JsonNode claims = decodeJwtClaims(result.get("TERRAKUBE_AWS_CREDENTIALS_FILE"));
+        JsonNode tags = claims.get("https://aws.amazon.com/tags");
+        assertNotNull(tags, "AWS token must carry the session-tags claim");
+
+        JsonNode principalTags = tags.get("principal_tags");
+        assertTrue(principalTags.has("terrakube:org"), "principal_tags must contain terrakube:org");
+        assertTrue(principalTags.has("terrakube:workspace"), "principal_tags must contain terrakube:workspace");
+
+        assertTrue(principalTags.get("terrakube:org").isArray());
+        assertEquals(1, principalTags.get("terrakube:org").size());
+        assertEquals(1, principalTags.get("terrakube:workspace").size());
+
+        JsonNode transitive = tags.get("transitive_tag_keys");
+        assertTrue(transitive.isArray());
+    }
+
+    @Test
+    void testAwsTokenOmitsProjectTagWhenNoProject() throws IOException {
+        Job job = createMockJob();
+        job.getWorkspace().setProject(null);
+
+        HashMap<String, String> envVariables = new HashMap<>();
+        envVariables.put("WORKLOAD_IDENTITY_AUDIENCE_AWS", "sts.amazonaws.com");
+        envVariables.put("WORKLOAD_IDENTITY_ROLE_AWS", "arn:aws:iam::123456789012:role/test-role");
+
+        HashMap<String, String> result = dynamicCredentialsService.generateDynamicCredentialsAws(job, envVariables);
+
+        JsonNode principalTags = decodeJwtClaims(result.get("TERRAKUBE_AWS_CREDENTIALS_FILE"))
+                .get("https://aws.amazon.com/tags").get("principal_tags");
+        assertFalse(principalTags.has("terrakube:project"),
+                "terrakube:project must be absent when the workspace has no project");
+    }
+
+    @Test
+    void testAwsTokenIncludesProjectTagWhenPresent() throws IOException {
+        Job job = createMockJob();
+        Project project = new Project();
+        project.setName("my-project");
+        job.getWorkspace().setProject(project);
+
+        HashMap<String, String> envVariables = new HashMap<>();
+        envVariables.put("WORKLOAD_IDENTITY_AUDIENCE_AWS", "sts.amazonaws.com");
+        envVariables.put("WORKLOAD_IDENTITY_ROLE_AWS", "arn:aws:iam::123456789012:role/test-role");
+
+        HashMap<String, String> result = dynamicCredentialsService.generateDynamicCredentialsAws(job, envVariables);
+
+        JsonNode principalTags = decodeJwtClaims(result.get("TERRAKUBE_AWS_CREDENTIALS_FILE"))
+                .get("https://aws.amazon.com/tags").get("principal_tags");
+        assertTrue(principalTags.has("terrakube:project"),
+                "terrakube:project must be present when the workspace has a project");
+        assertEquals("my-project", principalTags.get("terrakube:project").get(0).asText());
+    }
+
+    @Test
+    void testNonAwsTokensDoNotContainAwsTagsClaim() throws IOException {
+        Job job = createMockJob();
+
+        HashMap<String, String> azureEnv = new HashMap<>();
+        azureEnv.put("WORKLOAD_IDENTITY_AUDIENCE_AZURE", "api://AzureADTokenExchange");
+        String azureToken = dynamicCredentialsService.generateDynamicCredentialsAzure(job, azureEnv).get("ARM_OIDC_TOKEN");
+        assertFalse(decodeJwtClaims(azureToken).has("https://aws.amazon.com/tags"),
+                "Azure token must not carry the AWS session-tags claim");
+
+        HashMap<String, String> gcpEnv = new HashMap<>();
+        gcpEnv.put("WORKLOAD_IDENTITY_AUDIENCE_GCP", "//iam.googleapis.com/pool/provider");
+        gcpEnv.put("WORKLOAD_IDENTITY_SERVICE_ACCOUNT_EMAIL", "sa@project.iam.gserviceaccount.com");
+        String gcpFile = dynamicCredentialsService.generateDynamicCredentialsGcp(job, gcpEnv).get("TERRAKUBE_GCP_CREDENTIALS_FILE");
+        String gcpToken = new ObjectMapper().readTree(gcpFile).get("access_token").asText();
+        assertFalse(decodeJwtClaims(gcpToken).has("https://aws.amazon.com/tags"),
+                "GCP token must not carry the AWS session-tags claim");
+
+        String vaultToken = ReflectionTestUtils.invokeMethod(dynamicCredentialsService, "generateJwt",
+                job.getOrganization().getName(), job.getWorkspace().getName(), "vault.example.com",
+                job.getOrganization().getId().toString(), job.getWorkspace().getId().toString(), job.getId());
+        assertFalse(decodeJwtClaims(vaultToken).has("https://aws.amazon.com/tags"),
+                "Vault token must not carry the AWS session-tags claim");
+    }
+
+    @Test
+    void testSanitizeTagNeutralizesForbiddenCharacters() {
+        String sanitized = ReflectionTestUtils.invokeMethod(dynamicCredentialsService, "sanitizeTag", "my*org#name");
+        assertEquals("my_org_name", sanitized);
     }
 
     @Test

--- a/dynamic-credential-setup/aws/README.md
+++ b/dynamic-credential-setup/aws/README.md
@@ -47,12 +47,68 @@ provider "aws" {
 
 }
 
-resource "aws_s3_bucket" "example" {
-  bucket = "my-tf-superbucket-awerqerq"
+# The role created by this setup is scoped by the terrakube:workspace session tag,
+# so it can only access the prefix that matches the workspace name.
+# The bucket "my-terrakube-bucket" is expected to already exist.
+resource "aws_s3_object" "example" {
+  bucket  = "my-terrakube-bucket"
+  key     = "dynamic-workspace-aws/example.txt"
+  content = "hello from terrakube dynamic credentials"
+}
+```
 
-  tags = {
-    Name        = "My bucket"
-    Environment = "Dev"
+## Session tags (ABAC)
+
+The AWS web identity token issued by Terrakube also carries AWS session tags. This lets you scope IAM roles with `aws:PrincipalTag` (attribute-based access control) instead of creating one role per workspace.
+
+The following tags are sent as transitive principal tags:
+
+- `terrakube:org` - organization name
+- `terrakube:workspace` - workspace name
+- `terrakube:project` - project name (only when the workspace belongs to a project)
+
+Two things are required in the role trust policy:
+
+- The `sts:TagSession` action must be allowed, otherwise the assume call fails.
+- A `ForAllValues:StringEquals` condition on `aws:TagKeys` restricts which tag keys are accepted. This prevents Terrakube from setting any tag key other than the ones listed. The `main.tf` in this folder already applies this guardrail:
+
+The `main.tf` in this folder uses a wildcard `sub` so a single role serves every workspace of the organization, and relies on the session tag to scope access per workspace:
+
+```json
+"Action": [
+  "sts:AssumeRoleWithWebIdentity",
+  "sts:TagSession"
+],
+"Condition": {
+  "StringEquals": {
+    "terrakube-api.mydomain.com:aud": "aws.workload.identity"
+  },
+  "StringLike": {
+    "terrakube-api.mydomain.com:sub": "organization:my-org:workspace:*"
+  },
+  "ForAllValues:StringEquals": {
+    "aws:TagKeys": [
+      "terrakube:org",
+      "terrakube:workspace",
+      "terrakube:project"
+    ]
   }
 }
 ```
+
+Once the tags are set, you can reference them in permission policies. For example, this policy (used in `main.tf`) allows access only to the S3 prefix that matches the caller workspace:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:*",
+      "Resource": "arn:aws:s3:::my-terrakube-bucket/${aws:PrincipalTag/terrakube:workspace}/*"
+    }
+  ]
+}
+```
+
+You can also restrict the accepted tag values (not only the keys) with `aws:RequestTag/<key>` in the trust policy if you want to pin a role to a specific organization or workspace.

--- a/dynamic-credential-setup/aws/main.tf
+++ b/dynamic-credential-setup/aws/main.tf
@@ -24,11 +24,23 @@ resource "aws_iam_role" "terrakube_role" {
      "Principal": {
        "Federated": "${aws_iam_openid_connect_provider.terrakube_provider.arn}"
      },
-     "Action": "sts:AssumeRoleWithWebIdentity",
+     "Action": [
+       "sts:AssumeRoleWithWebIdentity",
+       "sts:TagSession"
+     ],
      "Condition": {
         "StringEquals": {
-        "${var.terrakube_api_hostname}:aud": "${var.terrakube_federated_credentials_audience}",
-        "${var.terrakube_api_hostname}:sub": "organization:${var.terrakube_organization_name}:workspace:${var.terrakube_workspace_name}"
+        "${var.terrakube_api_hostname}:aud": "${var.terrakube_federated_credentials_audience}"
+        },
+        "StringLike": {
+        "${var.terrakube_api_hostname}:sub": "organization:${var.terrakube_organization_name}:workspace:*"
+        },
+        "ForAllValues:StringEquals": {
+        "aws:TagKeys": [
+          "terrakube:org",
+          "terrakube:workspace",
+          "terrakube:project"
+        ]
         }
      }
    }
@@ -47,10 +59,18 @@ resource "aws_iam_policy" "terrakube_policy" {
  "Statement": [
    {
      "Effect": "Allow",
-     "Action": [
-       "s3:*"
-     ],
-     "Resource": "*"
+     "Action": "s3:ListBucket",
+     "Resource": "arn:aws:s3:::my-terrakube-bucket",
+     "Condition": {
+       "StringLike": {
+         "s3:prefix": "$${aws:PrincipalTag/terrakube:workspace}/*"
+       }
+     }
+   },
+   {
+     "Effect": "Allow",
+     "Action": "s3:*",
+     "Resource": "arn:aws:s3:::my-terrakube-bucket/$${aws:PrincipalTag/terrakube:workspace}/*"
    }
  ]
 }


### PR DESCRIPTION
**Feature description**

Terrakube signs an OIDC JWT that is used with AWS `AssumeRoleWithWebIdentity` to get dynamic credentials. Today this token only carries sub and the `terrakube_*` claims. It does not carry AWS session tags.

The proposal is to add AWS session tags to the token on the AWS path:

- `terrakube:org` = organization name
- `terrakube:workspace` = workspace name
- `terrakube:project` = project name (only when the workspace belongs to a project)

These would be sent as transitive principal tags, in the nested format AWS expects (https://aws.amazon.com/tags claim).

**Why**

Without session tags, an IAM role cannot know which organization, workspace or project the token comes from. In practice this forces users to create one IAM role per workspace, because the only way to isolate access is a separate trust policy each time.

With session tags, users can use attribute-based access control. A single role can be reused across many workspaces, and IAM policies restrict access using `aws:PrincipalTag/terrakube:org`, `aws:PrincipalTag/terrakube:workspace`, etc. 

For example, a policy can allow access to an S3 prefix only when `aws:PrincipalTag/terrakube:workspace` matches the workspace name. 

The change is limited to the AWS path. Azure, Vault and GCP tokens stay exactly the same.

[More details here](https://github.com/terrakube-io/terrakube/issues/3283).