### PR TITLE
fix(ui): use absolute base URL so deep-link reloads work (#3287)

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -13,7 +13,7 @@
     <link rel="manifest" href="/manifest.json" />
     <!-- Generated at container start by env.sh to inject runtime env vars into window._env_.
          Must remain a classic script (not type=module) so it runs before the React entry. -->
-    <script src="./env-config.js" data-vite-ignore></script>
+    <script src="%BASE_URL%env-config.js" data-vite-ignore></script>
     <title>Terrakube</title>
   </head>
   <body>

--- a/ui/vite.config.mts
+++ b/ui/vite.config.mts
@@ -10,8 +10,12 @@ export default defineConfig(({ mode }) => {
   const isProd = mode === "production";
   const analyze = process.env.ANALYZE === "1" || process.env.ANALYZE === "true";
   return {
-    // Use relative asset URLs so the same build can be hosted at / or a subpath such as /ui/.
-    base: "./",
+    // Absolute base so asset and env-config.js URLs resolve from the site root on
+    // any route. A relative base ("./") breaks deep-link hard reloads: the browser
+    // resolves assets against the current path (e.g. /organizations/.../workspaces/)
+    // and the server returns index.html instead, failing the page load. To host
+    // under a subpath, set VITE_BASE to an absolute prefix such as "/ui/".
+    base: process.env.VITE_BASE ?? "/",
     server: {
       host: true,
       allowedHosts: true,


### PR DESCRIPTION
The Vite base was relative ("./"), so on a non-root URL the browser resolves asset and env-config.js requests against the current route (e.g. /organizations/<id>/workspaces/assets/...). Those paths don't exist, nginx's SPA fallback returns index.html, and the page fails to load with MIME/JSON errors. A client-side-routed SPA cannot use a relative base.

- vite.config.mts: default base to absolute "/", with subpath hosting via an absolute VITE_BASE (e.g. "/ui/") instead of a relative path.
- index.html: reference env-config.js via %BASE_URL% (the vite-ignored script tag kept a literal "./"), so it also resolves from the base, not the route.

Fixes #3286