### PR TITLE
fix(ui): keep organization dropdown reachable and in sync with one org

### DIFF
--- a/ui/src/domain/Home/App.tsx
+++ b/ui/src/domain/Home/App.tsx
@@ -7,6 +7,7 @@ import {
   useParams,
   useNavigate,
   useOutletContext,
+  useLocation,
 } from "react-router-dom";
 import { useAuth } from "../../config/authConfig";
 import { getBasePath } from "../../config/basePath";
@@ -124,6 +125,7 @@ const ModuleDetailsRoute = () => {
 
 const AppLayout = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const [organizationName, setOrganizationName] = useState<string>("");
   const [orgs, setOrgs] = useState<FlatOrganization[]>([]);
   const { colorScheme, themeMode } = useTheme();
@@ -165,6 +167,8 @@ const AppLayout = () => {
   }, []);
 
   useEffect(() => {
+    // Re-fetch on every navigation so newly created/deleted organizations
+    // show up in the header dropdown without a full page reload.
     organizationService
       .listOrganizationsGraphQL()
       .then((organizations) => {
@@ -173,7 +177,7 @@ const AppLayout = () => {
       .catch((error) => {
         console.error("Failed to load organizations:", error);
       });
-  }, []);
+  }, [location.pathname]);
 
   const handleOrgChange = (orgId: string) => {
     const org = orgs.find((o) => o.id === orgId);

--- a/ui/src/modules/organizations/OrganizationsPickerPage.tsx
+++ b/ui/src/modules/organizations/OrganizationsPickerPage.tsx
@@ -65,13 +65,20 @@ export default function OrganizationsPickerPage() {
   }, [location.pathname]);
 
   useEffect(() => {
+    // Don't auto-redirect when the user explicitly navigated to /organizations
+    // (e.g. via "Manage Organizations"), otherwise they can never reach the
+    // picker/create page when they only have a single organization.
+    if (location.pathname === "/organizations") {
+      return;
+    }
+
     if (organizations.length === 1) {
       const organization = organizations[0];
       sessionStorage.setItem(ORGANIZATION_ARCHIVE, organization.id);
       sessionStorage.setItem(ORGANIZATION_NAME, organization.name);
       navigate(`/organizations/${organization.id}/workspaces`, { replace: true });
     }
-  }, [navigate, organizations]);
+  }, [navigate, organizations, location.pathname]);
 
   return (
     <PageWrapper


### PR DESCRIPTION
### Problem
With exactly one organization, the header org dropdown is effectively broken for admins:

**1. "Manage Organizations" is unreachable**. `OrganizationsPickerPage` had an effect that unconditionally redirected to the single org's workspace whenever` organizations.length === 1`, with no check on the current route. So clicking "Manage Organizations" (which navigates to `/organizations`) got immediately overridden by that redirect, bouncing the user back to their workspace before the picker/"Create organization" page could ever render. This only reproduced with exactly one org — with 2+, the condition never fires and the page works fine.

**2. New organizations don't appear in the dropdown.** The header dropdown's org list (`AppLayout` in `App.tsx`) was fetched once on mount with an empty dependency array. Since the app shell never remounts during client-side navigation, creating a new org and navigating into it never refreshed that list — the new org showed up on the `/organizations` list page but not in the dropdown until a full page reload.

### The fix
- `OrganizationsPickerPage.tsx`: skip the single-org auto-redirect when `location.pathname === "/organizations"`, matching the same guard already used by `initPage()` just above it — so an explicit visit to the organizations page is never redirected away.
- `App.tsx`: re-fetch the organization list on every navigation (`location.pathname` added as an effect dependency) instead of only once on mount, so the header dropdown reflects newly created (or deleted) organizations without requiring a reload.

Fixes #3326