### PR TITLE
Allow region configuration for custom S3 clients

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/storage/configuration/StorageTypeAutoConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/storage/configuration/StorageTypeAutoConfiguration.java
@@ -76,7 +76,7 @@ public class StorageTypeAutoConfiguration {
                             .build();
 
                     s3client = S3Client.builder()
-                            .region(Region.of("auto"))
+                            .region(awsStorageTypeProperties.getRegion())
                             .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsStorageTypeProperties)))
                             .endpointOverride(URI.create(awsStorageTypeProperties.getEndpoint()))
                             .serviceConfiguration(serviceConfiguration)

--- a/api/src/main/java/io/terrakube/api/plugin/storage/configuration/StorageTypeAutoConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/storage/configuration/StorageTypeAutoConfiguration.java
@@ -76,7 +76,7 @@ public class StorageTypeAutoConfiguration {
                             .build();
 
                     s3client = S3Client.builder()
-                            .region(awsStorageTypeProperties.getRegion())
+                            .region(Region.of(awsStorageTypeProperties.getRegion()))
                             .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsStorageTypeProperties)))
                             .endpointOverride(URI.create(awsStorageTypeProperties.getEndpoint()))
                             .serviceConfiguration(serviceConfiguration)

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
@@ -91,7 +91,7 @@ public class TerraformStateAutoConfiguration {
 
                         s3client = S3Client.builder()
                                 .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsTerraformStateProperties)))
-                                .region(Region.of("auto"))
+                                .region(Region.of(awsTerraformStateProperties.getRegion()))
                                 .endpointOverride(URI.create(awsTerraformStateProperties.getEndpoint()))
                                 .serviceConfiguration(serviceConfiguration)
                                 .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfiguration.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfiguration.java
@@ -82,7 +82,7 @@ public class StorageAutoConfiguration {
                             .build();
 
                     s3client = S3Client.builder()
-                            .region(Region.of("auto"))
+                            .region(Region.of(awsStorageServiceProperties.getRegion()))
                             .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsStorageServiceProperties)))
                             .endpointOverride(URI.create(awsStorageServiceProperties.getEndpoint()))
                             .serviceConfiguration(serviceConfiguration)


### PR DESCRIPTION
Allows region selection for non-AWS clients, setting the region to "auto" can mess with access tokens for certain S3 providers and/or servers like garage.