### PR TITLE
feat: Optional AWS Session Tags FF

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/token/dynamic/DynamicCredentialsService.java
@@ -158,6 +158,11 @@ public class DynamicCredentialsService {
 
     @Transactional
     public HashMap<String, String> generateDynamicCredentialsAws(Job job, HashMap<String, String> workspaceEnvVariables) {
+        Map<String, Object> extraClaims = null;
+        if (Boolean.parseBoolean(workspaceEnvVariables.get("ENABLE_AWS_SESSION_TAGS"))) {
+            extraClaims = Map.of("https://aws.amazon.com/tags", buildAwsSessionTags(job));
+        }
+
         String awsWebIdentityToken = generateJwt(
                 job.getOrganization().getName(),
                 job.getWorkspace().getName(),
@@ -165,7 +170,7 @@ public class DynamicCredentialsService {
                 job.getOrganization().getId().toString(),
                 job.getWorkspace().getId().toString(),
                 job.getId(),
-                Map.of("https://aws.amazon.com/tags", buildAwsSessionTags(job))
+                extraClaims
         );
 
         log.debug("TERRAKUBE_AWS_CREDENTIALS_FILE: {}", awsWebIdentityToken);

--- a/api/src/test/java/io/terrakube/api/DynamicCredentialsTests.java
+++ b/api/src/test/java/io/terrakube/api/DynamicCredentialsTests.java
@@ -167,6 +167,7 @@ public class DynamicCredentialsTests extends ServerApplicationTests {
         HashMap<String, String> envVariables = new HashMap<>();
         envVariables.put("WORKLOAD_IDENTITY_AUDIENCE_AWS", "sts.amazonaws.com");
         envVariables.put("WORKLOAD_IDENTITY_ROLE_AWS", "arn:aws:iam::123456789012:role/test-role");
+        envVariables.put("ENABLE_AWS_SESSION_TAGS", "true");
 
         HashMap<String, String> result = dynamicCredentialsService.generateDynamicCredentialsAws(job, envVariables);
 
@@ -187,6 +188,20 @@ public class DynamicCredentialsTests extends ServerApplicationTests {
     }
 
     @Test
+    void testAwsTokenHasNoSessionTagsWhenFlagDisabled() throws IOException {
+        Job job = createMockJob();
+
+        HashMap<String, String> envVariables = new HashMap<>();
+        envVariables.put("WORKLOAD_IDENTITY_AUDIENCE_AWS", "sts.amazonaws.com");
+        envVariables.put("WORKLOAD_IDENTITY_ROLE_AWS", "arn:aws:iam::123456789012:role/test-role");
+
+        HashMap<String, String> result = dynamicCredentialsService.generateDynamicCredentialsAws(job, envVariables);
+
+        assertFalse(decodeJwtClaims(result.get("TERRAKUBE_AWS_CREDENTIALS_FILE")).has("https://aws.amazon.com/tags"),
+                "AWS token must not carry the session-tags claim when ENABLE_AWS_SESSION_TAGS is not set");
+    }
+
+    @Test
     void testAwsTokenOmitsProjectTagWhenNoProject() throws IOException {
         Job job = createMockJob();
         job.getWorkspace().setProject(null);
@@ -194,6 +209,7 @@ public class DynamicCredentialsTests extends ServerApplicationTests {
         HashMap<String, String> envVariables = new HashMap<>();
         envVariables.put("WORKLOAD_IDENTITY_AUDIENCE_AWS", "sts.amazonaws.com");
         envVariables.put("WORKLOAD_IDENTITY_ROLE_AWS", "arn:aws:iam::123456789012:role/test-role");
+        envVariables.put("ENABLE_AWS_SESSION_TAGS", "true");
 
         HashMap<String, String> result = dynamicCredentialsService.generateDynamicCredentialsAws(job, envVariables);
 
@@ -213,6 +229,7 @@ public class DynamicCredentialsTests extends ServerApplicationTests {
         HashMap<String, String> envVariables = new HashMap<>();
         envVariables.put("WORKLOAD_IDENTITY_AUDIENCE_AWS", "sts.amazonaws.com");
         envVariables.put("WORKLOAD_IDENTITY_ROLE_AWS", "arn:aws:iam::123456789012:role/test-role");
+        envVariables.put("ENABLE_AWS_SESSION_TAGS", "true");
 
         HashMap<String, String> result = dynamicCredentialsService.generateDynamicCredentialsAws(job, envVariables);
 

--- a/dynamic-credential-setup/aws/README.md
+++ b/dynamic-credential-setup/aws/README.md
@@ -59,7 +59,9 @@ resource "aws_s3_object" "example" {
 
 ## Session tags (ABAC)
 
-The AWS web identity token issued by Terrakube also carries AWS session tags. This lets you scope IAM roles with `aws:PrincipalTag` (attribute-based access control) instead of creating one role per workspace.
+The AWS web identity token issued by Terrakube can also carry AWS session tags. This lets you scope IAM roles with `aws:PrincipalTag` (attribute-based access control) instead of creating one role per workspace.
+
+Session tags are opt-in. They are only added when the workspace sets the `ENABLE_AWS_SESSION_TAGS` environment variable to `true`. This is required because emitting session tags needs `sts:TagSession` in the role trust policy; without it `AssumeRoleWithWebIdentity` fails. Leaving the variable unset keeps the token unchanged, so existing workspaces are not affected.
 
 The following tags are sent as transitive principal tags:
 

--- a/dynamic-credential-setup/aws/main.tf
+++ b/dynamic-credential-setup/aws/main.tf
@@ -139,3 +139,14 @@ resource "terrakube_workspace_variable" "env4" {
   sensitive       = false
   hcl             = false
 }
+
+resource "terrakube_workspace_variable" "env5" {
+  organization_id = data.terrakube_organization.org.id
+  workspace_id    = terrakube_workspace_cli.dynamic_credentials_workspace.id
+  key             = "ENABLE_AWS_SESSION_TAGS"
+  value           = "true"
+  description     = "ENABLE_AWS_SESSION_TAGS"
+  category        = "ENV"
+  sensitive       = false
+  hcl             = false
+}


### PR DESCRIPTION
Follow-up to #3284: make AWS session tags opt-in

#3284 emits AWS session tags in the web identity token unconditionally. Since session tags require sts:TagSession in the role trust policy, this can affect existing AWS workspaces on upgrade if their trust policy hasn't been updated yet.

This PR gates the tags behind an explicit opt-in. Session tags are only added when the workspace sets ENABLE_AWS_SESSION_TAGS=true. Unset (default) leaves the token unchanged, so existing installs keep working without any IAM change.

**Changes**

- DynamicCredentialsService: emit the https://aws.amazon.com/tags claim only when ENABLE_AWS_SESSION_TAGS is true.
- Tests: cover both flag on and off.
- AWS example + README: add the variable and document the opt-in and the sts:TagSession requirement.
