### PR TITLE
fix: widen vcs access_token/refresh_token columns for oversized OAuth tokens

### DIFF
--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -105,4 +105,5 @@
     <include file="/db/changelog/local/changelog-2.32.0-project-access.xml"/>
     <include file="/db/changelog/local/changelog-2.32.0-job-step-cascade.xml"/>
     <include file="/db/changelog/local/changelog-2.32.0-performance-fk-indexes.xml" />
+    <include file="/db/changelog/local/changelog-2.33.0-vcs-token-size.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-vcs-token-size.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-vcs-token-size.xml
@@ -4,13 +4,13 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
-    <changeSet id="2-33-0-1" author="alfespa17@gmail.com">
+    <changeSet id="2-33-0-1" author="mvanhorn">
         <modifyDataType
                 columnName="access_token"
                 newDataType="varchar2(4096)"
                 tableName="vcs"/>
     </changeSet>
-    <changeSet id="2-33-0-2" author="alfespa17@gmail.com">
+    <changeSet id="2-33-0-2" author="mvanhorn">
         <modifyDataType
                 columnName="refresh_token"
                 newDataType="varchar2(4096)"

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-vcs-token-size.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-vcs-token-size.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-33-0-1" author="alfespa17@gmail.com">
+        <modifyDataType
+                columnName="access_token"
+                newDataType="varchar2(4096)"
+                tableName="vcs"/>
+    </changeSet>
+    <changeSet id="2-33-0-2" author="alfespa17@gmail.com">
+        <modifyDataType
+                columnName="refresh_token"
+                newDataType="varchar2(4096)"
+                tableName="vcs"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## What

Adds a Liquibase migration (`changelog-2.33.0-vcs-token-size.xml`) that widens `vcs.access_token` and `vcs.refresh_token` to `varchar2(4096)`, and registers it in the master `changelog.xml`.

## Why

When configuring a Bitbucket Cloud (and other OAuth) VCS provider, saving the `vcs` row fails with:

```
value too long for type character varying(2048)
```

Atlassian and other providers now issue OAuth access/refresh tokens longer than the current column widths. `access_token` was previously widened from `varchar2(1024)` to `varchar2(2048)` in `changelog-2.26.0-size-access-token.xml`, but `refresh_token` is still `varchar2(1024)`, and even 2048 is no longer enough for current tokens. A reporter confirmed the fix by manually running `ALTER TABLE public.vcs ALTER COLUMN access_token TYPE varchar(4096)` (and the same for `refresh_token`).

This follows the maintainer's suggestion on the issue to send a Liquibase migration to increase the column sizes.

## How

- New file `api/src/main/resources/db/changelog/local/changelog-2.33.0-vcs-token-size.xml` with two `modifyDataType` changeSets (`2-33-0-1`, `2-33-0-2`) widening `vcs.access_token` and `vcs.refresh_token` to `varchar2(4096)`, following the exact shape of the existing `changelog-2.26.0-size-access-token.xml`.
- One `<include>` line appended to the master `changelog.xml` after the `2.32.0-*` entries.

The abstract Liquibase `varchar2` type maps to `varchar` on Postgres and `varchar2` on Oracle, matching how the existing size migration already ships cross-DB without a Postgres-specific variant. No entity or Java change is needed since the JPA `String` fields are unbounded at the app layer; the constraint was purely the DB column width.

## Scope

This addresses the column-size half of the issue (the `varchar(2048)` overflow the maintainer invited a migration for). The separately reported `null value in column "source"` workspace-import error is a distinct problem in the TFC import path and is out of scope here.

Refs #2255
