### PR TITLE
feat(api): add Azure DevOps webhooks v1 support

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -10,6 +10,7 @@ import io.terrakube.api.plugin.softdelete.SoftDeleteService;
 import io.terrakube.api.plugin.variable.IncompleteVariableException;
 import io.terrakube.api.plugin.variable.WorkspaceVariableValidationService;
 import io.terrakube.api.plugin.vcs.PrCommentService;
+import io.terrakube.api.plugin.vcs.provider.azdevops.AzDevOpsWebhookService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
 import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
 import io.terrakube.api.repository.*;
@@ -69,6 +70,7 @@ public class ScheduleJob implements org.quartz.Job {
     RedisTemplate<String, Object> redisTemplate;
 
     GitHubWebhookService gitHubWebhookService;
+    AzDevOpsWebhookService azDevOpsWebhookService;
     PrCommentService prCommentService;
     GlobalVarRepository globalVarRepository;
     VariableRepository variableRepository;
@@ -478,6 +480,10 @@ public class ScheduleJob implements org.quartz.Job {
                 break;
             case GITLAB:
                 gitLabWebhookService.sendCommitStatus(job, jobStatus);
+                break;
+            case AZURE_DEVOPS:
+            case AZURE_SP_MI:
+                azDevOpsWebhookService.sendCommitStatus(job, jobStatus);
                 break;
             default:
                 break;

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/inactive/InactiveJobs.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/inactive/InactiveJobs.java
@@ -1,5 +1,6 @@
 package io.terrakube.api.plugin.scheduler.inactive;
 
+import io.terrakube.api.plugin.vcs.provider.azdevops.AzDevOpsWebhookService;
 import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
 import io.terrakube.api.rs.vcs.Vcs;
 import lombok.AllArgsConstructor;
@@ -33,6 +34,7 @@ public class InactiveJobs implements org.quartz.Job {
     private final JobRepository jobRepository;
     private final RedisTemplate<String, Object> redisTemplate;
     private final GitHubWebhookService gitHubWebhookService;
+    private final AzDevOpsWebhookService azDevOpsWebhookService;
     private final StepRepository stepRepository;
 
     @Transactional
@@ -100,6 +102,11 @@ public class InactiveJobs implements org.quartz.Job {
             case GITLAB:
                 log.info("Updating VCS information for GITLAB on job {}", job.getId());
                 gitLabWebhookService.sendCommitStatus(job, JobStatus.unknown);
+                break;
+            case AZURE_DEVOPS:
+            case AZURE_SP_MI:
+                log.info("Updating VCS information for AZURE_DEVOPS on job {}", job.getId());
+                azDevOpsWebhookService.sendCommitStatus(job, JobStatus.unknown);
                 break;
             default:
                 break;

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
@@ -7,6 +7,7 @@ import io.terrakube.api.rs.webhook.WebhookEvent;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import io.terrakube.api.plugin.scheduler.ScheduleJobService;
+import io.terrakube.api.plugin.vcs.provider.azdevops.AzDevOpsWebhookService;
 import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
 import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
@@ -38,6 +39,7 @@ public class WebhookService {
     GitHubWebhookService gitHubWebhookService;
     GitLabWebhookService gitLabWebhookService;
     BitBucketWebhookService bitBucketWebhookService;
+    AzDevOpsWebhookService azDevOpsWebhookService;
     JobRepository jobRepository;
     ScheduleJobService scheduleJobService;
     ObjectMapper objectMapper;
@@ -74,6 +76,11 @@ public class WebhookService {
             case BITBUCKET:
                 webhookResult = bitBucketWebhookService.processWebhook(jsonPayload, headers,
                         base64WorkspaceId);
+                break;
+            case AZURE_DEVOPS:
+            case AZURE_SP_MI:
+                webhookResult = azDevOpsWebhookService.processWebhook(jsonPayload, headers,
+                        base64WorkspaceId, workspace);
                 break;
             default:
                 break;
@@ -163,6 +170,53 @@ public class WebhookService {
         return savedJob;
     }
 
+    /**
+     * Triggers a plan for a push detected by outbound polling, reusing the same event matching and
+     * job scheduling as an inbound webhook. Returns true when a job was created.
+     */
+    @Transactional
+    public boolean triggerPolledPush(UUID webhookId, WebhookResult webhookResult) {
+        Webhook webhook = webhookRepository.findById(webhookId).orElse(null);
+        if (webhook == null) {
+            log.warn("Polled webhook {} no longer exists", webhookId);
+            return false;
+        }
+        Workspace workspace = webhook.getWorkspace();
+        try {
+            WebhookEvent matchedEvent = findMatchingPushEventForPoll(webhookResult, webhook);
+            log.info("Polled push for workspace {}, using template with id {}", workspace.getName(),
+                    matchedEvent.getTemplateId());
+            Job savedJob = createAndScheduleJob(matchedEvent.getTemplateId(), webhookResult, workspace);
+            sendCommitStatus(savedJob);
+            return true;
+        } catch (IllegalArgumentException e) {
+            log.info("No matching push event for polled commit on workspace {}: {}", workspace.getName(),
+                    e.getMessage());
+            return false;
+        } catch (Exception e) {
+            log.error("Error creating job for polled push on workspace {}", workspace.getName(), e);
+            return false;
+        }
+    }
+
+    /**
+     * Event matching for polled pushes: the branch must match, and the path filter is applied only
+     * when the changed files are known. When the file list is empty/unknown (the diff couldn't be
+     * resolved) a detected commit still triggers, so polling reliably runs on any new commit rather
+     * than silently dropping it.
+     */
+    private WebhookEvent findMatchingPushEventForPoll(WebhookResult result, Webhook webhook) {
+        return webhookEventRepository
+                .findByWebhookAndEventOrderByPriorityAsc(webhook, WebhookEventType.PUSH)
+                .stream()
+                .filter(webhookEvent -> checkBranch(result.getBranch(), webhookEvent)
+                        && (result.getFileChanges() == null || result.getFileChanges().isEmpty()
+                                || checkFileChanges(result.getFileChanges(), webhookEvent)))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "No PUSH webhook event matches branch " + result.getBranch()));
+    }
+
     private WebhookEvent findMatchingEvent(WebhookResult result, Webhook webhook) {
         WebhookEventType eventType = result.isPrComment()
                 ? WebhookEventType.PULL_REQUEST
@@ -207,6 +261,10 @@ public class WebhookService {
             case BITBUCKET:
                 webhookRemoteId = bitBucketWebhookService.createOrUpdateWebhook(workspace, persistedWebhook);
                 break;
+            case AZURE_DEVOPS:
+            case AZURE_SP_MI:
+                webhookRemoteId = azDevOpsWebhookService.createOrUpdateWebhook(workspace, persistedWebhook);
+                break;
             default:
                 break;
         }
@@ -242,6 +300,10 @@ public class WebhookService {
                 break;
             case BITBUCKET:
                 bitBucketWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
+                break;
+            case AZURE_DEVOPS:
+            case AZURE_SP_MI:
+                azDevOpsWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
                 break;
             default:
                 break;
@@ -294,6 +356,10 @@ public class WebhookService {
                 break;
             case GITLAB:
                 gitLabWebhookService.sendCommitStatus(job, JobStatus.pending);
+                break;
+            case AZURE_DEVOPS:
+            case AZURE_SP_MI:
+                azDevOpsWebhookService.sendCommitStatus(job, JobStatus.pending);
                 break;
             default:
                 break;

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsPollingService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsPollingService.java
@@ -1,0 +1,158 @@
+package io.terrakube.api.plugin.vcs.provider.azdevops;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PreDestroy;
+
+import io.terrakube.api.plugin.vcs.WebhookResult;
+import io.terrakube.api.plugin.vcs.WebhookService;
+import io.terrakube.api.repository.WebhookRepository;
+import io.terrakube.api.rs.vcs.VcsType;
+import io.terrakube.api.rs.webhook.Webhook;
+import io.terrakube.api.rs.workspace.Workspace;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Polls Azure DevOps for new commits and triggers a plan, as an alternative to inbound service hook
+ * webhooks. Azure DevOps Services (dev.azure.com) delivers service hooks from the public cloud, which
+ * cannot reach a Terrakube running on a private network. Polling reverses the direction: Terrakube
+ * makes outbound calls (which already work for token/clone) to detect new commits.
+ *
+ * <p>For every workspace backed by an Azure DevOps VCS that has a webhook configured, the tip commit
+ * of the workspace branch is fetched and compared against the previously seen commit (kept in Redis).
+ * When it changes, the same event-matching and job-scheduling used by inbound webhooks runs.
+ *
+ * <p>Disabled by default; enable with {@code io.terrakube.vcs.azuredevops.polling.enabled=true}.
+ */
+@Service
+@Slf4j
+@ConditionalOnProperty(name = "io.terrakube.vcs.azuredevops.polling.enabled", havingValue = "true")
+public class AzDevOpsPollingService {
+
+    private static final String KEY_PREFIX = "azdo-poll:";
+    private static final List<VcsType> AZURE_TYPES = List.of(VcsType.AZURE_DEVOPS, VcsType.AZURE_SP_MI);
+    private static final int MAX_POLL_THREADS = 8;
+    private static final AtomicInteger THREAD_COUNTER = new AtomicInteger();
+
+    private final WebhookRepository webhookRepository;
+    private final AzDevOpsWebhookService azDevOpsWebhookService;
+    private final WebhookService webhookService;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ExecutorService pollExecutor;
+
+    public AzDevOpsPollingService(WebhookRepository webhookRepository,
+            AzDevOpsWebhookService azDevOpsWebhookService, WebhookService webhookService,
+            RedisTemplate<String, Object> redisTemplate) {
+        this.webhookRepository = webhookRepository;
+        this.azDevOpsWebhookService = azDevOpsWebhookService;
+        this.webhookService = webhookService;
+        this.redisTemplate = redisTemplate;
+        this.pollExecutor = Executors.newFixedThreadPool(MAX_POLL_THREADS, runnable -> {
+            Thread thread = new Thread(runnable, "azdo-poll-" + THREAD_COUNTER.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        });
+        log.info("Azure DevOps commit polling is enabled");
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        pollExecutor.shutdown();
+        try {
+            if (!pollExecutor.awaitTermination(10, TimeUnit.SECONDS)) {
+                pollExecutor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            pollExecutor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Scheduled(fixedDelayString = "${io.terrakube.vcs.azuredevops.polling.interval:15000}",
+            initialDelayString = "${io.terrakube.vcs.azuredevops.polling.initial-delay:10000}")
+    public void poll() {
+        List<Webhook> webhooks;
+        try {
+            webhooks = webhookRepository.findByWorkspaceVcsTypeIn(AZURE_TYPES);
+        } catch (Exception e) {
+            log.error("Azure DevOps polling: failed to load webhooks", e);
+            return;
+        }
+
+        if (webhooks.isEmpty()) {
+            return;
+        }
+
+        // Poll every workspace concurrently (bounded by MAX_POLL_THREADS) so the time to detect a new
+        // commit stays close to the configured interval regardless of how many workspaces are tracked,
+        // rather than growing linearly with a serial loop.
+        CompletableFuture<?>[] futures = webhooks.stream()
+                .map(webhook -> CompletableFuture.runAsync(() -> {
+                    try {
+                        pollWebhook(webhook);
+                    } catch (Exception e) {
+                        log.error("Azure DevOps polling error for webhook {}", webhook.getId(), e);
+                    }
+                }, pollExecutor))
+                .toArray(CompletableFuture[]::new);
+
+        CompletableFuture.allOf(futures).join();
+    }
+
+    private void pollWebhook(Webhook webhook) {
+        Workspace workspace = webhook.getWorkspace();
+        if (workspace == null || workspace.getVcs() == null) {
+            return;
+        }
+        String branch = workspace.getBranch();
+        if (branch == null || branch.isEmpty()) {
+            log.debug("Skipping Azure DevOps polling for workspace {}: no branch configured", workspace.getId());
+            return;
+        }
+
+        String latestCommit = azDevOpsWebhookService.getLatestCommit(workspace, branch);
+        if (latestCommit == null || latestCommit.isEmpty()) {
+            return;
+        }
+
+        String key = KEY_PREFIX + workspace.getId() + ":" + branch;
+        Object previous = redisTemplate.opsForValue().get(key);
+        String previousCommit = previous != null ? previous.toString() : null;
+
+        if (previousCommit == null) {
+            // First observation: remember the current tip without triggering a run.
+            redisTemplate.opsForValue().set(key, latestCommit);
+            log.info("Azure DevOps polling baseline for workspace {} branch {} set to {}",
+                    workspace.getName(), branch, latestCommit);
+            return;
+        }
+
+        if (latestCommit.equals(previousCommit)) {
+            return;
+        }
+
+        log.info("Azure DevOps polling detected new commit on {}/{}: {} -> {}",
+                workspace.getName(), branch, previousCommit, latestCommit);
+        WebhookResult result = azDevOpsWebhookService.buildPushResult(workspace, branch, previousCommit, latestCommit);
+        boolean triggered = webhookService.triggerPolledPush(webhook.getId(), result);
+
+        // Advance the baseline even if no event matched, so the same commit is not evaluated again.
+        redisTemplate.opsForValue().set(key, latestCommit);
+
+        if (triggered) {
+            log.info("Azure DevOps polling triggered a plan for workspace {} on commit {}",
+                    workspace.getName(), latestCommit);
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookService.java
@@ -522,6 +522,9 @@ public class AzDevOpsWebhookService extends WebhookServiceBase {
 
         Map<String, Object> consumerInputs = new LinkedHashMap<>();
         consumerInputs.put("url", webhookUrl);
+        consumerInputs.put("resourceDetailsToSend", "all");
+        consumerInputs.put("detailedMessagesToSend", "all");
+        consumerInputs.put("messagesToSend", "all");
         // Accept self-signed / internal certificates so deliveries are not dropped on TLS
         // validation (otherwise Azure puts the subscription on probation and loses events).
         consumerInputs.put("acceptUntrustedCerts", "true");

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookService.java
@@ -1,0 +1,800 @@
+package io.terrakube.api.plugin.vcs.provider.azdevops;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.terrakube.api.plugin.vcs.WebhookResult;
+import io.terrakube.api.plugin.vcs.WebhookServiceBase;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.JobVia;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.vcs.VcsType;
+import io.terrakube.api.rs.webhook.Webhook;
+import io.terrakube.api.rs.webhook.WebhookEvent;
+import io.terrakube.api.rs.webhook.WebhookEventType;
+import io.terrakube.api.rs.workspace.Workspace;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Handles Azure DevOps integration for Terrakube webhooks.
+ *
+ * Azure DevOps does not expose per-repository "webhooks"; instead it uses
+ * <a href="https://learn.microsoft.com/en-us/rest/api/azure/devops/hooks/subscriptions">Service Hook
+ * subscriptions</a>. A single Terrakube {@link Webhook} can map to several Azure DevOps subscriptions
+ * (one per event type), so the comma separated list of subscription ids is stored in
+ * {@link Webhook#getRemoteHookId()}.
+ *
+ * Azure DevOps service hooks cannot sign the payload (no HMAC), but they can send custom HTTP headers.
+ * We therefore authenticate the incoming request by comparing the {@code X-Terrakube-Token} header
+ * against the base64 encoded workspace id (the same secret the other providers use), mirroring the
+ * token comparison strategy used for GitLab.
+ */
+@Service
+@Slf4j
+public class AzDevOpsWebhookService extends WebhookServiceBase {
+
+    private static final String API_VERSION = "7.0";
+    private static final String HOOKS_API_VERSION = "7.0-preview.1";
+    private static final String TOKEN_HEADER = "x-terrakube-token";
+
+    // Azure DevOps service hook event types
+    private static final String EVENT_PUSH = "git.push";
+    private static final String EVENT_PR_CREATED = "git.pullrequest.created";
+    private static final String EVENT_PR_UPDATED = "git.pullrequest.updated";
+    private static final String EVENT_PR_COMMENT = "ms.vss-code.git-pullrequest-comment-event";
+
+    private final ObjectMapper objectMapper;
+    private final AzDevOpsTokenService azDevOpsTokenService;
+
+    @Value("${io.terrakube.hostname}")
+    private String hostname;
+    @Value("${io.terrakube.ui.url}")
+    private String uiUrl;
+
+    public AzDevOpsWebhookService(ObjectMapper objectMapper, AzDevOpsTokenService azDevOpsTokenService) {
+        this.objectMapper = objectMapper;
+        this.azDevOpsTokenService = azDevOpsTokenService;
+    }
+
+    public WebhookResult processWebhook(String jsonPayload, Map<String, String> headers, String token,
+            Workspace workspace) {
+        WebhookResult result = new WebhookResult();
+        result.setBranch("");
+        result.setVia(JobVia.AzureDevops.name());
+        result.setFileChanges(new ArrayList<>());
+        result.setWorkspaceId(workspace.getId().toString());
+
+        String tokenHeader = headers.get(TOKEN_HEADER);
+        if (tokenHeader == null || !tokenHeader.equals(token)) {
+            log.error("{} header is missing or doesn't match!", TOKEN_HEADER);
+            result.setValid(false);
+            return result;
+        }
+        result.setValid(true);
+
+        log.info("Parsing Azure DevOps webhook payload");
+        try {
+            return handleEvent(jsonPayload, result, workspace);
+        } catch (Exception e) {
+            log.error("Error processing the Azure DevOps webhook", e);
+            result.setValid(false);
+            return result;
+        }
+    }
+
+    public WebhookResult handleEvent(String jsonPayload, WebhookResult result, Workspace workspace) throws Exception {
+        JsonNode rootNode = objectMapper.readTree(jsonPayload);
+        String eventType = rootNode.path("eventType").asText();
+        log.info("Azure DevOps event type: {}", eventType);
+
+        switch (eventType) {
+            case EVENT_PUSH:
+                return handlePushEvent(rootNode, result, workspace);
+            case EVENT_PR_CREATED:
+            case EVENT_PR_UPDATED:
+                return handlePullRequestEvent(rootNode, result, workspace);
+            case EVENT_PR_COMMENT:
+                return handlePullRequestCommentEvent(rootNode, result, workspace);
+            default:
+                log.error("Unsupported Azure DevOps event: {}", eventType);
+                result.setValid(false);
+                return result;
+        }
+    }
+
+    private WebhookResult handlePushEvent(JsonNode rootNode, WebhookResult result, Workspace workspace) {
+        JsonNode resource = rootNode.path("resource");
+        JsonNode refUpdate = resource.path("refUpdates").path(0);
+        String refName = refUpdate.path("name").asText();
+
+        // Tag pushes (refs/tags/...) are treated as releases, branch pushes as regular pushes
+        if (refName.startsWith("refs/tags/")) {
+            result.setEvent("release");
+            result.setRelease(true);
+            result.setBranch(refName.substring("refs/tags/".length()));
+        } else {
+            result.setEvent("push");
+            result.setBranch(stripRefPrefix(refName));
+        }
+
+        result.setCommit(refUpdate.path("newObjectId").asText());
+        result.setCreatedBy(resolveUser(resource.path("pushedBy")));
+
+        // Azure DevOps push payloads do not contain the changed files, so we collect them
+        // from the API. The event's commits[] array is unreliable (often empty), so we
+        // prefer diffing the pushed range oldObjectId..newObjectId.
+        JsonNode repository = resource.path("repository");
+        String repositoryId = repository.path("id").asText();
+        AzureRepo repo = parseSource(workspace.getSource());
+
+        if (!result.isRelease() && repo != null && !repositoryId.isEmpty()) {
+            result.setFileChanges(getPushFileChanges(workspace.getVcs(), repo, repositoryId, resource, refUpdate));
+            log.info("Azure DevOps push detected {} changed file(s) on branch {}: {}",
+                    result.getFileChanges().size(), result.getBranch(), result.getFileChanges());
+        }
+
+        return result;
+    }
+
+    /**
+     * Resolves the files changed by a push. Azure does not send them in the webhook payload, and the
+     * event's {@code commits[]} array is frequently empty, so we prefer the diff of the pushed range
+     * (oldObjectId..newObjectId) and fall back to per-commit / tip-commit changes.
+     */
+    private List<String> getPushFileChanges(Vcs vcs, AzureRepo repo, String repositoryId, JsonNode resource,
+            JsonNode refUpdate) {
+        String oldObjectId = refUpdate.path("oldObjectId").asText();
+        String newObjectId = refUpdate.path("newObjectId").asText();
+        boolean newBranch = oldObjectId == null || oldObjectId.isEmpty() || oldObjectId.chars().allMatch(c -> c == '0');
+
+        Set<String> files = new LinkedHashSet<>();
+
+        // Primary: diff the whole pushed range (covers every commit in the push)
+        if (!newBranch && !newObjectId.isEmpty()) {
+            files.addAll(getDiffChanges(vcs, repo, repositoryId, oldObjectId, newObjectId));
+        }
+
+        // Fallback 1: per-commit changes from the event payload
+        if (files.isEmpty()) {
+            for (JsonNode commit : resource.path("commits")) {
+                String commitId = commit.path("commitId").asText();
+                if (!commitId.isEmpty()) {
+                    files.addAll(getCommitChanges(vcs, repo, repositoryId, commitId));
+                }
+            }
+        }
+
+        // Fallback 2: changes of the tip commit
+        if (files.isEmpty() && !newObjectId.isEmpty()) {
+            files.addAll(getCommitChanges(vcs, repo, repositoryId, newObjectId));
+        }
+
+        return new ArrayList<>(files);
+    }
+
+    private List<String> getDiffChanges(Vcs vcs, AzureRepo repo, String repositoryId, String baseCommit,
+            String targetCommit) {
+        List<String> changedFiles = new ArrayList<>();
+        String apiUrl = String.format(
+                "%s/%s/_apis/git/repositories/%s/diffs/commits?baseVersionType=commit&baseVersion=%s"
+                        + "&targetVersionType=commit&targetVersion=%s&api-version=%s",
+                repo.orgBaseUrl, UriUtils.encodePathSegment(repo.project, StandardCharsets.UTF_8),
+                repositoryId, baseCommit, targetCommit, API_VERSION);
+
+        ResponseEntity<String> response = callAzureApi(vcs, "", apiUrl, HttpMethod.GET);
+        if (response == null || !response.getStatusCode().is2xxSuccessful()) {
+            log.error("Failed to fetch Azure DevOps diff {}..{}", baseCommit, targetCommit);
+            return changedFiles;
+        }
+        try {
+            JsonNode rootNode = objectMapper.readTree(response.getBody());
+            for (JsonNode change : rootNode.path("changes")) {
+                addChangedFile(changedFiles, change);
+            }
+        } catch (Exception e) {
+            log.error("Error parsing Azure DevOps commit diff", e);
+        }
+        return changedFiles;
+    }
+
+    private WebhookResult handlePullRequestEvent(JsonNode rootNode, WebhookResult result, Workspace workspace) {
+        result.setEvent("pull_request");
+        JsonNode resource = rootNode.path("resource");
+
+        int prNumber = resource.path("pullRequestId").asInt();
+        result.setPrNumber(prNumber);
+        result.setBranch(stripRefPrefix(resource.path("sourceRefName").asText()));
+        result.setCommit(resource.path("lastMergeSourceCommit").path("commitId").asText());
+        result.setCreatedBy(resolveUser(resource.path("createdBy")));
+
+        JsonNode repository = resource.path("repository");
+        String repositoryId = repository.path("id").asText();
+        AzureRepo repo = parseSource(workspace.getSource());
+
+        if (repo != null && !repositoryId.isEmpty() && prNumber > 0) {
+            result.setFileChanges(getPullRequestChanges(workspace.getVcs(), repo, repositoryId, prNumber));
+        }
+
+        return result;
+    }
+
+    private WebhookResult handlePullRequestCommentEvent(JsonNode rootNode, WebhookResult result, Workspace workspace) {
+        result.setEvent("issue_comment");
+        JsonNode resource = rootNode.path("resource");
+
+        String commentBody = resource.path("comment").path("content").asText().trim();
+        String command = parseTerrakubeCommand(commentBody);
+        if (command == null) {
+            result.setValid(false);
+            return result;
+        }
+
+        JsonNode pullRequest = resource.path("pullRequest");
+        int prNumber = pullRequest.path("pullRequestId").asInt();
+
+        result.setPrComment(true);
+        result.setCommentBody(commentBody);
+        result.setCommentCommand(command);
+        result.setPrNumber(prNumber);
+        result.setCreatedBy(resolveUser(resource.path("comment").path("author")));
+        result.setBranch(stripRefPrefix(pullRequest.path("sourceRefName").asText()));
+        result.setCommit(pullRequest.path("lastMergeSourceCommit").path("commitId").asText());
+
+        JsonNode repository = pullRequest.path("repository");
+        String repositoryId = repository.path("id").asText();
+        AzureRepo repo = parseSource(workspace.getSource());
+
+        if (repo != null && !repositoryId.isEmpty() && prNumber > 0) {
+            result.setFileChanges(getPullRequestChanges(workspace.getVcs(), repo, repositoryId, prNumber));
+        }
+
+        return result;
+    }
+
+    public String createOrUpdateWebhook(Workspace workspace, Webhook webhook) {
+        AzureRepo repo = parseSource(workspace.getSource());
+        if (repo == null) {
+            log.error("Unable to parse Azure DevOps repository from source {}", workspace.getSource());
+            return "";
+        }
+
+        String[] repositoryAndProject = resolveRepository(workspace.getVcs(), repo);
+        if (repositoryAndProject == null) {
+            log.error("Unable to resolve Azure DevOps repository id for {}", workspace.getSource());
+            return "";
+        }
+        String repositoryId = repositoryAndProject[0];
+        String projectId = repositoryAndProject[1];
+
+        // Recreate the subscriptions on update to honour any event configuration change.
+        if (webhook.getRemoteHookId() != null && !webhook.getRemoteHookId().isEmpty()) {
+            deleteWebhook(workspace, webhook.getRemoteHookId());
+        }
+
+        String secret = Base64.getEncoder()
+                .encodeToString(workspace.getId().toString().getBytes(StandardCharsets.UTF_8));
+        String webhookUrl = String.format("https://%s/webhook/v1/%s", hostname, webhook.getId());
+
+        Set<String> azureEventTypes = resolveAzureEventTypes(webhook);
+
+        List<String> subscriptionIds = new ArrayList<>();
+        for (String azureEventType : azureEventTypes) {
+            String subscriptionId = createSubscription(workspace.getVcs(), repo, azureEventType, repositoryId,
+                    projectId, webhookUrl, secret);
+            if (subscriptionId != null && !subscriptionId.isEmpty()) {
+                subscriptionIds.add(subscriptionId);
+            }
+        }
+
+        if (subscriptionIds.isEmpty()) {
+            log.error("No Azure DevOps subscriptions were created for workspace {}/{}",
+                    workspace.getOrganization().getName(), workspace.getName());
+            return "";
+        }
+
+        log.info("Azure DevOps service hooks created successfully for workspace {}/{} with ids {}",
+                workspace.getOrganization().getName(), workspace.getName(), subscriptionIds);
+        return String.join(",", subscriptionIds);
+    }
+
+    public void deleteWebhook(Workspace workspace, String webhookRemoteId) {
+        AzureRepo repo = parseSource(workspace.getSource());
+        if (repo == null) {
+            log.warn("Unable to parse Azure DevOps repository from source {}, skipping deletion",
+                    workspace.getSource());
+            return;
+        }
+
+        for (String subscriptionId : webhookRemoteId.split(",")) {
+            subscriptionId = subscriptionId.trim();
+            if (subscriptionId.isEmpty()) {
+                continue;
+            }
+            String apiUrl = String.format("%s/_apis/hooks/subscriptions/%s?api-version=%s",
+                    repo.orgBaseUrl, subscriptionId, HOOKS_API_VERSION);
+            ResponseEntity<String> response = callAzureApi(workspace.getVcs(), "", apiUrl, HttpMethod.DELETE);
+            if (response != null && response.getStatusCode().is2xxSuccessful()) {
+                log.info("Azure DevOps subscription {} deleted successfully", subscriptionId);
+            } else {
+                log.warn("Failed to delete Azure DevOps subscription {}, message {}", subscriptionId,
+                        response != null ? response.getBody() : "No response");
+            }
+        }
+    }
+
+    public void sendCommitStatus(Job job, JobStatus jobStatus) {
+        Workspace workspace = job.getWorkspace();
+        if (job.getCommitId() == null || job.getCommitId().isBlank()) {
+            log.warn("No commit id available for job {}, skipping Azure DevOps commit status", job.getId());
+            return;
+        }
+
+        AzureRepo repo = parseSource(workspace.getSource());
+        if (repo == null) {
+            log.error("Unable to parse Azure DevOps repository from source {}", workspace.getSource());
+            return;
+        }
+        String[] repositoryAndProject = resolveRepository(workspace.getVcs(), repo);
+        if (repositoryAndProject == null) {
+            log.error("Unable to resolve Azure DevOps repository id for commit status on {}", workspace.getSource());
+            return;
+        }
+
+        String jobUrl = String.format("%s/organizations/%s/workspaces/%s/runs/%s", uiUrl,
+                workspace.getOrganization().getId(), workspace.getId(), job.getId());
+        String state;
+        String description;
+        switch (jobStatus) {
+            case completed:
+                state = "succeeded";
+                description = "Your task has been completed successfully.";
+                break;
+            case failed:
+            case rejected:
+            case cancelled:
+                state = "failed";
+                description = "Your task has failed.";
+                break;
+            case unknown:
+                state = "error";
+                description = "Your task ran into errors.";
+                break;
+            default:
+                state = "pending";
+                description = "Your task is in Terrakube queue.";
+                break;
+        }
+
+        Map<String, Object> context = new LinkedHashMap<>();
+        context.put("name", workspace.getOrganization().getName() + "-" + workspace.getName());
+        context.put("genre", "Terrakube");
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("state", state);
+        body.put("description", description);
+        body.put("targetUrl", jobUrl);
+        body.put("context", context);
+
+        String apiUrl = String.format("%s/%s/_apis/git/repositories/%s/commits/%s/statuses?api-version=%s",
+                repo.orgBaseUrl, UriUtils.encodePathSegment(repo.project, StandardCharsets.UTF_8),
+                repositoryAndProject[0], job.getCommitId(), API_VERSION);
+
+        try {
+            ResponseEntity<String> response = callAzureApi(workspace.getVcs(), objectMapper.writeValueAsString(body),
+                    apiUrl, HttpMethod.POST);
+            if (response != null && response.getStatusCode().is2xxSuccessful()) {
+                log.info("Job status sent successfully to Azure DevOps for commit {}", job.getCommitId());
+            } else {
+                log.error("Failed to send job status to Azure DevOps, message {}",
+                        response != null ? response.getBody() : "No response");
+            }
+        } catch (Exception e) {
+            log.error("Error sending commit status to Azure DevOps", e);
+        }
+    }
+
+    /**
+     * Returns the current tip commit id of {@code branch}, or null if it cannot be resolved.
+     * Used by outbound polling so new commits can be detected without an inbound webhook endpoint
+     * (e.g. when Terrakube runs on a private network unreachable by Azure DevOps service hooks).
+     */
+    public String getLatestCommit(Workspace workspace, String branch) {
+        AzureRepo repo = parseSource(workspace.getSource());
+        if (repo == null) {
+            log.error("Unable to parse Azure DevOps repository from source {}", workspace.getSource());
+            return null;
+        }
+        String[] repositoryAndProject = resolveRepository(workspace.getVcs(), repo);
+        if (repositoryAndProject == null) {
+            return null;
+        }
+
+        String filter = "heads/" + UriUtils.encodeQueryParam(branch, StandardCharsets.UTF_8);
+        String apiUrl = String.format("%s/%s/_apis/git/repositories/%s/refs?filter=%s&api-version=%s",
+                repo.orgBaseUrl, UriUtils.encodePathSegment(repo.project, StandardCharsets.UTF_8),
+                repositoryAndProject[0], filter, API_VERSION);
+
+        ResponseEntity<String> response = callAzureApi(workspace.getVcs(), "", apiUrl, HttpMethod.GET);
+        if (response == null || !response.getStatusCode().is2xxSuccessful()) {
+            log.error("Failed to fetch Azure DevOps branch tip for {}/{}", repo.repository, branch);
+            return null;
+        }
+        try {
+            JsonNode rootNode = objectMapper.readTree(response.getBody());
+            String expectedName = "refs/heads/" + branch;
+            for (JsonNode ref : rootNode.path("value")) {
+                if (expectedName.equals(ref.path("name").asText())) {
+                    return ref.path("objectId").asText();
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error parsing Azure DevOps refs response", e);
+        }
+        return null;
+    }
+
+    /**
+     * Builds a push {@link WebhookResult} for a commit detected by polling, resolving the files
+     * changed between {@code baseCommit} (the previously seen commit, may be null) and {@code newCommit}.
+     */
+    public WebhookResult buildPushResult(Workspace workspace, String branch, String baseCommit, String newCommit) {
+        WebhookResult result = new WebhookResult();
+        result.setVia(JobVia.AzureDevops.name());
+        result.setEvent("push");
+        result.setValid(true);
+        result.setBranch(branch);
+        result.setCommit(newCommit);
+        result.setCreatedBy("azuredevops-poll");
+        result.setWorkspaceId(workspace.getId().toString());
+        result.setFileChanges(new ArrayList<>());
+
+        AzureRepo repo = parseSource(workspace.getSource());
+        if (repo != null) {
+            String[] repositoryAndProject = resolveRepository(workspace.getVcs(), repo);
+            if (repositoryAndProject != null) {
+                List<String> files = (baseCommit != null && !baseCommit.isEmpty())
+                        ? getDiffChanges(workspace.getVcs(), repo, repositoryAndProject[0], baseCommit, newCommit)
+                        : getCommitChanges(workspace.getVcs(), repo, repositoryAndProject[0], newCommit);
+                // Fallback to the tip commit's own changes when the range diff yields nothing
+                if (files.isEmpty() && newCommit != null && !newCommit.isEmpty()) {
+                    files = getCommitChanges(workspace.getVcs(), repo, repositoryAndProject[0], newCommit);
+                }
+                result.setFileChanges(files);
+            }
+        }
+        return result;
+    }
+
+    private Set<String> resolveAzureEventTypes(Webhook webhook) {
+        Set<String> azureEventTypes = new LinkedHashSet<>();
+        for (WebhookEvent event : webhook.getEvents()) {
+            WebhookEventType eventType = event.getEvent();
+            if (eventType == null) {
+                continue;
+            }
+            switch (eventType) {
+                case PUSH:
+                case RELEASE:
+                    // Tag (release) pushes arrive through the same git.push subscription
+                    azureEventTypes.add(EVENT_PUSH);
+                    break;
+                case PULL_REQUEST:
+                    azureEventTypes.add(EVENT_PR_CREATED);
+                    azureEventTypes.add(EVENT_PR_UPDATED);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        boolean hasPrWorkflow = webhook.getEvents().stream().anyMatch(WebhookEvent::isPrWorkflowEnabled);
+        if (hasPrWorkflow) {
+            azureEventTypes.add(EVENT_PR_COMMENT);
+        }
+        return azureEventTypes;
+    }
+
+    private String createSubscription(Vcs vcs, AzureRepo repo, String azureEventType, String repositoryId,
+            String projectId, String webhookUrl, String secret) {
+        Map<String, Object> publisherInputs = new LinkedHashMap<>();
+        publisherInputs.put("projectId", projectId);
+        publisherInputs.put("repository", repositoryId);
+
+        Map<String, Object> consumerInputs = new LinkedHashMap<>();
+        consumerInputs.put("url", webhookUrl);
+        // Accept self-signed / internal certificates so deliveries are not dropped on TLS
+        // validation (otherwise Azure puts the subscription on probation and loses events).
+        consumerInputs.put("acceptUntrustedCerts", "true");
+        consumerInputs.put("httpHeaders", "X-Terrakube-Token:" + secret);
+
+        // Current Azure DevOps resource version is 2.0 for git.push and the pull request events;
+        // the pull request comment event uses 1.0.
+        String resourceVersion = EVENT_PR_COMMENT.equals(azureEventType) ? "1.0" : "2.0";
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("publisherId", "tfs");
+        body.put("eventType", azureEventType);
+        body.put("resourceVersion", resourceVersion);
+        body.put("consumerId", "webHooks");
+        body.put("consumerActionId", "httpRequest");
+        body.put("publisherInputs", publisherInputs);
+        body.put("consumerInputs", consumerInputs);
+
+        String apiUrl = String.format("%s/_apis/hooks/subscriptions?api-version=%s", repo.orgBaseUrl,
+                HOOKS_API_VERSION);
+
+        try {
+            ResponseEntity<String> response = callAzureApi(vcs, objectMapper.writeValueAsString(body), apiUrl,
+                    HttpMethod.POST);
+            if (response != null && response.getStatusCode().is2xxSuccessful()) {
+                JsonNode rootNode = objectMapper.readTree(response.getBody());
+                String id = rootNode.path("id").asText();
+                log.info("Created Azure DevOps subscription {} for event {}", id, azureEventType);
+                return id;
+            }
+            log.error("Failed to create Azure DevOps subscription for event {}, message {}", azureEventType,
+                    response != null ? response.getBody() : "No response");
+        } catch (Exception e) {
+            log.error("Error creating Azure DevOps subscription for event {}", azureEventType, e);
+        }
+        return null;
+    }
+
+    /**
+     * Resolves the Azure DevOps repository id and project id from the repository name in the source URL.
+     *
+     * @return a two element array {@code [repositoryId, projectId]} or {@code null} on failure.
+     */
+    private String[] resolveRepository(Vcs vcs, AzureRepo repo) {
+        String apiUrl = String.format("%s/%s/_apis/git/repositories/%s?api-version=%s",
+                repo.orgBaseUrl, UriUtils.encodePathSegment(repo.project, StandardCharsets.UTF_8),
+                UriUtils.encodePathSegment(repo.repository, StandardCharsets.UTF_8), API_VERSION);
+
+        ResponseEntity<String> response = callAzureApi(vcs, "", apiUrl, HttpMethod.GET);
+        if (response == null || !response.getStatusCode().is2xxSuccessful()) {
+            log.error("Failed to resolve Azure DevOps repository {}/{}", repo.project, repo.repository);
+            return null;
+        }
+        try {
+            JsonNode rootNode = objectMapper.readTree(response.getBody());
+            String repositoryId = rootNode.path("id").asText();
+            String projectId = rootNode.path("project").path("id").asText();
+            return new String[] { repositoryId, projectId };
+        } catch (Exception e) {
+            log.error("Error parsing Azure DevOps repository response", e);
+            return null;
+        }
+    }
+
+    private List<String> getCommitChanges(Vcs vcs, AzureRepo repo, String repositoryId, String commitId) {
+        List<String> changedFiles = new ArrayList<>();
+        String apiUrl = String.format("%s/%s/_apis/git/repositories/%s/commits/%s/changes?api-version=%s",
+                repo.orgBaseUrl, UriUtils.encodePathSegment(repo.project, StandardCharsets.UTF_8),
+                repositoryId, commitId, API_VERSION);
+
+        ResponseEntity<String> response = callAzureApi(vcs, "", apiUrl, HttpMethod.GET);
+        if (response == null || !response.getStatusCode().is2xxSuccessful()) {
+            log.error("Failed to fetch Azure DevOps changes for commit {}", commitId);
+            return changedFiles;
+        }
+        try {
+            JsonNode rootNode = objectMapper.readTree(response.getBody());
+            for (JsonNode change : rootNode.path("changes")) {
+                addChangedFile(changedFiles, change);
+            }
+        } catch (Exception e) {
+            log.error("Error parsing Azure DevOps commit changes", e);
+        }
+        return changedFiles;
+    }
+
+    private List<String> getPullRequestChanges(Vcs vcs, AzureRepo repo, String repositoryId, int prNumber) {
+        List<String> changedFiles = new ArrayList<>();
+        String encodedProject = UriUtils.encodePathSegment(repo.project, StandardCharsets.UTF_8);
+        String iterationsUrl = String.format(
+                "%s/%s/_apis/git/repositories/%s/pullRequests/%s/iterations?api-version=%s",
+                repo.orgBaseUrl, encodedProject, repositoryId, prNumber, API_VERSION);
+
+        ResponseEntity<String> iterationsResponse = callAzureApi(vcs, "", iterationsUrl, HttpMethod.GET);
+        if (iterationsResponse == null || !iterationsResponse.getStatusCode().is2xxSuccessful()) {
+            log.error("Failed to fetch Azure DevOps iterations for pull request {}", prNumber);
+            return changedFiles;
+        }
+
+        int latestIteration = -1;
+        try {
+            JsonNode rootNode = objectMapper.readTree(iterationsResponse.getBody());
+            for (JsonNode iteration : rootNode.path("value")) {
+                latestIteration = Math.max(latestIteration, iteration.path("id").asInt());
+            }
+        } catch (Exception e) {
+            log.error("Error parsing Azure DevOps pull request iterations", e);
+            return changedFiles;
+        }
+
+        if (latestIteration < 0) {
+            return changedFiles;
+        }
+
+        String changesUrl = String.format(
+                "%s/%s/_apis/git/repositories/%s/pullRequests/%s/iterations/%s/changes?api-version=%s",
+                repo.orgBaseUrl, encodedProject, repositoryId, prNumber, latestIteration, API_VERSION);
+
+        ResponseEntity<String> changesResponse = callAzureApi(vcs, "", changesUrl, HttpMethod.GET);
+        if (changesResponse == null || !changesResponse.getStatusCode().is2xxSuccessful()) {
+            log.error("Failed to fetch Azure DevOps changes for pull request {}", prNumber);
+            return changedFiles;
+        }
+        try {
+            JsonNode rootNode = objectMapper.readTree(changesResponse.getBody());
+            for (JsonNode change : rootNode.path("changeEntries")) {
+                addChangedFile(changedFiles, change);
+            }
+        } catch (Exception e) {
+            log.error("Error parsing Azure DevOps pull request changes", e);
+        }
+        return changedFiles;
+    }
+
+    private void addChangedFile(List<String> changedFiles, JsonNode change) {
+        JsonNode item = change.path("item");
+        // Skip folder entries, Terrakube path filters operate on files
+        if (item.path("isFolder").asBoolean(false) || "tree".equals(item.path("gitObjectType").asText())) {
+            return;
+        }
+        String path = item.path("path").asText();
+        if (path == null || path.isEmpty()) {
+            return;
+        }
+        // Azure DevOps paths are absolute (start with '/'), align them with the other providers
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+        if (!changedFiles.contains(path)) {
+            changedFiles.add(path);
+        }
+    }
+
+    private ResponseEntity<String> callAzureApi(Vcs vcs, String body, String apiUrl, HttpMethod httpMethod) {
+        String token = resolveToken(vcs);
+        if (token == null || token.isEmpty()) {
+            log.error("No Azure DevOps access token available for vcs {}", vcs.getId());
+            return null;
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", "application/json");
+        headers.set("Content-Type", "application/json");
+        headers.set("Authorization", "Bearer " + token);
+
+        try {
+            return makeApiRequest(headers, body, apiUrl, httpMethod);
+        } catch (RestClientException e) {
+            log.error("Error calling Azure DevOps API {}: {}", apiUrl, e.getMessage());
+            return null;
+        }
+    }
+
+    private String resolveToken(Vcs vcs) {
+        if (vcs.getVcsType() == VcsType.AZURE_SP_MI) {
+            return azDevOpsTokenService.getAzureDefaultToken();
+        }
+        return vcs.getAccessToken();
+    }
+
+    private String resolveUser(JsonNode userNode) {
+        String uniqueName = userNode.path("uniqueName").asText();
+        if (uniqueName != null && !uniqueName.isEmpty()) {
+            return uniqueName;
+        }
+        String displayName = userNode.path("displayName").asText();
+        return displayName == null || displayName.isEmpty() ? "system" : displayName;
+    }
+
+    private String stripRefPrefix(String ref) {
+        if (ref == null) {
+            return "";
+        }
+        if (ref.startsWith("refs/heads/")) {
+            return ref.substring("refs/heads/".length());
+        }
+        if (ref.startsWith("refs/tags/")) {
+            return ref.substring("refs/tags/".length());
+        }
+        return ref;
+    }
+
+    /**
+     * Parses the org scoped base url, project and repository name out of a Terrakube Azure DevOps source url.
+     *
+     * Supported shapes (with or without the {@code _git} segment and an optional {@code .git} suffix):
+     * <ul>
+     *   <li>{@code https://dev.azure.com/{org}/{project}/_git/{repo}}</li>
+     *   <li>{@code https://dev.azure.com/{org}/{project}/{repo}}</li>
+     *   <li>{@code https://{org}.visualstudio.com/{project}/_git/{repo}}</li>
+     *   <li>{@code https://{org}.visualstudio.com/{project}/{repo}}</li>
+     * </ul>
+     */
+    protected AzureRepo parseSource(String source) {
+        try {
+            String cleaned = source.replaceAll("\\.git$", "");
+            URI uri = new URI(cleaned);
+            String host = uri.getHost();
+            String scheme = uri.getScheme();
+            if (host == null || scheme == null) {
+                return null;
+            }
+            // Build host[:port] WITHOUT the userinfo component. Azure DevOps clone urls
+            // frequently include a userinfo (e.g. https://org@dev.azure.com/...), but the
+            // HTTP client rejects a request URI whose authority carries the deprecated
+            // userinfo component, so it must be stripped here (getAuthority keeps it).
+            int port = uri.getPort();
+            String hostPort = host + (port != -1 ? ":" + port : "");
+
+            List<String> segments = new ArrayList<>();
+            for (String segment : uri.getPath().split("/")) {
+                if (!segment.isEmpty() && !"_git".equals(segment)) {
+                    segments.add(segment);
+                }
+            }
+
+            String orgBaseUrl;
+            String project;
+            String repository;
+            if (host.endsWith("visualstudio.com")) {
+                // org is the subdomain, path is {project}/{repo}
+                orgBaseUrl = scheme + "://" + hostPort;
+                if (segments.size() < 2) {
+                    return null;
+                }
+                project = segments.get(0);
+                repository = segments.get(segments.size() - 1);
+            } else {
+                // dev.azure.com or Azure DevOps Server, path is {org}/{project}/{repo}
+                if (segments.size() < 3) {
+                    return null;
+                }
+                orgBaseUrl = scheme + "://" + hostPort + "/" + segments.get(0);
+                project = segments.get(1);
+                repository = segments.get(segments.size() - 1);
+            }
+            return new AzureRepo(orgBaseUrl, project, repository);
+        } catch (Exception e) {
+            log.error("Error extracting the Azure DevOps repository from {}", source, e);
+            return null;
+        }
+    }
+
+    /** Holds the org scoped base url, project and repository name parsed from a source url. */
+    protected static class AzureRepo {
+        final String orgBaseUrl;
+        final String project;
+        final String repository;
+
+        AzureRepo(String orgBaseUrl, String project, String repository) {
+            this.orgBaseUrl = orgBaseUrl;
+            this.project = project;
+            this.repository = repository;
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookService.java
@@ -57,12 +57,12 @@ public class AzDevOpsWebhookService extends WebhookServiceBase {
     private static final String HOOKS_API_VERSION = "7.1";
     private static final String TOKEN_HEADER = "x-terrakube-token";
     /**
-     * Azure DevOps webHooks consumer uses an empty string for "All" (see consumers API
-     * {@code resourceDetailsToSend} / {@code messagesToSend} possibleValues). The literal
-     * {@code "all"} is not a valid enum value when {@code isLimitedToPossibleValues} is true,
-     * and can leave deliveries with {@code resource: null}.
+     * Value for webHooks {@code resourceDetailsToSend} / {@code messagesToSend} /
+     * {@code detailedMessagesToSend}. Azure's consumers metadata lists {@code ""} as "All",
+     * but posting an empty string is rejected as a missing ConsumerInput.Value; the API
+     * accepts {@code "all"} (same as the Terraform Azure DevOps provider).
      */
-    private static final String SEND_ALL = "";
+    private static final String SEND_ALL = "all";
 
     // Azure DevOps service hook event types
     private static final String EVENT_PUSH = "git.push";
@@ -540,7 +540,6 @@ public class AzDevOpsWebhookService extends WebhookServiceBase {
 
         Map<String, Object> consumerInputs = new LinkedHashMap<>();
         consumerInputs.put("url", webhookUrl);
-        // Empty string = "All" per Azure DevOps webHooks consumer inputDescriptors.
         consumerInputs.put("resourceDetailsToSend", SEND_ALL);
         consumerInputs.put("detailedMessagesToSend", SEND_ALL);
         consumerInputs.put("messagesToSend", SEND_ALL);

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookService.java
@@ -54,8 +54,15 @@ import lombok.extern.slf4j.Slf4j;
 public class AzDevOpsWebhookService extends WebhookServiceBase {
 
     private static final String API_VERSION = "7.0";
-    private static final String HOOKS_API_VERSION = "7.0-preview.1";
+    private static final String HOOKS_API_VERSION = "7.1";
     private static final String TOKEN_HEADER = "x-terrakube-token";
+    /**
+     * Azure DevOps webHooks consumer uses an empty string for "All" (see consumers API
+     * {@code resourceDetailsToSend} / {@code messagesToSend} possibleValues). The literal
+     * {@code "all"} is not a valid enum value when {@code isLimitedToPossibleValues} is true,
+     * and can leave deliveries with {@code resource: null}.
+     */
+    private static final String SEND_ALL = "";
 
     // Azure DevOps service hook event types
     private static final String EVENT_PUSH = "git.push";
@@ -106,6 +113,17 @@ public class AzDevOpsWebhookService extends WebhookServiceBase {
         JsonNode rootNode = objectMapper.readTree(jsonPayload);
         String eventType = rootNode.path("eventType").asText();
         log.info("Azure DevOps event type: {}", eventType);
+
+        JsonNode resource = rootNode.get("resource");
+        if (resource == null || resource.isNull()) {
+            // Typical when the Azure subscription was created with an invalid
+            // resourceDetailsToSend value or an unsupported resourceVersion.
+            log.error(
+                    "Azure DevOps webhook for event {} has resource=null (resourceVersion={}); recreate the service hook subscription",
+                    eventType, rootNode.path("resourceVersion").asText(null));
+            result.setValid(false);
+            return result;
+        }
 
         switch (eventType) {
             case EVENT_PUSH:
@@ -522,17 +540,19 @@ public class AzDevOpsWebhookService extends WebhookServiceBase {
 
         Map<String, Object> consumerInputs = new LinkedHashMap<>();
         consumerInputs.put("url", webhookUrl);
-        consumerInputs.put("resourceDetailsToSend", "all");
-        consumerInputs.put("detailedMessagesToSend", "all");
-        consumerInputs.put("messagesToSend", "all");
+        // Empty string = "All" per Azure DevOps webHooks consumer inputDescriptors.
+        consumerInputs.put("resourceDetailsToSend", SEND_ALL);
+        consumerInputs.put("detailedMessagesToSend", SEND_ALL);
+        consumerInputs.put("messagesToSend", SEND_ALL);
         // Accept self-signed / internal certificates so deliveries are not dropped on TLS
         // validation (otherwise Azure puts the subscription on probation and loses events).
         consumerInputs.put("acceptUntrustedCerts", "true");
         consumerInputs.put("httpHeaders", "X-Terrakube-Token:" + secret);
 
-        // Current Azure DevOps resource version is 2.0 for git.push and the pull request events;
-        // the pull request comment event uses 1.0.
-        String resourceVersion = EVENT_PR_COMMENT.equals(azureEventType) ? "1.0" : "2.0";
+        // Use 1.0 for every event type. Microsoft recommends 1.0 as the safest resource version;
+        // requesting 2.0 for git.push / PR events has been observed to yield deliveries with
+        // resource=null and resourceVersion=null while messages still arrive.
+        String resourceVersion = "1.0";
 
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("publisherId", "tfs");
@@ -552,7 +572,17 @@ public class AzDevOpsWebhookService extends WebhookServiceBase {
             if (response != null && response.getStatusCode().is2xxSuccessful()) {
                 JsonNode rootNode = objectMapper.readTree(response.getBody());
                 String id = rootNode.path("id").asText();
-                log.info("Created Azure DevOps subscription {} for event {}", id, azureEventType);
+                String storedVersion = rootNode.path("resourceVersion").asText(null);
+                String storedResourceDetails = rootNode.path("consumerInputs").path("resourceDetailsToSend")
+                        .asText(null);
+                log.info(
+                        "Created Azure DevOps subscription {} for event {} (resourceVersion={}, resourceDetailsToSend={})",
+                        id, azureEventType, storedVersion, storedResourceDetails);
+                if (storedVersion == null || storedVersion.isEmpty()) {
+                    log.warn(
+                            "Azure DevOps subscription {} was created without a resourceVersion; webhook payloads may omit resource",
+                            id);
+                }
                 return id;
             }
             log.error("Failed to create Azure DevOps subscription for event {}, message {}", azureEventType,

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/README.md
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/README.md
@@ -1,0 +1,68 @@
+# Azure DevOps VCS provider
+
+Adds Azure DevOps (`dev.azure.com` and Azure DevOps Server) as a VCS provider for Terrakube
+workspaces. It supports both VCS connection types already used elsewhere in Terrakube:
+
+- `AZURE_DEVOPS` — OAuth / Personal Access Token connection.
+- `AZURE_SP_MI` — Service Principal / Managed Identity (token resolved via `DefaultAzureCredential`).
+
+There are two ways to start a run when code changes: inbound **service hooks** (default) and outbound
+**commit polling** (opt-in).
+
+## Inbound service hooks (default)
+
+When a workspace with an Azure DevOps VCS is saved, Terrakube creates an Azure DevOps
+[service hook](https://learn.microsoft.com/azure/devops/service-hooks/overview) subscription that
+posts to the Terrakube webhook endpoint. Supported events:
+
+| Event | `eventType` | `resourceVersion` |
+|-------|-------------|-------------------|
+| Code pushed | `git.push` | `2.0` |
+| Pull request created | `git.pullrequest.created` | `2.0` |
+| Pull request updated | `git.pullrequest.updated` | `2.0` |
+| Pull request comment | `ms.vss-code.git-pullrequest-comment-event` | `1.0` |
+
+Each delivery is authenticated with a per-webhook `x-terrakube-token` header. Commit status is
+reported back to Azure DevOps as the run progresses.
+
+Service hooks are delivered from the Azure DevOps cloud, so the Terrakube webhook endpoint must be
+reachable from the public internet. The service principal / token must have **Edit Subscriptions**
+permission to create them.
+
+## Outbound commit polling (opt-in)
+
+If Terrakube runs on a **private network** that the Azure DevOps cloud cannot reach, inbound service
+hooks will silently fail (and Azure DevOps eventually disables the subscription). Polling reverses the
+direction: Terrakube periodically makes an **outbound** call to fetch the tip commit of each Azure
+DevOps workspace branch and starts a run when it changes. It reuses the same credentials already used
+for cloning, so **no inbound network exposure is required**.
+
+Polling runs every workspace check concurrently each cycle, so detection latency stays close to the
+configured interval regardless of how many workspaces are tracked. The last-seen commit per
+workspace/branch is stored in Redis (`azdo-poll:{workspaceId}:{branch}`); the first observation only
+records a baseline and does not trigger a run.
+
+### Configuration
+
+Polling is **disabled by default**. Enable it with the following environment variables (Spring
+properties in parentheses):
+
+| Environment variable | Property | Default | Description |
+|----------------------|----------|---------|-------------|
+| `AzureDevOpsPollingEnabled` | `io.terrakube.vcs.azuredevops.polling.enabled` | `false` | Enable outbound commit polling. |
+| `AzureDevOpsPollingInterval` | `io.terrakube.vcs.azuredevops.polling.interval` | `15000` | Milliseconds between polls of each workspace. Lower to detect commits sooner; raise to reduce API traffic. |
+| `AzureDevOpsPollingInitialDelay` | `io.terrakube.vcs.azuredevops.polling.initial-delay` | `10000` | Milliseconds to wait after startup before the first poll. |
+
+Example (Helm `values.yaml`, API environment):
+
+```yaml
+env:
+  - name: AzureDevOpsPollingEnabled
+    value: "true"
+  - name: AzureDevOpsPollingInterval
+    value: "15000"
+```
+
+When polling is enabled, leave the workspace's branch configured normally; Terrakube polls that
+branch. Event matching (branch and file-path filters on the workspace webhook) is applied exactly as
+it is for inbound pushes.

--- a/api/src/main/java/io/terrakube/api/repository/WebhookRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/WebhookRepository.java
@@ -1,9 +1,20 @@
 package io.terrakube.api.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import io.terrakube.api.rs.vcs.VcsType;
 import io.terrakube.api.rs.webhook.Webhook;
 
 public interface WebhookRepository extends JpaRepository<Webhook, UUID> {
+
+    // Webhooks whose workspace is backed by one of the given VCS types. workspace and vcs are
+    // eagerly fetched so the poller can read them outside an open session. The Workspace entity is
+    // annotated with @SQLRestriction("deleted = false"), so deleted workspaces are excluded.
+    @Query("SELECT wh FROM webhook wh JOIN FETCH wh.workspace w JOIN FETCH w.vcs v WHERE v.vcsType IN :types")
+    List<Webhook> findByWorkspaceVcsTypeIn(@Param("types") List<VcsType> types);
 }

--- a/api/src/main/java/io/terrakube/api/rs/job/JobVia.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/JobVia.java
@@ -6,5 +6,6 @@ public enum JobVia {
    Github,
    Gitlab,
    Bitbucket,
+   AzureDevops,
    Schedule
 }

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -227,4 +227,21 @@ io.terrakube.importer.allowedUrl=${ImporterAllowedUrl:https://app.terraform.io}
 io.terrakube.vcs.gitlab.timeout=${VcsGitlabTimeOut:30}
 io.terrakube.vcs.gitlab.pageSize=${VcsGitlabPageSize:25}
 
+#################
+#AZURE DEVOPS VCS#
+#################
+# Outbound commit polling for Azure DevOps. Use this when Terrakube runs on a private network
+# that Azure DevOps Services (dev.azure.com) cannot reach with inbound service hooks. Instead of
+# waiting for Azure DevOps to push an event, Terrakube periodically fetches the tip commit of each
+# Azure DevOps workspace branch and starts a run when it changes. Every call is outbound and reuses
+# the existing VCS credentials, so no inbound network exposure is required.
+#
+#   AzureDevOpsPollingEnabled      Enable polling (true/false). Disabled by default.
+#   AzureDevOpsPollingInterval     Milliseconds between polls of each workspace (default 15000 = 15s).
+#                                  Lower it to detect commits sooner; raise it to reduce API traffic.
+#   AzureDevOpsPollingInitialDelay Milliseconds to wait after startup before the first poll (default 10000).
+io.terrakube.vcs.azuredevops.polling.enabled=${AzureDevOpsPollingEnabled:false}
+io.terrakube.vcs.azuredevops.polling.interval=${AzureDevOpsPollingInterval:15000}
+io.terrakube.vcs.azuredevops.polling.initial-delay=${AzureDevOpsPollingInitialDelay:10000}
+
 # logging.level.org.springframework.security=DEBUG

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -231,6 +231,23 @@ io.terrakube.importer.allowedUrl=${ImporterAllowedUrl:https://app.terraform.io}
 io.terrakube.vcs.gitlab.timeout=${VcsGitlabTimeOut:30}
 io.terrakube.vcs.gitlab.pageSize=${VcsGitlabPageSize:25}
 
+#################
+#AZURE DEVOPS VCS#
+#################
+# Outbound commit polling for Azure DevOps. Use this when Terrakube runs on a private network
+# that Azure DevOps Services (dev.azure.com) cannot reach with inbound service hooks. Instead of
+# waiting for Azure DevOps to push an event, Terrakube periodically fetches the tip commit of each
+# Azure DevOps workspace branch and starts a run when it changes. Every call is outbound and reuses
+# the existing VCS credentials, so no inbound network exposure is required.
+#
+#   AzureDevOpsPollingEnabled      Enable polling (true/false). Disabled by default.
+#   AzureDevOpsPollingInterval     Milliseconds between polls of each workspace (default 15000 = 15s).
+#                                  Lower it to detect commits sooner; raise it to reduce API traffic.
+#   AzureDevOpsPollingInitialDelay Milliseconds to wait after startup before the first poll (default 10000).
+io.terrakube.vcs.azuredevops.polling.enabled=${AzureDevOpsPollingEnabled:false}
+io.terrakube.vcs.azuredevops.polling.interval=${AzureDevOpsPollingInterval:15000}
+io.terrakube.vcs.azuredevops.polling.initial-delay=${AzureDevOpsPollingInitialDelay:10000}
+
 # logging.level.org.springframework=DEBUG
 # logging.level.io.terrakube=DEBUG
 # logging.level.com.yahoo.elide=DEBUG

--- a/api/src/test/java/io/terrakube/api/ServerApplicationTests.java
+++ b/api/src/test/java/io/terrakube/api/ServerApplicationTests.java
@@ -11,6 +11,7 @@ import io.terrakube.api.plugin.scheduler.job.tcl.TclService;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorService;
 import io.terrakube.api.plugin.security.encryption.EncryptionService;
 import io.terrakube.api.plugin.token.pat.PatService;
+import io.terrakube.api.plugin.vcs.provider.azdevops.AzDevOpsWebhookService;
 import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
 import io.terrakube.api.repository.*;
 import net.minidev.json.JSONArray;
@@ -57,6 +58,9 @@ class ServerApplicationTests {
 
     @Autowired
     BitBucketWebhookService bitBucketWebhookService;
+
+    @Autowired
+    AzDevOpsWebhookService azDevOpsWebhookService;
 
     @Autowired
     EncryptionService encryptionService;

--- a/api/src/test/java/io/terrakube/api/VcsAzureDevopsTests.java
+++ b/api/src/test/java/io/terrakube/api/VcsAzureDevopsTests.java
@@ -1,0 +1,232 @@
+package io.terrakube.api;
+
+import io.terrakube.api.plugin.vcs.WebhookResult;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.vcs.VcsType;
+import io.terrakube.api.rs.workspace.Workspace;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.Assert;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.mockito.Mockito.when;
+
+public class VcsAzureDevopsTests extends ServerApplicationTests {
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        wireMockServer.resetAll();
+    }
+
+    private Vcs createAzureVcs() {
+        Vcs vcs = new Vcs();
+        vcs.setAccessToken("1234567890");
+        vcs.setClientId("123");
+        vcs.setClientSecret("123");
+        vcs.setName("azure");
+        vcs.setDescription("1234");
+        vcs.setVcsType(VcsType.AZURE_DEVOPS);
+        vcs.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
+        return vcsRepository.save(vcs);
+    }
+
+    private Workspace createWorkspace(Vcs vcs) {
+        Workspace workspace = new Workspace();
+        workspace.setName(UUID.randomUUID().toString());
+        // points the org scoped base url at the WireMock server: <host>/myorg/myproject/myrepo
+        workspace.setSource("http://localhost:" + wireMockServer.port() + "/myorg/myproject/myrepo");
+        workspace.setBranch("main");
+        workspace.setIacType("terraform");
+        workspace.setTerraformVersion("1.0");
+        workspace.setVcs(vcs);
+        workspace.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
+        return workspaceRepository.save(workspace);
+    }
+
+    private void cleanup(Workspace workspace, Vcs vcs) {
+        workspace.setDeleted(true);
+        workspace.setVcs(null);
+        workspaceRepository.save(workspace);
+        vcsRepository.delete(vcs);
+    }
+
+    @Test
+    void azureDevopsWebhookPush() {
+        String payload = "{\n" +
+                "  \"eventType\": \"git.push\",\n" +
+                "  \"publisherId\": \"tfs\",\n" +
+                "  \"resource\": {\n" +
+                "    \"commits\": [ { \"commitId\": \"33b55f7cb7e7e245323987634f960cf4a6e6bc74\" } ],\n" +
+                "    \"refUpdates\": [ {\n" +
+                "        \"name\": \"refs/heads/main\",\n" +
+                "        \"oldObjectId\": \"aaaa\",\n" +
+                "        \"newObjectId\": \"33b55f7cb7e7e245323987634f960cf4a6e6bc74\"\n" +
+                "    } ],\n" +
+                "    \"repository\": {\n" +
+                "      \"id\": \"repo-guid\",\n" +
+                "      \"name\": \"myrepo\",\n" +
+                "      \"project\": { \"id\": \"proj-guid\", \"name\": \"myproject\" }\n" +
+                "    },\n" +
+                "    \"pushedBy\": { \"displayName\": \"John Doe\", \"uniqueName\": \"john@example.com\" }\n" +
+                "  }\n" +
+                "}";
+
+        String changesResponse = "{ \"changes\": [ " +
+                "{ \"item\": { \"gitObjectType\": \"blob\", \"path\": \"/work1/main.tf\" }, \"changeType\": \"edit\" }, " +
+                "{ \"item\": { \"gitObjectType\": \"tree\", \"path\": \"/work1\", \"isFolder\": true }, \"changeType\": \"edit\" } " +
+                "] }";
+
+        stubFor(get(urlPathEqualTo("/myorg/myproject/_apis/git/repositories/repo-guid/commits/33b55f7cb7e7e245323987634f960cf4a6e6bc74/changes"))
+                .withPort(wireMockServer.port())
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(changesResponse)));
+
+        Vcs vcs = createAzureVcs();
+        Workspace workspace = createWorkspace(vcs);
+
+        WebhookResult result = new WebhookResult();
+        try {
+            result = azDevOpsWebhookService.handleEvent(payload, result, workspace);
+        } catch (Exception e) {
+            Assert.isTrue(false, "Unexpected exception: " + e.getMessage());
+        }
+
+        Assert.isTrue("push".equals(result.getEvent()), "Event is not push");
+        Assert.isTrue("main".equals(result.getBranch()), "Branch is not main");
+        Assert.isTrue("33b55f7cb7e7e245323987634f960cf4a6e6bc74".equals(result.getCommit()), "Commit id mismatch");
+        Assert.isTrue("john@example.com".equals(result.getCreatedBy()), "Created by mismatch");
+        Assert.isTrue(result.getFileChanges().size() == 1, "File changes (excluding folders) is not 1");
+        Assert.isTrue(result.getFileChanges().contains("work1/main.tf"), "File change path mismatch");
+
+        cleanup(workspace, vcs);
+    }
+
+    @Test
+    void azureDevopsWebhookTag() {
+        String payload = "{\n" +
+                "  \"eventType\": \"git.push\",\n" +
+                "  \"resource\": {\n" +
+                "    \"commits\": [ { \"commitId\": \"abc\" } ],\n" +
+                "    \"refUpdates\": [ {\n" +
+                "        \"name\": \"refs/tags/v1.0\",\n" +
+                "        \"newObjectId\": \"abc\"\n" +
+                "    } ],\n" +
+                "    \"repository\": { \"id\": \"repo-guid\", \"project\": { \"id\": \"proj-guid\" } },\n" +
+                "    \"pushedBy\": { \"uniqueName\": \"john@example.com\" }\n" +
+                "  }\n" +
+                "}";
+
+        Vcs vcs = createAzureVcs();
+        Workspace workspace = createWorkspace(vcs);
+
+        WebhookResult result = new WebhookResult();
+        try {
+            result = azDevOpsWebhookService.handleEvent(payload, result, workspace);
+        } catch (Exception e) {
+            Assert.isTrue(false, "Unexpected exception: " + e.getMessage());
+        }
+
+        Assert.isTrue(result.isRelease(), "Tag push is not flagged as release");
+        Assert.isTrue("release".equals(result.getEvent()), "Event is not release");
+        Assert.isTrue("v1.0".equals(result.getBranch()), "Tag name mismatch");
+
+        cleanup(workspace, vcs);
+    }
+
+    @Test
+    void azureDevopsWebhookPullRequest() {
+        String payload = "{\n" +
+                "  \"eventType\": \"git.pullrequest.created\",\n" +
+                "  \"resource\": {\n" +
+                "    \"pullRequestId\": 5,\n" +
+                "    \"status\": \"active\",\n" +
+                "    \"sourceRefName\": \"refs/heads/feature\",\n" +
+                "    \"targetRefName\": \"refs/heads/main\",\n" +
+                "    \"lastMergeSourceCommit\": { \"commitId\": \"def456\" },\n" +
+                "    \"createdBy\": { \"displayName\": \"Jane\", \"uniqueName\": \"jane@example.com\" },\n" +
+                "    \"repository\": { \"id\": \"repo-guid\", \"project\": { \"id\": \"proj-guid\" } }\n" +
+                "  }\n" +
+                "}";
+
+        stubFor(get(urlPathEqualTo("/myorg/myproject/_apis/git/repositories/repo-guid/pullRequests/5/iterations"))
+                .withPort(wireMockServer.port())
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{ \"value\": [ { \"id\": 1 }, { \"id\": 2 } ] }")));
+
+        stubFor(get(urlPathEqualTo("/myorg/myproject/_apis/git/repositories/repo-guid/pullRequests/5/iterations/2/changes"))
+                .withPort(wireMockServer.port())
+                .willReturn(aResponse()
+                        .withStatus(HttpStatus.OK.value())
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{ \"changeEntries\": [ { \"item\": { \"gitObjectType\": \"blob\", \"path\": \"/work1/main.tf\" } } ] }")));
+
+        Vcs vcs = createAzureVcs();
+        Workspace workspace = createWorkspace(vcs);
+
+        WebhookResult result = new WebhookResult();
+        try {
+            result = azDevOpsWebhookService.handleEvent(payload, result, workspace);
+        } catch (Exception e) {
+            Assert.isTrue(false, "Unexpected exception: " + e.getMessage());
+        }
+
+        Assert.isTrue("pull_request".equals(result.getEvent()), "Event is not pull_request");
+        Assert.isTrue("feature".equals(result.getBranch()), "Branch is not feature");
+        Assert.isTrue("def456".equals(result.getCommit()), "Commit id mismatch");
+        Assert.isTrue(result.getPrNumber().intValue() == 5, "PR number mismatch");
+        Assert.isTrue(result.getFileChanges().contains("work1/main.tf"), "PR file change path mismatch");
+
+        cleanup(workspace, vcs);
+    }
+
+    @Test
+    void azureDevopsWebhookTokenValidation() {
+        String payload = "{\n" +
+                "  \"eventType\": \"git.push\",\n" +
+                "  \"resource\": {\n" +
+                "    \"refUpdates\": [ { \"name\": \"refs/tags/v1.0\", \"newObjectId\": \"abc\" } ],\n" +
+                "    \"repository\": { \"id\": \"repo-guid\", \"project\": { \"id\": \"proj-guid\" } },\n" +
+                "    \"pushedBy\": { \"uniqueName\": \"john@example.com\" }\n" +
+                "  }\n" +
+                "}";
+
+        Vcs vcs = createAzureVcs();
+        Workspace workspace = createWorkspace(vcs);
+
+        String secret = Base64.getEncoder()
+                .encodeToString(workspace.getId().toString().getBytes(StandardCharsets.UTF_8));
+
+        // Missing token header -> rejected
+        WebhookResult invalid = azDevOpsWebhookService.processWebhook(payload, new HashMap<>(), secret, workspace);
+        Assert.isTrue(!invalid.isValid(), "Webhook without token header should be invalid");
+
+        // Wrong token header -> rejected
+        Map<String, String> wrongHeaders = new HashMap<>();
+        wrongHeaders.put("x-terrakube-token", "not-the-secret");
+        WebhookResult wrong = azDevOpsWebhookService.processWebhook(payload, wrongHeaders, secret, workspace);
+        Assert.isTrue(!wrong.isValid(), "Webhook with wrong token header should be invalid");
+
+        // Correct token header -> accepted (tag push, no API calls needed)
+        Map<String, String> headers = new HashMap<>();
+        headers.put("x-terrakube-token", secret);
+        WebhookResult valid = azDevOpsWebhookService.processWebhook(payload, headers, secret, workspace);
+        Assert.isTrue(valid.isValid(), "Webhook with correct token header should be valid");
+        Assert.isTrue(valid.isRelease(), "Tag push should be flagged as release");
+
+        cleanup(workspace, vcs);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
@@ -117,6 +117,7 @@ public class ScheduleJobTest {
                 scheduleJobService,
                 null,
                 gitHubWebhookService,
+                null,
                 prCommentService,
                 globalVarRepository,
                 variableRepository,


### PR DESCRIPTION
PR with some improvements from #3239, this will add support for v1 webhooks.

Service hook is created correctly

<img width="1811" height="801" alt="imagen" src="https://github.com/user-attachments/assets/c56b90c1-c5c4-4319-9be2-d909bb2ede60" />

<img width="1749" height="382" alt="imagen" src="https://github.com/user-attachments/assets/a49cce07-9f36-4640-8310-8148d4482955" />

This will have to be migrated to shared web hooks but it is a good starting point because all initial logic to setup the hooks are present now


fix #3239 1793