### PR TITLE
fix(ui): show save feedback and auto-refresh after CRUD actions

### DIFF
--- a/ui/src/domain/Settings/AddTemplate.tsx
+++ b/ui/src/domain/Settings/AddTemplate.tsx
@@ -134,6 +134,7 @@ export const AddTemplate = ({ setMode, loadTemplates }: Props) => {
       })
       .then((response) => {
         if (response.status == 201) {
+          message.success("Template created successfully");
           loadTemplates();
           setMode("list");
         }

--- a/ui/src/domain/Settings/AddVCS.tsx
+++ b/ui/src/domain/Settings/AddVCS.tsx
@@ -755,6 +755,8 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
                 response.data.data.attributes.endpoint
               )
             );
+          } else {
+            message.success("VCS provider created successfully");
           }
           loadVCS();
           setMode("list");

--- a/ui/src/domain/Settings/Agents.tsx
+++ b/ui/src/domain/Settings/Agents.tsx
@@ -49,6 +49,7 @@ export const AgentSettings = ({ managePermission = true }: Props) => {
     axiosInstance
       .delete(`organization/${orgid}/agent/${id}`)
       .then(() => {
+        message.success("Agent pool deleted successfully");
         loadAgents();
       })
       .catch((err) => {
@@ -75,6 +76,7 @@ export const AgentSettings = ({ managePermission = true }: Props) => {
         },
       })
       .then((response) => {
+        message.success("Agent pool created successfully");
         loadAgents();
         setVisible(false);
         form.resetFields();
@@ -103,6 +105,7 @@ export const AgentSettings = ({ managePermission = true }: Props) => {
         },
       })
       .then(() => {
+        message.success("Agent pool updated successfully");
         loadAgents();
         setVisible(false);
         form.resetFields();

--- a/ui/src/domain/Settings/CollectionItems.tsx
+++ b/ui/src/domain/Settings/CollectionItems.tsx
@@ -1,8 +1,22 @@
 import { DeleteOutlined, EditOutlined, InfoCircleOutlined, PlusOutlined, CloseCircleOutlined } from "@ant-design/icons";
-import { Button, Form, Input, Modal, Popconfirm, Radio, Space, Spin, Table, Tag, Typography, Checkbox } from "antd";
+import {
+  Button,
+  Form,
+  Input,
+  message,
+  Modal,
+  Popconfirm,
+  Radio,
+  Space,
+  Spin,
+  Table,
+  Tag,
+  Typography,
+  Checkbox,
+} from "antd";
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import axiosInstance from "../../config/axiosConfig";
+import axiosInstance, { getErrorMessage } from "../../config/axiosConfig";
 import "./Settings.css";
 
 // Type definitions for Collection Items
@@ -122,17 +136,22 @@ export const CollectionItemsSettings = ({ collectionId, collectionName }: Props)
     setMode("edit");
     setItemId(id);
     setVisible(true);
-    axiosInstance.get(`organization/${orgid}/collection/${collectionId}/item/${id}`).then((response) => {
-      setItemKey(response.data.data.attributes.key);
-      form.setFieldsValue({
-        key: response.data.data.attributes.key,
-        value: response.data.data.attributes.value,
-        hcl: response.data.data.attributes.hcl,
-        sensitive: response.data.data.attributes.sensitive,
-        category: response.data.data.attributes.category,
-        description: response.data.data.attributes.description,
+    axiosInstance
+      .get(`organization/${orgid}/collection/${collectionId}/item/${id}`)
+      .then((response) => {
+        setItemKey(response.data.data.attributes.key);
+        form.setFieldsValue({
+          key: response.data.data.attributes.key,
+          value: response.data.data.attributes.value,
+          hcl: response.data.data.attributes.hcl,
+          sensitive: response.data.data.attributes.sensitive,
+          category: response.data.data.attributes.category,
+          description: response.data.data.attributes.description,
+        });
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
       });
-    });
   };
 
   const onNew = () => {
@@ -143,9 +162,15 @@ export const CollectionItemsSettings = ({ collectionId, collectionName }: Props)
   };
 
   const onDelete = (id: string) => {
-    axiosInstance.delete(`organization/${orgid}/collection/${collectionId}/item/${id}`).then(() => {
-      loadItems();
-    });
+    axiosInstance
+      .delete(`organization/${orgid}/collection/${collectionId}/item/${id}`)
+      .then(() => {
+        message.success("Variable deleted successfully");
+        loadItems();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+      });
   };
 
   const onCreate = (values: CollectionItemFormValues) => {
@@ -170,9 +195,13 @@ export const CollectionItemsSettings = ({ collectionId, collectionName }: Props)
         },
       })
       .then(() => {
+        message.success("Variable added successfully");
         loadItems();
         setVisible(false);
         form.resetFields();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
       });
   };
 
@@ -198,17 +227,27 @@ export const CollectionItemsSettings = ({ collectionId, collectionName }: Props)
         },
       })
       .then(() => {
+        message.success("Variable updated successfully");
         loadItems();
         setVisible(false);
         form.resetFields();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
       });
   };
 
   const loadItems = () => {
-    axiosInstance.get(`organization/${orgid}/collection/${collectionId}/item`).then((response) => {
-      setItems(response.data.data);
-      setLoading(false);
-    });
+    axiosInstance
+      .get(`organization/${orgid}/collection/${collectionId}/item`)
+      .then((response) => {
+        setItems(response.data.data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+        setLoading(false);
+      });
   };
 
   useEffect(() => {

--- a/ui/src/domain/Settings/CollectionReferences.tsx
+++ b/ui/src/domain/Settings/CollectionReferences.tsx
@@ -1,8 +1,8 @@
 import { DeleteOutlined, PlusOutlined } from "@ant-design/icons";
-import { Button, Form, Input, Modal, Popconfirm, Select, Space, Spin, Table, Typography } from "antd";
+import { Button, Form, Input, message, Modal, Popconfirm, Select, Space, Spin, Table, Typography } from "antd";
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import axiosInstance from "../../config/axiosConfig";
+import axiosInstance, { getErrorMessage } from "../../config/axiosConfig";
 import "./Settings.css";
 
 // Type definitions for Collection References
@@ -108,9 +108,15 @@ export const CollectionReferencesSettings = ({ collectionId, collectionName }: P
   };
 
   const onDelete = (id: string) => {
-    axiosInstance.delete(`organization/${orgid}/collection/${collectionId}/reference/${id}`).then(() => {
-      loadReferences();
-    });
+    axiosInstance
+      .delete(`organization/${orgid}/collection/${collectionId}/reference/${id}`)
+      .then(() => {
+        message.success("Workspace reference removed successfully");
+        loadReferences();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+      });
   };
 
   const onCreate = (values: ReferenceFormValues) => {
@@ -138,17 +144,27 @@ export const CollectionReferencesSettings = ({ collectionId, collectionName }: P
         },
       })
       .then(() => {
+        message.success("Workspace reference added successfully");
         loadReferences();
         setVisible(false);
         form.resetFields();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
       });
   };
 
   const loadReferences = () => {
-    axiosInstance.get(`organization/${orgid}/collection/${collectionId}/reference`).then((response) => {
-      setReferences(response.data.data);
-      setLoading(false);
-    });
+    axiosInstance
+      .get(`organization/${orgid}/collection/${collectionId}/reference`)
+      .then((response) => {
+        setReferences(response.data.data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+        setLoading(false);
+      });
   };
 
   useEffect(() => {
@@ -157,18 +173,23 @@ export const CollectionReferencesSettings = ({ collectionId, collectionName }: P
     Promise.all([
       axiosInstance.get(`organization/${orgid}/collection/${collectionId}/reference`),
       axiosInstance.get(`organization/${orgid}/workspace`),
-    ]).then(([refsRes, workspacesRes]) => {
-      setReferences(refsRes.data.data);
-      setWorkspaces(workspacesRes.data.data);
+    ])
+      .then(([refsRes, workspacesRes]) => {
+        setReferences(refsRes.data.data);
+        setWorkspaces(workspacesRes.data.data);
 
-      // Create a map of workspace IDs to names for easier lookup
-      const map: { [key: string]: string } = {};
-      workspacesRes.data.data.forEach((workspace: Workspace) => {
-        map[workspace.id] = workspace.attributes.name;
+        // Create a map of workspace IDs to names for easier lookup
+        const map: { [key: string]: string } = {};
+        workspacesRes.data.data.forEach((workspace: Workspace) => {
+          map[workspace.id] = workspace.attributes.name;
+        });
+        setWorkspacesMap(map);
+        setLoading(false);
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+        setLoading(false);
       });
-      setWorkspacesMap(map);
-      setLoading(false);
-    });
   }, [orgid, collectionId]);
 
   return (

--- a/ui/src/domain/Settings/GlobalVariables.tsx
+++ b/ui/src/domain/Settings/GlobalVariables.tsx
@@ -141,6 +141,7 @@ export const GlobalVariablesSettings = ({ managePermission = true }: Props) => {
     axiosInstance
       .delete(`organization/${orgid}/globalvar/${id}`)
       .then((response) => {
+        message.success("Global variable deleted successfully");
         loadGlobalVariables();
       })
       .catch((err) => {
@@ -170,6 +171,7 @@ export const GlobalVariablesSettings = ({ managePermission = true }: Props) => {
         },
       })
       .then((response) => {
+        message.success("Global variable created successfully");
         loadGlobalVariables();
         setVisible(false);
         form.resetFields();
@@ -201,6 +203,7 @@ export const GlobalVariablesSettings = ({ managePermission = true }: Props) => {
         },
       })
       .then((response) => {
+        message.success("Global variable updated successfully");
         loadGlobalVariables();
         setVisible(false);
         form.resetFields();

--- a/ui/src/domain/Settings/VCS.tsx
+++ b/ui/src/domain/Settings/VCS.tsx
@@ -115,6 +115,7 @@ export const VCSSettings = ({ vcsMode, managePermission = true }: Props) => {
           axiosInstance
             .delete(`organization/${orgid}/vcs/${id}`)
             .then(() => {
+              message.success("VCS provider deleted successfully");
               loadVCS();
             })
             .catch((err) => {

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -782,9 +782,7 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
                         <Divider />
                         <h4>Project</h4>
                         {projectName && projectId ? (
-                          <Link to={`/organizations/${organizationId}/projects/${projectId}`}>
-                            {projectName}
-                          </Link>
+                          <Link to={`/organizations/${organizationId}/projects/${projectId}`}>{projectName}</Link>
                         ) : (
                           <Typography.Text type="secondary">No project</Typography.Text>
                         )}
@@ -826,10 +824,19 @@ export const WorkspaceDetails = ({ setOrganizationName, selectedTab }: Props) =>
                     collectionEnvVars={collectionEnvVariables}
                     globalVariables={globalVariables}
                     globalEnvVariables={globalEnvVariables}
+                    reload={() => loadWorkspace(false)}
                   />
                 </TabPane>
                 <TabPane tab="Schedules" key="5">
-                  {templates ? <Schedules schedules={schedule} manageWorkspace={manageWorkspace} /> : <p>Loading...</p>}
+                  {templates ? (
+                    <Schedules
+                      schedules={schedule}
+                      manageWorkspace={manageWorkspace}
+                      reload={() => loadWorkspace(false)}
+                    />
+                  ) : (
+                    <p>Loading...</p>
+                  )}
                 </TabPane>
                 <TabPane tab="Settings" key="6">
                   <Suspense fallback={<LoadingFallback />}>

--- a/ui/src/domain/Workspaces/Schedules.tsx
+++ b/ui/src/domain/Workspaces/Schedules.tsx
@@ -1,11 +1,11 @@
 import { ClockCircleOutlined, DeleteOutlined, EditOutlined, InfoCircleOutlined } from "@ant-design/icons";
-import { Button, Form, Input, Modal, Popconfirm, Select, Space, Table, Tag, Typography } from "antd";
+import { Button, Form, Input, message, Modal, Popconfirm, Select, Space, Table, Tag, Typography } from "antd";
 import cronstrue from "cronstrue";
 import { useEffect, useMemo, useState } from "react";
 import { Cron } from "react-js-cron";
 import "react-js-cron/dist/styles.css";
 import { ORGANIZATION_ARCHIVE, WORKSPACE_ARCHIVE } from "../../config/actionTypes";
-import axiosInstance from "../../config/axiosConfig";
+import axiosInstance, { getErrorMessage } from "../../config/axiosConfig";
 import * as C2Q from "cron-to-quartz";
 import { FlatSchedule, Template } from "../types";
 
@@ -23,9 +23,10 @@ const validateMessages = {
 type Props = {
   schedules: FlatSchedule[];
   manageWorkspace: boolean;
+  reload: () => void;
 };
 
-export const Schedules = ({ schedules, manageWorkspace }: Props) => {
+export const Schedules = ({ schedules, manageWorkspace, reload }: Props) => {
   const workspaceId = sessionStorage.getItem(WORKSPACE_ARCHIVE);
   const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
   const [form] = Form.useForm();
@@ -86,7 +87,7 @@ export const Schedules = ({ schedules, manageWorkspace }: Props) => {
               </Button>
               <Popconfirm
                 onConfirm={() => {
-                  deleteSchedule(record.id, organizationId!, workspaceId!);
+                  onDelete(record.id);
                 }}
                 title={
                   <p>
@@ -115,16 +116,22 @@ export const Schedules = ({ schedules, manageWorkspace }: Props) => {
   }, [organizationId]);
 
   const loadTemplates = () => {
-    axiosInstance.get(`organization/${organizationId}/template`).then((response) => {
-      const templatesList = response.data.data.filter(function (obj: Template) {
-        //exclude CLI based templates
-        return (
-          obj.attributes.name !== "Terraform-Plan/Apply-Cli" && obj.attributes.name !== "Terraform-Plan/Destroy-Cli"
-        );
+    axiosInstance
+      .get(`organization/${organizationId}/template`)
+      .then((response) => {
+        const templatesList = response.data.data.filter(function (obj: Template) {
+          //exclude CLI based templates
+          return (
+            obj.attributes.name !== "Terraform-Plan/Apply-Cli" && obj.attributes.name !== "Terraform-Plan/Destroy-Cli"
+          );
+        });
+        setTemplates(templatesList);
+        setLoading(false);
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+        setLoading(false);
       });
-      setTemplates(templatesList);
-      setLoading(false);
-    });
   };
 
   const onCancel = () => {
@@ -157,9 +164,14 @@ export const Schedules = ({ schedules, manageWorkspace }: Props) => {
           "Content-Type": "application/vnd.api+json",
         },
       })
-      .then((response) => {
+      .then(() => {
+        message.success("Schedule created successfully");
         setVisible(false);
         form.resetFields();
+        reload();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
       });
   };
 
@@ -181,9 +193,30 @@ export const Schedules = ({ schedules, manageWorkspace }: Props) => {
           "Content-Type": "application/vnd.api+json",
         },
       })
-      .then((response) => {
+      .then(() => {
+        message.success("Schedule updated successfully");
         setVisible(false);
         form.resetFields();
+        reload();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+      });
+  };
+
+  const onDelete = (deleteId: string) => {
+    axiosInstance
+      .delete(`organization/${organizationId}/workspace/${workspaceId}/schedule/${deleteId}`, {
+        headers: {
+          "Content-Type": "application/vnd.api+json",
+        },
+      })
+      .then(() => {
+        message.success("Schedule deleted successfully");
+        reload();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
       });
   };
 
@@ -263,16 +296,4 @@ export const Schedules = ({ schedules, manageWorkspace }: Props) => {
       </Modal>
     </div>
   );
-};
-
-const deleteSchedule = (scheduleId: string, organizationId: string, workspaceId: string) => {
-  axiosInstance
-    .delete(`organization/${organizationId}/workspace/${workspaceId}/schedule/${scheduleId}`, {
-      headers: {
-        "Content-Type": "application/vnd.api+json",
-      },
-    })
-    .then((response) => {
-      console.log(response);
-    });
 };

--- a/ui/src/domain/Workspaces/Tags.tsx
+++ b/ui/src/domain/Workspaces/Tags.tsx
@@ -1,6 +1,6 @@
-import { Select } from "antd";
+import { message, Select } from "antd";
 import { useEffect, useMemo, useState } from "react";
-import axiosInstance from "../../config/axiosConfig";
+import axiosInstance, { getErrorMessage } from "../../config/axiosConfig";
 import { Tag, ApiWorkspaceTag } from "../types";
 type Props = {
   organizationId: string;
@@ -58,10 +58,16 @@ export const Tags = ({ organizationId, workspaceId, manageWorkspace }: Props) =>
             .then((response) => {
               setTags((prev) => [...prev, response.data?.data]);
               addTagToWorkspace(response.data?.data?.id);
+            })
+            .catch((err) => {
+              message.error(getErrorMessage(err));
             });
         } else {
           addTagToWorkspace(existingTagId);
         }
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
       });
   };
   const addTagToWorkspace = (tagId: string) => {
@@ -82,6 +88,9 @@ export const Tags = ({ organizationId, workspaceId, manageWorkspace }: Props) =>
       })
       .then((response) => {
         setCurrentTags((prev) => [...prev, response.data.data]);
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
       });
   };
   const handleDeselect = (tagId: string) => {
@@ -92,12 +101,17 @@ export const Tags = ({ organizationId, workspaceId, manageWorkspace }: Props) =>
 
     const id = currentTags.find((x) => x.attributes.tagId === currentTag)?.id;
 
-    axiosInstance.delete(`organization/${organizationId}/workspace/${workspaceId}/workspaceTag/${id}`).then(() => {
-      const currentTagsFilter = currentTags.filter(function (x) {
-        return x.id !== id;
+    axiosInstance
+      .delete(`organization/${organizationId}/workspace/${workspaceId}/workspaceTag/${id}`)
+      .then(() => {
+        const currentTagsFilter = currentTags.filter(function (x) {
+          return x.id !== id;
+        });
+        setCurrentTags(currentTagsFilter);
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
       });
-      setCurrentTags(currentTagsFilter);
-    });
   };
 
   function isGuid(value: string) {
@@ -106,13 +120,25 @@ export const Tags = ({ organizationId, workspaceId, manageWorkspace }: Props) =>
     return match != null;
   }
   const loadTags = () => {
-    axiosInstance.get(`organization/${organizationId}/workspace/${workspaceId}/workspaceTag`).then((response) => {
-      setCurrentTags(response.data.data);
-      axiosInstance.get(`organization/${organizationId}/tag`).then((res) => {
-        setTags(res.data.data);
+    axiosInstance
+      .get(`organization/${organizationId}/workspace/${workspaceId}/workspaceTag`)
+      .then((response) => {
+        setCurrentTags(response.data.data);
+        axiosInstance
+          .get(`organization/${organizationId}/tag`)
+          .then((res) => {
+            setTags(res.data.data);
+            setLoading(false);
+          })
+          .catch((err) => {
+            message.error(getErrorMessage(err));
+            setLoading(false);
+          });
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
         setLoading(false);
       });
-    });
   };
   useEffect(() => {
     loadTags();

--- a/ui/src/domain/Workspaces/Variables.tsx
+++ b/ui/src/domain/Workspaces/Variables.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Form,
   Input,
+  message,
   Modal,
   Popconfirm,
   Radio,
@@ -17,13 +18,12 @@ import {
 } from "antd";
 import { useState } from "react";
 import { ORGANIZATION_ARCHIVE, WORKSPACE_ARCHIVE } from "../../config/actionTypes";
-import axiosInstance from "../../config/axiosConfig";
+import axiosInstance, { getErrorMessage } from "../../config/axiosConfig";
 import { CreateVariableForm, FlatVariable } from "../types";
 
 const VARIABLES_COLUMS = (
-  organizationId: string,
-  workspaceId: string,
   onEdit: (variable: FlatVariable) => void,
+  onDelete: (variableId: string) => void,
   manageWorkspace: boolean
 ) => [
   {
@@ -97,7 +97,7 @@ const VARIABLES_COLUMS = (
           </Button>
           <Popconfirm
             onConfirm={() => {
-              deleteVariable(record.id, organizationId, workspaceId);
+              onDelete(record.id);
             }}
             title={
               <p>
@@ -250,6 +250,7 @@ type Props = {
   collectionEnvVars: any[];
   globalVariables: FlatVariable[];
   globalEnvVariables: FlatVariable[];
+  reload: () => void;
 };
 
 export const Variables = ({
@@ -260,6 +261,7 @@ export const Variables = ({
   collectionEnvVars,
   globalVariables,
   globalEnvVariables,
+  reload,
 }: Props) => {
   const workspaceId = sessionStorage.getItem(WORKSPACE_ARCHIVE);
   const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
@@ -309,9 +311,14 @@ export const Variables = ({
           "Content-Type": "application/vnd.api+json",
         },
       })
-      .then((response) => {
+      .then(() => {
+        message.success("Variable created successfully");
         setVisible(false);
         form.resetFields();
+        reload();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
       });
   };
 
@@ -337,9 +344,30 @@ export const Variables = ({
           "Content-Type": "application/vnd.api+json",
         },
       })
-      .then((response) => {
+      .then(() => {
+        message.success("Variable updated successfully");
         setVisible(false);
         form.resetFields();
+        reload();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+      });
+  };
+
+  const onDelete = (deleteId: string) => {
+    axiosInstance
+      .delete(`organization/${organizationId}/workspace/${workspaceId}/variable/${deleteId}`, {
+        headers: {
+          "Content-Type": "application/vnd.api+json",
+        },
+      })
+      .then(() => {
+        message.success("Variable deleted successfully");
+        reload();
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
       });
   };
 
@@ -389,7 +417,7 @@ export const Variables = ({
 
       <Table
         dataSource={workspaceVariables}
-        columns={VARIABLES_COLUMS(organizationId!, workspaceId!, onEdit, manageWorkspace)}
+        columns={VARIABLES_COLUMS(onEdit, onDelete, manageWorkspace)}
         rowKey="key"
       />
       <Button
@@ -527,16 +555,4 @@ export const Variables = ({
       </Modal>
     </div>
   );
-};
-
-const deleteVariable = (variableId: string, organizationId: string, workspaceId: string) => {
-  axiosInstance
-    .delete(`organization/${organizationId}/workspace/${workspaceId}/variable/${variableId}`, {
-      headers: {
-        "Content-Type": "application/vnd.api+json",
-      },
-    })
-    .then((response) => {
-      console.log(response);
-    });
 };


### PR DESCRIPTION
## Problem

Adding, updating, or deleting a variable on a workspace gave no feedback and the variables table didn't refresh — users had to manually reload the page to see whether their change actually saved. The same "silent mutation" pattern also existed across several other CRUD screens in the UI: workspace Schedules, workspace Tags, Agents, Templates, VCS Providers, Global Variables, and Collection Items/References.

Fixes #3330

## Fix

- Workspace **Variables** and **Schedules**: added success/error toasts and wired a `reload` callback (via `Details.tsx`'s `loadWorkspace`) so the table refreshes automatically after create/update/delete
- Workspace **Tags**: added error toasts — failures were previously swallowed silently
- **Agents**, **Templates**, **VCS Providers**, **Global Variables**: added missing success toasts (the list already refreshed on save, but users had no confirmation it worked)
- **Collection Items** and **Collection References**: added full success/error toast handling, previously had neither
- Added error handling to remaining data-load calls that lacked a `.catch` (workspace tags, schedule templates, collection references initial load), so failed loads now surface an error instead of failing silently

All changes follow the existing codebase convention: `axiosInstance.<verb>(...).then(() => { message.success(...); reload(); }).catch(err => message.error(getErrorMessage(err)))`.

## Testing

- `yarn build` passes cleanly
- `tsc -b --noEmit` shows no new type errors (pre-existing error count went from 111 to 107, a net improvement)
- `eslint` shows no new lint errors introduced by these changes
- Manually verified in the workspace Variables tab that add/edit/delete now show a toast and refresh the table without a page reload