### PR TITLE
fix(ui): serve env-config.js with Cache-Control: no-store

### DIFF
--- a/ui/conf/conf.d/terrakube-ui.conf
+++ b/ui/conf/conf.d/terrakube-ui.conf
@@ -2,6 +2,12 @@ server {
   listen 0.0.0.0:8080;
   listen [::]:8080;
 
+  # Runtime config, regenerated per deploy — never cache (a stale API URL breaks the app)
+  location = /env-config.js {
+    root       /usr/share/nginx/html/;
+    add_header Cache-Control "no-store" always;
+  }
+
   location / {
     root   /usr/share/nginx/html/;
     index  index.html index.htm;


### PR DESCRIPTION
## Problem

`env-config.js` holds the UI's runtime configuration (`REACT_APP_TERRAKUBE_API_URL`, `REACT_APP_AUTHORITY`, …) and is regenerated on every container start by `env.sh`. nginx serves it with no cache headers, so browsers and any CDN/proxy in front of the UI may cache it.

When config changes between deploys — e.g. enabling TLS flips the API URL from `http://` to `https://` — a cached `env-config.js` strands clients on stale values. We hit this behind a CDN: a stale `env-config.js` served an `http://` API URL to an `https://` UI, so every API call was blocked as mixed content and the UI showed "Network Error" — while auth still worked (it reads the always-`https` authority), which made it very confusing to diagnose.

## Fix

Serve `env-config.js` with `Cache-Control: no-store` so runtime config is always fetched fresh. Hashed static assets are unaffected.

## Testing

- `curl -I https://<ui>/env-config.js` now returns `Cache-Control: no-store`.
- Other assets unchanged; the app loads correctly after a config change without a manual cache purge.

Signed-off-by: Yash Sharma <yasharma28@gmail.com>
