### PR TITLE
Fix to prevent Quartz thread exhaustion from blocking VCS module refresh

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/configuration/QuartzAutoConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/configuration/QuartzAutoConfiguration.java
@@ -47,6 +47,7 @@ public class QuartzAutoConfiguration {
         properties.put("org.quartz.jobStore.class","org.springframework.scheduling.quartz.LocalDataSourceJobStore");
         properties.put("org.quartz.jobStore.isClustered","true");
         properties.put("org.quartz.scheduler.instanceId","AUTO");
+        properties.put("org.quartz.threadPool.threadCount","20");
         switch(dataSourceConfigurationProperties.getType()){
             case SQL_AZURE:
                 properties.put("org.quartz.jobStore.driverDelegateClass","org.quartz.impl.jdbcjobstore.MSSQLDelegate");

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/module/ModuleRefreshJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/module/ModuleRefreshJob.java
@@ -215,6 +215,7 @@ public class ModuleRefreshJob implements Job {
                                 .build();
                         ((SshTransport) transport)
                                 .setSshSessionFactory(terrakubeSshdSessionFactory.getSshdSessionFactory());
+                        ((SshTransport) transport).setTimeout(GIT_TIMEOUT_SECONDS);
                     }
                 }
             };

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/module/ModuleRefreshJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/module/ModuleRefreshJob.java
@@ -37,6 +37,8 @@ import java.util.*;
 @Slf4j
 @Component
 public class ModuleRefreshJob implements Job {
+
+    private static final int GIT_TIMEOUT_SECONDS = 30;
     @Autowired
     private ModuleRefreshService moduleRefreshService;
     @Autowired
@@ -195,6 +197,7 @@ public class ModuleRefreshJob implements Job {
                     .setTags(true)
                     .setRemote(source)
                     .setCredentialsProvider(credentialsProvider)
+                    .setTimeout(GIT_TIMEOUT_SECONDS)
                     .callAsMap();
         }
 
@@ -220,6 +223,7 @@ public class ModuleRefreshJob implements Job {
                     .setTags(true)
                     .setRemote(source)
                     .setTransportConfigCallback(transportConfigCallback)
+                    .setTimeout(GIT_TIMEOUT_SECONDS)
                     .callAsMap();
         }
 
@@ -227,6 +231,7 @@ public class ModuleRefreshJob implements Job {
             originalTags = Git.lsRemoteRepository()
                     .setTags(true)
                     .setRemote(source)
+                    .setTimeout(GIT_TIMEOUT_SECONDS)
                     .callAsMap();
         }
 

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsTokenService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsTokenService.java
@@ -22,6 +22,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.util.Collections;
 
 @Service
@@ -112,7 +113,7 @@ public class AzDevOpsTokenService {
             DefaultAzureCredential credential = credBuilder.build();
             TokenRequestContext context = new TokenRequestContext()
                     .setScopes(Collections.singletonList(AZURE_DEVOPS_SCOPE));
-            AccessToken accessToken = credential.getToken(context).block();
+            AccessToken accessToken = credential.getToken(context).block(Duration.ofSeconds(30));
             if (accessToken == null || accessToken.getToken() == null) {
                 throw new Exception("Failed to acquire Managed Identity token. Check your environment configuration in Azure.");
             }


### PR DESCRIPTION
The Quartz scheduler shares a single thread pool across all background job types — module refresh, provider refresh, workspace scheduling, and job dispatch. That pool defaults to 10 threads and nobody had ever configured it explicitly.
ModuleRefreshJob makes a blocking JGit lsRemoteRepository call with no timeout. For AZURE_SP_MI VCS connections it also calls credential.getToken().block() before even getting to the git call — also no timeout. If a VCS endpoint is slow, returning errors, or the Azure AD token request hangs, that Quartz thread is stuck until the JVM decides to give up, which it never does.

With 50+ modules all refreshing on a 300-second interval, all 10 threads can get consumed by stuck module refresh jobs. At that point ScheduleJob can't dispatch workspace runs — jobs get written to the DB as running, never get a pod, and permanently block every subsequent job on the same workspace. Only fix was manually deleting the API pod.


**The Fix**

- Added a 30s timeout to all three JGit lsRemoteRepository call paths in ModuleRefreshJob (HTTPS, SSH, anonymous)
- Added a 30s timeout to the Azure AD credential.getToken().block() call in AzDevOpsTokenService
- Bumped the Quartz thread pool from the implicit default of 10 to 20

**Risks**

Low. If a module repo genuinely takes longer than 30s to respond to a ls-remote, the refresh will fail and retry on the next 300s cycle instead of hanging forever — which is strictly better. The thread pool bump is additive, nothing removed. Worth monitoring logs after deploy to make sure no legitimate refresh jobs are consistently hitting the timeout wall.