### PR TITLE
Fix: Ignore GitLab MR discussion resolutions to prevent spurious job …

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -191,6 +191,15 @@ public class GitLabWebhookService extends WebhookServiceBase {
                 return result;
             }
 
+            // Check if this is a discussion resolution event (no actual comment content)
+            // Discussion resolutions don't have actionable content and should be ignored
+            String discussionResolutionAction = rootNode.path("object_attributes").path("discussion_resolved").asText();
+            if (!discussionResolutionAction.isEmpty()) {
+                log.info("Ignoring GitLab note event: discussion resolution has no code changes");
+                result.setValid(false);
+                return result;
+            }
+
             String commentBody = noteNode.path("note").asText().trim();
             String command = parseTerrakubeCommand(commentBody);
             if (command == null) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -49,7 +49,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
     private int pagesize = 25;
     private int timeout = 30;
 
-    public GitLabWebhookService(ObjectMapper objectMapper, @Value("${io.terrakube.hostname}") String hostname, @Value("${io.terrakube.ui.url}") String uiUrl, WebClient.Builder webClientBuilder, @Value("${io.terrakube.pagesize:25}") int pageSize, @Value("${io.terrakube.timeout:30}") int timeout) {
+    public GitLabWebhookService(ObjectMapper objectMapper, @Value("${io.terrakube.hostname}") String hostname, @Value("${io.terrakube.ui.url}") String uiUrl, WebClient.Builder webClientBuilder, @Value("${io.terrakube.vcs.gitlab.timeout}") int timeout, @Value("${io.terrakube.vcs.gitlab.pageSize}") int pageSize) {
         this.objectMapper = objectMapper;
         this.hostname = hostname;
         this.webClientBuilder = webClientBuilder;

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -49,7 +49,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
     private int pagesize = 25;
     private int timeout = 30;
 
-    public GitLabWebhookService(ObjectMapper objectMapper, @Value("${io.terrakube.hostname}") String hostname, @Value("${io.terrakube.ui.url}") String uiUrl, WebClient.Builder webClientBuilder, @Value("${io.terrakube.vcs.gitlab.timeout}") int timeout, @Value("${io.terrakube.vcs.gitlab.pageSize}") int pageSize) {
+    public GitLabWebhookService(ObjectMapper objectMapper, @Value("${io.terrakube.hostname}") String hostname, @Value("${io.terrakube.ui.url}") String uiUrl, WebClient.Builder webClientBuilder, @Value("${io.terrakube.pagesize:25}") int pageSize, @Value("${io.terrakube.timeout:30}") int timeout) {
         this.objectMapper = objectMapper;
         this.hostname = hostname;
         this.webClientBuilder = webClientBuilder;
@@ -145,6 +145,15 @@ public class GitLabWebhookService extends WebhookServiceBase {
 
             String action = mrModel.getObjectAttributes().getAction();
 
+            // Check if this is a discussion resolution event (no actual code changes)
+            // When discussions are resolved, blocking_discussions_resolved is set to true
+            // but no commits are added, so we should ignore this update
+            if ("update".equals(action) && rootNode.path("blocking_discussions_resolved").asBoolean()) {
+                log.info("Ignoring GitLab MR update event: blocking discussions were resolved, no code changes");
+                result.setValid(false);
+                return result;
+            }
+
             switch (action) {
                 case "open":
                 case "update":
@@ -193,8 +202,8 @@ public class GitLabWebhookService extends WebhookServiceBase {
 
             // Check if this is a discussion resolution event (no actual comment content)
             // Discussion resolutions don't have actionable content and should be ignored
-            String discussionResolutionAction = rootNode.path("object_attributes").path("discussion_resolved").asText();
-            if (!discussionResolutionAction.isEmpty()) {
+            boolean isDiscussionResolved = rootNode.path("object_attributes").path("discussion_resolved").asBoolean();
+            if (isDiscussionResolved) {
                 log.info("Ignoring GitLab note event: discussion resolution has no code changes");
                 result.setValid(false);
                 return result;

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -142,17 +142,16 @@ public class GitLabWebhookService extends WebhookServiceBase {
         String ownerAndRepo = extractOwnerAndRepoGitlab(workspace.getSource());
         try {
             GitlabMergeRequestModel mrModel = objectMapper.readValue(jsonPayload, GitlabMergeRequestModel.class);
+			JsonNode rootNode = objectMapper.readTree(jsonPayload);
 
             String action = mrModel.getObjectAttributes().getAction();
 
-            // Check if this is a discussion resolution event (no actual code changes)
-            // When discussions are resolved, blocking_discussions_resolved is set to true
-            // but no commits are added, so we should ignore this update
-            if ("update".equals(action) && rootNode.path("blocking_discussions_resolved").asBoolean()) {
-                log.info("Ignoring GitLab MR update event: blocking discussions were resolved, no code changes");
-                result.setValid(false);
-                return result;
-            }
+			// Ignore update events triggered by resolving blocking discussions
+			if ("update".equals(action) && rootNode.has("blocking_discussions_resolved")) {
+				log.info("Ignoring GitLab MR update event: blocking discussions resolved");
+				result.setValid(false);
+				return result;
+			}
 
             switch (action) {
                 case "open":
@@ -196,15 +195,6 @@ public class GitLabWebhookService extends WebhookServiceBase {
             String noteableType = noteNode.path("noteable_type").asText();
 
             if (!"MergeRequest".equals(noteableType)) {
-                result.setValid(false);
-                return result;
-            }
-
-            // Check if this is a discussion resolution event (no actual comment content)
-            // Discussion resolutions don't have actionable content and should be ignored
-            boolean isDiscussionResolved = rootNode.path("object_attributes").path("discussion_resolved").asBoolean();
-            if (isDiscussionResolved) {
-                log.info("Ignoring GitLab note event: discussion resolution has no code changes");
                 result.setValid(false);
                 return result;
             }


### PR DESCRIPTION
When a GitLab MR discussion thread is resolved, it triggers a note webhook event, but there are no code changes associated with this action. Previously, Terrakube would incorrectly process these events and trigger jobs, wasting resources.

This fix adds a check in handleNoteEvent() to detect discussion resolution events and mark them as invalid, preventing unnecessary job creation.

Fixes #3304