### PR TITLE
Widen github_app_token.token for new GitHub installation token format

### DIFF
--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -106,4 +106,5 @@
     <include file="/db/changelog/local/changelog-2.32.0-job-step-cascade.xml"/>
     <include file="/db/changelog/local/changelog-2.32.0-performance-fk-indexes.xml" />
     <include file="/db/changelog/local/changelog-2.33.0-vcs-token-size.xml"/>
+    <include file="/db/changelog/local/changelog-2.33.0-github-app-token-size.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-github-app-token-size.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-github-app-token-size.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-33-0-3" author="dnl555">
+        <modifyDataType
+                columnName="token"
+                newDataType="varchar2(4096)"
+                tableName="github_app_token"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Summary
- GitHub's new installation access tokens (~383 chars) overflow `github_app_token.token` varchar(255), making the 55-minute token refresh fail with `value too long` and breaking all clones for GitHub App connections once the stale token expires
- Adds a changeset widening the column to 4096, same as 2.33.0 did for the `vcs` token columns

Fixes #3319
