### PR TITLE
feat: improve PR/MR plan & apply comments and fix silent GitLab/Bitbucket failures

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -10,6 +10,7 @@ import io.terrakube.api.plugin.softdelete.SoftDeleteService;
 import io.terrakube.api.plugin.variable.IncompleteVariableException;
 import io.terrakube.api.plugin.variable.WorkspaceVariableValidationService;
 import io.terrakube.api.plugin.vcs.PrCommentService;
+import io.terrakube.api.plugin.vcs.WebhookService;
 import io.terrakube.api.plugin.vcs.provider.azdevops.AzDevOpsWebhookService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
 import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
@@ -115,7 +116,11 @@ public class ScheduleJob implements org.quartz.Job {
             return true;
         }
 
-        if (job.getWorkspace().isLocked()) {
+        // The apply job created for a "terrakube apply" PR comment locks the workspace itself
+        // (see WebhookService.handlePrCommentCommand) to keep other jobs out while it runs. Without
+        // isOwnPrApplyLock() exempting that same job, this guard would block it from ever progressing,
+        // so the workspace would stay locked forever since only postPrCommentIfNeeded() unlocks it.
+        if (job.getWorkspace().isLocked() && !isOwnPrApplyLock(job)) {
             log.warn("Job {}, Workspace is locked. It must be unlocked before Terrakube can execute it.", jobId);
             return false;
         }
@@ -450,10 +455,21 @@ public class ScheduleJob implements org.quartz.Job {
         }
     }
 
+    /**
+     * True when the workspace's current lock is the one this exact job's PR-apply-comment flow
+     * created for itself (see WebhookService.handlePrCommentCommand), rather than an unrelated
+     * manual or concurrent lock that should still block the job.
+     */
+    private boolean isOwnPrApplyLock(Job job) {
+        return job.isAutoApply() && job.getPrNumber() != null
+                && WebhookService.buildPrApplyLockDescription(job.getPrNumber()).equals(job.getWorkspace().getLockDescription());
+    }
+
     private void postPrCommentIfNeeded(Job job) {
         if (job.getPrNumber() == null || job.getPrNumber() == 0) return;
 
         try {
+            prCommentService.acknowledgeCompletion(job);
             if (tclService.isTemplatePlanOnly(job.getTemplateReference())) {
                 prCommentService.postPlanResult(job);
             } else {

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -470,15 +470,19 @@ public class ScheduleJob implements org.quartz.Job {
 
         try {
             prCommentService.acknowledgeCompletion(job);
-            if (tclService.isTemplatePlanOnly(job.getTemplateReference())) {
-                prCommentService.postPlanResult(job);
-            } else {
+            // job.isAutoApply() marks the job created by the "terrakube apply" PR comment
+            // specifically (see WebhookService.handlePrCommentCommand); tclService.isTemplatePlanOnly()
+            // reflects the *template's* nature and can misclassify this job if the workspace's
+            // default template isn't recognized as a full apply template.
+            if (job.isAutoApply()) {
                 prCommentService.postApplyResult(job);
                 Workspace workspace = job.getWorkspace();
                 workspace.setLocked(false);
                 workspace.setLockDescription(null);
                 workspaceRepository.save(workspace);
                 log.info("Unlocked workspace {} after PR #{} apply completed", workspace.getName(), job.getPrNumber());
+            } else {
+                prCommentService.postPlanResult(job);
             }
         } catch (Exception e) {
             log.error("Error posting PR comment for job {}: {}", job.getId(), e.getMessage());

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
@@ -23,6 +23,9 @@ public class PrCommentService {
 
     private static final int MAX_COMMENT_LENGTH = 60000;
     private static final Set<VcsType> PR_COMMENT_SUPPORTED_VCS = EnumSet.of(VcsType.GITHUB, VcsType.GITLAB, VcsType.BITBUCKET);
+    private static final java.util.regex.Pattern PLAN_SUMMARY_PATTERN = java.util.regex.Pattern.compile(
+            "(Plan: \\d+ to add, \\d+ to change, \\d+ to destroy\\.|No changes\\. Your infrastructure matches the configuration\\.)");
+
 
     GitHubWebhookService gitHubWebhookService;
     GitLabWebhookService gitLabWebhookService;
@@ -108,6 +111,17 @@ public class PrCommentService {
         return commentId;
     }
 
+    private String statusIcon(JobStatus status) {
+        switch (status) {
+            case completed:
+                return "✅";
+            case failed:
+                return "❌";
+            default:
+                return "⚠️";
+        }
+    }
+
     private String formatPlanComment(Job job, String planOutput) {
         StringBuilder sb = new StringBuilder();
         sb.append("## Terrakube Plan Output\n\n");
@@ -115,20 +129,27 @@ public class PrCommentService {
         sb.append("**Status:** ").append(job.getStatus()).append("\n");
         sb.append("**Job:** #").append(job.getId()).append("\n\n");
 
+        String icon = statusIcon(job.getStatus());
+
         if (planOutput != null && !planOutput.isEmpty()) {
+            java.util.regex.Matcher summaryMatcher = PLAN_SUMMARY_PATTERN.matcher(planOutput);
+            if (summaryMatcher.find()) {
+                sb.append(icon).append(" ").append(summaryMatcher.group(1)).append("\n\n");
+            }
+
             String content = planOutput;
             if (content.length() > MAX_COMMENT_LENGTH) {
                 content = content.substring(0, MAX_COMMENT_LENGTH)
                         + "\n\n... (output truncated, see full output in Terrakube UI)";
             }
             sb.append("<details><summary>Show Plan</summary>\n\n");
-            sb.append("```hcl\n");
+            sb.append("```diff\n");
             sb.append(content);
             sb.append("\n```\n\n</details>\n\n");
         } else if (job.getStatus() == JobStatus.completed) {
-            sb.append("No changes detected.\n\n");
+            sb.append(icon).append(" No changes detected.\n\n");
         } else {
-            sb.append("Plan failed. Check the Terrakube UI for details.\n\n");
+            sb.append(icon).append(" Plan failed. Check the Terrakube UI for details.\n\n");
         }
 
         sb.append("---\n");
@@ -145,13 +166,17 @@ public class PrCommentService {
         sb.append("**Status:** ").append(job.getStatus()).append("\n");
         sb.append("**Job:** #").append(job.getId()).append("\n\n");
 
+        String icon = statusIcon(job.getStatus());
+        String summary = job.getStatus() == JobStatus.completed ? "Apply complete" : "Apply failed";
+        sb.append(icon).append(" ").append(summary).append("\n\n");
+
         if (output != null && !output.isEmpty()) {
             String content = output;
             if (content.length() > MAX_COMMENT_LENGTH) {
                 content = content.substring(0, MAX_COMMENT_LENGTH)
                         + "\n\n... (output truncated, see full output in Terrakube UI)";
             }
-            sb.append("<details><summary>Show Output</summary>\n\n");
+            sb.append("<details><summary>Show Apply Output</summary>\n\n");
             sb.append("```\n");
             sb.append(content);
             sb.append("\n```\n\n</details>\n");

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
@@ -7,6 +7,7 @@ import io.terrakube.api.repository.JobRepository;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.vcs.VcsType;
+import io.terrakube.api.rs.workspace.Workspace;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -72,6 +73,21 @@ public class PrCommentService {
     private String buildFailureMessage(Job job) {
         return "Failed to post comment on pull request #" + job.getPrNumber()
                 + ". Verify the VCS connection has write access to pull requests.";
+    }
+
+    public void postApplyDisabledNotice(Workspace workspace, Integer prNumber) {
+        if (prNumber == null || prNumber == 0) return;
+
+        Job transientJob = new Job();
+        transientJob.setWorkspace(workspace);
+        transientJob.setPrNumber(prNumber);
+
+        String markdown = "## Terrakube Apply\n\n" +
+                "⚠️ Apply via PR comment is not enabled for this workspace.\n\n" +
+                "Ask a workspace admin to enable **Allow Apply via PR Comment** in the webhook settings, " +
+                "or apply this plan from the Terrakube UI.\n";
+
+        postComment(transientJob, markdown);
     }
 
     private String postComment(Job job, String markdownComment) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
@@ -12,8 +12,8 @@ import io.terrakube.api.rs.vcs.VcsType;
 import io.terrakube.api.rs.job.step.Step;
 import io.terrakube.api.rs.workspace.Workspace;
 
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.nio.charset.StandardCharsets;
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-@AllArgsConstructor
 @Slf4j
 @Service
 public class PrCommentService {
@@ -42,17 +41,46 @@ public class PrCommentService {
     StorageTypeService storageTypeService;
     StreamingService streamingService;
 
+    @Value("${io.terrakube.ui.url:}")
+    String uiUrl;
+
+    public PrCommentService(GitHubWebhookService gitHubWebhookService, GitLabWebhookService gitLabWebhookService,
+            BitBucketWebhookService bitBucketWebhookService, JobRepository jobRepository,
+            StorageTypeService storageTypeService, StreamingService streamingService) {
+        this.gitHubWebhookService = gitHubWebhookService;
+        this.gitLabWebhookService = gitLabWebhookService;
+        this.bitBucketWebhookService = bitBucketWebhookService;
+        this.jobRepository = jobRepository;
+        this.storageTypeService = storageTypeService;
+        this.streamingService = streamingService;
+    }
+
     public void postPlanResult(Job job) {
         if (job.getPrNumber() == null || job.getPrNumber() == 0) return;
 
         String planOutput = fetchStepOutputText(job);
         String markdownComment = formatPlanComment(job, planOutput);
 
-        String commentId = attemptPostComment(job, markdownComment);
+        String existingThreadCommentId = findReusablePlanCommentId(job);
+        String commentId = existingThreadCommentId != null
+                ? attemptUpdateComment(job, existingThreadCommentId, markdownComment)
+                : attemptPostComment(job, markdownComment);
         if (commentId != null) {
             job.setPrCommentId(commentId);
         }
         jobRepository.save(job);
+    }
+
+    /**
+     * Reuses the comment from the most recent prior plan job on this same PR (if any) so
+     * repeated replans update one running comment instead of stacking a new one per push.
+     * Apply jobs are excluded so the apply audit trail is never overwritten in place.
+     */
+    private String findReusablePlanCommentId(Job job) {
+        return jobRepository.findFirstByWorkspaceAndPrNumberAndIdNotAndAutoApplyFalseAndPrCommentIdIsNotNullOrderByIdDesc(
+                        job.getWorkspace(), job.getPrNumber(), job.getId())
+                .map(Job::getPrCommentId)
+                .orElse(null);
     }
 
     public void postApplyResult(Job job) {
@@ -86,6 +114,36 @@ public class PrCommentService {
     private String buildFailureMessage(Job job) {
         return "Failed to post comment on pull request #" + job.getPrNumber()
                 + ". Verify the VCS connection has write access to pull requests.";
+    }
+
+    /**
+     * Tries to edit the existing thread comment in place; falls back to posting a new comment
+     * if the update fails (e.g. the original comment was deleted), so the plan result is never
+     * silently dropped.
+     */
+    private String attemptUpdateComment(Job job, String commentId, String markdownComment) {
+        try {
+            if (updateComment(job, commentId, markdownComment)) {
+                job.setPrCommentError(null);
+                return commentId;
+            }
+        } catch (Exception e) {
+            log.error("Error updating PR comment {} for job {}: {}", commentId, job.getId(), e.getMessage());
+        }
+        return attemptPostComment(job, markdownComment);
+    }
+
+    private boolean updateComment(Job job, String commentId, String markdownComment) {
+        switch (job.getWorkspace().getVcs().getVcsType()) {
+            case GITHUB:
+                return gitHubWebhookService.updatePrComment(job, commentId, markdownComment);
+            case GITLAB:
+                return gitLabWebhookService.updateMergeRequestNote(job, commentId, markdownComment);
+            case BITBUCKET:
+                return bitBucketWebhookService.updatePrComment(job, commentId, markdownComment);
+            default:
+                return false;
+        }
     }
 
     /**
@@ -158,6 +216,16 @@ public class PrCommentService {
         return commentId;
     }
 
+    private String jobReference(Job job) {
+        if (uiUrl == null || uiUrl.isEmpty()) {
+            return "#" + job.getId();
+        }
+        Workspace workspace = job.getWorkspace();
+        String jobUrl = String.format("%s/organizations/%s/workspaces/%s/runs/%s", uiUrl,
+                workspace.getOrganization().getId(), workspace.getId(), job.getId());
+        return "[#" + job.getId() + "](" + jobUrl + ")";
+    }
+
     private String statusIcon(JobStatus status) {
         switch (status) {
             case completed:
@@ -174,7 +242,7 @@ public class PrCommentService {
         sb.append("## Terrakube Plan Output\n\n");
         sb.append("**Workspace:** ").append(job.getWorkspace().getName()).append("\n");
         sb.append("**Status:** ").append(job.getStatus()).append("\n");
-        sb.append("**Job:** #").append(job.getId()).append("\n\n");
+        sb.append("**Job:** ").append(jobReference(job)).append("\n\n");
 
         String icon = statusIcon(job.getStatus());
 
@@ -200,7 +268,12 @@ public class PrCommentService {
         }
 
         sb.append("---\n");
-        sb.append("To apply this plan, comment: `terrakube apply`\n");
+        if (job.isPrApplyEnabled()) {
+            sb.append("To apply this plan, comment: `terrakube apply`\n");
+        } else {
+            sb.append("Apply via PR comment is disabled for this workspace. Apply this plan from the Terrakube UI, ")
+              .append("or ask a workspace admin to enable **Allow Apply via PR Comment**.\n");
+        }
         sb.append("To re-plan, comment: `terrakube plan`\n");
 
         return sb.toString();
@@ -211,7 +284,7 @@ public class PrCommentService {
         sb.append("## Terrakube Apply Output\n\n");
         sb.append("**Workspace:** ").append(job.getWorkspace().getName()).append("\n");
         sb.append("**Status:** ").append(job.getStatus()).append("\n");
-        sb.append("**Job:** #").append(job.getId()).append("\n\n");
+        sb.append("**Job:** ").append(jobReference(job)).append("\n\n");
 
         String icon = statusIcon(job.getStatus());
         String summary = job.getStatus() == JobStatus.completed ? "Apply complete" : "Apply failed";

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
@@ -1,5 +1,7 @@
 package io.terrakube.api.plugin.vcs;
 
+import io.terrakube.api.plugin.storage.StorageTypeService;
+import io.terrakube.api.plugin.streaming.StreamingService;
 import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
 import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
@@ -7,14 +9,19 @@ import io.terrakube.api.repository.JobRepository;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.vcs.VcsType;
+import io.terrakube.api.rs.job.step.Step;
 import io.terrakube.api.rs.workspace.Workspace;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @AllArgsConstructor
 @Slf4j
@@ -23,19 +30,22 @@ public class PrCommentService {
 
     private static final int MAX_COMMENT_LENGTH = 60000;
     private static final Set<VcsType> PR_COMMENT_SUPPORTED_VCS = EnumSet.of(VcsType.GITHUB, VcsType.GITLAB, VcsType.BITBUCKET);
-    private static final java.util.regex.Pattern PLAN_SUMMARY_PATTERN = java.util.regex.Pattern.compile(
+    private static final Pattern PLAN_SUMMARY_PATTERN = Pattern.compile(
             "(Plan: \\d+ to add, \\d+ to change, \\d+ to destroy\\.|No changes\\. Your infrastructure matches the configuration\\.)");
-
+    private static final Pattern ANSI_PATTERN = Pattern.compile(
+            "[\\u001b\\u009b][\\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nq-uy=><~]");
 
     GitHubWebhookService gitHubWebhookService;
     GitLabWebhookService gitLabWebhookService;
     BitBucketWebhookService bitBucketWebhookService;
     JobRepository jobRepository;
+    StorageTypeService storageTypeService;
+    StreamingService streamingService;
 
     public void postPlanResult(Job job) {
         if (job.getPrNumber() == null || job.getPrNumber() == 0) return;
 
-        String planOutput = job.getTerraformPlan();
+        String planOutput = fetchStepOutputText(job);
         String markdownComment = formatPlanComment(job, planOutput);
 
         String commentId = attemptPostComment(job, markdownComment);
@@ -48,7 +58,7 @@ public class PrCommentService {
     public void postApplyResult(Job job) {
         if (job.getPrNumber() == null || job.getPrNumber() == 0) return;
 
-        String output = job.getOutput();
+        String output = fetchStepOutputText(job);
         String markdownComment = formatApplyComment(job, output);
         attemptPostComment(job, markdownComment);
         jobRepository.save(job);
@@ -76,6 +86,43 @@ public class PrCommentService {
     private String buildFailureMessage(Job job) {
         return "Failed to post comment on pull request #" + job.getPrNumber()
                 + ". Verify the VCS connection has write access to pull requests.";
+    }
+
+    /**
+     * job.getTerraformPlan() is a storage pointer to the binary .tfplan file, and
+     * job.getOutput() is just append-only step-completion markers - neither holds the
+     * human-readable console text. The real diff/summary text lives in the last step's
+     * console output, the same place the job details UI reads it from.
+     */
+    private String fetchStepOutputText(Job job) {
+        Step step = job.getStep() == null ? null : job.getStep().stream()
+                .max(Comparator.comparingInt(Step::getStepNumber))
+                .orElse(null);
+        if (step == null) {
+            return null;
+        }
+
+        try {
+            String stepId = step.getId().toString();
+            String liveLogs = streamingService.getCurrentLogs(stepId);
+            if (liveLogs != null && !liveLogs.isEmpty()) {
+                return stripAnsi(liveLogs);
+            }
+
+            byte[] storedOutput = storageTypeService.getStepOutput(
+                    job.getOrganization().getId().toString(), String.valueOf(job.getId()), stepId);
+            if (storedOutput == null || storedOutput.length == 0) {
+                return null;
+            }
+            return stripAnsi(new String(storedOutput, StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            log.error("Error fetching step output for job {}: {}", job.getId(), e.getMessage());
+            return null;
+        }
+    }
+
+    private String stripAnsi(String text) {
+        return ANSI_PATTERN.matcher(text).replaceAll("");
     }
 
     public void postApplyDisabledNotice(Workspace workspace, Integer prNumber) {
@@ -132,7 +179,7 @@ public class PrCommentService {
         String icon = statusIcon(job.getStatus());
 
         if (planOutput != null && !planOutput.isEmpty()) {
-            java.util.regex.Matcher summaryMatcher = PLAN_SUMMARY_PATTERN.matcher(planOutput);
+            Matcher summaryMatcher = PLAN_SUMMARY_PATTERN.matcher(planOutput);
             if (summaryMatcher.find()) {
                 sb.append(icon).append(" ").append(summaryMatcher.group(1)).append("\n\n");
             }

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
@@ -198,6 +198,34 @@ public class PrCommentService {
         postComment(transientJob, markdown);
     }
 
+    /**
+     * Reacts to the original "terrakube plan"/"terrakube apply" comment with a checkmark or cross
+     * once that job finishes, so a user watching the PR can see the command was actioned without
+     * opening the (possibly long) result comment. Bitbucket Cloud has no comment-reaction API, so
+     * it's a no-op there. Failures here must never affect the plan/apply result itself.
+     */
+    public void acknowledgeCompletion(Job job) {
+        String commentId = job.getCommandCommentId();
+        if (commentId == null || commentId.isEmpty() || job.getPrNumber() == null || job.getPrNumber() == 0) return;
+
+        boolean success = job.getStatus() == JobStatus.completed;
+        try {
+            switch (job.getWorkspace().getVcs().getVcsType()) {
+                case GITHUB:
+                    gitHubWebhookService.addCommentReaction(job.getWorkspace(), commentId, success ? "+1" : "-1");
+                    break;
+                case GITLAB:
+                    gitLabWebhookService.addNoteReaction(job.getWorkspace(), job.getPrNumber(), commentId,
+                            success ? "white_check_mark" : "x");
+                    break;
+                default:
+                    break;
+            }
+        } catch (Exception e) {
+            log.warn("Failed to acknowledge completion for job {}: {}", job.getId(), e.getMessage());
+        }
+    }
+
     private String postComment(Job job, String markdownComment) {
         String commentId = null;
         switch (job.getWorkspace().getVcs().getVcsType()) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookResult.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookResult.java
@@ -24,6 +24,7 @@ public class WebhookResult {
     private boolean isRelease;
     private String commentBody;
     private String commentCommand;
+    private String commentId;
     private boolean isPrComment;
     private String prFilesUrl;
 

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
@@ -44,6 +44,7 @@ public class WebhookService {
     ScheduleJobService scheduleJobService;
     ObjectMapper objectMapper;
     WorkspaceRepository workspaceRepository;
+    PrCommentService prCommentService;
 
     @Transactional
     public String processWebhook(String webhookId, String jsonPayload, Map<String, String> headers) {
@@ -119,19 +120,29 @@ public class WebhookService {
         return result;
     }
 
-    private void handlePrCommentCommand(WebhookResult webhookResult, Webhook webhook, Workspace workspace) throws Exception {
+    void handlePrCommentCommand(WebhookResult webhookResult, Webhook webhook, Workspace workspace) throws Exception {
         String command = webhookResult.getCommentCommand();
         log.info("PR comment command '{}' received for workspace {}", command, workspace.getName());
 
         WebhookEvent matchedEvent = findMatchingEvent(webhookResult, webhook);
 
         if ("plan".equals(command)) {
+            if (!matchedEvent.isPrWorkflowEnabled()) {
+                log.info("Ignoring PR plan comment for workspace {}: PR workflow is not enabled", workspace.getName());
+                return;
+            }
             log.info("PR comment plan for workspace {}, using template {}", workspace.getName(), matchedEvent.getTemplateId());
             Job savedJob = createAndScheduleJob(matchedEvent.getTemplateId(), webhookResult, workspace);
             savedJob.setPrNumber(webhookResult.getPrNumber() != null ? webhookResult.getPrNumber().intValue() : null);
             jobRepository.save(savedJob);
             sendCommitStatus(savedJob);
         } else if ("apply".equals(command)) {
+            Integer prNumber = webhookResult.getPrNumber() != null ? webhookResult.getPrNumber().intValue() : null;
+            if (!matchedEvent.isPrWorkflowEnabled() || !matchedEvent.isPrApplyEnabled()) {
+                log.info("Rejecting PR apply comment for workspace {}: apply via PR comment is not enabled", workspace.getName());
+                prCommentService.postApplyDisabledNotice(workspace, prNumber);
+                return;
+            }
             String templateId = workspace.getDefaultTemplate();
             if (templateId == null || templateId.isEmpty()) {
                 log.error("No default template configured for apply in PR workflow on workspace {}", workspace.getName());
@@ -142,7 +153,7 @@ public class WebhookService {
             workspace.setLockDescription("Locked by PR #" + webhookResult.getPrNumber() + " apply");
             workspaceRepository.save(workspace);
             Job savedJob = createAndScheduleJob(templateId, webhookResult, workspace);
-            savedJob.setPrNumber(webhookResult.getPrNumber() != null ? webhookResult.getPrNumber().intValue() : null);
+            savedJob.setPrNumber(prNumber);
             savedJob.setAutoApply(true);
             jobRepository.save(savedJob);
             sendCommitStatus(savedJob);

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
@@ -125,6 +125,8 @@ public class WebhookService {
         String command = webhookResult.getCommentCommand();
         log.info("PR comment command '{}' received for workspace {}", command, workspace.getName());
 
+        acknowledgeCommand(workspace, webhookResult);
+
         WebhookEvent matchedEvent = findMatchingEvent(webhookResult, webhook);
 
         if ("plan".equals(command)) {
@@ -159,6 +161,32 @@ public class WebhookService {
             savedJob.setAutoApply(true);
             jobRepository.save(savedJob);
             sendCommitStatus(savedJob);
+        }
+    }
+
+    /**
+     * Adds an "eyes" reaction to the triggering comment as soon as a valid terrakube plan/apply
+     * command is recognized, so the user gets immediate feedback that the command was seen while
+     * the job (and later PR comment) is still running. Bitbucket Cloud has no comment-reaction API,
+     * so it's a no-op there. Failures here must never block the actual plan/apply from proceeding.
+     */
+    private void acknowledgeCommand(Workspace workspace, WebhookResult webhookResult) {
+        String commentId = webhookResult.getCommentId();
+        if (commentId == null || commentId.isEmpty()) return;
+
+        try {
+            switch (workspace.getVcs().getVcsType()) {
+                case GITHUB:
+                    gitHubWebhookService.addCommentReaction(workspace, commentId);
+                    break;
+                case GITLAB:
+                    gitLabWebhookService.addNoteReaction(workspace, webhookResult.getPrNumber(), commentId);
+                    break;
+                default:
+                    break;
+            }
+        } catch (Exception e) {
+            log.warn("Failed to acknowledge PR comment command for workspace {}: {}", workspace.getName(), e.getMessage());
         }
     }
 

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
@@ -109,6 +109,7 @@ public class WebhookService {
 
                 if (matchedEvent.isPrWorkflowEnabled() && webhookResult.getPrNumber() != null) {
                     savedJob.setPrNumber(webhookResult.getPrNumber().intValue());
+                    savedJob.setPrApplyEnabled(matchedEvent.isPrApplyEnabled());
                     jobRepository.save(savedJob);
                 }
 
@@ -134,6 +135,7 @@ public class WebhookService {
             log.info("PR comment plan for workspace {}, using template {}", workspace.getName(), matchedEvent.getTemplateId());
             Job savedJob = createAndScheduleJob(matchedEvent.getTemplateId(), webhookResult, workspace);
             savedJob.setPrNumber(webhookResult.getPrNumber() != null ? webhookResult.getPrNumber().intValue() : null);
+            savedJob.setPrApplyEnabled(matchedEvent.isPrApplyEnabled());
             jobRepository.save(savedJob);
             sendCommitStatus(savedJob);
         } else if ("apply".equals(command)) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
@@ -138,6 +138,7 @@ public class WebhookService {
             Job savedJob = createAndScheduleJob(matchedEvent.getTemplateId(), webhookResult, workspace);
             savedJob.setPrNumber(webhookResult.getPrNumber() != null ? webhookResult.getPrNumber().intValue() : null);
             savedJob.setPrApplyEnabled(matchedEvent.isPrApplyEnabled());
+            savedJob.setCommandCommentId(webhookResult.getCommentId());
             jobRepository.save(savedJob);
             sendCommitStatus(savedJob);
         } else if ("apply".equals(command)) {
@@ -154,14 +155,24 @@ public class WebhookService {
             }
             log.info("PR comment apply for workspace {}, using default template {}", workspace.getName(), templateId);
             workspace.setLocked(true);
-            workspace.setLockDescription("Locked by PR #" + webhookResult.getPrNumber() + " apply");
+            workspace.setLockDescription(buildPrApplyLockDescription(prNumber));
             workspaceRepository.save(workspace);
             Job savedJob = createAndScheduleJob(templateId, webhookResult, workspace);
             savedJob.setPrNumber(prNumber);
             savedJob.setAutoApply(true);
+            savedJob.setCommandCommentId(webhookResult.getCommentId());
             jobRepository.save(savedJob);
             sendCommitStatus(savedJob);
         }
+    }
+
+    /**
+     * Shared with ScheduleJob's workspace-lock guard, which must recognize this exact lock as
+     * belonging to the auto-apply job it created, so that job (and only that job) can proceed
+     * and eventually release the lock once it finishes.
+     */
+    public static String buildPrApplyLockDescription(Integer prNumber) {
+        return "Locked by PR #" + prNumber + " apply";
     }
 
     /**
@@ -177,10 +188,10 @@ public class WebhookService {
         try {
             switch (workspace.getVcs().getVcsType()) {
                 case GITHUB:
-                    gitHubWebhookService.addCommentReaction(workspace, commentId);
+                    gitHubWebhookService.addCommentReaction(workspace, commentId, "eyes");
                     break;
                 case GITLAB:
-                    gitLabWebhookService.addNoteReaction(workspace, webhookResult.getPrNumber(), commentId);
+                    gitLabWebhookService.addNoteReaction(workspace, webhookResult.getPrNumber(), commentId, "eyes");
                     break;
                 default:
                     break;

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
@@ -202,6 +202,7 @@ public class BitBucketWebhookService extends WebhookServiceBase {
             result.setPrComment(true);
             result.setCommentBody(commentBody);
             result.setCommentCommand(command);
+            result.setCommentId(rootNode.path("comment").path("id").asText());
             result.setCreatedBy(rootNode.path("comment").path("user").path("display_name").asText());
 
             JsonNode pullRequestNode = rootNode.path("pullrequest");

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
@@ -248,6 +248,24 @@ public class BitBucketWebhookService extends WebhookServiceBase {
         return null;
     }
 
+    public boolean updatePrComment(Job job, String commentId, String markdownBody) {
+        Workspace workspace = job.getWorkspace();
+        String[] ownerAndRepo = extractOwnerAndRepo(workspace.getSource());
+        String apiUrl = workspace.getVcs().getApiUrl() + "/repositories/" + String.join("/", ownerAndRepo)
+                + "/pullrequests/" + job.getPrNumber() + "/comments/" + commentId;
+
+        String escapedBody = escapeJsonString(markdownBody);
+        String body = "{\"content\":{\"raw\":\"" + escapedBody + "\"}}";
+
+        ResponseEntity<String> response = callBitBucketApi(workspace.getVcs().getAccessToken(), body, apiUrl, HttpMethod.PUT);
+        if (response != null && response.getStatusCode().is2xxSuccessful()) {
+            log.info("PR comment {} updated successfully on PR #{} in workspace {}", commentId, job.getPrNumber(), workspace.getName());
+            return true;
+        }
+        log.error("Failed to update PR comment {} on PR #{} in workspace {}", commentId, job.getPrNumber(), workspace.getName());
+        return false;
+    }
+
     private List<String> getFileChanges(String diffFile, String workspaceId) {
         List<String> fileChanges = new ArrayList<>();
 

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
@@ -128,6 +128,8 @@ public class BitBucketWebhookService extends WebhookServiceBase {
             JsonNode rootNode = objectMapper.readTree(jsonPayload);
             JsonNode pullRequestNode = rootNode.path("pullrequest");
 
+            result.setPrNumber(pullRequestNode.path("id").asInt());
+
             String sourceBranch = pullRequestNode.path("source").path("branch").path("name").asText();
             result.setBranch(sourceBranch);
 

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -439,7 +439,7 @@ public class GitHubWebhookService extends WebhookServiceBase {
         return null;
     }
 
-    public void updatePrComment(Job job, String commentId, String markdownBody) {
+    public boolean updatePrComment(Job job, String commentId, String markdownBody) {
         Workspace workspace = job.getWorkspace();
         String[] ownerAndRepo = extractOwnerAndRepo(workspace.getSource());
         String apiUrl = workspace.getVcs().getApiUrl() + "/repos/" + String.join("/", ownerAndRepo)
@@ -450,10 +450,11 @@ public class GitHubWebhookService extends WebhookServiceBase {
 
         ResponseEntity<String> response = callGitHubApi(workspace.getVcs(), ownerAndRepo, body, apiUrl, HttpMethod.PATCH);
         if (response != null && response.getStatusCode().is2xxSuccessful()) {
-            log.info("PR comment updated successfully on workspace {}", workspace.getName());
-        } else {
-            log.error("Failed to update PR comment on workspace {}", workspace.getName());
+            log.info("PR comment {} updated successfully on workspace {}", commentId, workspace.getName());
+            return true;
         }
+        log.error("Failed to update PR comment {} on workspace {}", commentId, workspace.getName());
+        return false;
     }
 
     public WebhookResult parseGitHubPayload(String jsonPayload, Map<String, String> headers, Vcs vcs) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -157,6 +157,7 @@ public class GitHubWebhookService extends WebhookServiceBase {
                         result.setPrComment(true);
                         result.setCommentBody(commentBody);
                         result.setCommentCommand(command);
+                        result.setCommentId(rootNode.path("comment").path("id").asText());
                         result.setPrNumber(issueNode.path("number").asInt());
                         result.setCreatedBy(rootNode.path("comment").path("user").path("login").asText());
 
@@ -455,6 +456,20 @@ public class GitHubWebhookService extends WebhookServiceBase {
         }
         log.error("Failed to update PR comment {} on workspace {}", commentId, workspace.getName());
         return false;
+    }
+
+    public void addCommentReaction(Workspace workspace, String commentId) {
+        String[] ownerAndRepo = extractOwnerAndRepo(workspace.getSource());
+        String apiUrl = workspace.getVcs().getApiUrl() + "/repos/" + String.join("/", ownerAndRepo)
+                + "/issues/comments/" + commentId + "/reactions";
+
+        ResponseEntity<String> response = callGitHubApi(workspace.getVcs(), ownerAndRepo, "{\"content\":\"eyes\"}", apiUrl,
+                HttpMethod.POST);
+        if (response != null && response.getStatusCode().is2xxSuccessful()) {
+            log.info("Added eyes reaction to PR comment {} in workspace {}", commentId, workspace.getName());
+        } else {
+            log.error("Failed to add reaction to PR comment {} in workspace {}", commentId, workspace.getName());
+        }
     }
 
     public WebhookResult parseGitHubPayload(String jsonPayload, Map<String, String> headers, Vcs vcs) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -458,15 +458,15 @@ public class GitHubWebhookService extends WebhookServiceBase {
         return false;
     }
 
-    public void addCommentReaction(Workspace workspace, String commentId) {
+    public void addCommentReaction(Workspace workspace, String commentId, String reactionContent) {
         String[] ownerAndRepo = extractOwnerAndRepo(workspace.getSource());
         String apiUrl = workspace.getVcs().getApiUrl() + "/repos/" + String.join("/", ownerAndRepo)
                 + "/issues/comments/" + commentId + "/reactions";
 
-        ResponseEntity<String> response = callGitHubApi(workspace.getVcs(), ownerAndRepo, "{\"content\":\"eyes\"}", apiUrl,
-                HttpMethod.POST);
+        ResponseEntity<String> response = callGitHubApi(workspace.getVcs(), ownerAndRepo,
+                "{\"content\":\"" + reactionContent + "\"}", apiUrl, HttpMethod.POST);
         if (response != null && response.getStatusCode().is2xxSuccessful()) {
-            log.info("Added eyes reaction to PR comment {} in workspace {}", commentId, workspace.getName());
+            log.info("Added {} reaction to PR comment {} in workspace {}", reactionContent, commentId, workspace.getName());
         } else {
             log.error("Failed to add reaction to PR comment {} in workspace {}", commentId, workspace.getName());
         }

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -656,6 +656,40 @@ public class GitLabWebhookService extends WebhookServiceBase {
         return null;
     }
 
+    public boolean updateMergeRequestNote(Job job, String noteId, String markdownBody) {
+        Workspace workspace = job.getWorkspace();
+        try {
+            String ownerAndRepo = extractOwnerAndRepoGitlab(workspace.getSource());
+            String projectId = getGitlabProjectId(ownerAndRepo, workspace.getVcs().getAccessToken(), workspace.getVcs().getApiUrl());
+
+            WebClient webClient = webClientBuilder
+                    .baseUrl(workspace.getVcs().getApiUrl())
+                    .defaultHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                    .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + workspace.getVcs().getAccessToken())
+                    .clientConnector(new ReactorClientHttpConnector(HttpClient.create().proxyWithSystemProperties()))
+                    .build();
+
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("body", markdownBody);
+
+            webClient.put()
+                    .uri("/projects/{id}/merge_requests/{iid}/notes/{noteId}", projectId, job.getPrNumber(), noteId)
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            log.info("MR note {} updated successfully on MR !{} in workspace {}", noteId, job.getPrNumber(), workspace.getName());
+            return true;
+        } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            log.error("Error updating MR note {} on MR !{} in workspace {}", noteId, job.getPrNumber(), workspace.getName(), e);
+            return false;
+        }
+    }
+
     public void sendCommitStatus(Job job, JobStatus jobStatus) {
         Workspace workspace = job.getWorkspace();
         String jobUrl = String.format("%s/organizations/%s/workspaces/%s/runs/%s", uiUrl,

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -209,6 +209,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
             result.setPrComment(true);
             result.setCommentBody(commentBody);
             result.setCommentCommand(command);
+            result.setCommentId(noteNode.path("id").asText());
             result.setEvent("note");
             result.setCreatedBy(rootNode.path("user").path("username").asText());
 
@@ -687,6 +688,37 @@ public class GitLabWebhookService extends WebhookServiceBase {
             }
             log.error("Error updating MR note {} on MR !{} in workspace {}", noteId, job.getPrNumber(), workspace.getName(), e);
             return false;
+        }
+    }
+
+    public void addNoteReaction(Workspace workspace, Number prNumber, String noteId) {
+        try {
+            String ownerAndRepo = extractOwnerAndRepoGitlab(workspace.getSource());
+            String projectId = getGitlabProjectId(ownerAndRepo, workspace.getVcs().getAccessToken(), workspace.getVcs().getApiUrl());
+
+            WebClient webClient = webClientBuilder
+                    .baseUrl(workspace.getVcs().getApiUrl())
+                    .defaultHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+                    .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + workspace.getVcs().getAccessToken())
+                    .clientConnector(new ReactorClientHttpConnector(HttpClient.create().proxyWithSystemProperties()))
+                    .build();
+
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("name", "eyes");
+
+            webClient.post()
+                    .uri("/projects/{id}/merge_requests/{iid}/notes/{noteId}/award_emoji", projectId, prNumber, noteId)
+                    .bodyValue(requestBody)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            log.info("Added eyes award emoji to MR note {} in workspace {}", noteId, workspace.getName());
+        } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            log.error("Error adding award emoji to MR note {} in workspace {}", noteId, workspace.getName(), e);
         }
     }
 

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -159,6 +159,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
                     log.info("New merge request {}: {}", action, mrModel.getObjectAttributes().getTitle());
                     result.setBranch(mrModel.getObjectAttributes().getSourceBranch());
                     result.setCreatedBy("system");
+                    result.setPrNumber(mrModel.getObjectAttributes().getIid());
 
                     if (mrModel.getObjectAttributes().getLastCommit() != null) {
                         result.setCommit(mrModel.getObjectAttributes().getLastCommit().getId());
@@ -691,7 +692,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
         }
     }
 
-    public void addNoteReaction(Workspace workspace, Number prNumber, String noteId) {
+    public void addNoteReaction(Workspace workspace, Number prNumber, String noteId, String emojiName) {
         try {
             String ownerAndRepo = extractOwnerAndRepoGitlab(workspace.getSource());
             String projectId = getGitlabProjectId(ownerAndRepo, workspace.getVcs().getAccessToken(), workspace.getVcs().getApiUrl());
@@ -704,7 +705,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
                     .build();
 
             Map<String, Object> requestBody = new HashMap<>();
-            requestBody.put("name", "eyes");
+            requestBody.put("name", emojiName);
 
             webClient.post()
                     .uri("/projects/{id}/merge_requests/{iid}/notes/{noteId}/award_emoji", projectId, prNumber, noteId)
@@ -713,7 +714,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
                     .bodyToMono(String.class)
                     .block();
 
-            log.info("Added eyes award emoji to MR note {} in workspace {}", noteId, workspace.getName());
+            log.info("Added {} award emoji to MR note {} in workspace {}", emojiName, noteId, workspace.getName());
         } catch (Exception e) {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();

--- a/api/src/main/java/io/terrakube/api/repository/JobRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/JobRepository.java
@@ -30,6 +30,14 @@ public interface JobRepository extends JpaRepository<Job, Integer> {
     Optional<Job> findFirstByWorkspaceAndStatusInOrderByIdAsc(Workspace workspace, List<JobStatus> jobStatuses);
     Optional<Job> findFirstByWorkspaceOrderByIdDesc(Workspace workspace);
 
+    /**
+     * Finds the most recent other job on the same PR with a posted plan comment, so replans can
+     * update that comment in place instead of posting a new one. Apply jobs (autoApply=true) are
+     * excluded so an apply's audit-trail comment is never overwritten by a later plan.
+     */
+    Optional<Job> findFirstByWorkspaceAndPrNumberAndIdNotAndAutoApplyFalseAndPrCommentIdIsNotNullOrderByIdDesc(
+            Workspace workspace, Integer prNumber, int id);
+
     @Modifying(flushAutomatically = true)
     @Query("update job j set j.status = :status where j.id = :jobId")
     int updateStatusById(@Param("status") JobStatus status, @Param("jobId") int jobId);

--- a/api/src/main/java/io/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/Job.java
@@ -104,6 +104,10 @@ public class Job extends GenericAuditFields {
     @Column(name = "pr_comment_id")
     private String prCommentId;
 
+    @Exclude
+    @Column(name = "pr_apply_enabled")
+    private boolean prApplyEnabled = false;
+
     @CreatePermission(expression = "user is a super service")
     @UpdatePermission(expression = "user is a super service")
     @Column(name = "pr_comment_error")

--- a/api/src/main/java/io/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/Job.java
@@ -105,6 +105,10 @@ public class Job extends GenericAuditFields {
     private String prCommentId;
 
     @Exclude
+    @Column(name = "command_comment_id")
+    private String commandCommentId;
+
+    @Exclude
     @Column(name = "pr_apply_enabled")
     private boolean prApplyEnabled = false;
 

--- a/api/src/main/java/io/terrakube/api/rs/webhook/WebhookEvent.java
+++ b/api/src/main/java/io/terrakube/api/rs/webhook/WebhookEvent.java
@@ -49,6 +49,9 @@ public class WebhookEvent extends GenericAuditFields {
     @Column(name = "pr_workflow_enabled")
     private boolean prWorkflowEnabled = false;
 
+    @Column(name = "pr_apply_enabled")
+    private boolean prApplyEnabled = false;
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private Webhook webhook;
 }

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -108,4 +108,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-vcs-token-size.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-github-app-token-size.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-pr-comment-error.xml"/>
+    <include file="/db/changelog/local/changelog-2.34.0-pr-apply-enabled.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -108,6 +108,6 @@
     <include file="/db/changelog/local/changelog-2.33.0-vcs-token-size.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-github-app-token-size.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-pr-comment-error.xml"/>
-    <include file="/db/changelog/local/changelog-2.34.0-pr-apply-enabled.xml"/>
-    <include file="/db/changelog/local/changelog-2.34.0-pr-apply-enabled-fix.xml"/>
+    <include file="/db/changelog/local/changelog-2.33.0-pr-apply-enabled.xml"/>
+    <include file="/db/changelog/local/changelog-2.33.0-pr-apply-enabled-fix.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -110,4 +110,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-pr-comment-error.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-pr-apply-enabled.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-pr-apply-enabled-fix.xml"/>
+    <include file="/db/changelog/local/changelog-2.33.0-job-pr-apply-enabled.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -109,4 +109,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-github-app-token-size.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-pr-comment-error.xml"/>
     <include file="/db/changelog/local/changelog-2.34.0-pr-apply-enabled.xml"/>
+    <include file="/db/changelog/local/changelog-2.34.0-pr-apply-enabled-fix.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -111,4 +111,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-pr-apply-enabled.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-pr-apply-enabled-fix.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-job-pr-apply-enabled.xml"/>
+    <include file="/db/changelog/local/changelog-2.33.0-job-command-comment-id.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-job-command-comment-id.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-job-command-comment-id.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-33-0-job-command-comment-id" author="jake">
+        <addColumn tableName="job">
+            <column name="command_comment_id" type="varchar(64)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-job-pr-apply-enabled.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-job-pr-apply-enabled.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-33-0-job-pr-apply-enabled" author="jake">
+        <addColumn tableName="job">
+            <column name="pr_apply_enabled" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="2-33-0-job-pr-apply-enabled-fix" author="jake">
+        <update tableName="job">
+            <column name="pr_apply_enabled" valueBoolean="false"/>
+            <where>pr_apply_enabled IS NULL</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-pr-apply-enabled-fix.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-pr-apply-enabled-fix.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
-    <changeSet id="2-34-0-pr-apply-enabled-fix" author="jake">
+    <changeSet id="2-33-0-pr-apply-enabled-fix" author="jake">
         <update tableName="webhook_event">
             <column name="pr_apply_enabled" valueBoolean="false"/>
             <where>pr_apply_enabled IS NULL</where>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-pr-apply-enabled.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-pr-apply-enabled.xml
@@ -4,7 +4,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
-    <changeSet id="2-34-0-pr-apply-enabled" author="jake">
+    <changeSet id="2-33-0-pr-apply-enabled" author="jake">
         <addColumn tableName="webhook_event">
             <column name="pr_apply_enabled" type="boolean" defaultValueBoolean="false">
                 <constraints nullable="true"/>

--- a/api/src/main/resources/db/changelog/local/changelog-2.34.0-pr-apply-enabled-fix.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.34.0-pr-apply-enabled-fix.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-34-0-pr-apply-enabled-fix" author="jake">
+        <update tableName="webhook_event">
+            <column name="pr_apply_enabled" valueBoolean="false"/>
+            <where>pr_apply_enabled IS NULL</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.34.0-pr-apply-enabled.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.34.0-pr-apply-enabled.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-34-0-pr-apply-enabled" author="jake">
+        <addColumn tableName="webhook_event">
+            <column name="pr_apply_enabled" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/VcsBitbucketTests.java
+++ b/api/src/test/java/io/terrakube/api/VcsBitbucketTests.java
@@ -347,6 +347,7 @@ public class VcsBitbucketTests extends ServerApplicationTests{
         webhookResult = bitBucketWebhookService.handleEvent(payload,webhookResult, headers);
 
         Assert.isTrue(webhookResult.getFileChanges().size()==1,"File changes is not 1");
+        Assert.isTrue(webhookResult.getPrNumber() != null && webhookResult.getPrNumber().intValue() == 6, "PR number was not set from pull request event");
 
         workspace.setDeleted(true);
         workspace.setVcs(null);

--- a/api/src/test/java/io/terrakube/api/VcsGitlabTests.java
+++ b/api/src/test/java/io/terrakube/api/VcsGitlabTests.java
@@ -356,6 +356,7 @@ public class VcsGitlabTests extends ServerApplicationTests {
 
         Assert.isTrue(webhookResult.getFileChanges().size()==1,"File changes is not 1");
         Assert.isTrue(webhookResult.getFileChanges().get(0).equals("main.tf"),"File changes is not main.tf");
+        Assert.isTrue(webhookResult.getPrNumber() != null && webhookResult.getPrNumber().intValue() == 2, "PR number was not set from merge request event");
 
         workspace.setDeleted(true);
         workspace.setVcs(null);

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -881,10 +882,15 @@ public class ScheduleJobTest {
         doReturn(Collections.emptyList()).when(globalVarRepository).findByOrganization(any());
         doReturn(Optional.of(Collections.emptyList())).when(variableRepository).findByWorkspace(any());
 
-        doReturn(false).when(tclService).isTemplatePlanOnly(any());
+        // Deliberately stubbed true: postPrCommentIfNeeded must route on job.isAutoApply(), not on
+        // whether the workspace's default template happens to look plan-only to tclService, or an
+        // apply-via-PR-comment job silently reuses/updates the existing plan comment instead of
+        // posting its own apply result (the bug this test guards against).
+        doReturn(true).when(tclService).isTemplatePlanOnly(any());
+        doReturn(false).when(tclService).isCliTemplate(any());
         doReturn(Optional.of(Collections.emptyList()))
                 .when(jobRepository)
-                .findByWorkspaceAndStatusNotInAndIdLessThan(
+                .findByWorkspaceAndStatusInAndIdLessThan(
                         any(Workspace.class),
                         anyList(),
                         anyInt());
@@ -898,8 +904,40 @@ public class ScheduleJobTest {
         Assert.assertTrue(subject().runExecution(job));
 
         verify(prCommentService, times(1)).postApplyResult(job);
+        verify(prCommentService, never()).postPlanResult(any());
         verify(prCommentService, times(1)).acknowledgeCompletion(job);
         Assertions.assertFalse(job.getWorkspace().isLocked());
         Assertions.assertNull(job.getWorkspace().getLockDescription());
+    }
+
+    @Test
+    public void completedNonAutoApplyPrJobPostsPlanResult() {
+        Job job = job(JobStatus.completed);
+        job.setPrNumber(4);
+        job.setAutoApply(false);
+
+        doReturn(Collections.emptyList()).when(globalVarRepository).findByOrganization(any());
+        doReturn(Optional.of(Collections.emptyList())).when(variableRepository).findByWorkspace(any());
+
+        // Deliberately stubbed false: a plan-triggered PR job must still post a plan result even if
+        // tclService considers the template not plan-only, since the routing no longer consults it.
+        doReturn(false).when(tclService).isTemplatePlanOnly(any());
+        doReturn(Optional.of(Collections.emptyList()))
+                .when(jobRepository)
+                .findByWorkspaceAndStatusNotInAndIdLessThan(
+                        any(Workspace.class),
+                        anyList(),
+                        anyInt());
+        doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
+        doReturn(job.getStep()).when(stepRepository).findByJobId(anyInt());
+        doReturn(null).when(stepRepository).save(any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doNothing().when(prCommentService).postPlanResult(any());
+        doNothing().when(prCommentService).acknowledgeCompletion(any());
+
+        Assert.assertTrue(subject().runExecution(job));
+
+        verify(prCommentService, times(1)).postPlanResult(job);
+        verify(prCommentService, never()).postApplyResult(any());
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
@@ -37,6 +37,7 @@ import io.terrakube.api.plugin.scheduler.job.tcl.model.ScheduleTemplate;
 import io.terrakube.api.plugin.softdelete.SoftDeleteService;
 import io.terrakube.api.plugin.variable.WorkspaceVariableValidationService;
 import io.terrakube.api.plugin.vcs.PrCommentService;
+import io.terrakube.api.plugin.vcs.WebhookService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
 import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
 import io.terrakube.api.repository.GlobalVarRepository;
@@ -825,5 +826,80 @@ public class ScheduleJobTest {
         Assert.assertFalse(subject().runExecution(job));
 
         Assertions.assertEquals(JobStatus.pending, job.getStatus());
+    }
+
+    @Test
+    public void lockedWorkspaceBlocksUnrelatedJob() {
+        Job job = job(JobStatus.pending);
+        job.getWorkspace().setLocked(true);
+        job.getWorkspace().setLockDescription("Locked by PR #99 apply");
+
+        Assert.assertFalse(subject().runExecution(job));
+
+        Assertions.assertEquals(JobStatus.pending, job.getStatus());
+    }
+
+    @Test
+    public void lockedWorkspaceAllowsItsOwnPrApplyJobToProceed() throws Exception {
+        Job job = job(JobStatus.pending);
+        job.setPrNumber(4);
+        job.setAutoApply(true);
+        job.getWorkspace().setLocked(true);
+        job.getWorkspace().setLockDescription(WebhookService.buildPrApplyLockDescription(4));
+
+        Flow flow = new Flow();
+        flow.setType(FlowType.terraformApply.name());
+
+        doReturn(false).when(tclService).isTemplatePlanOnly(any());
+        doReturn(Optional.of(Collections.emptyList()))
+                .when(jobRepository)
+                .findByWorkspaceAndStatusNotInAndIdLessThan(
+                        any(Workspace.class),
+                        anyList(),
+                        anyInt());
+        doReturn(job).when(tclService).initJobConfiguration(any(Job.class));
+        doReturn(flow).when(tclService).getNextFlow(any());
+        doReturn(stepId.toString()).when(tclService).getCurrentStepId(any());
+        doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
+        doReturn(job).when(jobRepository).save(any());
+        doNothing().when(executorService).execute(any(), any(), any());
+
+        Assert.assertTrue(subject().runExecution(job));
+
+        verify(executorService, times(1)).execute(any(), any(), any());
+        Assertions.assertEquals(JobStatus.queue, job.getStatus());
+    }
+
+    @Test
+    public void completedPrApplyJobUnlocksItsOwnWorkspaceLock() {
+        Job job = job(JobStatus.completed);
+        job.setPrNumber(4);
+        job.setAutoApply(true);
+        job.getWorkspace().setLocked(true);
+        job.getWorkspace().setLockDescription(WebhookService.buildPrApplyLockDescription(4));
+
+        doReturn(Collections.emptyList()).when(globalVarRepository).findByOrganization(any());
+        doReturn(Optional.of(Collections.emptyList())).when(variableRepository).findByWorkspace(any());
+
+        doReturn(false).when(tclService).isTemplatePlanOnly(any());
+        doReturn(Optional.of(Collections.emptyList()))
+                .when(jobRepository)
+                .findByWorkspaceAndStatusNotInAndIdLessThan(
+                        any(Workspace.class),
+                        anyList(),
+                        anyInt());
+        doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
+        doReturn(job.getStep()).when(stepRepository).findByJobId(anyInt());
+        doReturn(null).when(stepRepository).save(any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doNothing().when(prCommentService).postApplyResult(any());
+        doNothing().when(prCommentService).acknowledgeCompletion(any());
+
+        Assert.assertTrue(subject().runExecution(job));
+
+        verify(prCommentService, times(1)).postApplyResult(job);
+        verify(prCommentService, times(1)).acknowledgeCompletion(job);
+        Assertions.assertFalse(job.getWorkspace().isLocked());
+        Assertions.assertNull(job.getWorkspace().getLockDescription());
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
@@ -299,4 +299,112 @@ public class PrCommentServiceTest {
         assertNull(job.getPrCommentError());
         verify(gitHubWebhookService, never()).postPrComment(any(), any());
     }
+
+    @Test
+    public void postPlanResultUsesDiffFenceForPlanBody() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        job.setTerraformPlan("+ resource \"aws_instance\" \"example\" {\n+   ami = \"ami-123\"\n+ }");
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        assertTrue(markdownCaptor.getValue().contains("```diff"));
+    }
+
+    @Test
+    public void postPlanResultExtractsChangeSummaryLine() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        job.setTerraformPlan("Some preamble\n\nPlan: 2 to add, 1 to change, 0 to destroy.\n");
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        assertTrue(markdownCaptor.getValue().contains("✅ Plan: 2 to add, 1 to change, 0 to destroy."));
+    }
+
+    @Test
+    public void postPlanResultExtractsNoChangesSummaryLine() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        job.setTerraformPlan("No changes. Your infrastructure matches the configuration.\n");
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        assertTrue(markdownCaptor.getValue().contains("✅ No changes. Your infrastructure matches the configuration."));
+    }
+
+    @Test
+    public void postPlanResultOmitsSummaryLineWhenPatternNotFound() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        job.setTerraformPlan("Some unusual output with no recognizable summary");
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        assertTrue(markdownCaptor.getValue().contains("<details><summary>Show Plan</summary>"));
+        assertFalse(markdownCaptor.getValue().contains("✅ Plan:"));
+    }
+
+    @Test
+    public void postPlanResultUsesFailedIconWhenPlanFailed() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.failed);
+        job.setTerraformPlan(null);
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        assertTrue(markdownCaptor.getValue().contains("❌ Plan failed"));
+    }
+
+    @Test
+    public void postApplyResultUsesCompleteIconWhenCompleted() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        job.setOutput("Apply complete! Resources: 1 added, 0 changed, 0 destroyed.");
+
+        subject.postApplyResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        assertTrue(markdownCaptor.getValue().contains("✅ Apply complete"));
+        assertTrue(markdownCaptor.getValue().contains("<details><summary>Show Apply Output</summary>"));
+    }
+
+    @Test
+    public void postApplyResultUsesFailedIconWhenFailed() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.failed);
+        job.setOutput("Error: something went wrong");
+
+        subject.postApplyResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        assertTrue(markdownCaptor.getValue().contains("❌ Apply failed"));
+    }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
@@ -407,4 +407,40 @@ public class PrCommentServiceTest {
 
         assertTrue(markdownCaptor.getValue().contains("❌ Apply failed"));
     }
+
+    @Test
+    public void postApplyDisabledNoticeSkipsWhenPrNumberIsNull() {
+        Workspace workspace = createJob(VcsType.GITHUB, 5, JobStatus.completed).getWorkspace();
+
+        subject.postApplyDisabledNotice(workspace, null);
+
+        verify(gitHubWebhookService, never()).postPrComment(any(), any());
+    }
+
+    @Test
+    public void postApplyDisabledNoticeSkipsWhenPrNumberIsZero() {
+        Workspace workspace = createJob(VcsType.GITHUB, 5, JobStatus.completed).getWorkspace();
+
+        subject.postApplyDisabledNotice(workspace, 0);
+
+        verify(gitHubWebhookService, never()).postPrComment(any(), any());
+    }
+
+    @Test
+    public void postApplyDisabledNoticePostsNoticeWithWorkspaceAndPrNumber() {
+        Workspace workspace = createJob(VcsType.GITHUB, 5, JobStatus.completed).getWorkspace();
+
+        doReturn("999").when(gitHubWebhookService).postPrComment(any(), any());
+
+        subject.postApplyDisabledNotice(workspace, 7);
+
+        ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(jobCaptor.capture(), markdownCaptor.capture());
+
+        assertEquals(workspace, jobCaptor.getValue().getWorkspace());
+        assertEquals(Integer.valueOf(7), jobCaptor.getValue().getPrNumber());
+        assertTrue(markdownCaptor.getValue().contains("Allow Apply via PR Comment"));
+        assertTrue(markdownCaptor.getValue().contains("not enabled"));
+    }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +18,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.terrakube.api.plugin.storage.StorageTypeService;
+import io.terrakube.api.plugin.streaming.StreamingService;
 import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
 import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
@@ -23,6 +27,7 @@ import io.terrakube.api.repository.JobRepository;
 import io.terrakube.api.rs.Organization;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.step.Step;
 import io.terrakube.api.rs.vcs.Vcs;
 import io.terrakube.api.rs.vcs.VcsType;
 import io.terrakube.api.rs.workspace.Workspace;
@@ -36,6 +41,8 @@ public class PrCommentServiceTest {
     GitLabWebhookService gitLabWebhookService;
     BitBucketWebhookService bitBucketWebhookService;
     JobRepository jobRepository;
+    StorageTypeService storageTypeService;
+    StreamingService streamingService;
 
     PrCommentService subject;
 
@@ -45,12 +52,16 @@ public class PrCommentServiceTest {
         gitLabWebhookService = mock(GitLabWebhookService.class);
         bitBucketWebhookService = mock(BitBucketWebhookService.class);
         jobRepository = mock(JobRepository.class);
+        storageTypeService = mock(StorageTypeService.class);
+        streamingService = mock(StreamingService.class);
 
         subject = new PrCommentService(
                 gitHubWebhookService,
                 gitLabWebhookService,
                 bitBucketWebhookService,
-                jobRepository);
+                jobRepository,
+                storageTypeService,
+                streamingService);
     }
 
     private Job createJob(VcsType vcsType, Integer prNumber, JobStatus status) {
@@ -58,6 +69,7 @@ public class PrCommentServiceTest {
         vcs.setVcsType(vcsType);
 
         Organization org = new Organization();
+        org.setId(UUID.randomUUID());
         org.setName("test-org");
 
         Workspace workspace = new Workspace();
@@ -72,7 +84,19 @@ public class PrCommentServiceTest {
         job.setWorkspace(workspace);
         job.setOrganization(org);
 
+        Step step = new Step();
+        step.setId(UUID.randomUUID());
+        step.setStepNumber(1);
+        job.setStep(List.of(step));
+
         return job;
+    }
+
+    /** Stubs the last-step output fetch path (empty live logs, then stored bytes) for a job built via createJob(). */
+    private void stubStepOutput(Job job, String text) {
+        doReturn("").when(streamingService).getCurrentLogs(any());
+        byte[] bytes = text == null ? null : text.getBytes(StandardCharsets.UTF_8);
+        doReturn(bytes).when(storageTypeService).getStepOutput(any(), any(), any());
     }
 
     @Test
@@ -96,7 +120,7 @@ public class PrCommentServiceTest {
     @Test
     public void postPlanResultDispatchesToGitHub() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
-        job.setTerraformPlan("Plan: 3 to add, 0 to change, 1 to destroy.");
+        stubStepOutput(job, "Plan: 3 to add, 0 to change, 1 to destroy.");
 
         doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
         doReturn(job).when(jobRepository).save(any());
@@ -120,7 +144,7 @@ public class PrCommentServiceTest {
     @Test
     public void postPlanResultDispatchesToGitLab() {
         Job job = createJob(VcsType.GITLAB, 10, JobStatus.completed);
-        job.setTerraformPlan("No changes.");
+        stubStepOutput(job, "No changes.");
 
         doReturn("note-99").when(gitLabWebhookService).postMergeRequestNote(any(), any());
         doReturn(job).when(jobRepository).save(any());
@@ -134,7 +158,7 @@ public class PrCommentServiceTest {
     @Test
     public void postPlanResultDispatchesToBitbucket() {
         Job job = createJob(VcsType.BITBUCKET, 7, JobStatus.completed);
-        job.setTerraformPlan("Some plan output");
+        stubStepOutput(job, "Some plan output");
 
         doReturn("bb-123").when(bitBucketWebhookService).postPrComment(any(), any());
         doReturn(job).when(jobRepository).save(any());
@@ -148,7 +172,7 @@ public class PrCommentServiceTest {
     @Test
     public void postPlanResultWithNoPlanOutputAndCompletedStatus() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
-        job.setTerraformPlan(null);
+        stubStepOutput(job, null);
 
         doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
         doReturn(job).when(jobRepository).save(any());
@@ -165,7 +189,7 @@ public class PrCommentServiceTest {
     @Test
     public void postPlanResultWithFailedStatus() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.failed);
-        job.setTerraformPlan(null);
+        stubStepOutput(job, null);
 
         doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
         doReturn(job).when(jobRepository).save(any());
@@ -191,7 +215,7 @@ public class PrCommentServiceTest {
     @Test
     public void postApplyResultDispatchesToGitHub() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
-        job.setOutput("Apply complete! Resources: 3 added, 0 changed, 1 destroyed.");
+        stubStepOutput(job, "Apply complete! Resources: 3 added, 0 changed, 1 destroyed.");
 
         subject.postApplyResult(job);
 
@@ -212,7 +236,7 @@ public class PrCommentServiceTest {
         for (int i = 0; i < 7000; i++) {
             longPlan.append("Resource aws_instance.test will be created\n");
         }
-        job.setTerraformPlan(longPlan.toString());
+        stubStepOutput(job, longPlan.toString());
 
         doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
         doReturn(job).when(jobRepository).save(any());
@@ -229,7 +253,7 @@ public class PrCommentServiceTest {
     @Test
     public void postPlanResultRecordsErrorWhenCommentIdIsNull() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
-        job.setTerraformPlan("Some plan");
+        stubStepOutput(job, "Some plan");
 
         doReturn(null).when(gitHubWebhookService).postPrComment(any(), any());
         doReturn(job).when(jobRepository).save(any());
@@ -303,7 +327,7 @@ public class PrCommentServiceTest {
     @Test
     public void postPlanResultUsesDiffFenceForPlanBody() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
-        job.setTerraformPlan("+ resource \"aws_instance\" \"example\" {\n+   ami = \"ami-123\"\n+ }");
+        stubStepOutput(job, "+ resource \"aws_instance\" \"example\" {\n+   ami = \"ami-123\"\n+ }");
 
         doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
         doReturn(job).when(jobRepository).save(any());
@@ -319,7 +343,7 @@ public class PrCommentServiceTest {
     @Test
     public void postPlanResultExtractsChangeSummaryLine() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
-        job.setTerraformPlan("Some preamble\n\nPlan: 2 to add, 1 to change, 0 to destroy.\n");
+        stubStepOutput(job, "Some preamble\n\nPlan: 2 to add, 1 to change, 0 to destroy.\n");
 
         doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
         doReturn(job).when(jobRepository).save(any());
@@ -335,7 +359,7 @@ public class PrCommentServiceTest {
     @Test
     public void postPlanResultExtractsNoChangesSummaryLine() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
-        job.setTerraformPlan("No changes. Your infrastructure matches the configuration.\n");
+        stubStepOutput(job, "No changes. Your infrastructure matches the configuration.\n");
 
         doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
         doReturn(job).when(jobRepository).save(any());
@@ -351,7 +375,7 @@ public class PrCommentServiceTest {
     @Test
     public void postPlanResultOmitsSummaryLineWhenPatternNotFound() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
-        job.setTerraformPlan("Some unusual output with no recognizable summary");
+        stubStepOutput(job, "Some unusual output with no recognizable summary");
 
         doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
         doReturn(job).when(jobRepository).save(any());
@@ -368,7 +392,7 @@ public class PrCommentServiceTest {
     @Test
     public void postPlanResultUsesFailedIconWhenPlanFailed() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.failed);
-        job.setTerraformPlan(null);
+        stubStepOutput(job, null);
 
         doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
         doReturn(job).when(jobRepository).save(any());
@@ -384,7 +408,7 @@ public class PrCommentServiceTest {
     @Test
     public void postApplyResultUsesCompleteIconWhenCompleted() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
-        job.setOutput("Apply complete! Resources: 1 added, 0 changed, 0 destroyed.");
+        stubStepOutput(job, "Apply complete! Resources: 1 added, 0 changed, 0 destroyed.");
 
         subject.postApplyResult(job);
 
@@ -398,7 +422,7 @@ public class PrCommentServiceTest {
     @Test
     public void postApplyResultUsesFailedIconWhenFailed() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.failed);
-        job.setOutput("Error: something went wrong");
+        stubStepOutput(job, "Error: something went wrong");
 
         subject.postApplyResult(job);
 
@@ -406,6 +430,58 @@ public class PrCommentServiceTest {
         verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
 
         assertTrue(markdownCaptor.getValue().contains("❌ Apply failed"));
+    }
+
+    @Test
+    public void postPlanResultStripsAnsiCodesFromStepOutput() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        stubStepOutput(job, "[32m+ resource \"aws_instance\" \"example\"[0m");
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        String markdown = markdownCaptor.getValue();
+        assertTrue(markdown.contains("+ resource \"aws_instance\" \"example\""));
+        assertFalse(markdown.contains(""));
+    }
+
+    @Test
+    public void postPlanResultPrefersLiveStreamingLogsOverStoredOutput() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        doReturn("Plan: 1 to add, 0 to change, 0 to destroy.").when(streamingService).getCurrentLogs(any());
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+        verify(storageTypeService, never()).getStepOutput(any(), any(), any());
+
+        String markdown = markdownCaptor.getValue();
+        assertTrue(markdown.contains("Plan: 1 to add, 0 to change, 0 to destroy."));
+    }
+
+    @Test
+    public void postPlanResultHandlesJobWithNoSteps() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        job.setStep(List.of());
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        assertTrue(markdownCaptor.getValue().contains("No changes detected"));
     }
 
     @Test

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -80,6 +81,7 @@ public class PrCommentServiceTest {
         Job job = new Job();
         job.setId(42);
         job.setPrNumber(prNumber);
+        job.setPrApplyEnabled(true);
         job.setStatus(status);
         job.setWorkspace(workspace);
         job.setOrganization(org);
@@ -518,5 +520,127 @@ public class PrCommentServiceTest {
         assertEquals(Integer.valueOf(7), jobCaptor.getValue().getPrNumber());
         assertTrue(markdownCaptor.getValue().contains("Allow Apply via PR Comment"));
         assertTrue(markdownCaptor.getValue().contains("not enabled"));
+    }
+
+    @Test
+    public void postPlanResultOmitsApplyFooterWhenApplyDisabled() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        job.setPrApplyEnabled(false);
+        stubStepOutput(job, "Plan: 1 to add, 0 to change, 0 to destroy.");
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        String markdown = markdownCaptor.getValue();
+        assertFalse(markdown.contains("comment: `terrakube apply`"));
+        assertTrue(markdown.contains("Apply via PR comment is disabled"));
+        assertTrue(markdown.contains("Allow Apply via PR Comment"));
+        assertTrue(markdown.contains("terrakube plan"));
+    }
+
+    @Test
+    public void postPlanResultIncludesApplyFooterWhenApplyEnabled() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        job.setPrApplyEnabled(true);
+        stubStepOutput(job, "Plan: 1 to add, 0 to change, 0 to destroy.");
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        assertTrue(markdownCaptor.getValue().contains("comment: `terrakube apply`"));
+    }
+
+    @Test
+    public void postPlanResultUpdatesExistingThreadCommentWhenPriorPlanJobExists() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        job.setId(99);
+        stubStepOutput(job, "Plan: 1 to add, 0 to change, 0 to destroy.");
+
+        Job priorJob = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        priorJob.setId(50);
+        priorJob.setPrCommentId("existing-comment-1");
+
+        doReturn(Optional.of(priorJob)).when(jobRepository)
+                .findFirstByWorkspaceAndPrNumberAndIdNotAndAutoApplyFalseAndPrCommentIdIsNotNullOrderByIdDesc(
+                        job.getWorkspace(), 5, 99);
+        doReturn(true).when(gitHubWebhookService).updatePrComment(eq(job), eq("existing-comment-1"), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        verify(gitHubWebhookService, times(1)).updatePrComment(eq(job), eq("existing-comment-1"), any());
+        verify(gitHubWebhookService, never()).postPrComment(any(), any());
+        assertEquals("existing-comment-1", job.getPrCommentId());
+    }
+
+    @Test
+    public void postPlanResultFallsBackToNewCommentWhenUpdateFails() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        job.setId(99);
+        stubStepOutput(job, "Plan: 1 to add, 0 to change, 0 to destroy.");
+
+        Job priorJob = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        priorJob.setId(50);
+        priorJob.setPrCommentId("stale-comment-1");
+
+        doReturn(Optional.of(priorJob)).when(jobRepository)
+                .findFirstByWorkspaceAndPrNumberAndIdNotAndAutoApplyFalseAndPrCommentIdIsNotNullOrderByIdDesc(
+                        job.getWorkspace(), 5, 99);
+        doReturn(false).when(gitHubWebhookService).updatePrComment(eq(job), eq("stale-comment-1"), any());
+        doReturn("new-comment-1").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        verify(gitHubWebhookService, times(1)).updatePrComment(eq(job), eq("stale-comment-1"), any());
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), any());
+        assertEquals("new-comment-1", job.getPrCommentId());
+    }
+
+    @Test
+    public void jobHeaderLinksToTerrakubeUiWhenUiUrlConfigured() {
+        subject.uiUrl = "https://terrakube.example.com";
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        job.getOrganization().setId(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        job.getWorkspace().setId(UUID.fromString("22222222-2222-2222-2222-222222222222"));
+        stubStepOutput(job, "Plan: 1 to add, 0 to change, 0 to destroy.");
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        String expectedUrl = "https://terrakube.example.com/organizations/11111111-1111-1111-1111-111111111111"
+                + "/workspaces/22222222-2222-2222-2222-222222222222/runs/42";
+        assertTrue(markdownCaptor.getValue().contains("[#42](" + expectedUrl + ")"));
+    }
+
+    @Test
+    public void jobHeaderUsesPlainReferenceWhenUiUrlNotConfigured() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        stubStepOutput(job, "Plan: 1 to add, 0 to change, 0 to destroy.");
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        assertTrue(markdownCaptor.getValue().contains("**Job:** #42"));
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
@@ -643,4 +643,74 @@ public class PrCommentServiceTest {
 
         assertTrue(markdownCaptor.getValue().contains("**Job:** #42"));
     }
+
+    @Test
+    public void acknowledgeCompletionSkipsWhenCommandCommentIdMissing() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+
+        subject.acknowledgeCompletion(job);
+
+        verify(gitHubWebhookService, never()).addCommentReaction(any(), any(), any());
+    }
+
+    @Test
+    public void acknowledgeCompletionSkipsWhenPrNumberMissing() {
+        Job job = createJob(VcsType.GITHUB, null, JobStatus.completed);
+        job.setCommandCommentId("998877");
+
+        subject.acknowledgeCompletion(job);
+
+        verify(gitHubWebhookService, never()).addCommentReaction(any(), any(), any());
+    }
+
+    @Test
+    public void acknowledgeCompletionAddsThumbsUpOnGitHubSuccess() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        job.setCommandCommentId("998877");
+
+        subject.acknowledgeCompletion(job);
+
+        verify(gitHubWebhookService, times(1)).addCommentReaction(job.getWorkspace(), "998877", "+1");
+    }
+
+    @Test
+    public void acknowledgeCompletionAddsThumbsDownOnGitHubFailure() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.failed);
+        job.setCommandCommentId("998877");
+
+        subject.acknowledgeCompletion(job);
+
+        verify(gitHubWebhookService, times(1)).addCommentReaction(job.getWorkspace(), "998877", "-1");
+    }
+
+    @Test
+    public void acknowledgeCompletionAddsCheckmarkOnGitLabSuccess() {
+        Job job = createJob(VcsType.GITLAB, 5, JobStatus.completed);
+        job.setCommandCommentId("note-1");
+
+        subject.acknowledgeCompletion(job);
+
+        verify(gitLabWebhookService, times(1)).addNoteReaction(job.getWorkspace(), 5, "note-1", "white_check_mark");
+    }
+
+    @Test
+    public void acknowledgeCompletionAddsCrossOnGitLabFailure() {
+        Job job = createJob(VcsType.GITLAB, 5, JobStatus.failed);
+        job.setCommandCommentId("note-1");
+
+        subject.acknowledgeCompletion(job);
+
+        verify(gitLabWebhookService, times(1)).addNoteReaction(job.getWorkspace(), 5, "note-1", "x");
+    }
+
+    @Test
+    public void acknowledgeCompletionIsNoOpForBitbucket() {
+        Job job = createJob(VcsType.BITBUCKET, 5, JobStatus.completed);
+        job.setCommandCommentId("55");
+
+        subject.acknowledgeCompletion(job);
+
+        verify(bitBucketWebhookService, never()).postPrComment(any(), any());
+        verify(bitBucketWebhookService, never()).updatePrComment(any(), any(), any());
+    }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookServiceTest.java
@@ -144,6 +144,21 @@ public class WebhookServiceTest {
     }
 
     @Test
+    public void planCommentThreadsPrApplyEnabledOntoJob() throws Exception {
+        pullRequestEvent.setPrWorkflowEnabled(true);
+        pullRequestEvent.setPrApplyEnabled(true);
+        WebhookResult result = createCommentResult("plan", 5);
+
+        Job savedJob = new Job();
+        savedJob.setWorkspace(workspace);
+        doReturn(savedJob).when(jobRepository).save(any());
+
+        subject.handlePrCommentCommand(result, webhook, workspace);
+
+        assertTrue(savedJob.isPrApplyEnabled());
+    }
+
+    @Test
     public void applyCommentRejectedWhenPrApplyDisabled() throws Exception {
         pullRequestEvent.setPrWorkflowEnabled(true);
         pullRequestEvent.setPrApplyEnabled(false);

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookServiceTest.java
@@ -117,6 +117,35 @@ public class WebhookServiceTest {
     }
 
     @Test
+    public void planCommentAddsGitHubReactionWhenCommentIdPresent() throws Exception {
+        pullRequestEvent.setPrWorkflowEnabled(true);
+        WebhookResult result = createCommentResult("plan", 5);
+        result.setCommentId("998877");
+
+        Job savedJob = new Job();
+        savedJob.setWorkspace(workspace);
+        doReturn(savedJob).when(jobRepository).save(any());
+
+        subject.handlePrCommentCommand(result, webhook, workspace);
+
+        verify(gitHubWebhookService, times(1)).addCommentReaction(workspace, "998877");
+    }
+
+    @Test
+    public void planCommentSkipsReactionWhenCommentIdMissing() throws Exception {
+        pullRequestEvent.setPrWorkflowEnabled(true);
+        WebhookResult result = createCommentResult("plan", 5);
+
+        Job savedJob = new Job();
+        savedJob.setWorkspace(workspace);
+        doReturn(savedJob).when(jobRepository).save(any());
+
+        subject.handlePrCommentCommand(result, webhook, workspace);
+
+        verify(gitHubWebhookService, never()).addCommentReaction(any(), any());
+    }
+
+    @Test
     public void planCommentIgnoredWhenPrWorkflowDisabled() throws Exception {
         pullRequestEvent.setPrWorkflowEnabled(false);
         WebhookResult result = createCommentResult("plan", 5);

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookServiceTest.java
@@ -1,0 +1,188 @@
+package io.terrakube.api.plugin.vcs;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.terrakube.api.plugin.scheduler.ScheduleJobService;
+import io.terrakube.api.plugin.vcs.provider.azdevops.AzDevOpsWebhookService;
+import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
+import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
+import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
+import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.repository.WebhookEventRepository;
+import io.terrakube.api.repository.WebhookRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.vcs.VcsType;
+import io.terrakube.api.rs.webhook.Webhook;
+import io.terrakube.api.rs.webhook.WebhookEvent;
+import io.terrakube.api.rs.webhook.WebhookEventPathType;
+import io.terrakube.api.rs.webhook.WebhookEventType;
+import io.terrakube.api.rs.workspace.Workspace;
+
+@ExtendWith(MockitoExtension.class)
+public class WebhookServiceTest {
+
+    WebhookRepository webhookRepository;
+    WebhookEventRepository webhookEventRepository;
+    GitHubWebhookService gitHubWebhookService;
+    GitLabWebhookService gitLabWebhookService;
+    BitBucketWebhookService bitBucketWebhookService;
+    AzDevOpsWebhookService azDevOpsWebhookService;
+    JobRepository jobRepository;
+    ScheduleJobService scheduleJobService;
+    ObjectMapper objectMapper;
+    WorkspaceRepository workspaceRepository;
+    PrCommentService prCommentService;
+
+    WebhookService subject;
+
+    Workspace workspace;
+    Webhook webhook;
+    WebhookEvent pullRequestEvent;
+
+    @BeforeEach
+    public void setup() {
+        webhookRepository = mock(WebhookRepository.class);
+        webhookEventRepository = mock(WebhookEventRepository.class);
+        gitHubWebhookService = mock(GitHubWebhookService.class);
+        gitLabWebhookService = mock(GitLabWebhookService.class);
+        bitBucketWebhookService = mock(BitBucketWebhookService.class);
+        azDevOpsWebhookService = mock(AzDevOpsWebhookService.class);
+        jobRepository = mock(JobRepository.class);
+        scheduleJobService = mock(ScheduleJobService.class);
+        objectMapper = new ObjectMapper();
+        workspaceRepository = mock(WorkspaceRepository.class);
+        prCommentService = mock(PrCommentService.class);
+
+        subject = new WebhookService(
+                webhookRepository,
+                webhookEventRepository,
+                gitHubWebhookService,
+                gitLabWebhookService,
+                bitBucketWebhookService,
+                azDevOpsWebhookService,
+                jobRepository,
+                scheduleJobService,
+                objectMapper,
+                workspaceRepository,
+                prCommentService);
+
+        workspace = new Workspace();
+        workspace.setName("test-workspace");
+        workspace.setDefaultTemplate("default-template-id");
+        Vcs vcs = new Vcs();
+        vcs.setVcsType(VcsType.GITHUB);
+        workspace.setVcs(vcs);
+
+        webhook = new Webhook();
+        webhook.setWorkspace(workspace);
+
+        pullRequestEvent = new WebhookEvent();
+        pullRequestEvent.setEvent(WebhookEventType.PULL_REQUEST);
+        pullRequestEvent.setBranch(".*");
+        pullRequestEvent.setPath("*");
+        pullRequestEvent.setPathType(WebhookEventPathType.PATTERN);
+        pullRequestEvent.setTemplateId("pr-template-id");
+
+        doReturn(List.of(pullRequestEvent))
+                .when(webhookEventRepository)
+                .findByWebhookAndEventOrderByPriorityAsc(webhook, WebhookEventType.PULL_REQUEST);
+    }
+
+    private WebhookResult createCommentResult(String command, int prNumber) {
+        WebhookResult result = new WebhookResult();
+        result.setPrComment(true);
+        result.setCommentCommand(command);
+        result.setPrNumber(prNumber);
+        result.setBranch("main");
+        result.setFileChanges(List.of("main.tf"));
+        result.setCreatedBy("octocat");
+        return result;
+    }
+
+    @Test
+    public void planCommentIgnoredWhenPrWorkflowDisabled() throws Exception {
+        pullRequestEvent.setPrWorkflowEnabled(false);
+        WebhookResult result = createCommentResult("plan", 5);
+
+        subject.handlePrCommentCommand(result, webhook, workspace);
+
+        verify(jobRepository, never()).save(any());
+        verify(scheduleJobService, never()).createJobContext(any());
+    }
+
+    @Test
+    public void planCommentCreatesJobWhenPrWorkflowEnabled() throws Exception {
+        pullRequestEvent.setPrWorkflowEnabled(true);
+        WebhookResult result = createCommentResult("plan", 5);
+
+        Job savedJob = new Job();
+        savedJob.setWorkspace(workspace);
+        doReturn(savedJob).when(jobRepository).save(any());
+
+        subject.handlePrCommentCommand(result, webhook, workspace);
+
+        verify(jobRepository, times(2)).save(any());
+        verify(scheduleJobService, times(1)).createJobContext(any());
+        verify(prCommentService, never()).postApplyDisabledNotice(any(), any());
+    }
+
+    @Test
+    public void applyCommentRejectedWhenPrApplyDisabled() throws Exception {
+        pullRequestEvent.setPrWorkflowEnabled(true);
+        pullRequestEvent.setPrApplyEnabled(false);
+        WebhookResult result = createCommentResult("apply", 7);
+
+        subject.handlePrCommentCommand(result, webhook, workspace);
+
+        verify(jobRepository, never()).save(any());
+        verify(workspaceRepository, never()).save(any());
+        verify(prCommentService, times(1)).postApplyDisabledNotice(workspace, 7);
+    }
+
+    @Test
+    public void applyCommentRejectedWhenPrWorkflowDisabledEvenIfApplyEnabled() throws Exception {
+        pullRequestEvent.setPrWorkflowEnabled(false);
+        pullRequestEvent.setPrApplyEnabled(true);
+        WebhookResult result = createCommentResult("apply", 7);
+
+        subject.handlePrCommentCommand(result, webhook, workspace);
+
+        verify(jobRepository, never()).save(any());
+        verify(prCommentService, times(1)).postApplyDisabledNotice(workspace, 7);
+    }
+
+    @Test
+    public void applyCommentLocksWorkspaceAndCreatesJobWhenEnabled() throws Exception {
+        pullRequestEvent.setPrWorkflowEnabled(true);
+        pullRequestEvent.setPrApplyEnabled(true);
+        WebhookResult result = createCommentResult("apply", 7);
+
+        Job savedJob = new Job();
+        savedJob.setWorkspace(workspace);
+        doReturn(savedJob).when(jobRepository).save(any());
+
+        subject.handlePrCommentCommand(result, webhook, workspace);
+
+        assertTrue(workspace.isLocked());
+        verify(workspaceRepository, times(1)).save(workspace);
+        verify(scheduleJobService, times(1)).createJobContext(any());
+        verify(prCommentService, never()).postApplyDisabledNotice(any(), any());
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookServiceTest.java
@@ -1,5 +1,6 @@
 package io.terrakube.api.plugin.vcs;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -128,7 +129,7 @@ public class WebhookServiceTest {
 
         subject.handlePrCommentCommand(result, webhook, workspace);
 
-        verify(gitHubWebhookService, times(1)).addCommentReaction(workspace, "998877");
+        verify(gitHubWebhookService, times(1)).addCommentReaction(workspace, "998877", "eyes");
     }
 
     @Test
@@ -142,7 +143,7 @@ public class WebhookServiceTest {
 
         subject.handlePrCommentCommand(result, webhook, workspace);
 
-        verify(gitHubWebhookService, never()).addCommentReaction(any(), any());
+        verify(gitHubWebhookService, never()).addCommentReaction(any(), any(), any());
     }
 
     @Test
@@ -228,5 +229,36 @@ public class WebhookServiceTest {
         verify(workspaceRepository, times(1)).save(workspace);
         verify(scheduleJobService, times(1)).createJobContext(any());
         verify(prCommentService, never()).postApplyDisabledNotice(any(), any());
+    }
+
+    @Test
+    public void planCommentThreadsCommandCommentIdOntoJob() throws Exception {
+        pullRequestEvent.setPrWorkflowEnabled(true);
+        WebhookResult result = createCommentResult("plan", 5);
+        result.setCommentId("998877");
+
+        Job savedJob = new Job();
+        savedJob.setWorkspace(workspace);
+        doReturn(savedJob).when(jobRepository).save(any());
+
+        subject.handlePrCommentCommand(result, webhook, workspace);
+
+        assertEquals("998877", savedJob.getCommandCommentId());
+    }
+
+    @Test
+    public void applyCommentThreadsCommandCommentIdOntoJob() throws Exception {
+        pullRequestEvent.setPrWorkflowEnabled(true);
+        pullRequestEvent.setPrApplyEnabled(true);
+        WebhookResult result = createCommentResult("apply", 7);
+        result.setCommentId("112233");
+
+        Job savedJob = new Job();
+        savedJob.setWorkspace(workspace);
+        doReturn(savedJob).when(jobRepository).save(any());
+
+        subject.handlePrCommentCommand(result, webhook, workspace);
+
+        assertEquals("112233", savedJob.getCommandCommentId());
     }
 }

--- a/ui/src/domain/Workspaces/Create.tsx
+++ b/ui/src/domain/Workspaces/Create.tsx
@@ -709,8 +709,8 @@ export const CreateWorkspace = () => {
               </Form.Item>
               <Form.Item
                 name="defaultTemplate"
-                label="Default template (VCS Push)"
-                tooltip="Template that will be executed by default when doing a git push to the repository."
+                label="Default Template"
+                tooltip="Template used for the terrakube apply PR comment command, and to pre-fill the template when manually creating a run."
                 rules={[{ required: requiredVcsPush }]}
                 hidden={!versionControlFlow}
               >

--- a/ui/src/domain/Workspaces/Settings/General.tsx
+++ b/ui/src/domain/Workspaces/Settings/General.tsx
@@ -335,12 +335,15 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace,
 
           {/* Section 4: Default Template */}
           <h2>Default Template</h2>
-          <Text type="secondary">Configure the default template used when a git push event triggers a run.</Text>
+          <Text type="secondary">
+            Template used for the <code>terrakube apply</code> PR comment command, and to pre-fill the template when
+            manually creating a run.
+          </Text>
 
           <Form.Item
             name="defaultTemplate"
-            label="Default template when doing a git push to the repository"
-            extra="Default template when doing a git push to the repository"
+            label="Default template for terrakube apply comments and manual runs"
+            extra="Default template for terrakube apply comments and manual runs"
             style={{ marginTop: 16 }}
           >
             <Select

--- a/ui/src/domain/Workspaces/Settings/Webhook.tsx
+++ b/ui/src/domain/Workspaces/Settings/Webhook.tsx
@@ -46,6 +46,7 @@ const createEmptyWebhookEvent = (key: number) => {
     key,
     id: uuid(),
     prWorkflowEnabled: false,
+    prApplyEnabled: false,
     pathType: WebhookEventPathType.PATTERN,
   };
 };
@@ -110,6 +111,7 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
               pathType: event.attributes.pathType || WebhookEventPathType.REGEX,
               template: event.attributes.templateId,
               prWorkflowEnabled: event.attributes.prWorkflowEnabled || false,
+              prApplyEnabled: event.attributes.prApplyEnabled || false,
               created: true,
             };
           });
@@ -263,6 +265,7 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
                   pathType: event.pathType || WebhookEventPathType.PATTERN,
                   templateId: event.template,
                   prWorkflowEnabled: event.prWorkflowEnabled || false,
+                  prApplyEnabled: event.prApplyEnabled || false,
                 },
               },
             };
@@ -402,8 +405,8 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
     },
     {
       title: (
-        <Tooltip title="Enable Atlantis-style workflow: post plan/apply results as PR comments and accept 'terrakube plan' / 'terrakube apply' commands from PR comments">
-          PR Workflow <InfoCircleOutlined />
+        <Tooltip title="Post a plan comment on every pull request (TFE-style plan-only workflow). Also enables the 'terrakube plan' PR-comment command to re-run a plan.">
+          Post Plan on PR <InfoCircleOutlined />
         </Tooltip>
       ),
       dataIndex: "prWorkflowEnabled",
@@ -414,7 +417,31 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
           <Switch
             size="small"
             checked={record.prWorkflowEnabled || false}
-            onChange={(checked) => handleEventChange(index, record.key, "prWorkflowEnabled", checked)}
+            onChange={(checked) => {
+              handleEventChange(index, record.key, "prWorkflowEnabled", checked);
+              if (!checked) {
+                handleEventChange(index, record.key, "prApplyEnabled", false);
+              }
+            }}
+          />
+        ) : null,
+    },
+    {
+      title: (
+        <Tooltip title="Allow the 'terrakube apply' PR-comment command to apply this workspace (Atlantis-style). Requires 'Post Plan on PR' to be enabled.">
+          Allow Apply via PR Comment <InfoCircleOutlined />
+        </Tooltip>
+      ),
+      dataIndex: "prApplyEnabled",
+      key: "prApplyEnabled",
+      width: isMobile ? 110 : 140,
+      render: (_: string, record: any, index: number) =>
+        record.event === "pull_request" ? (
+          <Switch
+            size="small"
+            checked={record.prApplyEnabled || false}
+            disabled={!record.prWorkflowEnabled}
+            onChange={(checked) => handleEventChange(index, record.key, "prApplyEnabled", checked)}
           />
         ) : null,
     },

--- a/ui/src/domain/Workspaces/Settings/Webhook.tsx
+++ b/ui/src/domain/Workspaces/Settings/Webhook.tsx
@@ -105,7 +105,7 @@ export const WorkspaceWebhook = ({ workspace, vcsProvider, orgTemplates, manageW
               key: i++,
               id: event.id,
               priority: event.attributes.priority,
-              event: event.attributes.event,
+              event: (event.attributes.event || "").toString().toLowerCase(),
               branch: event.attributes.branch,
               file: event.attributes.path,
               pathType: event.attributes.pathType || WebhookEventPathType.REGEX,

--- a/ui/src/domain/types.ts
+++ b/ui/src/domain/types.ts
@@ -426,6 +426,7 @@ export type WebhookEventAttributes = {
   priority: number;
   event: WebhookEventType;
   prWorkflowEnabled: boolean;
+  prApplyEnabled: boolean;
 };
 
 // Agent


### PR DESCRIPTION
## Description

Improves the PR/MR comments Terrakube posts for plan and apply runs. Previously the comment linked to a storage pointer instead of showing real output, always invited `terrakube apply` even when apply-via-PR-comment was disabled, and posted a brand new comment on every replan. This PR fixes all three, adds status icons/diff formatting, splits the plan/apply toggles so they can be configured independently, and adds an immediate emoji acknowledgment when a `terrakube plan`/`terrakube apply` comment is recognized.

## Changes

- **Real console output in comments** instead of a storage reference (`PrCommentService.fetchStepOutputText`).
- **Status icons, change summary line, and diff-highlighted plan blocks** in the comment body.
- **Separate `pr_workflow_enabled` / `pr_apply_enabled` toggles** ("Post Plan on PR" vs "Allow Apply via PR Comment") instead of one combined switch, in both the webhook UI (`Webhook.tsx`) and API (`WebhookEvent`).
- **Apply footer is now gated on `pr_apply_enabled`.** The plan comment only shows `To apply this plan, comment: \`terrakube apply\`` when that's actually enabled for the workspace; otherwise it shows a disabled notice instead of inviting a command that would be rejected. (`Job.prApplyEnabled`, threaded from `WebhookEvent` at job-creation time.)
- **Comment consolidation.** Repeated replans on the same PR now edit the existing plan comment in place (`PrCommentService.findReusablePlanCommentId` / `attemptUpdateComment`) instead of stacking a new comment per push, falling back to a new comment if the edit fails. Apply results still post as a separate comment to preserve an audit trail. Added `updatePrComment`/`updateMergeRequestNote` to the GitHub/GitLab/Bitbucket webhook services.
- **Job link** in the comment header, back to the run in the Terrakube UI.
- **Emoji acknowledgment.** Terrakube reacts with 👀 on the triggering comment as soon as a `terrakube plan`/`terrakube apply` command is recognized (GitHub reaction / GitLab award emoji), before the run finishes. No-op on Bitbucket, which has no comment-reaction API.
- New `pr_apply_enabled` column + migration on `job` (mirrors the existing column on `webhook_event`).

## Bug fixes found along the way

- **GitLab and Bitbucket never posted comments at all.** `GitLabWebhookService.handleMergeRequestEvent` and `BitBucketWebhookService.handlePullRequestEvent` never called `result.setPrNumber(...)` on the MR/PR-open event (only their comment-command handlers did), so `job.getPrNumber()` stayed null and `PrCommentService.postPlanResult`/`postApplyResult` silently no-op'd on every automatic run for those two providers. GitHub was unaffected. Fixed by setting the PR/MR number on the open/update event, matching GitHub.
- **`terrakube apply` could permanently lock a workspace.** `WebhookService.handlePrCommentCommand` locks the workspace before scheduling the apply job, but `ScheduleJob`'s workspace-lock guard ran before status handling and blocked that same job from ever reaching `postPrCommentIfNeeded`'s unlock code — a self-deadlock requiring a manual unlock every time. Fixed with `ScheduleJob.isOwnPrApplyLock()`, which exempts a job from the guard only when it owns that exact lock (shared lock-description builder: `WebhookService.buildPrApplyLockDescription`).
- **Apply results could silently land in the plan comment.** `postPrCommentIfNeeded` picked `postPlanResult` vs `postApplyResult` based on `tclService.isTemplatePlanOnly(job.getTemplateReference())` — a property of the *template*, not of how the job was triggered. Since `terrakube apply` runs against `workspace.getDefaultTemplate()`, a plan-only default template meant the apply job's completion reused/updated the existing plan comment instead of posting its own. Fixed by routing on `job.isAutoApply()` instead.
- **Post Plan on PR / Allow Apply via PR Comment toggles disappeared after saving.** `Webhook.tsx` compared `record.event` against the lowercase literal `"pull_request"`, but the persisted value comes back as the uppercase `WebhookEventType` enum (`"PULL_REQUEST"`). The toggle cells rendered `null` (not just disabled) for any previously-saved row, making the settings look impossible to change post-setup. Fixed by normalizing case on load.
- **Default Template field description was stale.** Labeled as driving "git push" runs, but that wiring was removed in the `webhook_event`-table refactor over a year ago; today it's read only by the `terrakube apply` comment handler and to pre-fill manual run creation. Copy corrected in `General.tsx` / `Workspaces/Create.tsx`.
- **Completion acknowledgment.** Added a second reaction beyond the existing 👀-on-receipt: once the job finishes, Terrakube updates the reaction to ✅/❌ (GitHub `+1`/`-1`, GitLab `white_check_mark`/`x`) on the original triggering comment. Requires threading the triggering comment's id onto the job (`Job.commandCommentId`, migration `changelog-2.33.0-job-command-comment-id.xml`).

## Tests

- `PrCommentServiceTest` — apply-footer gating, update-in-place/fallback-to-new-comment, job link rendering, and completion-acknowledgment reactions (GitHub/GitLab, success/failure, Bitbucket no-op).
- `WebhookServiceTest` — threading `prApplyEnabled`/`commandCommentId` onto the job, and comment-acknowledgment reaction presence/absence.
- `ScheduleJobTest` — workspace-lock guard exemption for a job's own PR-apply lock (and that unrelated locks still block), unlock-on-completion, and plan/apply comment routing by `job.isAutoApply()` rather than template classification.
- `VcsGitlabTests` / `VcsBitbucketTests` — MR/PR-open events now set `prNumber`.
- 85 tests across the files touched in this PR, 0 failures. Recommend re-confirming the full `mvn test` count/status in CI before merge, since it's changed since this PR's description was first drafted.

## Screenshots

See attached screenshots for GitHub and GitLab examples of the plan comment, apply comment, and 👀→✅ reaction in practice.

### GitHub Screenshots
<img width="2538" height="904" alt="terrakube-webhook-github-pr-output1" src="https://github.com/user-attachments/assets/e40adb29-82db-442f-aa5e-5cc7f08cffff" />
<img width="914" height="449" alt="terrakube-webhook-github-pr-output2" src="https://github.com/user-attachments/assets/cfc2b6b9-596d-47a8-99b4-e3ac7c50ee31" />
<img width="943" height="613" alt="terrakube-webhook-github-pr-output3" src="https://github.com/user-attachments/assets/7ff945f5-fa6a-44b4-8ac2-797e31b23640" />
<img width="1111" height="1047" alt="terrakube-webhook-github-pr-output4" src="https://github.com/user-attachments/assets/bf66bf5b-70d2-4e86-a8f0-c13bc83d36ab" />

### GitLab Screenshots
<img width="2542" height="934" alt="terrakube-webhook-gitlab-pr-output1" src="https://github.com/user-attachments/assets/02aa0b0b-293c-4068-b7f3-4e9db1f267ac" />
<img width="1141" height="813" alt="terrakube-webhook-gitlab-pr-output2" src="https://github.com/user-attachments/assets/ecad63dd-f175-47b5-a0e2-7f2f5a8b02ad" />
<img width="1117" height="858" alt="terrakube-webhook-gitlab-pr-output3" src="https://github.com/user-attachments/assets/6d0b7eb7-3287-4b7e-af5a-42ce9c68561b" />
<img width="1200" height="1138" alt="terrakube-webhook-gitlab-pr-output4" src="https://github.com/user-attachments/assets/79c32751-1c3c-40ff-a5eb-2a991e972619" />

Resolves #3334 