### PR TITLE
feat(ui): workspace access

### DIFF
--- a/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamLimitedManageWorkspaceAccess.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamLimitedManageWorkspaceAccess.java
@@ -1,0 +1,53 @@
+package io.terrakube.api.rs.checks.workspace;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import io.terrakube.api.plugin.security.groups.GroupService;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.workspace.Workspace;
+import io.terrakube.api.rs.workspace.access.Access;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamLimitedManageWorkspaceAccess.RULE)
+public class TeamLimitedManageWorkspaceAccess extends OperationCheck<Access> {
+
+    public static final String RULE = "team limited manage workspace access";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    GroupService groupService;
+
+    @Autowired
+    RbacService rbacService;
+
+    @Override
+    public boolean ok(Access access, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team limited manage workspace access {}", access.getId());
+        Workspace workspace = access.getWorkspace();
+        if (workspace == null) return false;
+        List<Access> accessList = workspace.getAccess();
+        if (accessList == null || accessList.isEmpty()) return false;
+        for (Access existingAccess : accessList) {
+            if (authenticatedUser.isServiceAccount(requestScope.getUser())) {
+                if (groupService.isServiceMember(requestScope.getUser(), existingAccess.getName()) && rbacService.canManageWorkspace(existingAccess)) {
+                    return true;
+                }
+            } else {
+                if (groupService.isMember(requestScope.getUser(), existingAccess.getName()) && rbacService.canManageWorkspace(existingAccess)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamManageWorkspaceAccess.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamManageWorkspaceAccess.java
@@ -1,0 +1,50 @@
+package io.terrakube.api.rs.checks.workspace;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import io.terrakube.api.plugin.security.groups.GroupService;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.team.Team;
+import io.terrakube.api.rs.workspace.access.Access;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamManageWorkspaceAccess.RULE)
+public class TeamManageWorkspaceAccess extends OperationCheck<Access> {
+
+    public static final String RULE = "team manage workspace access";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    GroupService groupService;
+
+    @Autowired
+    RbacService rbacService;
+
+    @Override
+    public boolean ok(Access access, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team manage workspace access {}", access.getId());
+        List<Team> teamList = access.getWorkspace().getOrganization().getTeam();
+        for (Team team : teamList) {
+            if (authenticatedUser.isServiceAccount(requestScope.getUser())) {
+                if (groupService.isServiceMember(requestScope.getUser(), team.getName()) && rbacService.canManageWorkspace(team)) {
+                    return true;
+                }
+            } else {
+                if (groupService.isMember(requestScope.getUser(), team.getName()) && rbacService.canManageWorkspace(team)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamWorkspaceAdminManagesAccessField.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/workspace/TeamWorkspaceAdminManagesAccessField.java
@@ -1,0 +1,51 @@
+package io.terrakube.api.rs.checks.workspace;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import io.terrakube.api.plugin.security.groups.GroupService;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.workspace.Workspace;
+import io.terrakube.api.rs.workspace.access.Access;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamWorkspaceAdminManagesAccessField.RULE)
+public class TeamWorkspaceAdminManagesAccessField extends OperationCheck<Workspace> {
+
+    public static final String RULE = "team workspace admin manages access field";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    GroupService groupService;
+
+    @Autowired
+    RbacService rbacService;
+
+    @Override
+    public boolean ok(Workspace workspace, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team workspace admin manages access field {}", workspace.getId());
+        List<Access> accessList = workspace.getAccess();
+        if (accessList == null || accessList.isEmpty()) return false;
+        for (Access existingAccess : accessList) {
+            if (authenticatedUser.isServiceAccount(requestScope.getUser())) {
+                if (groupService.isServiceMember(requestScope.getUser(), existingAccess.getName()) && rbacService.canManageWorkspace(existingAccess)) {
+                    return true;
+                }
+            } else {
+                if (groupService.isMember(requestScope.getUser(), existingAccess.getName()) && rbacService.canManageWorkspace(existingAccess)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
@@ -149,6 +149,6 @@ public class Workspace extends GenericAuditFields {
     private List<Reference> reference;
 
     @OneToMany(mappedBy = "workspace")
-    @UpdatePermission(expression = "user is a superuser")
+    @UpdatePermission(expression = "user is a superuser OR team manage workspace OR team workspace admin manages access field")
     private List<Access> access;
 }

--- a/api/src/main/java/io/terrakube/api/rs/workspace/access/Access.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/access/Access.java
@@ -3,6 +3,7 @@ package io.terrakube.api.rs.workspace.access;
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -14,9 +15,10 @@ import io.terrakube.api.rs.workspace.Workspace;
 import java.sql.Types;
 import java.util.UUID;
 
-@CreatePermission(expression = "user is a superuser")
-@UpdatePermission(expression = "user is a superuser")
-@DeletePermission(expression = "user is a superuser")
+@ReadPermission(expression = "user is a superuser OR team manage workspace access OR team limited manage workspace access")
+@CreatePermission(expression = "user is a superuser OR team manage workspace access OR team limited manage workspace access")
+@UpdatePermission(expression = "user is a superuser OR team manage workspace access OR team limited manage workspace access")
+@DeletePermission(expression = "user is a superuser OR team manage workspace access OR team limited manage workspace access")
 @Include(rootLevel = false)
 @Getter
 @Setter

--- a/api/src/test/java/io/terrakube/api/AccessTests.java
+++ b/api/src/test/java/io/terrakube/api/AccessTests.java
@@ -102,14 +102,53 @@ public class AccessTests extends ServerApplicationTests {
     }
 
     @Test
-    void createWorkspaceAccessAsNonAdmin() {
-        given()
+    void createWorkspaceAccessAsOrgManageWorkspaceTeam() {
+        // TERRAKUBE_DEVELOPERS is an org-level team with manage-workspace rights; it should
+        // be able to manage workspace access the same way an org admin can, without needing
+        // a superuser PAT (mirrors ProjectAccess behavior for project-level teams).
+        String accessId = given()
                 .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
                 .body("{\n" +
                         "  \"data\": {\n" +
                         "    \"type\": \"access\",\n" +
                         "    \"attributes\": {\n" +
-                        "      \"name\": \"NEW_TEAM_WORKSPACE_ACCESS_ONLY\",\n" +
+                        "      \"name\": \"NEW_TEAM_WORKSPACE_ACCESS_BY_ORG_TEAM\",\n" +
+                        "      \"manageWorkspace\": true,\n" +
+                        "      \"manageJob\": true,\n" +
+                        "      \"manageState\": true\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/workspace/5ed411ca-7ab8-4d2f-b591-02d0d5788afc/access")
+                .then()
+                .log()
+                .all()
+                .body("data.attributes.name", IsEqual.equalTo("NEW_TEAM_WORKSPACE_ACCESS_BY_ORG_TEAM"))
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/workspace/5ed411ca-7ab8-4d2f-b591-02d0d5788afc/access/" + accessId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    void createWorkspaceAccessAsUnrelatedTeam() {
+        // PROJECT_TEAM_MEMBER has no org-level manage-workspace rights and no existing
+        // access grant on this workspace, so it must not be able to create workspace access.
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_TEAM_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"SHOULD_NOT_BE_CREATED\",\n" +
                         "      \"manageWorkspace\": true,\n" +
                         "      \"manageJob\": true,\n" +
                         "      \"manageState\": true\n" +
@@ -122,6 +161,122 @@ public class AccessTests extends ServerApplicationTests {
                 .log()
                 .all()
                 .statusCode(HttpStatus.FORBIDDEN.value());
+    }
+
+    @Test
+    void manageWorkspaceAccessWithWorkspaceAdminRole() {
+        String workspaceId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"workspace\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"manageWorkspaceAccessWithWorkspaceAdminRole\",\n" +
+                        "      \"source\": \"https://github.com/AzBuilder/terraform-azurerm-terrakube-app-registration.git\",\n" +
+                        "      \"branch\": \"main\",\n" +
+                        "      \"terraformVersion\": \"1.0.11\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/workspace")
+                .then()
+                .assertThat()
+                .body("data.attributes.name", IsEqual.equalTo("manageWorkspaceAccessWithWorkspaceAdminRole"))
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        // WORKSPACE_ACCESS_ADMIN_MEMBER cannot manage workspace access before being granted admin role
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("WORKSPACE_ACCESS_ADMIN_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"SOME_TEAM\",\n" +
+                        "      \"role\": \"read\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/workspace/" + workspaceId + "/access")
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+
+        // Org admin grants WORKSPACE_ACCESS_ADMIN_MEMBER an admin role on the workspace
+        String adminAccessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"WORKSPACE_ACCESS_ADMIN_MEMBER\",\n" +
+                        "      \"role\": \"admin\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/workspace/" + workspaceId + "/access")
+                .then()
+                .log()
+                .all()
+                .body("data.attributes.name", IsEqual.equalTo("WORKSPACE_ACCESS_ADMIN_MEMBER"))
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        // WORKSPACE_ACCESS_ADMIN_MEMBER can now create a new access entry
+        String newAccessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("WORKSPACE_ACCESS_ADMIN_MEMBER"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"SOME_TEAM\",\n" +
+                        "      \"role\": \"read\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/workspace/" + workspaceId + "/access")
+                .then()
+                .log()
+                .all()
+                .body("data.attributes.name", IsEqual.equalTo("SOME_TEAM"))
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        // WORKSPACE_ACCESS_ADMIN_MEMBER can delete the access entry it just created
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("WORKSPACE_ACCESS_ADMIN_MEMBER"))
+                .when()
+                .delete("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/workspace/" + workspaceId + "/access/" + newAccessId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        // Cleanup
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/workspace/" + workspaceId + "/access/" + adminAccessId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/workspace/" + workspaceId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
     }
 
     @Test

--- a/api/src/test/java/io/terrakube/api/VcsRepositoryDiscoveryAzureDevOpsTests.java
+++ b/api/src/test/java/io/terrakube/api/VcsRepositoryDiscoveryAzureDevOpsTests.java
@@ -6,12 +6,14 @@ import io.terrakube.api.plugin.vcs.discovery.VcsRepositoryPage;
 import io.terrakube.api.plugin.vcs.discovery.azdevops.AzDevOpsRepositoryDiscoveryService;
 import io.terrakube.api.rs.vcs.Vcs;
 import io.terrakube.api.rs.vcs.VcsType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -25,6 +27,11 @@ public class VcsRepositoryDiscoveryAzureDevOpsTests extends ServerApplicationTes
     @Autowired
     AzDevOpsRepositoryDiscoveryService azDevOpsRepositoryDiscoveryService;
 
+    // Vcs rows are persisted directly via vcsRepository (bypassing the REST API), so they
+    // must be torn down manually or they leak into the shared test org and are picked up
+    // by unrelated tests (e.g. AccessTests) that assume a clean org.
+    private final List<UUID> createdVcsIds = new ArrayList<>();
+
     @BeforeEach
     public void setup() {
         MockitoAnnotations.openMocks(this);
@@ -33,6 +40,12 @@ public class VcsRepositoryDiscoveryAzureDevOpsTests extends ServerApplicationTes
         // WireMock can't stand in for the real app.vssps.visualstudio.com hostname
         ReflectionTestUtils.setField(azDevOpsRepositoryDiscoveryService, "profileEndpoint",
                 "http://localhost:" + wireMockServer.port());
+    }
+
+    @AfterEach
+    public void cleanup() {
+        createdVcsIds.forEach(vcsRepository::deleteById);
+        createdVcsIds.clear();
     }
 
     private Vcs oauthVcs() {
@@ -45,7 +58,9 @@ public class VcsRepositoryDiscoveryAzureDevOpsTests extends ServerApplicationTes
         vcs.setAccessToken("azdevops-token-abc");
         vcs.setApiUrl("http://localhost:" + wireMockServer.port());
         vcs.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
-        return vcsRepository.save(vcs);
+        Vcs saved = vcsRepository.save(vcs);
+        createdVcsIds.add(saved.getId());
+        return saved;
     }
 
     private Vcs managedIdentityVcs() {
@@ -57,7 +72,9 @@ public class VcsRepositoryDiscoveryAzureDevOpsTests extends ServerApplicationTes
         vcs.setClientSecret("123");
         vcs.setApiUrl("http://localhost:" + wireMockServer.port());
         vcs.setOrganization(organizationRepository.findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).get());
-        return vcsRepository.save(vcs);
+        Vcs saved = vcsRepository.save(vcs);
+        createdVcsIds.add(saved.getId());
+        return saved;
     }
 
     @Test

--- a/ui/src/domain/Workspaces/Settings/TeamAccess.tsx
+++ b/ui/src/domain/Workspaces/Settings/TeamAccess.tsx
@@ -1,0 +1,483 @@
+import {
+  CheckCircleFilled,
+  CloseCircleOutlined,
+  DeleteOutlined,
+  PlusOutlined,
+  TeamOutlined,
+  UsergroupAddOutlined,
+} from "@ant-design/icons";
+import {
+  Button,
+  Card,
+  Checkbox,
+  Empty,
+  Form,
+  Popconfirm,
+  Select,
+  Space,
+  Spin,
+  Table,
+  Tag,
+  Tooltip,
+  Typography,
+  message,
+  theme,
+} from "antd";
+import { useEffect, useRef, useState } from "react";
+import axiosInstance from "@/config/axiosConfig";
+import workspaceAccessService, {
+  WorkspaceAccessModel,
+  WorkspaceAccessPermissions,
+} from "@/modules/workspaces/workspaceAccessService";
+import { Workspace } from "../../types";
+
+type Props = {
+  workspace: Workspace;
+  manageWorkspace: boolean;
+};
+
+type AddTeamForm = {
+  teamName: string;
+  role: string;
+  manageWorkspace?: boolean;
+  manageState?: boolean;
+  planJob?: boolean;
+  approveJob?: boolean;
+};
+
+type TeamOption = { id: string; name: string };
+
+const ROLES = [
+  {
+    value: "admin",
+    label: "Admin",
+    color: "red",
+    description: "Full control — manages the workspace, runs plans and approvals, controls workspace team access.",
+  },
+  {
+    value: "write",
+    label: "Write",
+    color: "orange",
+    description: "Can manage the workspace, and queue and apply plans.",
+  },
+  {
+    value: "plan",
+    label: "Plan",
+    color: "blue",
+    description: "Can queue plans to propose changes but cannot approve or apply them.",
+  },
+  {
+    value: "read",
+    label: "Read",
+    color: "default",
+    description: "Read-only access. Cannot make any changes.",
+  },
+  {
+    value: "custom",
+    label: "Custom",
+    color: "purple",
+    description: "Choose individual permissions for this team.",
+  },
+];
+
+const PERMISSION_FIELDS: { key: keyof WorkspaceAccessPermissions; label: string; shortLabel: string }[] = [
+  { key: "manageWorkspace", label: "Manage Workspace", shortLabel: "Workspace" },
+  { key: "manageState", label: "Manage State", shortLabel: "State" },
+  { key: "planJob", label: "Plan Runs", shortLabel: "Plan" },
+  { key: "approveJob", label: "Approve Runs", shortLabel: "Approve" },
+];
+
+function roleColor(role: string): string {
+  return ROLES.find((r) => r.value === role)?.color ?? "default";
+}
+
+function roleDescription(role: string): string {
+  return ROLES.find((r) => r.value === role)?.description ?? "";
+}
+
+function effectivePermissions(record: WorkspaceAccessModel): WorkspaceAccessPermissions {
+  switch (record.role) {
+    case "admin":
+    case "write":
+      return { manageWorkspace: true, manageState: true, planJob: true, approveJob: true };
+    case "plan":
+      return { manageWorkspace: false, manageState: false, planJob: true, approveJob: false };
+    case "read":
+      return { manageWorkspace: false, manageState: false, planJob: false, approveJob: false };
+    default:
+      return {
+        manageWorkspace: record.manageWorkspace,
+        manageState: record.manageState,
+        planJob: record.planJob,
+        approveJob: record.approveJob,
+      };
+  }
+}
+
+export const WorkspaceTeamAccess = ({ workspace, manageWorkspace }: Props) => {
+  const orgid = workspace.relationships.organization.data.id;
+  const workspaceId = workspace.id;
+  const canManage = manageWorkspace;
+
+  const [accessList, setAccessList] = useState<WorkspaceAccessModel[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const [teams, setTeams] = useState<TeamOption[]>([]);
+  const [loadingTeams, setLoadingTeams] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingRole, setEditingRole] = useState<string>("");
+  const [editingPermissions, setEditingPermissions] = useState<WorkspaceAccessPermissions>({
+    manageWorkspace: false,
+    manageState: false,
+    planJob: false,
+    approveJob: false,
+  });
+  const [savingRole, setSavingRole] = useState(false);
+  const [form] = Form.useForm<AddTeamForm>();
+  const addRole = Form.useWatch("role", form);
+  const addFormRef = useRef<HTMLDivElement>(null);
+  const { token } = theme.useToken();
+
+  const scrollToAddForm = () => {
+    addFormRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const result = await workspaceAccessService.listWorkspaceAccess(orgid, workspaceId);
+      if (!result.isError) {
+        setAccessList(result.data);
+      } else {
+        message.error("Failed to load team access list");
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, [workspaceId]);
+
+  useEffect(() => {
+    setLoadingTeams(true);
+    axiosInstance
+      .get(`organization/${orgid}/team`)
+      .then((res) => {
+        const list = (res.data?.data ?? []).map((t: any) => ({
+          id: t.id,
+          name: t.attributes.name,
+        }));
+        setTeams(list);
+      })
+      .finally(() => setLoadingTeams(false));
+  }, [orgid]);
+
+  const onAdd = async (values: AddTeamForm) => {
+    setAdding(true);
+    try {
+      const permissions =
+        values.role === "custom"
+          ? {
+              manageWorkspace: !!values.manageWorkspace,
+              manageState: !!values.manageState,
+              planJob: !!values.planJob,
+              approveJob: !!values.approveJob,
+            }
+          : undefined;
+      await workspaceAccessService.addWorkspaceAccess(orgid, workspaceId, values.teamName, values.role, permissions);
+      message.success(`Team "${values.teamName}" added to workspace`);
+      form.resetFields();
+      await load();
+    } catch (err: any) {
+      if (err?.response?.status === 403) {
+        message.error("You are not authorized to manage workspace team access.");
+      } else {
+        message.error(err?.message ?? "Failed to add team access");
+      }
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const onRemove = async (accessId: string, teamName: string) => {
+    try {
+      await workspaceAccessService.removeWorkspaceAccess(orgid, workspaceId, accessId);
+      message.success(`Team "${teamName}" removed from workspace`);
+      await load();
+    } catch (err: any) {
+      if (err?.response?.status === 403) {
+        message.error("You are not authorized to manage workspace team access.");
+      } else {
+        message.error(err?.message ?? "Failed to remove team access");
+      }
+    }
+  };
+
+  const onEditRole = (record: WorkspaceAccessModel) => {
+    setEditingId(record.id);
+    setEditingRole(record.role);
+    setEditingPermissions(effectivePermissions(record));
+  };
+
+  const onSaveRole = async (record: WorkspaceAccessModel) => {
+    setSavingRole(true);
+    try {
+      const permissions = editingRole === "custom" ? editingPermissions : undefined;
+      await workspaceAccessService.updateWorkspaceAccess(orgid, workspaceId, record.id, editingRole, permissions);
+      message.success(`Role for "${record.name}" updated to ${editingRole}`);
+      setEditingId(null);
+      await load();
+    } catch (err: any) {
+      if (err?.response?.status === 403) {
+        message.error("You are not authorized to manage workspace team access.");
+      } else {
+        message.error(err?.message ?? "Failed to update role");
+      }
+    } finally {
+      setSavingRole(false);
+    }
+  };
+
+  const renderRoleSelect = (value: string, onChange: (value: string) => void) => (
+    <Select
+      size="small"
+      value={value}
+      onChange={onChange}
+      style={{ width: 160 }}
+      options={ROLES.map((r) => ({ value: r.value, label: r.label }))}
+      optionRender={(opt) => {
+        const r = ROLES.find((x) => x.value === opt.value);
+        if (!r) return opt.label;
+        return (
+          <Space direction="vertical" size={2} style={{ paddingTop: 4, paddingBottom: 4 }}>
+            <Tag color={r.color}>{r.label}</Tag>
+            <Typography.Text type="secondary" style={{ fontSize: 12, whiteSpace: "normal" }}>
+              {r.description}
+            </Typography.Text>
+          </Space>
+        );
+      }}
+      labelRender={(item) => {
+        const r = ROLES.find((x) => x.value === item.value);
+        return r ? <Tag color={r.color}>{r.label}</Tag> : <span>{String(item.label ?? "")}</span>;
+      }}
+    />
+  );
+
+  const columns = [
+    {
+      title: "Team",
+      dataIndex: "name",
+      key: "name",
+      render: (name: string) => (
+        <Space size={8}>
+          <TeamOutlined style={{ color: token.colorTextSecondary }} />
+          <Typography.Text strong>{name}</Typography.Text>
+        </Space>
+      ),
+    },
+    {
+      title: "Role",
+      dataIndex: "role",
+      key: "role",
+      render: (role: string, record: WorkspaceAccessModel) => {
+        if (canManage && editingId === record.id) {
+          return (
+            <Space direction="vertical" size={8}>
+              {renderRoleSelect(editingRole, setEditingRole)}
+              {editingRole === "custom" && (
+                <Space wrap size={12}>
+                  {PERMISSION_FIELDS.map((field) => (
+                    <Checkbox
+                      key={field.key}
+                      checked={editingPermissions[field.key]}
+                      onChange={(e) => setEditingPermissions((prev) => ({ ...prev, [field.key]: e.target.checked }))}
+                    >
+                      {field.label}
+                    </Checkbox>
+                  ))}
+                </Space>
+              )}
+              <Space>
+                <Button type="primary" size="small" loading={savingRole} onClick={() => onSaveRole(record)}>
+                  Save
+                </Button>
+                <Button size="small" onClick={() => setEditingId(null)}>
+                  Cancel
+                </Button>
+              </Space>
+            </Space>
+          );
+        }
+        return (
+          <Space>
+            <Tooltip title={roleDescription(role)}>
+              <Tag color={roleColor(role)} style={{ cursor: "default" }}>
+                {role ?? "custom"}
+              </Tag>
+            </Tooltip>
+            {canManage && (
+              <Button
+                type="link"
+                size="small"
+                style={{ padding: 0, height: "auto" }}
+                onClick={() => onEditRole(record)}
+              >
+                Change
+              </Button>
+            )}
+          </Space>
+        );
+      },
+    },
+    {
+      title: "Permissions",
+      key: "permissions",
+      children: PERMISSION_FIELDS.map((field) => ({
+        title: (
+          <Tooltip title={field.label}>
+            <span>{field.shortLabel}</span>
+          </Tooltip>
+        ),
+        key: field.key,
+        align: "center" as const,
+        width: 84,
+        render: (_: any, record: WorkspaceAccessModel) => {
+          const granted = effectivePermissions(record)[field.key];
+          return granted ? (
+            <Tooltip title={`Can ${field.label.toLowerCase()}`}>
+              <CheckCircleFilled style={{ color: token.colorSuccess, fontSize: 16 }} />
+            </Tooltip>
+          ) : (
+            <Tooltip title={`Cannot ${field.label.toLowerCase()}`}>
+              <CloseCircleOutlined style={{ color: token.colorTextQuaternary, fontSize: 16 }} />
+            </Tooltip>
+          );
+        },
+      })),
+    },
+    {
+      title: "",
+      key: "actions",
+      align: "right" as const,
+      render: (_: any, record: WorkspaceAccessModel) => (
+        <Popconfirm
+          title={`Remove team "${record.name}" from this workspace?`}
+          onConfirm={() => onRemove(record.id, record.name)}
+          okText="Yes"
+          cancelText="No"
+          placement="left"
+          disabled={!canManage}
+        >
+          <Button danger icon={<DeleteOutlined />} size="small" disabled={!canManage}>
+            Remove
+          </Button>
+        </Popconfirm>
+      ),
+    },
+  ];
+
+  const teamCountLabel =
+    accessList.length === 0
+      ? "No teams have access yet"
+      : `${accessList.length} team${accessList.length === 1 ? "" : "s"} have access`;
+
+  return (
+    <div style={{ width: "100%" }}>
+      <h1>Team Access</h1>
+      <p>Teams granted access to this workspace via the Terrakube UI or the terrakube_workspace_access resource.</p>
+
+      <Space align="center" style={{ marginBottom: 12 }}>
+        <TeamOutlined style={{ color: token.colorTextSecondary }} />
+        <Typography.Text type="secondary">{teamCountLabel}</Typography.Text>
+      </Space>
+
+      <Spin spinning={loading}>
+        <Table
+          dataSource={accessList}
+          columns={columns}
+          rowKey="id"
+          pagination={false}
+          locale={{
+            emptyText: (
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description={
+                  canManage
+                    ? "No teams have been granted workspace-level access."
+                    : "You don't have permission to view or manage team assignments for this workspace."
+                }
+              >
+                {canManage && (
+                  <Button type="primary" icon={<PlusOutlined />} onClick={scrollToAddForm}>
+                    Add a team
+                  </Button>
+                )}
+              </Empty>
+            ),
+          }}
+          style={{ marginBottom: 32 }}
+        />
+      </Spin>
+
+      {canManage && (
+        <Card
+          ref={addFormRef}
+          size="small"
+          title={
+            <Space>
+              <UsergroupAddOutlined />
+              <span>Grant Access</span>
+            </Space>
+          }
+          style={{ maxWidth: 640, marginBottom: 16 }}
+        >
+          <Form form={form} layout="vertical" onFinish={onAdd}>
+            <Space align="start" wrap>
+              <Form.Item name="teamName" label="Team" rules={[{ required: true, message: "Team name is required" }]}>
+                <Select
+                  showSearch
+                  placeholder="Select a team"
+                  optionFilterProp="label"
+                  loading={loadingTeams}
+                  style={{ minWidth: 220 }}
+                  options={teams.map((t) => ({
+                    label: t.name,
+                    value: t.name,
+                    disabled: accessList.some((a) => a.name === t.name),
+                  }))}
+                />
+              </Form.Item>
+              <Form.Item name="role" label="Role" initialValue="write" rules={[{ required: true }]}>
+                {renderRoleSelect(addRole ?? "write", (value) => form.setFieldsValue({ role: value }))}
+              </Form.Item>
+            </Space>
+
+            {addRole === "custom" && (
+              <Space wrap size={16} style={{ marginBottom: 8 }}>
+                {PERMISSION_FIELDS.map((field) => (
+                  <Form.Item key={field.key} name={field.key} valuePropName="checked" style={{ marginBottom: 0 }}>
+                    <Checkbox>{field.label}</Checkbox>
+                  </Form.Item>
+                ))}
+              </Space>
+            )}
+
+            <Form.Item style={{ marginBottom: 0 }}>
+              <Button type="primary" htmlType="submit" icon={<PlusOutlined />} loading={adding}>
+                Add Team
+              </Button>
+            </Form.Item>
+          </Form>
+        </Card>
+      )}
+
+      <Typography.Text type="secondary" style={{ fontSize: 12, display: "block", marginTop: 16 }}>
+        Teams added here can access this workspace based on their assigned role, in addition to any organization-level
+        or project-level permissions they already have.
+      </Typography.Text>
+    </div>
+  );
+};

--- a/ui/src/domain/Workspaces/Settings/TeamAccess.tsx
+++ b/ui/src/domain/Workspaces/Settings/TeamAccess.tsx
@@ -271,6 +271,7 @@ export const WorkspaceTeamAccess = ({ workspace, manageWorkspace }: Props) => {
       title: "Team",
       dataIndex: "name",
       key: "name",
+      width: 220,
       render: (name: string) => (
         <Space size={8}>
           <TeamOutlined style={{ color: token.colorTextSecondary }} />
@@ -282,6 +283,7 @@ export const WorkspaceTeamAccess = ({ workspace, manageWorkspace }: Props) => {
       title: "Role",
       dataIndex: "role",
       key: "role",
+      width: 320,
       render: (role: string, record: WorkspaceAccessModel) => {
         if (canManage && editingId === record.id) {
           return (
@@ -362,6 +364,7 @@ export const WorkspaceTeamAccess = ({ workspace, manageWorkspace }: Props) => {
       title: "",
       key: "actions",
       align: "right" as const,
+      width: 120,
       render: (_: any, record: WorkspaceAccessModel) => (
         <Popconfirm
           title={`Remove team "${record.name}" from this workspace?`}
@@ -400,6 +403,8 @@ export const WorkspaceTeamAccess = ({ workspace, manageWorkspace }: Props) => {
           columns={columns}
           rowKey="id"
           pagination={false}
+          tableLayout="fixed"
+          scroll={{ x: 996 }}
           locale={{
             emptyText: (
               <Empty

--- a/ui/src/domain/Workspaces/Settings/WorkspaceSettings.tsx
+++ b/ui/src/domain/Workspaces/Settings/WorkspaceSettings.tsx
@@ -6,6 +6,7 @@ import { WorkspaceSSHKey } from "./SSHKey";
 import { WorkspaceWebhook } from "./Webhook";
 import { WorkspaceAdvanced } from "./Advanced";
 import { WorkspaceStateShared } from "./StateShared";
+import { WorkspaceTeamAccess } from "./TeamAccess";
 import { Workspace, Template, VcsType } from "../../types";
 import type { MenuProps } from "antd";
 
@@ -70,6 +71,8 @@ export const WorkspaceSettings = ({
         return <WorkspaceAdvanced workspace={workspace} manageWorkspace={manageWorkspace} />;
       case "state-shared":
         return <WorkspaceStateShared workspace={workspace} manageWorkspace={manageWorkspace} onWorkspaceUpdate={handleWorkspaceUpdate} />;
+      case "team-access":
+        return <WorkspaceTeamAccess workspace={workspace} manageWorkspace={manageWorkspace} />;
       default:
         return (
           <WorkspaceGeneral workspaceData={workspace} orgTemplates={orgTemplates} manageWorkspace={manageWorkspace} onWorkspaceUpdate={handleWorkspaceUpdate} />
@@ -88,6 +91,7 @@ export const WorkspaceSettings = ({
         { key: "sshkey", label: "SSH Key" },
         { key: "webhook", label: "Webhook" },
         { key: "state-shared", label: "State Shared" },
+        { key: "team-access", label: "Team Access" },
         { key: "advanced", label: "Destruction and Deletion" },
       ],
     },

--- a/ui/src/modules/workspaces/workspaceAccessService.ts
+++ b/ui/src/modules/workspaces/workspaceAccessService.ts
@@ -1,0 +1,134 @@
+import axiosInstance from "@/config/axiosConfig";
+import { apiPost } from "@/modules/api/apiWrapper";
+import { ApiResponse } from "@/modules/api/types";
+
+export type WorkspaceAccessModel = {
+  id: string;
+  name: string;
+  role: string;
+  manageWorkspace: boolean;
+  manageState: boolean;
+  planJob: boolean;
+  approveJob: boolean;
+};
+
+export type WorkspaceAccessPermissions = {
+  manageWorkspace: boolean;
+  manageState: boolean;
+  planJob: boolean;
+  approveJob: boolean;
+};
+
+async function listWorkspaceAccess(
+  organizationId: string,
+  workspaceId: string
+): Promise<ApiResponse<WorkspaceAccessModel[]>> {
+  const body = {
+    query: `{
+      workspace(ids: ["${workspaceId}"]) {
+        edges {
+          node {
+            access {
+              edges {
+                node {
+                  id
+                  name
+                  role
+                  manageWorkspace
+                  manageState
+                  planJob
+                  approveJob
+                }
+              }
+            }
+          }
+        }
+      }
+    }`,
+  };
+
+  const tempData = await apiPost<unknown, any>("/graphql/api/v1", body, {
+    dataWrapped: true,
+    contentType: "application/json",
+  });
+
+  if (tempData.isError) {
+    return {
+      isError: true,
+      responseCode: tempData.responseCode,
+      error: tempData.error,
+      data: [],
+    };
+  }
+
+  const edges = tempData.data?.workspace?.edges?.[0]?.node?.access?.edges ?? [];
+
+  return {
+    isError: false,
+    responseCode: tempData.responseCode,
+    data: edges.map((edge: any) => ({
+      id: edge.node.id,
+      name: edge.node.name,
+      role: edge.node.role ?? "custom",
+      manageWorkspace: edge.node.manageWorkspace ?? false,
+      manageState: edge.node.manageState ?? false,
+      planJob: edge.node.planJob ?? false,
+      approveJob: edge.node.approveJob ?? false,
+    })),
+  };
+}
+
+async function addWorkspaceAccess(
+  organizationId: string,
+  workspaceId: string,
+  teamName: string,
+  role: string,
+  permissions?: WorkspaceAccessPermissions
+): Promise<void> {
+  const body = {
+    data: {
+      type: "access",
+      attributes: {
+        name: teamName,
+        role,
+        ...(permissions ?? {}),
+      },
+    },
+  };
+
+  await axiosInstance.post(`organization/${organizationId}/workspace/${workspaceId}/access`, body, {
+    headers: { "Content-Type": "application/vnd.api+json" },
+  });
+}
+
+async function updateWorkspaceAccess(
+  organizationId: string,
+  workspaceId: string,
+  accessId: string,
+  role: string,
+  permissions?: WorkspaceAccessPermissions
+): Promise<void> {
+  const body = {
+    data: {
+      id: accessId,
+      type: "access",
+      attributes: { role, ...(permissions ?? {}) },
+    },
+  };
+  await axiosInstance.patch(`organization/${organizationId}/workspace/${workspaceId}/access/${accessId}`, body, {
+    headers: { "Content-Type": "application/vnd.api+json" },
+  });
+}
+
+async function removeWorkspaceAccess(organizationId: string, workspaceId: string, accessId: string): Promise<void> {
+  await axiosInstance.delete(`organization/${organizationId}/workspace/${workspaceId}/access/${accessId}`);
+}
+
+const methods = {
+  listWorkspaceAccess,
+  addWorkspaceAccess,
+  updateWorkspaceAccess,
+  removeWorkspaceAccess,
+};
+
+export default methods;


### PR DESCRIPTION
## Description

Previously, granting a team access to a specific workspace had no UI — it could only be done via the `terrakube_workspace_access` Terraform resource or directly against the API. This PR adds a "Team Access" tab to workspace settings so workspace/organization admins can view, grant, edit, and revoke team access directly from the UI.

Fixes #3313.

## What was added / how it was solved

**API**
- Relaxed `Access` entity permissions (`Access.java`) so team admins with `manageWorkspace` (or the new limited variant) can create/read/update/delete workspace access records, not just superusers.
- Added new Elide permission expressions: `TeamManageWorkspaceAccess`, `TeamLimitedManageWorkspaceAccess`, and `TeamWorkspaceAdminManagesAccessField` to scope who can manage workspace-level team access.

**UI**
- New `WorkspaceTeamAccess` component (`ui/src/domain/Workspaces/Settings/TeamAccess.tsx`) rendering a table of teams with access to the workspace, their role (Admin / Write / Plan / Read / Custom), and a per-permission breakdown (Manage Workspace, Manage State, Plan Runs, Approve Runs).
- Inline role editing (including custom per-permission checkboxes), add-team form, and remove-with-confirmation.
- New `workspaceAccessService.ts` module wrapping the list/add/update/remove GraphQL/REST calls.
- Wired the new tab into `WorkspaceSettings.tsx`.
- Fixed the table to use fixed column widths (`tableLayout="fixed"` + explicit widths) so editing a row's role no longer shifts the Team/Permissions/Actions columns around — only the row being edited grows vertically.

## Testing

- Added/extended `AccessTests.java` covering the new permission expressions (team admin, team member with limited access, non-member).
- Manually verified in the browser: add a team, change role (including custom permissions), remove a team, and confirm permission errors surface correctly for non-admins.
- Verified the column-stability fix with before screenshots — entering edit mode only grows the Role cell, other columns stay fixed in place (see screenshots).

## Screenshots

<img width="2538" height="1078" alt="terrakube-team-access-ui-1" src="https://github.com/user-attachments/assets/10d430ae-0575-42fd-8129-e408c499cc19" />
<img width="2541" height="1101" alt="terrakube-team-access-ui-2" src="https://github.com/user-attachments/assets/4f829e49-c3cb-4a1e-8e34-48d637a86ee8" />
<img width="2538" height="1210" alt="terrakube-team-access-ui-3" src="https://github.com/user-attachments/assets/d216d30e-b457-4568-b53c-78bc71b439ba" />
