### PR TITLE
fix: validate GitHub App token expiry and clean up orphaned VCS refs

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenService.java
@@ -7,6 +7,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
@@ -48,6 +49,9 @@ import reactor.netty.transport.ProxyProvider;
 public class GitHubTokenService implements GetAccessToken<GitHubToken> {
 
     private static final String DEFAULT_ENDPOINT = "https://github.com";
+    // Treat a cached token as expired slightly before GitHub actually expires it,
+    // so a request never races the real expiry.
+    private static final Duration EXPIRY_SAFETY_BUFFER = Duration.ofMinutes(1);
 
     @Autowired
     ObjectMapper objectMapper;
@@ -110,9 +114,23 @@ public class GitHubTokenService implements GetAccessToken<GitHubToken> {
     public String refreshAccessToken(GitHubAppToken gitHubAppToken)
             throws NoSuchAlgorithmException, InvalidKeySpecException, JsonMappingException, JsonProcessingException {
         Vcs vcs = vcsRepository.findFirstByClientId(gitHubAppToken.getAppId());
+        if (vcs == null) {
+            log.warn("No Vcs found for GitHub App id {}, removing orphaned GitHubAppToken {} for owner {}",
+                    gitHubAppToken.getAppId(), gitHubAppToken.getId(), gitHubAppToken.getOwner());
+            try {
+                scheduleGitHubAppTokenService.deleteTask(gitHubAppToken.getId().toString());
+            } catch (SchedulerException e) {
+                log.error("Failed to delete refresh schedule for orphaned GitHubAppToken {}, error {}",
+                        gitHubAppToken.getId(), e);
+            }
+            gitHubAppTokenRepository.delete(gitHubAppToken);
+            return null;
+        }
         String jws = generateJWT(vcs.getClientId(), vcs.getPrivateKey());
-        return fetchGitHubAppInstallationToken(gitHubAppToken.getInstallationId(), vcs.getApiUrl(), jws,
-                gitHubAppToken.getOwner());
+        GitHubAppInstallationToken installationToken = fetchGitHubAppInstallationToken(
+                gitHubAppToken.getInstallationId(), vcs.getApiUrl(), jws, gitHubAppToken.getOwner());
+        gitHubAppToken.setExpiresAt(installationToken.expiresAt());
+        return installationToken.token();
     }
 
     public GitHubAppToken getGitHubAppToken(Vcs vcs, String[] ownerAndRepo)
@@ -122,6 +140,15 @@ public class GitHubTokenService implements GetAccessToken<GitHubToken> {
         if (gitHubAppToken == null) {
             log.info("No token found in GitHubAppToken table, fetching new token");
             gitHubAppToken = fetchGitHubAppInstallationToken(vcs, ownerAndRepo);
+        } else if (isExpired(gitHubAppToken.getExpiresAt())) {
+            log.info("Cached GitHub App token for user/organization {} is expired or missing an expiry, refreshing",
+                    ownerAndRepo[0]);
+            String jws = generateJWT(vcs.getClientId(), vcs.getPrivateKey());
+            GitHubAppInstallationToken installationToken = fetchGitHubAppInstallationToken(
+                    gitHubAppToken.getInstallationId(), vcs.getApiUrl(), jws, ownerAndRepo[0]);
+            gitHubAppToken.setToken(installationToken.token());
+            gitHubAppToken.setExpiresAt(installationToken.expiresAt());
+            gitHubAppToken = gitHubAppTokenRepository.save(gitHubAppToken);
         }
 
         log.info("Token fetched for user/organization {}", ownerAndRepo[0]);
@@ -149,9 +176,10 @@ public class GitHubTokenService implements GetAccessToken<GitHubToken> {
             gitHubAppToken.setInstallationId(installationId);
             gitHubAppToken.setOwner(ownerAndRepo[0]);
             gitHubAppToken.setAppId(vcs.getClientId());
-            gitHubAppToken
-                    .setToken(fetchGitHubAppInstallationToken(installationId, vcs.getApiUrl(), jws, ownerAndRepo[0]));
-
+            GitHubAppInstallationToken installationToken = fetchGitHubAppInstallationToken(installationId,
+                    vcs.getApiUrl(), jws, ownerAndRepo[0]);
+            gitHubAppToken.setToken(installationToken.token());
+            gitHubAppToken.setExpiresAt(installationToken.expiresAt());
         }
 
         gitHubAppToken = gitHubAppTokenRepository.save(gitHubAppToken);
@@ -171,16 +199,26 @@ public class GitHubTokenService implements GetAccessToken<GitHubToken> {
 
     // Gets the access token with app installation ID for a specific installation of
     // the app
-    private String fetchGitHubAppInstallationToken(String installationId, String vcsApiUrl, String jws, String owner)
-            throws JsonMappingException, JsonProcessingException {
+    private GitHubAppInstallationToken fetchGitHubAppInstallationToken(String installationId, String vcsApiUrl,
+            String jws, String owner) throws JsonMappingException, JsonProcessingException {
         String token = null;
+        Instant expiresAt = null;
         String url = vcsApiUrl + "/app/installations/" + installationId + "/access_tokens";
         log.debug("Getting access token for installation {} on user/organization {}", installationId, owner);
         ResponseEntity<String> tokenResponse = callGithubAPI("", url, HttpMethod.POST, jws);
         if (tokenResponse.getStatusCode().value() == 201) {
-            token = objectMapper.readTree(tokenResponse.getBody()).path("token").asText();
+            JsonNode rootNode = objectMapper.readTree(tokenResponse.getBody());
+            token = rootNode.path("token").asText();
+            expiresAt = Instant.parse(rootNode.path("expires_at").asText());
         }
-        return token;
+        return new GitHubAppInstallationToken(token, expiresAt);
+    }
+
+    private boolean isExpired(Instant expiresAt) {
+        return expiresAt == null || !expiresAt.isAfter(Instant.now().plus(EXPIRY_SAFETY_BUFFER));
+    }
+
+    private record GitHubAppInstallationToken(String token, Instant expiresAt) {
     }
 
     // Generates a JWT token for the GitHub App

--- a/api/src/main/java/io/terrakube/api/rs/vcs/GitHubAppToken.java
+++ b/api/src/main/java/io/terrakube/api/rs/vcs/GitHubAppToken.java
@@ -1,6 +1,7 @@
 package io.terrakube.api.rs.vcs;
 
 import java.sql.Types;
+import java.time.Instant;
 import java.util.UUID;
 
 import org.hibernate.annotations.JdbcTypeCode;
@@ -42,4 +43,7 @@ public class GitHubAppToken extends GenericAuditFields {
 
     @Column(name = "app_id")
     private String appId;
+
+    @Column(name = "expires_at")
+    private Instant expiresAt;
 }

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -108,4 +108,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-vcs-token-size.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-github-app-token-size.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-pr-comment-error.xml"/>
+    <include file="/db/changelog/local/changelog-2.33.0-github-app-token-expiry.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-github-app-token-expiry.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-github-app-token-expiry.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-33-0-4" author="jake.groves">
+        <addColumn tableName="github_app_token">
+            <column name="expires_at" type="datetime">
+                <constraints nullable="true" />
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenServiceTest.java
@@ -1,0 +1,228 @@
+package io.terrakube.api.plugin.vcs.provider.github;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.SchedulerException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+
+import io.terrakube.api.plugin.scheduler.ScheduleGitHubAppTokenService;
+import io.terrakube.api.repository.GitHubAppTokenRepository;
+import io.terrakube.api.repository.VcsRepository;
+import io.terrakube.api.rs.vcs.GitHubAppToken;
+import io.terrakube.api.rs.vcs.Vcs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class GitHubTokenServiceTest {
+
+    private static final String OWNER = "testowner";
+    private static final String REPO = "testrepo";
+    private static final String INSTALLATION_ID = "98765";
+    private static final String APP_ID = "app-client-id";
+
+    private GitHubAppTokenRepository gitHubAppTokenRepository;
+    private VcsRepository vcsRepository;
+    private ScheduleGitHubAppTokenService scheduleGitHubAppTokenService;
+    private GitHubTokenService subject;
+
+    private HttpServer httpServer;
+    private String privateKeyPem;
+    private AtomicInteger accessTokenHits;
+    private AtomicInteger installationHits;
+    private String tokenToReturn;
+    private String expiresAtToReturn;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        gitHubAppTokenRepository = mock(GitHubAppTokenRepository.class);
+        vcsRepository = mock(VcsRepository.class);
+        scheduleGitHubAppTokenService = mock(ScheduleGitHubAppTokenService.class);
+
+        subject = new GitHubTokenService();
+        subject.objectMapper = new ObjectMapper();
+        subject.gitHubAppTokenRepository = gitHubAppTokenRepository;
+        subject.vcsRepository = vcsRepository;
+        subject.scheduleGitHubAppTokenService = scheduleGitHubAppTokenService;
+
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        privateKeyPem = "-----BEGIN PRIVATE KEY-----\n"
+                + Base64.getMimeEncoder(64, "\n".getBytes()).encodeToString(keyPair.getPrivate().getEncoded())
+                + "\n-----END PRIVATE KEY-----";
+
+        accessTokenHits = new AtomicInteger(0);
+        installationHits = new AtomicInteger(0);
+        tokenToReturn = "ghs_refreshed-token";
+        expiresAtToReturn = Instant.now().plus(1, ChronoUnit.HOURS).toString();
+
+        httpServer = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        httpServer.createContext("/repos/" + OWNER + "/" + REPO + "/installation", exchange -> {
+            installationHits.incrementAndGet();
+            writeJson(exchange, 200, "{\"id\":\"" + INSTALLATION_ID + "\"}");
+        });
+        httpServer.createContext("/app/installations/" + INSTALLATION_ID + "/access_tokens", exchange -> {
+            accessTokenHits.incrementAndGet();
+            writeJson(exchange, 201,
+                    "{\"token\":\"" + tokenToReturn + "\",\"expires_at\":\"" + expiresAtToReturn + "\"}");
+        });
+        httpServer.start();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        httpServer.stop(0);
+    }
+
+    private static void writeJson(com.sun.net.httpserver.HttpExchange exchange, int status, String body)
+            throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    private Vcs createVcs() {
+        Vcs vcs = new Vcs();
+        vcs.setId(UUID.randomUUID());
+        vcs.setClientId(APP_ID);
+        vcs.setPrivateKey(privateKeyPem);
+        vcs.setApiUrl("http://localhost:" + httpServer.getAddress().getPort());
+        return vcs;
+    }
+
+    private GitHubAppToken createCachedToken(Instant expiresAt) {
+        GitHubAppToken token = new GitHubAppToken();
+        token.setId(UUID.randomUUID());
+        token.setAppId(APP_ID);
+        token.setOwner(OWNER);
+        token.setInstallationId(INSTALLATION_ID);
+        token.setToken("ghs_stale-token");
+        token.setExpiresAt(expiresAt);
+        return token;
+    }
+
+    // Issue 1: cached token past expiry must be treated as a miss and refreshed in place,
+    // not served as-is.
+    @Test
+    public void getGitHubAppToken_expiredCachedToken_refetchesAndUpdatesInPlace() throws Exception {
+        Vcs vcs = createVcs();
+        GitHubAppToken cached = createCachedToken(Instant.now().minus(5, ChronoUnit.MINUTES));
+
+        when(gitHubAppTokenRepository.findByAppIdAndOwner(APP_ID, OWNER)).thenReturn(cached);
+        when(gitHubAppTokenRepository.save(any(GitHubAppToken.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        GitHubAppToken result = subject.getGitHubAppToken(vcs, new String[] { OWNER, REPO });
+
+        assertEquals(tokenToReturn, result.getToken());
+        assertEquals(cached.getId(), result.getId(), "must update the existing row, not create a new one");
+        assertEquals(0, installationHits.get(), "should not re-discover the installation, it is already known");
+        assertEquals(1, accessTokenHits.get());
+        verify(gitHubAppTokenRepository, times(1)).save(any(GitHubAppToken.class));
+    }
+
+    // A token with no expiry recorded (e.g. rows created before this fix shipped) must be
+    // treated the same as expired, so it self-heals on the next read instead of being served forever.
+    @Test
+    public void getGitHubAppToken_missingExpiry_treatedAsExpired() throws Exception {
+        Vcs vcs = createVcs();
+        GitHubAppToken cached = createCachedToken(null);
+
+        when(gitHubAppTokenRepository.findByAppIdAndOwner(APP_ID, OWNER)).thenReturn(cached);
+        when(gitHubAppTokenRepository.save(any(GitHubAppToken.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        GitHubAppToken result = subject.getGitHubAppToken(vcs, new String[] { OWNER, REPO });
+
+        assertEquals(tokenToReturn, result.getToken());
+        assertEquals(1, accessTokenHits.get());
+    }
+
+    @Test
+    public void getGitHubAppToken_validCachedToken_isServedWithoutAnyHttpCall() throws Exception {
+        Vcs vcs = createVcs();
+        GitHubAppToken cached = createCachedToken(Instant.now().plus(30, ChronoUnit.MINUTES));
+
+        when(gitHubAppTokenRepository.findByAppIdAndOwner(APP_ID, OWNER)).thenReturn(cached);
+
+        GitHubAppToken result = subject.getGitHubAppToken(vcs, new String[] { OWNER, REPO });
+
+        assertEquals("ghs_stale-token", result.getToken());
+        assertEquals(0, accessTokenHits.get());
+        assertEquals(0, installationHits.get());
+        verify(gitHubAppTokenRepository, never()).save(any(GitHubAppToken.class));
+    }
+
+    // Issue 2: if the Vcs backing a cached token has been deleted (or recreated with a
+    // different row), refreshAccessToken must not NPE - it should clean up the orphaned
+    // row and its refresh schedule instead of leaving a stale token behind forever.
+    @Test
+    public void refreshAccessToken_noMatchingVcs_deletesOrphanedTokenAndSchedule() throws Exception {
+        GitHubAppToken orphaned = createCachedToken(Instant.now().minus(1, ChronoUnit.HOURS));
+        when(vcsRepository.findFirstByClientId(APP_ID)).thenReturn(null);
+
+        String result = subject.refreshAccessToken(orphaned);
+
+        assertNull(result);
+        verify(scheduleGitHubAppTokenService, times(1)).deleteTask(orphaned.getId().toString());
+        verify(gitHubAppTokenRepository, times(1)).delete(orphaned);
+        assertEquals(0, accessTokenHits.get());
+    }
+
+    @Test
+    public void refreshAccessToken_schedulerFailureDuringCleanup_stillDeletesOrphanedRow() throws Exception {
+        GitHubAppToken orphaned = createCachedToken(Instant.now().minus(1, ChronoUnit.HOURS));
+        when(vcsRepository.findFirstByClientId(APP_ID)).thenReturn(null);
+        doAnswer(invocation -> {
+            throw new SchedulerException("boom");
+        }).when(scheduleGitHubAppTokenService).deleteTask(orphaned.getId().toString());
+
+        String result = subject.refreshAccessToken(orphaned);
+
+        assertNull(result);
+        verify(gitHubAppTokenRepository, times(1)).delete(orphaned);
+    }
+
+    @Test
+    public void refreshAccessToken_matchingVcs_returnsRefreshedTokenAndSetsExpiry() throws Exception {
+        Vcs vcs = createVcs();
+        GitHubAppToken existing = createCachedToken(Instant.now().minus(1, ChronoUnit.HOURS));
+        when(vcsRepository.findFirstByClientId(APP_ID)).thenReturn(vcs);
+
+        String result = subject.refreshAccessToken(existing);
+
+        assertEquals(tokenToReturn, result);
+        assertNotNull(existing.getExpiresAt());
+        assertEquals(1, accessTokenHits.get());
+    }
+}


### PR DESCRIPTION
## Description

GitHub App installation tokens were cached indefinitely with no expiry check on read, so any gap in the background refresh job left every clone for that owner permanently failing with `not authorized`. Separately, if a GitHub App VCS was deleted and recreated, `refreshAccessToken` NPE'd on the missing VCS instead of cleaning up the orphaned token row, compounding the same failure with no self-recovery.

## How solved

- Added `expires_at` to `GitHubAppToken` (new Liquibase migration), populated from GitHub's installation-token response.
- `getGitHubAppToken` now treats a missing/near-expiry token as a cache miss and refreshes it in place (same row, no duplicates) instead of blindly returning it.
- `refreshAccessToken` null-checks the VCS lookup; on an orphaned token (no matching VCS) it deletes the row and cancels its Quartz refresh trigger instead of throwing.

## Tests added

- `GitHubTokenServiceTest` (6 cases): expired/missing-expiry tokens trigger a re-fetch, valid cached tokens are served with zero HTTP calls, and orphaned-VCS refresh cleans up the token row + schedule (including when trigger deletion itself fails).

Fixes #3317
Fixes #3318