### PR TITLE
fix(ui): use absolute base URL so deep-link reloads work (#3286)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -13,7 +13,7 @@
     <link rel="manifest" href="/manifest.json" />
     <!-- Generated at container start by env.sh to inject runtime env vars into window._env_.
          Must remain a classic script (not type=module) so it runs before the React entry. -->
-    <script src="./env-config.js" data-vite-ignore></script>
+    <script src="%BASE_URL%env-config.js" data-vite-ignore></script>
     <title>Terrakube</title>
   </head>
   <body>

--- a/ui/vite.config.mts
+++ b/ui/vite.config.mts
@@ -10,8 +10,12 @@ export default defineConfig(({ mode }) => {
   const isProd = mode === "production";
   const analyze = process.env.ANALYZE === "1" || process.env.ANALYZE === "true";
   return {
-    // Use relative asset URLs so the same build can be hosted at / or a subpath such as /ui/.
-    base: "./",
+    // Absolute base so asset and env-config.js URLs resolve from the site root on
+    // any route. A relative base ("./") breaks deep-link hard reloads: the browser
+    // resolves assets against the current path (e.g. /organizations/.../workspaces/)
+    // and the server returns index.html instead, failing the page load. To host
+    // under a subpath, set VITE_BASE to an absolute prefix such as "/ui/".
+    base: process.env.VITE_BASE ?? "/",
     server: {
       host: true,
       allowedHosts: true,


### PR DESCRIPTION
## What

Change the UI Vite `base` from a relative `"./"` to an absolute default (`"/"`), configurable for subpath hosting via an absolute `VITE_BASE`.

## Why

Fixes #3286.

The UI sets `base: "./"` in `ui/vite.config.mts`. Because the app is a client-side-routed SPA, a **relative** base breaks any non-root URL on hard reload: the browser resolves asset and `env-config.js` requests against the current route, e.g.

```
https://<host>/organizations/<id>/workspaces/<id>/assets/index-*.js
https://<host>/organizations/<id>/workspaces/<id>/env-config.js
```

instead of `/(assets|env-config.js)/...`. Those paths don't exist, so the nginx SPA fallback returns `index.html`, and the browser then fails with:

- `env-config.js:1 Uncaught SyntaxError: Unexpected token '<'`
- `'text/html' is not a valid JavaScript MIME type`
- `Did not parse stylesheet ... because non CSS MIME types are not allowed in strict mode`

Result: a blank page on every deep-link hard reload (only `/` works). This appeared in 2.32.0.

## Fix

A client-side-routed SPA must use an **absolute** base so assets resolve from the site root regardless of the current route:

```js
base: process.env.VITE_BASE ?? "/",
```

The original intent (host at `/` or a subpath like `/ui/`) is preserved: subpath deployments set `VITE_BASE=/ui/` at build time. An absolute subpath prefix also resolves correctly on deep-link reloads, whereas a relative base never can.

## Testing

- Build with default base → `index.html` references `/assets/...` (absolute); hard-reloading a deep URL loads assets and the app.
- Build with `VITE_BASE=/ui/` → assets reference `/ui/assets/...`.
