### PR TITLE
fix(executor): surface init failures on remote-content runs

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -478,11 +478,20 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         if (terraformJob.isShowHeader()) {
             initSuccessful = Boolean.TRUE.equals(terraformClient.init(terraformProcessData, output, errorOutput).get());
         } else {
-            initSuccessful = Boolean.TRUE.equals(terraformClient.init(terraformProcessData, s -> {
+            // Remote operations (CLI-driven runs) keep init quiet on success, but the
+            // stream must still reach the step output when init fails; otherwise the
+            // error is only visible in the executor log and the client sees an empty
+            // step. Buffer the lines (stderr is merged into stdout via
+            // setRedirectErrorStream) and flush them on failure.
+            TextStringBuilder initOutput = new TextStringBuilder();
+            Consumer<String> quietOutput = s -> {
                 log.info(s);
-            }, s -> {
-                log.info(s);
-            }).get());
+                initOutput.appendln(s);
+            };
+            initSuccessful = Boolean.TRUE.equals(terraformClient.init(terraformProcessData, quietOutput, quietOutput).get());
+            if (!initSuccessful) {
+                output.accept(initOutput.toString());
+            }
         }
 
         log.warn("Terraform init Executed Successfully: {}", initSuccessful);


### PR DESCRIPTION
## Description

Fixes #3290.

Remote operations (CLI-driven runs, `showHeader == false`) routed the entire `terraform init` stream to the executor log only. When init failed, the step output stayed empty: nothing in the stored step log, nothing streamed back to the terraform CLI — the failure was diagnosable only from the executor pod log.

This change keeps init quiet on success for remote operations (the terraform CLI draws its own frame, and TFC behaves the same way), but buffers the init lines and flushes them to the step output consumer when init fails. Stderr is merged into stdout by `setRedirectErrorStream(true)`, so a single buffered consumer covers both.

VCS-driven runs (`showHeader == true`) are unchanged.

## Testing

- Reproduced on a self-hosted instance: CLI-driven plan with a module missing a `required_providers` entry for a non-hashicorp provider → init fails at provider resolution → empty step log before the change; with the change the init error reaches the step output.
- VCS webhook runs on the same config keep showing the full init section as before.
