### PR TITLE
fix(ui): make header logo navigate home

### DIFF
--- a/ui/src/domain/Home/App.tsx
+++ b/ui/src/domain/Home/App.tsx
@@ -189,7 +189,7 @@ const AppLayout = () => {
     <ConfigProvider theme={getThemeConfig(colorScheme, themeMode)}>
       <Layout className="layout mh-100">
         <Header>
-          <a>
+          <a onClick={() => navigate("/")} style={{ cursor: "pointer" }}>
             <img className="logo" src={logo} alt="Logo"></img>
           </a>
           <OrganizationSelector


### PR DESCRIPTION
## Description

Fixes #3292.

The header logo was wrapped in an anchor with no `href` and no click handler, so clicking it did nothing. Pages outside an organization context — account settings (`/settings/tokens`, `/settings/theme`) — render no main menu and no clickable breadcrumb root, leaving no in-app way back; the only exits were the browser back button or editing the URL.

Point the logo at the root route via the router (SPA navigation, no full reload). `/` renders the organization picker, a sensible home from any context. This follows the near-universal convention that the product logo links to the application home.

## Testing

- From `/settings/theme`, clicking the logo now returns to the organization picker.
- Logo shows a pointer cursor to signal clickability.
