### PR TITLE
feat(vcs): add repository auto-discovery for workspace creation

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/controller/VcsRepositoryController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/controller/VcsRepositoryController.java
@@ -1,0 +1,73 @@
+package io.terrakube.api.plugin.vcs.controller;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.terrakube.api.plugin.vcs.discovery.VcsDiscoveryNotSupportedException;
+import io.terrakube.api.plugin.vcs.discovery.VcsGroupSummary;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryDiscoveryFacade;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryPage;
+import io.terrakube.api.repository.VcsRepository;
+import io.terrakube.api.rs.vcs.Vcs;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/vcs/v1")
+public class VcsRepositoryController {
+
+    private final VcsRepositoryDiscoveryFacade discoveryFacade;
+    private final VcsRepository vcsRepository;
+
+    public VcsRepositoryController(VcsRepositoryDiscoveryFacade discoveryFacade, VcsRepository vcsRepository) {
+        this.discoveryFacade = discoveryFacade;
+        this.vcsRepository = vcsRepository;
+    }
+
+    @GetMapping("/{vcsId}/groups")
+    @PreAuthorize("@vcsRepositoryAccessService.hasViewPermission(authentication, #vcsId)")
+    public ResponseEntity<List<VcsGroupSummary>> listGroups(@PathVariable String vcsId) {
+        Vcs vcs = vcsRepository.findById(UUID.fromString(vcsId)).orElse(null);
+        if (vcs == null) {
+            return ResponseEntity.notFound().build();
+        }
+        try {
+            return ResponseEntity.ok(discoveryFacade.listGroups(vcs));
+        } catch (VcsDiscoveryNotSupportedException e) {
+            return ResponseEntity.unprocessableEntity().body(List.of());
+        } catch (Exception e) {
+            log.error("Error listing VCS groups for vcs {}: {}", vcsId, e.getMessage());
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @GetMapping("/{vcsId}/repositories")
+    @PreAuthorize("@vcsRepositoryAccessService.hasViewPermission(authentication, #vcsId)")
+    public ResponseEntity<VcsRepositoryPage> listRepositories(@PathVariable String vcsId,
+            @RequestParam String group,
+            @RequestParam(required = false, defaultValue = "") String search,
+            @RequestParam(required = false, defaultValue = "1") int page) {
+        Vcs vcs = vcsRepository.findById(UUID.fromString(vcsId)).orElse(null);
+        if (vcs == null) {
+            return ResponseEntity.notFound().build();
+        }
+        try {
+            return ResponseEntity.ok(discoveryFacade.listRepositories(vcs, group, search, page));
+        } catch (VcsDiscoveryNotSupportedException e) {
+            return ResponseEntity.unprocessableEntity()
+                    .body(VcsRepositoryPage.builder().items(List.of()).page(page).hasMore(false).build());
+        } catch (Exception e) {
+            log.error("Error listing repositories for vcs {}: {}", vcsId, e.getMessage());
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/VcsDiscoveryNotSupportedException.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/VcsDiscoveryNotSupportedException.java
@@ -1,0 +1,7 @@
+package io.terrakube.api.plugin.vcs.discovery;
+
+public class VcsDiscoveryNotSupportedException extends RuntimeException {
+    public VcsDiscoveryNotSupportedException(String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/VcsGroupSummary.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/VcsGroupSummary.java
@@ -1,0 +1,15 @@
+package io.terrakube.api.plugin.vcs.discovery;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class VcsGroupSummary {
+    private String id;
+    private String name;
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/VcsRepositoryAccessService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/VcsRepositoryAccessService.java
@@ -1,0 +1,56 @@
+package io.terrakube.api.plugin.vcs.discovery;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.repository.TeamRepository;
+import io.terrakube.api.repository.VcsRepository;
+import io.terrakube.api.rs.team.Team;
+import io.terrakube.api.rs.vcs.Vcs;
+
+@Service
+public class VcsRepositoryAccessService {
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private VcsRepository vcsRepository;
+
+    @Autowired
+    private RbacService rbacService;
+
+    @Transactional
+    public boolean hasViewPermission(Authentication authentication, String vcsId) {
+        if (((JwtAuthenticationToken) authentication).getTokenAttributes().get("iss").equals("TerrakubeInternal")) {
+            return true;
+        }
+
+        Vcs vcs = vcsRepository.findById(UUID.fromString(vcsId)).orElse(null);
+        if (vcs == null || vcs.getOrganization() == null) {
+            return false;
+        }
+
+        Object groupNames = ((JwtAuthenticationToken) authentication).getTokenAttributes().get("groups");
+        if (groupNames == null) {
+            return false;
+        }
+
+        @SuppressWarnings("unchecked")
+        List<Team> teams = teamRepository.findAllByOrganizationIdAndNameIn(vcs.getOrganization().getId(),
+                (List<String>) groupNames);
+        for (Team team : teams) {
+            if (rbacService.canManageVcs(team) || rbacService.canManageWorkspace(team)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/VcsRepositoryDiscoveryFacade.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/VcsRepositoryDiscoveryFacade.java
@@ -1,0 +1,53 @@
+package io.terrakube.api.plugin.vcs.discovery;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import io.terrakube.api.plugin.vcs.discovery.azdevops.AzDevOpsRepositoryDiscoveryService;
+import io.terrakube.api.plugin.vcs.discovery.bitbucket.BitbucketRepositoryDiscoveryService;
+import io.terrakube.api.plugin.vcs.discovery.github.GitHubRepositoryDiscoveryService;
+import io.terrakube.api.plugin.vcs.discovery.gitlab.GitLabRepositoryDiscoveryService;
+import io.terrakube.api.rs.vcs.Vcs;
+
+@Service
+public class VcsRepositoryDiscoveryFacade {
+
+    private final GitHubRepositoryDiscoveryService gitHubService;
+    private final GitLabRepositoryDiscoveryService gitLabService;
+    private final BitbucketRepositoryDiscoveryService bitbucketService;
+    private final AzDevOpsRepositoryDiscoveryService azDevOpsService;
+
+    public VcsRepositoryDiscoveryFacade(GitHubRepositoryDiscoveryService gitHubService,
+            GitLabRepositoryDiscoveryService gitLabService,
+            BitbucketRepositoryDiscoveryService bitbucketService,
+            AzDevOpsRepositoryDiscoveryService azDevOpsService) {
+        this.gitHubService = gitHubService;
+        this.gitLabService = gitLabService;
+        this.bitbucketService = bitbucketService;
+        this.azDevOpsService = azDevOpsService;
+    }
+
+    public List<VcsGroupSummary> listGroups(Vcs vcs) {
+        return provider(vcs).listGroups(vcs);
+    }
+
+    public VcsRepositoryPage listRepositories(Vcs vcs, String group, String search, int page) {
+        return provider(vcs).listRepositories(vcs, group, search, page);
+    }
+
+    private VcsRepositoryDiscoveryProvider provider(Vcs vcs) {
+        switch (vcs.getVcsType()) {
+            case GITHUB:
+                return gitHubService;
+            case GITLAB:
+                return gitLabService;
+            case BITBUCKET:
+                return bitbucketService;
+            case AZURE_DEVOPS:
+                return azDevOpsService;
+            default:
+                throw new VcsDiscoveryNotSupportedException("Repository discovery is not supported for this VCS connection type");
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/VcsRepositoryDiscoveryProvider.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/VcsRepositoryDiscoveryProvider.java
@@ -1,0 +1,12 @@
+package io.terrakube.api.plugin.vcs.discovery;
+
+import java.util.List;
+
+import io.terrakube.api.rs.vcs.Vcs;
+
+public interface VcsRepositoryDiscoveryProvider {
+
+    List<VcsGroupSummary> listGroups(Vcs vcs);
+
+    VcsRepositoryPage listRepositories(Vcs vcs, String group, String search, int page);
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/VcsRepositoryPage.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/VcsRepositoryPage.java
@@ -1,0 +1,18 @@
+package io.terrakube.api.plugin.vcs.discovery;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class VcsRepositoryPage {
+    private List<VcsRepositorySummary> items;
+    private boolean hasMore;
+    private int page;
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/VcsRepositorySummary.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/VcsRepositorySummary.java
@@ -1,0 +1,19 @@
+package io.terrakube.api.plugin.vcs.discovery;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class VcsRepositorySummary {
+    private String name;
+    private String fullName;
+    private String group;
+    private String url;
+    private boolean privateRepo;
+    private String defaultBranch;
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/azdevops/AzDevOpsRepositoryDiscoveryService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/azdevops/AzDevOpsRepositoryDiscoveryService.java
@@ -1,0 +1,138 @@
+package io.terrakube.api.plugin.vcs.discovery.azdevops;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import io.terrakube.api.plugin.vcs.discovery.VcsDiscoveryNotSupportedException;
+import io.terrakube.api.plugin.vcs.discovery.VcsGroupSummary;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryDiscoveryProvider;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryPage;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositorySummary;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.vcs.VcsType;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class AzDevOpsRepositoryDiscoveryService implements VcsRepositoryDiscoveryProvider {
+
+    private static final int PAGE_SIZE = 50;
+    private final ObjectMapper objectMapper;
+
+    // Overridable in tests (WireMock can't stand in for the real Microsoft hostname)
+    @Value("${io.terrakube.vcs.azuredevops.profile-endpoint:https://app.vssps.visualstudio.com}")
+    private String profileEndpoint;
+
+    // Azure DevOps' "list repositories" endpoint has no server-side search or pagination, so every
+    // keystroke in the UI search box would otherwise re-fetch the entire org's repo list. Cache the
+    // raw per-org response briefly so browsing/searching within an org only round-trips to Azure once.
+    private final Cache<String, JsonNode> repositoryListCache = Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofSeconds(60))
+            .maximumSize(200)
+            .build();
+
+    public AzDevOpsRepositoryDiscoveryService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<VcsGroupSummary> listGroups(Vcs vcs) {
+        requireOAuth(vcs);
+
+        JsonNode profile = callApi(profileEndpoint + "/_apis/profile/profiles/me?api-version=6.0", vcs.getAccessToken()).orElse(null);
+        if (profile == null) {
+            return new ArrayList<>();
+        }
+        String memberId = profile.path("id").asText();
+
+        JsonNode accounts = callApi(profileEndpoint + "/_apis/accounts?memberId=" + memberId + "&api-version=6.0",
+                vcs.getAccessToken()).orElse(null);
+        List<VcsGroupSummary> groups = new ArrayList<>();
+        if (accounts != null) {
+            for (JsonNode account : accounts.path("value")) {
+                groups.add(VcsGroupSummary.builder()
+                        .id(account.path("accountName").asText())
+                        .name(account.path("accountName").asText())
+                        .build());
+            }
+        }
+        return groups;
+    }
+
+    @Override
+    public VcsRepositoryPage listRepositories(Vcs vcs, String group, String search, int page) {
+        requireOAuth(vcs);
+
+        String cacheKey = vcs.getId() + "/" + group;
+        JsonNode response = repositoryListCache.get(cacheKey, key -> {
+            String url = vcs.getApiUrl() + "/" + group + "/_apis/git/repositories?api-version=6.0";
+            return callApi(url, vcs.getAccessToken()).orElse(null);
+        });
+
+        List<VcsRepositorySummary> matches = new ArrayList<>();
+        if (response != null) {
+            String lowerSearch = search == null ? "" : search.toLowerCase();
+            for (JsonNode repo : response.path("value")) {
+                String name = repo.path("name").asText();
+                if (lowerSearch.isEmpty() || name.toLowerCase().contains(lowerSearch)) {
+                    matches.add(toSummary(repo, group));
+                }
+            }
+        }
+
+        int fromIndex = Math.min((Math.max(page, 1) - 1) * PAGE_SIZE, matches.size());
+        int toIndex = Math.min(fromIndex + PAGE_SIZE, matches.size());
+        List<VcsRepositorySummary> pageItems = new ArrayList<>(matches.subList(fromIndex, toIndex));
+        return VcsRepositoryPage.builder().items(pageItems).page(page).hasMore(toIndex < matches.size()).build();
+    }
+
+    private void requireOAuth(Vcs vcs) {
+        if (vcs.getVcsType() != VcsType.AZURE_DEVOPS || vcs.getAccessToken() == null || vcs.getAccessToken().isEmpty()) {
+            throw new VcsDiscoveryNotSupportedException(
+                    "Repository discovery requires an OAuth Azure DevOps connection; managed-identity connections must enter the repository URL manually");
+        }
+    }
+
+    private VcsRepositorySummary toSummary(JsonNode repo, String org) {
+        return VcsRepositorySummary.builder()
+                .name(repo.path("name").asText())
+                .fullName(org + "/" + repo.path("project").path("name").asText() + "/" + repo.path("name").asText())
+                .group(org)
+                .url(repo.path("remoteUrl").asText())
+                .privateRepo(true)
+                .defaultBranch(repo.path("defaultBranch").asText(null))
+                .build();
+    }
+
+    private Optional<JsonNode> callApi(String url, String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + token);
+        try {
+            RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                return Optional.of(objectMapper.readTree(response.getBody()));
+            }
+        } catch (Exception e) {
+            log.error("Error calling Azure DevOps API {}: {}", url, e.getMessage());
+        }
+        return Optional.empty();
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/bitbucket/BitbucketRepositoryDiscoveryService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/bitbucket/BitbucketRepositoryDiscoveryService.java
@@ -1,0 +1,180 @@
+package io.terrakube.api.plugin.vcs.discovery.bitbucket;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.terrakube.api.plugin.vcs.discovery.VcsGroupSummary;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryDiscoveryProvider;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryPage;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositorySummary;
+import io.terrakube.api.rs.vcs.Vcs;
+
+import lombok.extern.slf4j.Slf4j;
+
+// Bitbucket Cloud and Bitbucket Server (on-premise/Data Center) are both stored with vcsType=BITBUCKET
+// (see AddVCS.tsx) and are only distinguishable by apiUrl: Cloud always uses api.bitbucket.org, while
+// Server instances point at a customer-hosted host with a completely different REST API shape.
+@Slf4j
+@Service
+public class BitbucketRepositoryDiscoveryService implements VcsRepositoryDiscoveryProvider {
+
+    private static final int PAGE_SIZE = 50;
+    private final ObjectMapper objectMapper;
+
+    public BitbucketRepositoryDiscoveryService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    private boolean isCloud(Vcs vcs) {
+        return vcs.getApiUrl() != null && vcs.getApiUrl().contains("api.bitbucket.org");
+    }
+
+    @Override
+    public List<VcsGroupSummary> listGroups(Vcs vcs) {
+        return isCloud(vcs) ? listCloudWorkspaces(vcs) : listServerProjects(vcs, null);
+    }
+
+    @Override
+    public VcsRepositoryPage listRepositories(Vcs vcs, String group, String search, int page) {
+        return isCloud(vcs) ? listCloudRepositories(vcs, group, search, page) : listServerRepositories(vcs, group, search, page);
+    }
+
+    private List<VcsGroupSummary> listCloudWorkspaces(Vcs vcs) {
+        String url = UriComponentsBuilder.fromHttpUrl(vcs.getApiUrl() + "/workspaces")
+                .queryParam("role", "member")
+                .queryParam("pagelen", 100)
+                .toUriString();
+        JsonNode response = callApi(url, vcs.getAccessToken()).orElse(null);
+        List<VcsGroupSummary> groups = new ArrayList<>();
+        if (response != null) {
+            for (JsonNode workspace : response.path("values")) {
+                groups.add(VcsGroupSummary.builder()
+                        .id(workspace.path("slug").asText())
+                        .name(workspace.path("name").asText())
+                        .build());
+            }
+        }
+        return groups;
+    }
+
+    private VcsRepositoryPage listCloudRepositories(Vcs vcs, String group, String search, int page) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(vcs.getApiUrl() + "/repositories/" + group)
+                .queryParam("pagelen", PAGE_SIZE)
+                .queryParam("page", page)
+                .queryParam("sort", "name");
+        if (search != null && !search.isBlank()) {
+            builder.queryParam("q", "name~\"" + search.replace("\"", "") + "\"");
+        }
+        JsonNode response = callApi(builder.toUriString(), vcs.getAccessToken()).orElse(null);
+        List<VcsRepositorySummary> items = new ArrayList<>();
+        if (response != null) {
+            for (JsonNode repo : response.path("values")) {
+                items.add(VcsRepositorySummary.builder()
+                        .name(repo.path("name").asText())
+                        .fullName(repo.path("full_name").asText())
+                        .group(group)
+                        .url(extractCloudCloneUrl(repo))
+                        .privateRepo(repo.path("is_private").asBoolean())
+                        .defaultBranch(repo.path("mainbranch").path("name").asText(null))
+                        .build());
+            }
+        }
+        boolean hasMore = response != null && response.hasNonNull("next");
+        return VcsRepositoryPage.builder().items(items).page(page).hasMore(hasMore).build();
+    }
+
+    private String extractCloudCloneUrl(JsonNode repo) {
+        for (JsonNode link : repo.path("links").path("clone")) {
+            if ("https".equals(link.path("name").asText())) {
+                return link.path("href").asText();
+            }
+        }
+        return repo.path("links").path("html").path("href").asText() + ".git";
+    }
+
+    private List<VcsGroupSummary> listServerProjects(Vcs vcs, String search) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(vcs.getApiUrl() + "/projects")
+                .queryParam("limit", 100);
+        if (search != null && !search.isBlank()) {
+            builder.queryParam("name", search);
+        }
+        JsonNode response = callApi(builder.toUriString(), vcs.getAccessToken()).orElse(null);
+        List<VcsGroupSummary> groups = new ArrayList<>();
+        if (response != null) {
+            for (JsonNode project : response.path("values")) {
+                groups.add(VcsGroupSummary.builder()
+                        .id(project.path("key").asText())
+                        .name(project.path("name").asText())
+                        .build());
+            }
+        }
+        return groups;
+    }
+
+    private VcsRepositoryPage listServerRepositories(Vcs vcs, String group, String search, int page) {
+        int start = (Math.max(page, 1) - 1) * PAGE_SIZE;
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromHttpUrl(vcs.getApiUrl() + "/projects/" + group + "/repos")
+                .queryParam("start", start)
+                .queryParam("limit", PAGE_SIZE);
+        if (search != null && !search.isBlank()) {
+            builder.queryParam("name", search);
+        }
+        JsonNode response = callApi(builder.toUriString(), vcs.getAccessToken()).orElse(null);
+        List<VcsRepositorySummary> items = new ArrayList<>();
+        if (response != null) {
+            for (JsonNode repo : response.path("values")) {
+                items.add(VcsRepositorySummary.builder()
+                        .name(repo.path("name").asText())
+                        .fullName(group + "/" + repo.path("slug").asText())
+                        .group(group)
+                        .url(extractServerCloneUrl(repo))
+                        .privateRepo(true)
+                        .defaultBranch(null)
+                        .build());
+            }
+        }
+        boolean hasMore = response != null && !response.path("isLastPage").asBoolean(true);
+        return VcsRepositoryPage.builder().items(items).page(page).hasMore(hasMore).build();
+    }
+
+    private String extractServerCloneUrl(JsonNode repo) {
+        for (JsonNode link : repo.path("links").path("clone")) {
+            if ("http".equalsIgnoreCase(link.path("name").asText()) || "https".equalsIgnoreCase(link.path("name").asText())) {
+                return link.path("href").asText();
+            }
+        }
+        if (repo.path("links").path("clone").isArray() && repo.path("links").path("clone").size() > 0) {
+            return repo.path("links").path("clone").get(0).path("href").asText();
+        }
+        return "";
+    }
+
+    private Optional<JsonNode> callApi(String url, String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + token);
+        try {
+            RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                return Optional.of(objectMapper.readTree(response.getBody()));
+            }
+        } catch (Exception e) {
+            log.error("Error calling Bitbucket API {}: {}", url, e.getMessage());
+        }
+        return Optional.empty();
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/github/GitHubRepositoryDiscoveryService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/github/GitHubRepositoryDiscoveryService.java
@@ -1,0 +1,249 @@
+package io.terrakube.api.plugin.vcs.discovery.github;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.terrakube.api.plugin.vcs.discovery.VcsDiscoveryNotSupportedException;
+import io.terrakube.api.plugin.vcs.discovery.VcsGroupSummary;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryDiscoveryProvider;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryPage;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositorySummary;
+import io.terrakube.api.plugin.vcs.provider.github.GitHubTokenService;
+import io.terrakube.api.rs.vcs.Vcs;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class GitHubRepositoryDiscoveryService implements VcsRepositoryDiscoveryProvider {
+
+    private static final int PAGE_SIZE = 50;
+    private static final String PERSONAL_ACCOUNT_GROUP = "@me";
+
+    private final GitHubTokenService gitHubTokenService;
+    private final ObjectMapper objectMapper;
+
+    public GitHubRepositoryDiscoveryService(GitHubTokenService gitHubTokenService, ObjectMapper objectMapper) {
+        this.gitHubTokenService = gitHubTokenService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<VcsGroupSummary> listGroups(Vcs vcs) {
+        if (isOAuth(vcs)) {
+            return listOAuthGroups(vcs);
+        }
+        return listAppInstallationGroups(vcs);
+    }
+
+    @Override
+    public VcsRepositoryPage listRepositories(Vcs vcs, String group, String search, int page) {
+        if (isOAuth(vcs)) {
+            return listOAuthRepositories(vcs, group, search, page);
+        }
+        return listAppRepositories(vcs, group, search, page);
+    }
+
+    private boolean isOAuth(Vcs vcs) {
+        return vcs.getAccessToken() != null && !vcs.getAccessToken().isEmpty();
+    }
+
+    private List<VcsGroupSummary> listOAuthGroups(Vcs vcs) {
+        List<VcsGroupSummary> groups = new ArrayList<>();
+
+        JsonNode me = callApi(vcs.getApiUrl() + "/user", vcs.getAccessToken()).orElse(null);
+        if (me != null) {
+            groups.add(VcsGroupSummary.builder().id(PERSONAL_ACCOUNT_GROUP).name(me.path("login").asText() + " (personal)").build());
+        }
+
+        JsonNode orgs = callApi(vcs.getApiUrl() + "/user/orgs?per_page=100", vcs.getAccessToken()).orElse(null);
+        if (orgs != null) {
+            for (JsonNode org : orgs) {
+                String login = org.path("login").asText();
+                groups.add(VcsGroupSummary.builder().id(login).name(login).build());
+            }
+        }
+
+        return groups;
+    }
+
+    private VcsRepositoryPage listOAuthRepositories(Vcs vcs, String group, String search, int page) {
+        String url;
+        if (search != null && !search.isBlank()) {
+            String scopedGroup = PERSONAL_ACCOUNT_GROUP.equals(group) ? null : group;
+            String query = search + " in:name" + (scopedGroup != null ? " user:" + scopedGroup : "");
+            url = UriComponentsBuilder.fromHttpUrl(vcs.getApiUrl() + "/search/repositories")
+                    .queryParam("q", query)
+                    .queryParam("per_page", PAGE_SIZE)
+                    .queryParam("page", page)
+                    .toUriString();
+            JsonNode response = callApi(url, vcs.getAccessToken()).orElse(null);
+            if (response == null) {
+                return emptyPage(page);
+            }
+            List<VcsRepositorySummary> items = new ArrayList<>();
+            for (JsonNode repo : response.path("items")) {
+                items.add(toSummary(repo));
+            }
+            return VcsRepositoryPage.builder().items(items).page(page)
+                    .hasMore(response.path("total_count").asInt() > page * PAGE_SIZE).build();
+        }
+
+        if (PERSONAL_ACCOUNT_GROUP.equals(group)) {
+            url = UriComponentsBuilder.fromHttpUrl(vcs.getApiUrl() + "/user/repos")
+                    .queryParam("affiliation", "owner")
+                    .queryParam("per_page", PAGE_SIZE)
+                    .queryParam("page", page)
+                    .toUriString();
+        } else {
+            url = UriComponentsBuilder.fromHttpUrl(vcs.getApiUrl() + "/orgs/" + group + "/repos")
+                    .queryParam("per_page", PAGE_SIZE)
+                    .queryParam("page", page)
+                    .toUriString();
+        }
+
+        JsonNode response = callApi(url, vcs.getAccessToken()).orElse(null);
+        if (response == null) {
+            return emptyPage(page);
+        }
+        List<VcsRepositorySummary> items = new ArrayList<>();
+        for (JsonNode repo : response) {
+            items.add(toSummary(repo));
+        }
+        return VcsRepositoryPage.builder().items(items).page(page).hasMore(items.size() == PAGE_SIZE).build();
+    }
+
+    private List<VcsGroupSummary> listAppInstallationGroups(Vcs vcs) {
+        if (vcs.getPrivateKey() == null || vcs.getPrivateKey().isEmpty()) {
+            throw new VcsDiscoveryNotSupportedException("Repository discovery is not supported for this VCS connection");
+        }
+        String jws = generateAppJwt(vcs);
+        List<VcsGroupSummary> groups = new ArrayList<>();
+        JsonNode response = callAppApi(vcs.getApiUrl() + "/app/installations", jws).orElse(null);
+        if (response != null) {
+            for (JsonNode installation : response) {
+                groups.add(VcsGroupSummary.builder()
+                        .id(installation.path("id").asText())
+                        .name(installation.path("account").path("login").asText())
+                        .build());
+            }
+        }
+        return groups;
+    }
+
+    private VcsRepositoryPage listAppRepositories(Vcs vcs, String installationId, String search, int page) {
+        String jws = generateAppJwt(vcs);
+        JsonNode installation = callAppApi(vcs.getApiUrl() + "/app/installations/" + installationId, jws).orElse(null);
+        String owner = installation != null ? installation.path("account").path("login").asText() : "";
+
+        String installationToken;
+        try {
+            installationToken = gitHubTokenService.getInstallationToken(installationId, vcs.getApiUrl(), jws, owner);
+        } catch (Exception e) {
+            log.error("Error fetching GitHub App installation token for installation {}: {}", installationId, e.getMessage());
+            return emptyPage(page);
+        }
+
+        if (search == null || search.isBlank()) {
+            String url = UriComponentsBuilder.fromHttpUrl(vcs.getApiUrl() + "/installation/repositories")
+                    .queryParam("per_page", PAGE_SIZE)
+                    .queryParam("page", page)
+                    .toUriString();
+            JsonNode response = callApi(url, installationToken).orElse(null);
+            List<VcsRepositorySummary> items = new ArrayList<>();
+            if (response != null) {
+                for (JsonNode repo : response.path("repositories")) {
+                    items.add(toSummary(repo));
+                }
+            }
+            return VcsRepositoryPage.builder().items(items).page(page).hasMore(items.size() == PAGE_SIZE).build();
+        }
+
+        // The installation-repositories endpoint doesn't support server-side search. Rather than
+        // scanning a fixed number of pages up front (which would silently miss matches in larger
+        // installations), each "page" the UI asks for maps directly to one provider page that we
+        // filter here; hasMore reflects whether that provider page was full, so repeatedly clicking
+        // "Load more" keeps scanning forward until the whole installation has been covered.
+        String url = UriComponentsBuilder.fromHttpUrl(vcs.getApiUrl() + "/installation/repositories")
+                .queryParam("per_page", PAGE_SIZE)
+                .queryParam("page", page)
+                .toUriString();
+        JsonNode response = callApi(url, installationToken).orElse(null);
+        List<VcsRepositorySummary> matches = new ArrayList<>();
+        int count = 0;
+        if (response != null) {
+            String lowerSearch = search.toLowerCase();
+            for (JsonNode repo : response.path("repositories")) {
+                count++;
+                if (repo.path("name").asText("").toLowerCase().contains(lowerSearch)) {
+                    matches.add(toSummary(repo));
+                }
+            }
+        }
+        return VcsRepositoryPage.builder().items(matches).page(page).hasMore(count == PAGE_SIZE).build();
+    }
+
+    private String generateAppJwt(Vcs vcs) {
+        try {
+            return gitHubTokenService.generateAppJwt(vcs);
+        } catch (Exception e) {
+            log.error("Error generating GitHub App JWT for vcs {}: {}", vcs.getId(), e.getMessage());
+            throw new VcsDiscoveryNotSupportedException("Unable to authenticate with GitHub App credentials");
+        }
+    }
+
+    private VcsRepositorySummary toSummary(JsonNode repo) {
+        return VcsRepositorySummary.builder()
+                .name(repo.path("name").asText())
+                .fullName(repo.path("full_name").asText())
+                .group(repo.path("owner").path("login").asText())
+                .url(repo.path("clone_url").asText(repo.path("html_url").asText() + ".git"))
+                .privateRepo(repo.path("private").asBoolean())
+                .defaultBranch(repo.path("default_branch").asText(null))
+                .build();
+    }
+
+    private VcsRepositoryPage emptyPage(int page) {
+        return VcsRepositoryPage.builder().items(new ArrayList<>()).page(page).hasMore(false).build();
+    }
+
+    private java.util.Optional<JsonNode> callApi(String url, String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", "application/vnd.github+json");
+        headers.set("Authorization", "Bearer " + token);
+        headers.set("X-GitHub-Api-Version", "2022-11-28");
+        return execute(url, headers);
+    }
+
+    private java.util.Optional<JsonNode> callAppApi(String url, String jws) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", "application/vnd.github+json");
+        headers.set("Authorization", "Bearer " + jws);
+        headers.set("X-GitHub-Api-Version", "2022-11-28");
+        return execute(url, headers);
+    }
+
+    private java.util.Optional<JsonNode> execute(String url, HttpHeaders headers) {
+        try {
+            RestTemplate restTemplate = gitHubTokenService.getRestTemplateWithProxy();
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                return java.util.Optional.of(objectMapper.readTree(response.getBody()));
+            }
+        } catch (Exception e) {
+            log.error("Error calling GitHub API {}: {}", url, e.getMessage());
+        }
+        return java.util.Optional.empty();
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/gitlab/GitLabRepositoryDiscoveryService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/discovery/gitlab/GitLabRepositoryDiscoveryService.java
@@ -1,0 +1,121 @@
+package io.terrakube.api.plugin.vcs.discovery.gitlab;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.terrakube.api.plugin.vcs.discovery.VcsGroupSummary;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryDiscoveryProvider;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryPage;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositorySummary;
+import io.terrakube.api.rs.vcs.Vcs;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class GitLabRepositoryDiscoveryService implements VcsRepositoryDiscoveryProvider {
+
+    private static final int PAGE_SIZE = 50;
+    private static final String PERSONAL_NAMESPACE_GROUP = "@me";
+    private final ObjectMapper objectMapper;
+
+    public GitLabRepositoryDiscoveryService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<VcsGroupSummary> listGroups(Vcs vcs) {
+        List<VcsGroupSummary> groups = new ArrayList<>();
+        groups.add(VcsGroupSummary.builder().id(PERSONAL_NAMESPACE_GROUP).name("My Projects").build());
+
+        String url = UriComponentsBuilder.fromHttpUrl(vcs.getApiUrl() + "/groups")
+                .queryParam("membership", true)
+                .queryParam("per_page", 100)
+                .toUriString();
+        JsonNode response = callApi(url, vcs.getAccessToken()).orElse(null);
+        if (response != null) {
+            for (JsonNode group : response) {
+                groups.add(VcsGroupSummary.builder()
+                        .id(group.path("id").asText())
+                        .name(group.path("full_path").asText())
+                        .build());
+            }
+        }
+        return groups;
+    }
+
+    @Override
+    public VcsRepositoryPage listRepositories(Vcs vcs, String group, String search, int page) {
+        UriComponentsBuilder builder;
+        if (PERSONAL_NAMESPACE_GROUP.equals(group)) {
+            builder = UriComponentsBuilder.fromHttpUrl(vcs.getApiUrl() + "/projects")
+                    .queryParam("owned", true);
+        } else {
+            builder = UriComponentsBuilder.fromHttpUrl(vcs.getApiUrl() + "/groups/" + group + "/projects")
+                    .queryParam("include_subgroups", true);
+        }
+        builder.queryParam("per_page", PAGE_SIZE).queryParam("page", page).queryParam("order_by", "name");
+        if (search != null && !search.isBlank()) {
+            builder.queryParam("search", search);
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + vcs.getAccessToken());
+        try {
+            RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+            ResponseEntity<String> response = restTemplate.exchange(builder.toUriString(), HttpMethod.GET,
+                    new HttpEntity<>(headers), String.class);
+            List<VcsRepositorySummary> items = new ArrayList<>();
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                for (JsonNode project : objectMapper.readTree(response.getBody())) {
+                    items.add(toSummary(project));
+                }
+            }
+            String nextPage = response.getHeaders().getFirst("X-Next-Page");
+            boolean hasMore = nextPage != null && !nextPage.isBlank();
+            return VcsRepositoryPage.builder().items(items).page(page).hasMore(hasMore).build();
+        } catch (Exception e) {
+            log.error("Error calling GitLab API {}: {}", builder.toUriString(), e.getMessage());
+            return VcsRepositoryPage.builder().items(new ArrayList<>()).page(page).hasMore(false).build();
+        }
+    }
+
+    private VcsRepositorySummary toSummary(JsonNode project) {
+        return VcsRepositorySummary.builder()
+                .name(project.path("name").asText())
+                .fullName(project.path("path_with_namespace").asText())
+                .group(project.path("namespace").path("full_path").asText())
+                .url(project.path("http_url_to_repo").asText())
+                .privateRepo(!"public".equals(project.path("visibility").asText()))
+                .defaultBranch(project.path("default_branch").asText(null))
+                .build();
+    }
+
+    private Optional<JsonNode> callApi(String url, String token) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + token);
+        try {
+            RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                return Optional.of(objectMapper.readTree(response.getBody()));
+            }
+        } catch (Exception e) {
+            log.error("Error calling GitLab API {}: {}", url, e.getMessage());
+        }
+        return Optional.empty();
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenService.java
@@ -217,6 +217,23 @@ public class GitHubTokenService implements GetAccessToken<GitHubToken> {
         return restTemplate.exchange(apiUrl, method, entity, String.class);
     }
 
+    // Generates the app-level JWT used to call GitHub App management endpoints (e.g. listing installations)
+    public String generateAppJwt(Vcs vcs) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        return generateJWT(vcs.getClientId(), vcs.getPrivateKey());
+    }
+
+    // Exposes the installation access token fetch for callers that already know the installation id
+    // (e.g. repository discovery, where the installation is picked from /app/installations)
+    public String getInstallationToken(String installationId, String apiUrl, String jws, String owner)
+            throws JsonMappingException, JsonProcessingException {
+        return fetchGitHubAppInstallationToken(installationId, apiUrl, jws, owner);
+    }
+
+    // Calls a GitHub API endpoint authenticated with the app JWT (used for /app/installations)
+    public ResponseEntity<String> callGithubAppApi(String apiUrl, HttpMethod method, String jws) {
+        return callGithubAPI("", apiUrl, method, jws);
+    }
+
     public RestTemplate getRestTemplateWithProxy() {
         if (System.getProperty("http.proxyHost") != null) {
             log.info("RestTemplate proxy host: {} port: {}", System.getProperty("http.proxyHost"), System.getProperty("http.proxyPort"));

--- a/api/src/test/java/io/terrakube/api/VcsRepositoryDiscoveryAzureDevOpsTests.java
+++ b/api/src/test/java/io/terrakube/api/VcsRepositoryDiscoveryAzureDevOpsTests.java
@@ -1,0 +1,133 @@
+package io.terrakube.api;
+
+import io.terrakube.api.plugin.vcs.discovery.VcsDiscoveryNotSupportedException;
+import io.terrakube.api.plugin.vcs.discovery.VcsGroupSummary;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryPage;
+import io.terrakube.api.plugin.vcs.discovery.azdevops.AzDevOpsRepositoryDiscoveryService;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.vcs.VcsType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+public class VcsRepositoryDiscoveryAzureDevOpsTests extends ServerApplicationTests {
+
+    @Autowired
+    AzDevOpsRepositoryDiscoveryService azDevOpsRepositoryDiscoveryService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        wireMockServer.resetAll();
+        // WireMock can't stand in for the real app.vssps.visualstudio.com hostname
+        ReflectionTestUtils.setField(azDevOpsRepositoryDiscoveryService, "profileEndpoint",
+                "http://localhost:" + wireMockServer.port());
+    }
+
+    private Vcs oauthVcs() {
+        Vcs vcs = new Vcs();
+        vcs.setVcsType(VcsType.AZURE_DEVOPS);
+        vcs.setName("azure-devops-oauth");
+        vcs.setDescription("azure-devops-oauth");
+        vcs.setClientId("123");
+        vcs.setClientSecret("123");
+        vcs.setAccessToken("azdevops-token-abc");
+        vcs.setApiUrl("http://localhost:" + wireMockServer.port());
+        vcs.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
+        return vcsRepository.save(vcs);
+    }
+
+    private Vcs managedIdentityVcs() {
+        Vcs vcs = new Vcs();
+        vcs.setVcsType(VcsType.AZURE_SP_MI);
+        vcs.setName("azure-devops-managed-identity");
+        vcs.setDescription("azure-devops-managed-identity");
+        vcs.setClientId("123");
+        vcs.setClientSecret("123");
+        vcs.setApiUrl("http://localhost:" + wireMockServer.port());
+        vcs.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
+        return vcsRepository.save(vcs);
+    }
+
+    @Test
+    void managedIdentityConnectionIsNotSupportedForDiscovery() {
+        Vcs vcs = managedIdentityVcs();
+
+        assertThatThrownBy(() -> azDevOpsRepositoryDiscoveryService.listGroups(vcs))
+                .isInstanceOf(VcsDiscoveryNotSupportedException.class);
+        assertThatThrownBy(() -> azDevOpsRepositoryDiscoveryService.listRepositories(vcs, "my-org", "", 1))
+                .isInstanceOf(VcsDiscoveryNotSupportedException.class);
+    }
+
+    @Test
+    void listGroupsResolvesOrganizationsThroughProfileAndAccountsApi() {
+        stubFor(get(urlPathEqualTo("/_apis/profile/profiles/me"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\":\"member-guid\"}")));
+        stubFor(get(urlPathEqualTo("/_apis/accounts"))
+                .withQueryParam("memberId", equalTo("member-guid"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("{\"value\":[{\"accountName\":\"my-org\"}]}")));
+
+        List<VcsGroupSummary> groups = azDevOpsRepositoryDiscoveryService.listGroups(oauthVcs());
+
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0).getId()).isEqualTo("my-org");
+        assertThat(groups.get(0).getName()).isEqualTo("my-org");
+    }
+
+    @Test
+    void listRepositoriesMapsFieldsFiltersAndPaginatesLocally() {
+        StringBuilder body = new StringBuilder("{\"value\":[");
+        for (int i = 0; i < 60; i++) {
+            if (i > 0) body.append(",");
+            String name = i == 5 ? "terraform-infra" : "other-repo-" + i;
+            body.append("{\"name\":\"").append(name).append("\",\"remoteUrl\":\"https://dev.azure.com/my-org/proj/_git/")
+                    .append(name).append("\",\"defaultBranch\":\"refs/heads/main\",\"project\":{\"name\":\"proj\"}}");
+        }
+        body.append("]}");
+        stubFor(get(urlPathEqualTo("/my-org/_apis/git/repositories"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody(body.toString())));
+
+        VcsRepositoryPage filtered = azDevOpsRepositoryDiscoveryService.listRepositories(oauthVcs(), "my-org", "terraform", 1);
+        assertThat(filtered.getItems()).hasSize(1);
+        assertThat(filtered.getItems().get(0).getName()).isEqualTo("terraform-infra");
+        assertThat(filtered.getItems().get(0).getFullName()).isEqualTo("my-org/proj/terraform-infra");
+        assertThat(filtered.getItems().get(0).getUrl()).isEqualTo("https://dev.azure.com/my-org/proj/_git/terraform-infra");
+        assertThat(filtered.isHasMore()).isFalse();
+
+        VcsRepositoryPage firstPage = azDevOpsRepositoryDiscoveryService.listRepositories(oauthVcs(), "my-org", "", 1);
+        assertThat(firstPage.getItems()).hasSize(50);
+        assertThat(firstPage.isHasMore()).isTrue();
+
+        VcsRepositoryPage secondPage = azDevOpsRepositoryDiscoveryService.listRepositories(oauthVcs(), "my-org", "", 2);
+        assertThat(secondPage.getItems()).hasSize(10);
+        assertThat(secondPage.isHasMore()).isFalse();
+    }
+
+    @Test
+    void listRepositoriesCachesTheFullOrgResponseBetweenCalls() {
+        Vcs vcs = oauthVcs();
+        stubFor(get(urlPathEqualTo("/my-org/_apis/git/repositories"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("{\"value\":[{\"name\":\"repo1\",\"remoteUrl\":\"https://dev.azure.com/my-org/proj/_git/repo1\"," +
+                                "\"project\":{\"name\":\"proj\"}}]}")));
+
+        azDevOpsRepositoryDiscoveryService.listRepositories(vcs, "my-org", "", 1);
+        azDevOpsRepositoryDiscoveryService.listRepositories(vcs, "my-org", "repo", 1);
+
+        // Two logical searches within the cache TTL should only hit Azure once
+        verify(exactly(1), getRequestedFor(urlPathEqualTo("/my-org/_apis/git/repositories")));
+    }
+}

--- a/api/src/test/java/io/terrakube/api/VcsRepositoryDiscoveryBitbucketTests.java
+++ b/api/src/test/java/io/terrakube/api/VcsRepositoryDiscoveryBitbucketTests.java
@@ -1,0 +1,165 @@
+package io.terrakube.api;
+
+import io.terrakube.api.plugin.vcs.discovery.VcsGroupSummary;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryPage;
+import io.terrakube.api.plugin.vcs.discovery.bitbucket.BitbucketRepositoryDiscoveryService;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.vcs.VcsType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Bitbucket Cloud and Server share vcsType=BITBUCKET and are only distinguished by apiUrl
+ * (see BitbucketRepositoryDiscoveryService#isCloud). Since WireMock can't stand in for the
+ * literal "api.bitbucket.org" host, the Cloud-shaped HTTP methods are exercised directly via
+ * ReflectionTestUtils, while the Server path is exercised through the normal public dispatch
+ * (a plain localhost apiUrl is correctly detected as "server").
+ */
+public class VcsRepositoryDiscoveryBitbucketTests extends ServerApplicationTests {
+
+    @Autowired
+    BitbucketRepositoryDiscoveryService bitbucketRepositoryDiscoveryService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        wireMockServer.resetAll();
+    }
+
+    private Vcs bitbucketVcs(String apiUrl) {
+        Vcs vcs = new Vcs();
+        vcs.setVcsType(VcsType.BITBUCKET);
+        vcs.setAccessToken("bitbucket-token-abc");
+        vcs.setApiUrl(apiUrl);
+        vcs.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
+        return vcs;
+    }
+
+    @Test
+    void detectsCloudVsServerFromApiUrl() {
+        Vcs cloudVcs = bitbucketVcs("https://api.bitbucket.org/2.0");
+        Vcs serverVcs = bitbucketVcs("https://bitbucket.mycompany.com/rest/api/1.0");
+
+        boolean cloud = ReflectionTestUtils.invokeMethod(bitbucketRepositoryDiscoveryService, "isCloud", cloudVcs);
+        boolean server = ReflectionTestUtils.invokeMethod(bitbucketRepositoryDiscoveryService, "isCloud", serverVcs);
+
+        assertThat(cloud).isTrue();
+        assertThat(server).isFalse();
+    }
+
+    // --- Bitbucket Cloud API shape ---
+
+    @Test
+    void cloudListGroupsMapsWorkspaces() {
+        Vcs vcs = bitbucketVcs("http://localhost:" + wireMockServer.port());
+        stubFor(get(urlPathEqualTo("/workspaces"))
+                .withQueryParam("role", equalTo("member"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("{\"values\":[{\"slug\":\"my-ws\",\"name\":\"My Workspace\"}]}")));
+
+        List<VcsGroupSummary> groups = ReflectionTestUtils.invokeMethod(bitbucketRepositoryDiscoveryService, "listCloudWorkspaces", vcs);
+
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0).getId()).isEqualTo("my-ws");
+        assertThat(groups.get(0).getName()).isEqualTo("My Workspace");
+    }
+
+    @Test
+    void cloudListRepositoriesMapsFieldsAndPagination() {
+        Vcs vcs = bitbucketVcs("http://localhost:" + wireMockServer.port());
+        String body = "{\"values\":[{\"name\":\"repo1\",\"full_name\":\"my-ws/repo1\",\"is_private\":true," +
+                "\"mainbranch\":{\"name\":\"main\"},\"links\":{\"clone\":[{\"name\":\"https\",\"href\":\"https://bitbucket.org/my-ws/repo1.git\"}]}}]," +
+                "\"next\":\"https://api.bitbucket.org/2.0/repositories/my-ws?page=2\"}";
+        stubFor(get(urlPathEqualTo("/repositories/my-ws"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody(body)));
+
+        VcsRepositoryPage page = ReflectionTestUtils.invokeMethod(bitbucketRepositoryDiscoveryService, "listCloudRepositories", vcs, "my-ws", "", 1);
+
+        assertThat(page.getItems()).hasSize(1);
+        assertThat(page.getItems().get(0).getFullName()).isEqualTo("my-ws/repo1");
+        assertThat(page.getItems().get(0).getUrl()).isEqualTo("https://bitbucket.org/my-ws/repo1.git");
+        assertThat(page.getItems().get(0).isPrivateRepo()).isTrue();
+        assertThat(page.isHasMore()).isTrue();
+    }
+
+    @Test
+    void cloudListRepositoriesPassesSearchQuery() {
+        Vcs vcs = bitbucketVcs("http://localhost:" + wireMockServer.port());
+        stubFor(get(urlPathEqualTo("/repositories/my-ws"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody("{\"values\":[]}")));
+
+        ReflectionTestUtils.invokeMethod(bitbucketRepositoryDiscoveryService, "listCloudRepositories", vcs, "my-ws", "terraform", 1);
+
+        verify(getRequestedFor(urlPathEqualTo("/repositories/my-ws")).withQueryParam("q", containing("terraform")));
+    }
+
+    // --- Bitbucket Server (on-premise) API shape ---
+
+    @Test
+    void serverListGroupsMapsProjects() {
+        Vcs vcs = bitbucketVcs("http://localhost:" + wireMockServer.port() + "/rest/api/1.0");
+        stubFor(get(urlPathEqualTo("/rest/api/1.0/projects"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("{\"values\":[{\"key\":\"PRJ\",\"name\":\"My Project\"}]}")));
+
+        List<VcsGroupSummary> groups = bitbucketRepositoryDiscoveryService.listGroups(vcs);
+
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0).getId()).isEqualTo("PRJ");
+        assertThat(groups.get(0).getName()).isEqualTo("My Project");
+    }
+
+    @Test
+    void serverListRepositoriesMapsFieldsAndPagination() {
+        Vcs vcs = bitbucketVcs("http://localhost:" + wireMockServer.port() + "/rest/api/1.0");
+        String body = "{\"values\":[{\"name\":\"repo1\",\"slug\":\"repo1\"," +
+                "\"links\":{\"clone\":[{\"name\":\"http\",\"href\":\"http://bitbucket.mycompany.com/scm/PRJ/repo1.git\"}]}}]," +
+                "\"isLastPage\":false}";
+        stubFor(get(urlPathEqualTo("/rest/api/1.0/projects/PRJ/repos"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody(body)));
+
+        VcsRepositoryPage page = bitbucketRepositoryDiscoveryService.listRepositories(vcs, "PRJ", "", 1);
+
+        assertThat(page.getItems()).hasSize(1);
+        assertThat(page.getItems().get(0).getFullName()).isEqualTo("PRJ/repo1");
+        assertThat(page.getItems().get(0).getUrl()).isEqualTo("http://bitbucket.mycompany.com/scm/PRJ/repo1.git");
+        assertThat(page.isHasMore()).isTrue();
+    }
+
+    @Test
+    void serverListRepositoriesIsLastPageMeansNoMore() {
+        Vcs vcs = bitbucketVcs("http://localhost:" + wireMockServer.port() + "/rest/api/1.0");
+        stubFor(get(urlPathEqualTo("/rest/api/1.0/projects/PRJ/repos"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("{\"values\":[],\"isLastPage\":true}")));
+
+        VcsRepositoryPage page = bitbucketRepositoryDiscoveryService.listRepositories(vcs, "PRJ", "", 1);
+
+        assertThat(page.isHasMore()).isFalse();
+    }
+
+    @Test
+    void serverListRepositoriesPassesNameFilterAndStartOffset() {
+        Vcs vcs = bitbucketVcs("http://localhost:" + wireMockServer.port() + "/rest/api/1.0");
+        stubFor(get(urlPathEqualTo("/rest/api/1.0/projects/PRJ/repos"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("{\"values\":[],\"isLastPage\":true}")));
+
+        bitbucketRepositoryDiscoveryService.listRepositories(vcs, "PRJ", "terraform", 3);
+
+        verify(getRequestedFor(urlPathEqualTo("/rest/api/1.0/projects/PRJ/repos"))
+                .withQueryParam("name", equalTo("terraform"))
+                .withQueryParam("start", equalTo("100")));
+    }
+}

--- a/api/src/test/java/io/terrakube/api/VcsRepositoryDiscoveryGitHubTests.java
+++ b/api/src/test/java/io/terrakube/api/VcsRepositoryDiscoveryGitHubTests.java
@@ -1,0 +1,207 @@
+package io.terrakube.api;
+
+import io.terrakube.api.plugin.vcs.discovery.VcsGroupSummary;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryPage;
+import io.terrakube.api.plugin.vcs.discovery.github.GitHubRepositoryDiscoveryService;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.vcs.VcsType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class VcsRepositoryDiscoveryGitHubTests extends ServerApplicationTests {
+
+    @Autowired
+    GitHubRepositoryDiscoveryService gitHubRepositoryDiscoveryService;
+
+    private static String privateKeyPem;
+
+    @BeforeAll
+    static void generateAppPrivateKey() throws NoSuchAlgorithmException {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        privateKeyPem = "-----BEGIN PRIVATE KEY-----\n"
+                + Base64.getMimeEncoder(64, "\n".getBytes()).encodeToString(keyPair.getPrivate().getEncoded())
+                + "\n-----END PRIVATE KEY-----";
+    }
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        wireMockServer.resetAll();
+    }
+
+    private Vcs oauthVcs() {
+        Vcs vcs = new Vcs();
+        vcs.setVcsType(VcsType.GITHUB);
+        vcs.setAccessToken("oauth-token-abc");
+        vcs.setApiUrl("http://localhost:" + wireMockServer.port());
+        vcs.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
+        return vcs;
+    }
+
+    private Vcs appVcs() {
+        Vcs vcs = new Vcs();
+        vcs.setVcsType(VcsType.GITHUB);
+        vcs.setClientId("app-client-id");
+        vcs.setPrivateKey(privateKeyPem);
+        vcs.setApiUrl("http://localhost:" + wireMockServer.port());
+        vcs.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
+        return vcs;
+    }
+
+    // --- OAuth connection ---
+
+    @Test
+    void oauthListGroupsIncludesPersonalAccountAndOrgs() {
+        stubFor(get(urlPathEqualTo("/user"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("{\"login\":\"octocat\"}")));
+        stubFor(get(urlPathEqualTo("/user/orgs"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("[{\"login\":\"my-org\"}]")));
+
+        List<VcsGroupSummary> groups = gitHubRepositoryDiscoveryService.listGroups(oauthVcs());
+
+        assertThat(groups).extracting(VcsGroupSummary::getId).containsExactlyInAnyOrder("@me", "my-org");
+        assertThat(groups).filteredOn(g -> g.getId().equals("my-org")).extracting(VcsGroupSummary::getName)
+                .containsExactly("my-org");
+    }
+
+    @Test
+    void oauthListRepositoriesBrowsesOrgRepos() {
+        String body = "[{\"name\":\"repo1\",\"full_name\":\"my-org/repo1\",\"owner\":{\"login\":\"my-org\"}," +
+                "\"clone_url\":\"https://github.com/my-org/repo1.git\",\"private\":true,\"default_branch\":\"main\"}]";
+        stubFor(get(urlPathEqualTo("/orgs/my-org/repos"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody(body)));
+
+        VcsRepositoryPage page = gitHubRepositoryDiscoveryService.listRepositories(oauthVcs(), "my-org", "", 1);
+
+        assertThat(page.getItems()).hasSize(1);
+        assertThat(page.getItems().get(0).getFullName()).isEqualTo("my-org/repo1");
+        assertThat(page.getItems().get(0).getUrl()).isEqualTo("https://github.com/my-org/repo1.git");
+        assertThat(page.getItems().get(0).isPrivateRepo()).isTrue();
+        assertThat(page.isHasMore()).isFalse();
+    }
+
+    @Test
+    void oauthListRepositoriesUsesSearchApiWhenFiltering() {
+        String body = "{\"total_count\":120,\"items\":[{\"name\":\"repo1\",\"full_name\":\"my-org/repo1\"," +
+                "\"owner\":{\"login\":\"my-org\"},\"clone_url\":\"https://github.com/my-org/repo1.git\",\"private\":false}]}";
+        stubFor(get(urlPathEqualTo("/search/repositories"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody(body)));
+
+        VcsRepositoryPage page = gitHubRepositoryDiscoveryService.listRepositories(oauthVcs(), "my-org", "repo", 1);
+
+        assertThat(page.getItems()).hasSize(1);
+        // total_count (120) > page(1) * PAGE_SIZE(50) so more results are available
+        assertThat(page.isHasMore()).isTrue();
+    }
+
+    @Test
+    void oauthListRepositoriesForPersonalAccountUsesUserRepos() {
+        stubFor(get(urlPathEqualTo("/user/repos"))
+                .withQueryParam("affiliation", equalTo("owner"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody("[]")));
+
+        VcsRepositoryPage page = gitHubRepositoryDiscoveryService.listRepositories(oauthVcs(), "@me", "", 1);
+
+        assertThat(page.getItems()).isEmpty();
+        verify(getRequestedFor(urlPathEqualTo("/user/repos")));
+    }
+
+    // --- GitHub App connection ---
+
+    @Test
+    void appListGroupsUsesInstallationsEndpoint() {
+        stubFor(get(urlPathEqualTo("/app/installations"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("[{\"id\":123,\"account\":{\"login\":\"my-app-org\"}}]")));
+
+        List<VcsGroupSummary> groups = gitHubRepositoryDiscoveryService.listGroups(appVcs());
+
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0).getId()).isEqualTo("123");
+        assertThat(groups.get(0).getName()).isEqualTo("my-app-org");
+    }
+
+    @Test
+    void appListRepositoriesBrowsesInstallationRepos() {
+        stubForInstallationToken();
+        stubFor(get(urlPathEqualTo("/installation/repositories"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("{\"repositories\":[{\"name\":\"repo1\",\"full_name\":\"my-app-org/repo1\"," +
+                                "\"owner\":{\"login\":\"my-app-org\"},\"clone_url\":\"https://github.com/my-app-org/repo1.git\"," +
+                                "\"private\":true}]}")));
+
+        VcsRepositoryPage page = gitHubRepositoryDiscoveryService.listRepositories(appVcs(), "123", "", 1);
+
+        assertThat(page.getItems()).hasSize(1);
+        assertThat(page.getItems().get(0).getFullName()).isEqualTo("my-app-org/repo1");
+    }
+
+    @Test
+    void appListRepositoriesSearchScansOnePageAtATimeWithoutHardCap() {
+        stubForInstallationToken();
+
+        // Page 1: a full page (50 repos), one match -> hasMore should be true (page was full)
+        StringBuilder page1 = new StringBuilder("{\"repositories\":[");
+        for (int i = 0; i < 50; i++) {
+            if (i > 0) page1.append(",");
+            String name = i == 25 ? "target-repo" : "other-repo-" + i;
+            page1.append("{\"name\":\"").append(name).append("\",\"full_name\":\"my-app-org/").append(name)
+                    .append("\",\"owner\":{\"login\":\"my-app-org\"},\"clone_url\":\"https://github.com/my-app-org/")
+                    .append(name).append(".git\",\"private\":true}");
+        }
+        page1.append("]}");
+        stubFor(get(urlPathEqualTo("/installation/repositories"))
+                .withQueryParam("page", equalTo("1"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody(page1.toString())));
+
+        // Page 2: not full (10 repos), no match -> hasMore should be false (no more pages)
+        StringBuilder page2 = new StringBuilder("{\"repositories\":[");
+        for (int i = 0; i < 10; i++) {
+            if (i > 0) page2.append(",");
+            page2.append("{\"name\":\"page2-repo-").append(i).append("\",\"full_name\":\"my-app-org/page2-repo-").append(i)
+                    .append("\",\"owner\":{\"login\":\"my-app-org\"},\"clone_url\":\"https://github.com/my-app-org/page2-repo-")
+                    .append(i).append(".git\",\"private\":true}");
+        }
+        page2.append("]}");
+        stubFor(get(urlPathEqualTo("/installation/repositories"))
+                .withQueryParam("page", equalTo("2"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody(page2.toString())));
+
+        VcsRepositoryPage firstPage = gitHubRepositoryDiscoveryService.listRepositories(appVcs(), "123", "target", 1);
+        assertThat(firstPage.getItems()).extracting(r -> r.getName()).containsExactly("target-repo");
+        assertThat(firstPage.isHasMore()).isTrue();
+
+        VcsRepositoryPage secondPage = gitHubRepositoryDiscoveryService.listRepositories(appVcs(), "123", "target", 2);
+        assertThat(secondPage.getItems()).isEmpty();
+        assertThat(secondPage.isHasMore()).isFalse();
+    }
+
+    private void stubForInstallationToken() {
+        stubFor(get(urlPathEqualTo("/app/installations/123"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("{\"account\":{\"login\":\"my-app-org\"}}")));
+        stubFor(post(urlPathEqualTo("/app/installations/123/access_tokens"))
+                .willReturn(aResponse().withStatus(HttpStatus.CREATED.value()).withHeader("Content-Type", "application/json")
+                        .withBody("{\"token\":\"installation-token-abc\"}")));
+    }
+}

--- a/api/src/test/java/io/terrakube/api/VcsRepositoryDiscoveryGitLabTests.java
+++ b/api/src/test/java/io/terrakube/api/VcsRepositoryDiscoveryGitLabTests.java
@@ -1,0 +1,105 @@
+package io.terrakube.api;
+
+import io.terrakube.api.plugin.vcs.discovery.VcsGroupSummary;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryPage;
+import io.terrakube.api.plugin.vcs.discovery.gitlab.GitLabRepositoryDiscoveryService;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.vcs.VcsType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class VcsRepositoryDiscoveryGitLabTests extends ServerApplicationTests {
+
+    @Autowired
+    GitLabRepositoryDiscoveryService gitLabRepositoryDiscoveryService;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        wireMockServer.resetAll();
+    }
+
+    private Vcs gitlabVcs() {
+        Vcs vcs = new Vcs();
+        vcs.setVcsType(VcsType.GITLAB);
+        vcs.setAccessToken("gitlab-token-abc");
+        vcs.setApiUrl("http://localhost:" + wireMockServer.port() + "/api/v4");
+        vcs.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
+        return vcs;
+    }
+
+    @Test
+    void listGroupsIncludesPersonalNamespaceAndRealGroups() {
+        stubFor(get(urlPathEqualTo("/api/v4/groups"))
+                .withQueryParam("membership", equalTo("true"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withBody("[{\"id\":42,\"full_path\":\"my-group\"}]")));
+
+        List<VcsGroupSummary> groups = gitLabRepositoryDiscoveryService.listGroups(gitlabVcs());
+
+        assertThat(groups).extracting(VcsGroupSummary::getId).containsExactlyInAnyOrder("@me", "42");
+        assertThat(groups).filteredOn(g -> g.getId().equals("42")).extracting(VcsGroupSummary::getName)
+                .containsExactly("my-group");
+    }
+
+    @Test
+    void listRepositoriesForGroupMapsFieldsAndNoMorePages() {
+        String body = "[{\"name\":\"repo1\",\"path_with_namespace\":\"my-group/repo1\"," +
+                "\"namespace\":{\"full_path\":\"my-group\"},\"http_url_to_repo\":\"https://gitlab.com/my-group/repo1.git\"," +
+                "\"visibility\":\"private\",\"default_branch\":\"main\"}]";
+        stubFor(get(urlPathEqualTo("/api/v4/groups/42/projects"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody(body)));
+
+        VcsRepositoryPage page = gitLabRepositoryDiscoveryService.listRepositories(gitlabVcs(), "42", "", 1);
+
+        assertThat(page.getItems()).hasSize(1);
+        assertThat(page.getItems().get(0).getFullName()).isEqualTo("my-group/repo1");
+        assertThat(page.getItems().get(0).getGroup()).isEqualTo("my-group");
+        assertThat(page.getItems().get(0).getUrl()).isEqualTo("https://gitlab.com/my-group/repo1.git");
+        assertThat(page.getItems().get(0).isPrivateRepo()).isTrue();
+        assertThat(page.isHasMore()).isFalse();
+    }
+
+    @Test
+    void listRepositoriesHasMoreWhenNextPageHeaderPresent() {
+        stubFor(get(urlPathEqualTo("/api/v4/groups/42/projects"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json")
+                        .withHeader("X-Next-Page", "2").withBody("[]")));
+
+        VcsRepositoryPage page = gitLabRepositoryDiscoveryService.listRepositories(gitlabVcs(), "42", "", 1);
+
+        assertThat(page.isHasMore()).isTrue();
+    }
+
+    @Test
+    void listRepositoriesForPersonalNamespaceUsesOwnedProjects() {
+        stubFor(get(urlPathEqualTo("/api/v4/projects"))
+                .withQueryParam("owned", equalTo("true"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody("[]")));
+
+        VcsRepositoryPage page = gitLabRepositoryDiscoveryService.listRepositories(gitlabVcs(), "@me", "", 1);
+
+        assertThat(page.getItems()).isEmpty();
+        verify(getRequestedFor(urlPathEqualTo("/api/v4/projects")).withQueryParam("owned", equalTo("true")));
+    }
+
+    @Test
+    void listRepositoriesPassesSearchQueryParam() {
+        stubFor(get(urlPathEqualTo("/api/v4/groups/42/projects"))
+                .willReturn(aResponse().withStatus(200).withHeader("Content-Type", "application/json").withBody("[]")));
+
+        gitLabRepositoryDiscoveryService.listRepositories(gitlabVcs(), "42", "terraform", 1);
+
+        verify(getRequestedFor(urlPathEqualTo("/api/v4/groups/42/projects")).withQueryParam("search", equalTo("terraform")));
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/controller/VcsRepositoryControllerTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/controller/VcsRepositoryControllerTest.java
@@ -1,0 +1,131 @@
+package io.terrakube.api.plugin.vcs.controller;
+
+import io.terrakube.api.plugin.vcs.discovery.VcsDiscoveryNotSupportedException;
+import io.terrakube.api.plugin.vcs.discovery.VcsGroupSummary;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryDiscoveryFacade;
+import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryPage;
+import io.terrakube.api.repository.VcsRepository;
+import io.terrakube.api.rs.vcs.Vcs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class VcsRepositoryControllerTest {
+
+    VcsRepositoryDiscoveryFacade discoveryFacade;
+    VcsRepository vcsRepository;
+    VcsRepositoryController subject;
+
+    final UUID vcsId = UUID.randomUUID();
+
+    @BeforeEach
+    void setup() {
+        discoveryFacade = mock(VcsRepositoryDiscoveryFacade.class);
+        vcsRepository = mock(VcsRepository.class);
+        subject = new VcsRepositoryController(discoveryFacade, vcsRepository);
+    }
+
+    private Vcs vcs() {
+        Vcs vcs = new Vcs();
+        vcs.setId(vcsId);
+        return vcs;
+    }
+
+    @Test
+    void listGroupsReturns404WhenVcsMissing() {
+        when(vcsRepository.findById(vcsId)).thenReturn(Optional.empty());
+
+        ResponseEntity<List<VcsGroupSummary>> response = subject.listGroups(vcsId.toString());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void listGroupsReturnsFacadeResult() {
+        Vcs vcs = vcs();
+        when(vcsRepository.findById(vcsId)).thenReturn(Optional.of(vcs));
+        List<VcsGroupSummary> groups = Collections.singletonList(VcsGroupSummary.builder().id("a").name("a").build());
+        when(discoveryFacade.listGroups(vcs)).thenReturn(groups);
+
+        ResponseEntity<List<VcsGroupSummary>> response = subject.listGroups(vcsId.toString());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(groups);
+    }
+
+    @Test
+    void listGroupsReturns422WhenDiscoveryNotSupported() {
+        Vcs vcs = vcs();
+        when(vcsRepository.findById(vcsId)).thenReturn(Optional.of(vcs));
+        when(discoveryFacade.listGroups(vcs)).thenThrow(new VcsDiscoveryNotSupportedException("nope"));
+
+        ResponseEntity<List<VcsGroupSummary>> response = subject.listGroups(vcsId.toString());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    void listGroupsReturns500OnUnexpectedError() {
+        Vcs vcs = vcs();
+        when(vcsRepository.findById(vcsId)).thenReturn(Optional.of(vcs));
+        when(discoveryFacade.listGroups(vcs)).thenThrow(new RuntimeException("boom"));
+
+        ResponseEntity<List<VcsGroupSummary>> response = subject.listGroups(vcsId.toString());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    void listRepositoriesReturns404WhenVcsMissing() {
+        when(vcsRepository.findById(vcsId)).thenReturn(Optional.empty());
+
+        ResponseEntity<VcsRepositoryPage> response = subject.listRepositories(vcsId.toString(), "group", "", 1);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void listRepositoriesReturnsFacadeResult() {
+        Vcs vcs = vcs();
+        when(vcsRepository.findById(vcsId)).thenReturn(Optional.of(vcs));
+        VcsRepositoryPage page = VcsRepositoryPage.builder().items(Collections.emptyList()).page(1).hasMore(false).build();
+        when(discoveryFacade.listRepositories(vcs, "group", "search", 1)).thenReturn(page);
+
+        ResponseEntity<VcsRepositoryPage> response = subject.listRepositories(vcsId.toString(), "group", "search", 1);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(page);
+    }
+
+    @Test
+    void listRepositoriesReturns422WhenDiscoveryNotSupported() {
+        Vcs vcs = vcs();
+        when(vcsRepository.findById(vcsId)).thenReturn(Optional.of(vcs));
+        when(discoveryFacade.listRepositories(vcs, "group", "", 1)).thenThrow(new VcsDiscoveryNotSupportedException("nope"));
+
+        ResponseEntity<VcsRepositoryPage> response = subject.listRepositories(vcsId.toString(), "group", "", 1);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    void listRepositoriesReturns500OnUnexpectedError() {
+        Vcs vcs = vcs();
+        when(vcsRepository.findById(vcsId)).thenReturn(Optional.of(vcs));
+        when(discoveryFacade.listRepositories(vcs, "group", "", 1)).thenThrow(new RuntimeException("boom"));
+
+        ResponseEntity<VcsRepositoryPage> response = subject.listRepositories(vcsId.toString(), "group", "", 1);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/discovery/VcsRepositoryAccessServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/discovery/VcsRepositoryAccessServiceTest.java
@@ -1,0 +1,124 @@
+package io.terrakube.api.plugin.vcs.discovery;
+
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.repository.TeamRepository;
+import io.terrakube.api.repository.VcsRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.team.Team;
+import io.terrakube.api.rs.vcs.Vcs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class VcsRepositoryAccessServiceTest {
+
+    TeamRepository teamRepository;
+    VcsRepository vcsRepository;
+    RbacService rbacService;
+    VcsRepositoryAccessService subject;
+
+    final UUID orgId = UUID.randomUUID();
+    final UUID vcsId = UUID.randomUUID();
+
+    @BeforeEach
+    void setup() {
+        teamRepository = mock(TeamRepository.class);
+        vcsRepository = mock(VcsRepository.class);
+        rbacService = mock(RbacService.class);
+
+        subject = new VcsRepositoryAccessService();
+        ReflectionTestUtils.setField(subject, "teamRepository", teamRepository);
+        ReflectionTestUtils.setField(subject, "vcsRepository", vcsRepository);
+        ReflectionTestUtils.setField(subject, "rbacService", rbacService);
+    }
+
+    private JwtAuthenticationToken authWithClaims(Map<String, Object> claims) {
+        JwtAuthenticationToken token = mock(JwtAuthenticationToken.class);
+        when(token.getTokenAttributes()).thenReturn(claims);
+        return token;
+    }
+
+    private Vcs vcsWithOrg() {
+        Organization org = new Organization();
+        org.setId(orgId);
+        Vcs vcs = new Vcs();
+        vcs.setId(vcsId);
+        vcs.setOrganization(org);
+        return vcs;
+    }
+
+    @Test
+    void internalIssuerBypassesAllChecks() {
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "TerrakubeInternal"));
+
+        assertThat(subject.hasViewPermission(token, vcsId.toString())).isTrue();
+    }
+
+    @Test
+    void returnsFalseWhenVcsNotFound() {
+        when(vcsRepository.findById(vcsId)).thenReturn(Optional.empty());
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube", "groups", List.of("team-a")));
+
+        assertThat(subject.hasViewPermission(token, vcsId.toString())).isFalse();
+    }
+
+    @Test
+    void returnsFalseWhenNoGroupsClaim() {
+        when(vcsRepository.findById(vcsId)).thenReturn(Optional.of(vcsWithOrg()));
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube"));
+
+        assertThat(subject.hasViewPermission(token, vcsId.toString())).isFalse();
+    }
+
+    @Test
+    void returnsFalseWhenNoTeamGrantsAccess() {
+        when(vcsRepository.findById(vcsId)).thenReturn(Optional.of(vcsWithOrg()));
+        Team readOnlyTeam = new Team();
+        readOnlyTeam.setRole("read");
+        when(teamRepository.findAllByOrganizationIdAndNameIn(eq(orgId), any())).thenReturn(List.of(readOnlyTeam));
+        when(rbacService.canManageVcs(readOnlyTeam)).thenReturn(false);
+        when(rbacService.canManageWorkspace(readOnlyTeam)).thenReturn(false);
+
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube", "groups", List.of("team-a")));
+
+        assertThat(subject.hasViewPermission(token, vcsId.toString())).isFalse();
+    }
+
+    @Test
+    void returnsTrueWhenTeamCanManageWorkspace() {
+        when(vcsRepository.findById(vcsId)).thenReturn(Optional.of(vcsWithOrg()));
+        Team writeTeam = new Team();
+        writeTeam.setRole("write");
+        when(teamRepository.findAllByOrganizationIdAndNameIn(eq(orgId), any())).thenReturn(List.of(writeTeam));
+        when(rbacService.canManageWorkspace(writeTeam)).thenReturn(true);
+
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube", "groups", List.of("team-a")));
+
+        assertThat(subject.hasViewPermission(token, vcsId.toString())).isTrue();
+    }
+
+    @Test
+    void returnsTrueWhenTeamCanManageVcs() {
+        when(vcsRepository.findById(vcsId)).thenReturn(Optional.of(vcsWithOrg()));
+        Team adminTeam = new Team();
+        adminTeam.setRole("admin");
+        when(teamRepository.findAllByOrganizationIdAndNameIn(eq(orgId), any())).thenReturn(List.of(adminTeam));
+        when(rbacService.canManageVcs(adminTeam)).thenReturn(true);
+
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube", "groups", List.of("team-a")));
+
+        assertThat(subject.hasViewPermission(token, vcsId.toString())).isTrue();
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/discovery/VcsRepositoryDiscoveryFacadeTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/discovery/VcsRepositoryDiscoveryFacadeTest.java
@@ -1,0 +1,88 @@
+package io.terrakube.api.plugin.vcs.discovery;
+
+import io.terrakube.api.plugin.vcs.discovery.azdevops.AzDevOpsRepositoryDiscoveryService;
+import io.terrakube.api.plugin.vcs.discovery.bitbucket.BitbucketRepositoryDiscoveryService;
+import io.terrakube.api.plugin.vcs.discovery.github.GitHubRepositoryDiscoveryService;
+import io.terrakube.api.plugin.vcs.discovery.gitlab.GitLabRepositoryDiscoveryService;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.vcs.VcsType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class VcsRepositoryDiscoveryFacadeTest {
+
+    GitHubRepositoryDiscoveryService gitHubService;
+    GitLabRepositoryDiscoveryService gitLabService;
+    BitbucketRepositoryDiscoveryService bitbucketService;
+    AzDevOpsRepositoryDiscoveryService azDevOpsService;
+    VcsRepositoryDiscoveryFacade subject;
+
+    @BeforeEach
+    void setup() {
+        gitHubService = mock(GitHubRepositoryDiscoveryService.class);
+        gitLabService = mock(GitLabRepositoryDiscoveryService.class);
+        bitbucketService = mock(BitbucketRepositoryDiscoveryService.class);
+        azDevOpsService = mock(AzDevOpsRepositoryDiscoveryService.class);
+        subject = new VcsRepositoryDiscoveryFacade(gitHubService, gitLabService, bitbucketService, azDevOpsService);
+    }
+
+    private Vcs vcs(VcsType type) {
+        Vcs vcs = new Vcs();
+        vcs.setVcsType(type);
+        return vcs;
+    }
+
+    @Test
+    void dispatchesGitHubToGitHubProvider() {
+        Vcs vcs = vcs(VcsType.GITHUB);
+        List<VcsGroupSummary> expected = Collections.singletonList(VcsGroupSummary.builder().id("a").name("a").build());
+        when(gitHubService.listGroups(vcs)).thenReturn(expected);
+
+        assertThat(subject.listGroups(vcs)).isEqualTo(expected);
+    }
+
+    @Test
+    void dispatchesGitLabToGitLabProvider() {
+        Vcs vcs = vcs(VcsType.GITLAB);
+        VcsRepositoryPage expected = VcsRepositoryPage.builder().items(Collections.emptyList()).page(1).hasMore(false).build();
+        when(gitLabService.listRepositories(vcs, "g", "s", 1)).thenReturn(expected);
+
+        assertThat(subject.listRepositories(vcs, "g", "s", 1)).isEqualTo(expected);
+    }
+
+    @Test
+    void dispatchesBitbucketToBitbucketProvider() {
+        Vcs vcs = vcs(VcsType.BITBUCKET);
+
+        subject.listGroups(vcs);
+
+        verify(bitbucketService).listGroups(vcs);
+    }
+
+    @Test
+    void dispatchesAzureDevOpsToAzureDevOpsProvider() {
+        Vcs vcs = vcs(VcsType.AZURE_DEVOPS);
+
+        subject.listGroups(vcs);
+
+        verify(azDevOpsService).listGroups(vcs);
+    }
+
+    @Test
+    void throwsForVcsTypesWithNoDiscoveryProvider() {
+        assertThatThrownBy(() -> subject.listGroups(vcs(VcsType.PUBLIC)))
+                .isInstanceOf(VcsDiscoveryNotSupportedException.class);
+
+        assertThatThrownBy(() -> subject.listGroups(vcs(VcsType.AZURE_SP_MI)))
+                .isInstanceOf(VcsDiscoveryNotSupportedException.class);
+    }
+}

--- a/ui/src/domain/Settings/AddVCS.tsx
+++ b/ui/src/domain/Settings/AddVCS.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { HiOutlineExternalLink } from "react-icons/hi";
 import { SiBitbucket } from "react-icons/si";
 import { VscAzureDevops } from "react-icons/vsc";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import { v1 as uuidv1 } from "uuid";
 import { ORGANIZATION_NAME } from "../../config/actionTypes";
 import axiosInstance from "../../config/axiosConfig";
@@ -45,9 +45,14 @@ type CreateVcsForm = {
 
 export const AddVCS = ({ setMode, loadVCS }: Props) => {
   const { orgid, vcsName } = useParams<Params>();
+  const [searchParams] = useSearchParams();
   const [current, setCurrent] = useState(vcsName ? 1 : 0);
   const [vcsType, setVcsType] = useState<VcsTypeExtended>(vcsName ? vcsName : VcsTypeExtended.GITHUB);
-  const [connectionType, setConnectionType] = useState(VcsConnectionType.OAUTH);
+  const [connectionType, setConnectionType] = useState(
+    searchParams.get("connectionType") === VcsConnectionType.STANDALONE
+      ? VcsConnectionType.STANDALONE
+      : VcsConnectionType.OAUTH
+  );
   const [uuid] = useState(uuidv1());
 
   const validatePrivateKeyFormat = (_: any, value: string) => {

--- a/ui/src/domain/Workspaces/Create.tsx
+++ b/ui/src/domain/Workspaces/Create.tsx
@@ -1,22 +1,26 @@
-import { DownOutlined, GithubOutlined, GitlabOutlined } from "@ant-design/icons";
+import { DownOutlined, GithubOutlined, GitlabOutlined, LockOutlined } from "@ant-design/icons";
 import {
+  Alert,
   AutoComplete,
   Breadcrumb,
   Button,
   Card,
   Dropdown,
+  Flex,
   Form,
   Input,
   Layout,
   List,
+  Segmented,
   Select,
   Space,
   Steps,
+  Tag,
   message,
   theme,
   Typography,
 } from "antd";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { IconContext } from "react-icons";
 import { BiBookBookmark, BiTerminal, BiUpload } from "react-icons/bi";
 import { SiBitbucket, SiGit } from "react-icons/si";
@@ -25,12 +29,23 @@ import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { v7 as uuid } from "uuid";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
 import axiosInstance from "../../config/axiosConfig";
-import { ProjectModel, SshKey, Template, TofuRelease, VcsModel, VcsType, VcsTypeExtended } from "../types";
+import {
+  ProjectModel,
+  SshKey,
+  Template,
+  TofuRelease,
+  VcsConnectionType,
+  VcsModel,
+  VcsRepositoryGroup,
+  VcsRepositoryPage,
+  VcsRepositorySummary,
+  VcsType,
+  VcsTypeExtended,
+} from "../types";
 import { compareVersions, validateTerraformVersion } from "./Workspaces";
 import projectService from "@/modules/projects/projectService";
 import { withBasePath } from "../../config/basePath";
 const { Content } = Layout;
-const { Step } = Steps;
 
 const validateMessages = {
   required: "${label} is required!",
@@ -61,9 +76,8 @@ type CreateWorkspaceForm = {
 };
 
 export const CreateWorkspace = () => {
-  const {
-    token: { colorBgContainer },
-  } = theme.useToken();
+  const { token } = theme.useToken();
+  const { colorBgContainer } = token;
   const [organizationName, setOrganizationName] = useState<string | null>();
   const [executionMode, setExecutionMode] = useState<string | null>();
   const [terraformVersions, setTerraformVersions] = useState<string[]>([]);
@@ -80,6 +94,19 @@ export const CreateWorkspace = () => {
   const [versionControlFlow, setVersionControlFlow] = useState(true);
   const [requiredVcsPush, setRequiredVcsPush] = useState(true);
   const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
+  const [repoPickerMode, setRepoPickerMode] = useState<"list" | "manual">("list");
+  const [discoveryUnsupported, setDiscoveryUnsupported] = useState(false);
+  const [vcsGroups, setVcsGroups] = useState<VcsRepositoryGroup[]>([]);
+  const [selectedGroup, setSelectedGroup] = useState<string>("");
+  const [groupsLoading, setGroupsLoading] = useState(false);
+  const [repoResults, setRepoResults] = useState<VcsRepositorySummary[]>([]);
+  const [repoSearch, setRepoSearch] = useState("");
+  const [repoPage, setRepoPage] = useState(1);
+  const [repoHasMore, setRepoHasMore] = useState(false);
+  const [repoLoading, setRepoLoading] = useState(false);
+  const [selectedRepoUrl, setSelectedRepoUrl] = useState("");
+  const [repoError, setRepoError] = useState<string | null>(null);
+  const repoSearchDebounce = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const [iacTypes, setIacTypes] = useState<IacType[]>([]);
   const [iacType, setIacType] = useState<IacType>({
     id: "terraform",
@@ -112,15 +139,29 @@ export const CreateWorkspace = () => {
 
   const githubItems = [
     {
-      label: "GitHub.com",
+      label: "GitHub.com (GitHub App)",
       key: "1",
+      onClick: () => {
+        handleVCSClick(VcsTypeExtended.GITHUB_APP, VcsConnectionType.STANDALONE);
+      },
+    },
+    {
+      label: "GitHub.com (oAuth App)",
+      key: "2",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITHUB);
       },
     },
     {
-      label: "GitHub Enterprise",
-      key: "2",
+      label: "GitHub Enterprise (GitHub App)",
+      key: "3",
+      onClick: () => {
+        handleVCSClick(VcsTypeExtended.GITHUB_ENTERPRISE, VcsConnectionType.STANDALONE);
+      },
+    },
+    {
+      label: "GitHub Enterprise (oAuth App)",
+      key: "4",
       onClick: () => {
         handleVCSClick(VcsTypeExtended.GITHUB_ENTERPRISE);
       },
@@ -220,17 +261,102 @@ export const CreateWorkspace = () => {
   const handleGitClick = (id: string) => {
     if (id === "git") {
       setSSHKeysVisible(true);
+      setRepoPickerMode("manual");
     } else {
       setSSHKeysVisible(false);
       setVcsId(id);
+      setRepoPickerMode("list");
+      setDiscoveryUnsupported(false);
+      setVcsGroups([]);
+      setRepoResults([]);
+      setRepoSearch("");
+      setSelectedRepoUrl("");
+      fetchVcsGroups(id);
     }
     setCurrent(3);
     setRequiredVcsPush(true);
     setStep3Hidden(false);
   };
 
-  const handleVCSClick = (vcsType: VcsTypeExtended) => {
-    navigate(`/organizations/${organizationId}/settings/vcs/new/${vcsType}`);
+  const vcsApiUrl = (path: string) => `${new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin}${path}`;
+
+  const fetchVcsGroups = (id: string) => {
+    setGroupsLoading(true);
+    setRepoError(null);
+    axiosInstance
+      .get(vcsApiUrl(`/vcs/v1/${id}/groups`))
+      .then((response) => {
+        const groups: VcsRepositoryGroup[] = response.data || [];
+        setVcsGroups(groups);
+        setGroupsLoading(false);
+        if (groups.length > 0) {
+          setSelectedGroup(groups[0].id);
+          fetchRepositories(id, groups[0].id, "", 1, false);
+        } else {
+          message.warning(
+            "No organizations were found for this VCS connection. Enter the repository URL manually instead."
+          );
+          setRepoPickerMode("manual");
+        }
+      })
+      .catch(() => {
+        setGroupsLoading(false);
+        setDiscoveryUnsupported(true);
+        setRepoPickerMode("manual");
+        message.warning(
+          "We couldn't automatically list repositories for this connection. Enter the repository URL manually instead."
+        );
+      });
+  };
+
+  const fetchRepositories = (id: string, group: string, search: string, page: number, append: boolean) => {
+    setRepoLoading(true);
+    if (!append) {
+      setRepoError(null);
+    }
+    axiosInstance
+      .get(vcsApiUrl(`/vcs/v1/${id}/repositories`), { params: { group, search, page } })
+      .then((response) => {
+        const data: VcsRepositoryPage = response.data;
+        setRepoResults((prev) => (append ? [...prev, ...data.items] : data.items));
+        setRepoHasMore(data.hasMore);
+        setRepoPage(data.page);
+        setRepoLoading(false);
+        setRepoError(null);
+      })
+      .catch(() => {
+        setRepoLoading(false);
+        setRepoError("Something went wrong while loading repositories from the VCS provider.");
+      });
+  };
+
+  const handleGroupChange = (group: string) => {
+    setSelectedGroup(group);
+    fetchRepositories(vcsId, group, repoSearch, 1, false);
+  };
+
+  const handleRepoSearchChange = (value: string) => {
+    setRepoSearch(value);
+    if (repoSearchDebounce.current) {
+      clearTimeout(repoSearchDebounce.current);
+    }
+    repoSearchDebounce.current = setTimeout(() => {
+      fetchRepositories(vcsId, selectedGroup, value, 1, false);
+    }, 400);
+  };
+
+  const handleLoadMoreRepos = () => {
+    fetchRepositories(vcsId, selectedGroup, repoSearch, repoPage + 1, true);
+  };
+
+  const handleRepoSelect = (repo: VcsRepositorySummary) => {
+    setSelectedRepoUrl(repo.url);
+    form.setFieldsValue({ source: repo.url });
+  };
+
+  const handleVCSClick = (vcsType: VcsTypeExtended, connectionType?: VcsConnectionType) => {
+    const query = connectionType ? `?connectionType=${connectionType}` : "";
+    navigate(`/organizations/${organizationId}/settings/vcs/new/${vcsType}${query}`);
   };
 
   const handleConnectDifferent = () => {
@@ -273,7 +399,7 @@ export const CreateWorkspace = () => {
 
   const [form] = Form.useForm();
   const handleGitContinueClick = () => {
-    setCurrent(3);
+    setCurrent(4);
     setStep4Hidden(false);
     setStep3Hidden(true);
     const source = form.getFieldValue("source");
@@ -413,6 +539,12 @@ export const CreateWorkspace = () => {
   };
 
   const handleChange = (currentVal: number) => {
+    // The breadcrumb can only step backward. Going forward again always requires redoing the
+    // actual step action (a card click / Continue button), never a direct jump, so stale
+    // choices from a step you've backed out of can't be skipped past silently.
+    if (currentVal >= current) {
+      return;
+    }
     setCurrent(currentVal);
     if (currentVal === 3) {
       setStep3Hidden(false);
@@ -471,43 +603,69 @@ export const CreateWorkspace = () => {
               (infrastructure as code), shared variable values, your current and historical state, and run logs.
             </Typography.Text>
           </div>
-          <Steps direction="horizontal" size="small" current={current} onChange={handleChange}>
-            <Step title="Choose IaC Type" />
-            <Step title="Choose Type" />
-            {versionControlFlow ? (
-              <>
-                <Step title="Connect to VCS" />
-                <Step title="Choose a repository" />
-              </>
-            ) : (
-              ""
-            )}
-            <Step title="Configure Settings" />
-          </Steps>
+          <div
+            style={{
+              background: token.colorFillAlter,
+              border: `1px solid ${token.colorBorderSecondary}`,
+              borderRadius: token.borderRadiusLG,
+              padding: "20px 24px",
+              margin: "16px 0 24px 0",
+            }}
+          >
+            <Steps
+              current={current}
+              onChange={handleChange}
+              responsive
+              items={(versionControlFlow
+                ? [
+                    { title: "Choose IaC type", description: "Terraform or OpenTofu" },
+                    { title: "Choose type", description: "How runs are triggered" },
+                    { title: "Connect to VCS", description: "Pick a git provider" },
+                    { title: "Choose a repository", description: "Select your source code" },
+                    { title: "Configure settings", description: "Name, branch & defaults" },
+                  ]
+                : [
+                    { title: "Choose IaC type", description: "Terraform or OpenTofu" },
+                    { title: "Choose type", description: "How runs are triggered" },
+                    { title: "Configure settings", description: "Name & defaults" },
+                  ]
+              ).map((step, index) => ({ ...step, disabled: index >= current }))}
+            />
+          </div>
           {current == 0 && (
             <Space className="chooseType" direction="vertical">
               <h3>Choose your IaC type </h3>
               <List
-                grid={{ gutter: 16, column: 4 }}
+                grid={{
+                  gutter: 24,
+                  xs: 1,
+                  sm: Math.min(iacTypes.length || 1, 2),
+                  md: Math.min(iacTypes.length || 1, 3),
+                  lg: Math.min(iacTypes.length || 1, 3),
+                  xl: Math.min(iacTypes.length || 1, 3),
+                }}
                 dataSource={iacTypes}
                 renderItem={(item) => (
                   <List.Item>
                     <Card
-                      style={{ textAlign: "center" }}
+                      style={{ textAlign: "center", minHeight: 220 }}
+                      styles={{ body: { padding: 32 } }}
                       hoverable
                       onClick={() => handleIacTypeClick(item)}
                     >
-                      <Space direction="vertical">
+                      <Space direction="vertical" align="center" size="middle" style={{ width: "100%" }}>
                         <img
                           style={{
-                            padding: "10px",
+                            padding: "14px",
                             backgroundColor: item.color,
-                            width: "60px",
+                            width: "96px",
+                            maxWidth: "100%",
+                            height: "auto",
                           }}
                           alt="example"
                           src={item.icon}
                         />
-                        <span style={{ fontWeight: "bold" }}>{item.name}</span>
+                        <span style={{ fontWeight: "bold", fontSize: 18, whiteSpace: "nowrap" }}>{item.name}</span>
                       </Space>
                     </Card>
                   </List.Item>
@@ -644,16 +802,124 @@ export const CreateWorkspace = () => {
             validateMessages={validateMessages}
             initialValues={{ folder: "/" }}
           >
-            <Space hidden={step2Hidden} className="chooseType" direction="vertical">
+            <Space hidden={step2Hidden} className="chooseType" direction="vertical" style={{ width: "100%" }}>
               <h3>Choose a repository</h3>
               <div className="workflowDescription2 App-text">
                 Choose the repository that hosts your {iacType?.name} source code.
               </div>
+
+              {!discoveryUnsupported && vcsId !== "" && (
+                <Segmented
+                  value={repoPickerMode}
+                  onChange={(value) => setRepoPickerMode(value as "list" | "manual")}
+                  options={[
+                    { label: "Browse repositories", value: "list" },
+                    { label: "Enter URL manually", value: "manual" },
+                  ]}
+                  style={{ marginBottom: 8 }}
+                />
+              )}
+
+              {repoPickerMode === "list" && (
+                <div style={{ width: "100%", maxWidth: 640 }}>
+                  <Card
+                    size="small"
+                    styles={{ body: { padding: 0 } }}
+                    style={{ borderRadius: token.borderRadiusLG, overflow: "hidden" }}
+                  >
+                    <Flex
+                      wrap="wrap"
+                      gap="small"
+                      justify="space-between"
+                      align="center"
+                      style={{
+                        padding: "12px",
+                        borderBottom: `1px solid ${token.colorBorderSecondary}`,
+                        backgroundColor: token.colorFillAlter,
+                      }}
+                    >
+                      <Select
+                        style={{ flex: "1 1 200px", minWidth: 180 }}
+                        loading={groupsLoading}
+                        value={selectedGroup || undefined}
+                        placeholder="Select organization"
+                        onChange={handleGroupChange}
+                        options={vcsGroups.map((group) => ({ label: group.name, value: group.id }))}
+                      />
+                      <Input.Search
+                        placeholder="Filter repositories by name"
+                        allowClear
+                        style={{ flex: "1 1 220px", minWidth: 180 }}
+                        value={repoSearch}
+                        onChange={(e) => handleRepoSearchChange(e.target.value)}
+                      />
+                    </Flex>
+
+                    {repoError && (
+                      <Alert type="error" showIcon banner message={repoError} style={{ borderRadius: 0 }} />
+                    )}
+
+                    <List
+                      loading={repoLoading && repoResults.length === 0}
+                      style={{ maxHeight: 420, overflowY: "auto" }}
+                      dataSource={repoResults}
+                      locale={{
+                        emptyText: repoSearch ? `No repositories match "${repoSearch}"` : "No repositories found",
+                      }}
+                      renderItem={(repo: VcsRepositorySummary) => (
+                        <List.Item
+                          onClick={() => handleRepoSelect(repo)}
+                          style={{
+                            cursor: "pointer",
+                            padding: "10px 12px",
+                            backgroundColor:
+                              selectedRepoUrl === repo.url ? token.controlItemBgActive : "transparent",
+                            borderLeft:
+                              selectedRepoUrl === repo.url
+                                ? `3px solid ${token.colorPrimary}`
+                                : "3px solid transparent",
+                          }}
+                        >
+                          <Flex justify="space-between" align="center" style={{ width: "100%" }}>
+                            <Space direction="vertical" size={0}>
+                              <span style={{ fontWeight: 500 }}>{repo.name}</span>
+                              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                                {repo.fullName}
+                              </Typography.Text>
+                            </Space>
+                            {repo.privateRepo && (
+                              <Tag icon={<LockOutlined />} style={{ marginRight: 0 }}>
+                                Private
+                              </Tag>
+                            )}
+                          </Flex>
+                        </List.Item>
+                      )}
+                    />
+
+                    {repoHasMore && (
+                      <div
+                        style={{
+                          textAlign: "center",
+                          padding: 8,
+                          borderTop: `1px solid ${token.colorBorderSecondary}`,
+                        }}
+                      >
+                        <Button onClick={handleLoadMoreRepos} loading={repoLoading} type="link" size="small">
+                          Load more repositories
+                        </Button>
+                      </div>
+                    )}
+                  </Card>
+                </div>
+              )}
+
               <Form.Item
                 name="source"
                 label="Git repo"
                 tooltip="e.g. https://github.com/Terrakube/terraform-sample-repository.git or git@github.com:AzBuilder/terraform-azurerm-webapp-sample.git"
                 extra=" Git repo must be a valid git url using either https or ssh protocol."
+                hidden={repoPickerMode === "list"}
                 rules={[
                   {
                     required: true,
@@ -665,6 +931,7 @@ export const CreateWorkspace = () => {
               >
                 <Input />
               </Form.Item>
+
               <Form.Item>
                 <Button onClick={handleGitContinueClick} type="primary">
                   Continue

--- a/ui/src/domain/types.ts
+++ b/ui/src/domain/types.ts
@@ -157,6 +157,26 @@ export enum VcsConnectionType {
   OAUTH = "OAUTH",
   STANDALONE = "STANDALONE",
 }
+
+export type VcsRepositoryGroup = {
+  id: string;
+  name: string;
+};
+
+export type VcsRepositorySummary = {
+  name: string;
+  fullName: string;
+  group: string;
+  url: string;
+  privateRepo: boolean;
+  defaultBranch?: string;
+};
+
+export type VcsRepositoryPage = {
+  items: VcsRepositorySummary[];
+  hasMore: boolean;
+  page: number;
+};
 export enum VcsStatus {
   PENDING = "PENDING",
   COMPLETED = "COMPLETED",


### PR DESCRIPTION
## Summary

Implements repository auto-discovery for workspace creation, closing #3267. Previously, connecting a workspace to VCS-hosted source code required manually typing the full git URL. This adds a searchable, paginated repository picker — similar to Terraform Cloud/Enterprise — backed live by each connected VCS provider's API, with a manual-entry fallback if discovery isn't available.

## Changes

### Backend
- Add `VcsRepositoryDiscoveryProvider` implementations for GitHub (OAuth + GitHub App), GitLab, Bitbucket Cloud, Bitbucket Server (on-prem), and Azure DevOps, each with server-side search and pagination so it scales to orgs with thousands of repos
- Add `GET /vcs/v1/{vcsId}/groups` and `GET /vcs/v1/{vcsId}/repositories` endpoints, gated by a new `VcsRepositoryAccessService` org-membership permission check
- Cache Azure DevOps' unpaginated repository list briefly (Caffeine), since that provider's API has no server-side search
- Fix GitHub App search silently capping at 150 repos instead of paginating honestly

### Frontend
- Replace the manual git-URL text box with a "Choose a repository" picker: org/group select, debounced search, paginated results, private-repo tags, and a clear browse/manual toggle with error fallback
- Redesign the workspace creation wizard's step breadcrumb: shows real progress and only allows navigating backward to already-completed steps (no skipping ahead)
- Fix IaC type cards (Terraform/OpenTofu) that were forced into an oversized grid, causing icon/text overflow
- Add a "GitHub App" connection option to the "connect a different VCS" dropdown, alongside the existing OAuth option

## Tests

- 47 new backend tests covering all five VCS providers via WireMock (`VcsRepositoryDiscovery{GitHub,GitLab,Bitbucket,AzureDevOps}Tests`), plus the discovery facade, permission logic, and controller status-code branching
- Verified no regression in existing `Vcs*Tests` and `WebhookTests`/`TokenTests`
- `mvn compile` and `yarn build` both pass clean

## Screenshots

<img width="2538" height="734" alt="terrakube-vcs-step1" src="https://github.com/user-attachments/assets/9fa782d8-83cf-4183-a7c9-72980b98db0a" />
<img width="2538" height="825" alt="terrakube-vcs-step2" src="https://github.com/user-attachments/assets/c3a0ae2c-30b7-49f4-873b-c3178660d48d" />
<img width="2544" height="713" alt="terrakube-vcs-step3" src="https://github.com/user-attachments/assets/e12ca82d-6bb8-484b-97b1-79d3e4149d79" />
<img width="2529" height="1089" alt="terrakube-vcs-step4" src="https://github.com/user-attachments/assets/59455d1a-831d-4d0b-852f-33af9d0e70d5" />
<img width="2533" height="1182" alt="terrakube-vcs-step5" src="https://github.com/user-attachments/assets/d333a4c1-c7b2-45fb-958d-1f3d7ae0038b" />


Closes #3267