### PR TITLE
fix: guard WebhookResult against null event and fix installation token return type

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookResult.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookResult.java
@@ -29,25 +29,27 @@ public class WebhookResult {
     private String prFilesUrl;
 
     public String getNormalizedEvent() {
-        String normalizedEvent = "";
-        switch (this.event) {
-            case "push":
-                normalizedEvent = "push";
-                break;
-            case "pull_request":
-            case "merge_request":
-                normalizedEvent = "pull_request";
-                break;
-            case "issue_comment":
-            case "note":
-                normalizedEvent = "pr_comment";
-                break;
-            case "release":
-                normalizedEvent = "release";
-                break;
-            default:
-                normalizedEvent = "unknown";
-                break;
+        String normalizedEvent = "unknown";
+        if (this.event != null) {
+            switch (this.event) {
+                case "push":
+                    normalizedEvent = "push";
+                    break;
+                case "pull_request":
+                case "merge_request":
+                    normalizedEvent = "pull_request";
+                    break;
+                case "issue_comment":
+                case "note":
+                    normalizedEvent = "pr_comment";
+                    break;
+                case "release":
+                    normalizedEvent = "release";
+                    break;
+                default:
+                    normalizedEvent = "unknown";
+                    break;
+            }
         }
         log.info("Current event {} Normalized event: {}", this.event, normalizedEvent);
         return normalizedEvent;

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenService.java
@@ -209,7 +209,8 @@ public class GitHubTokenService implements GetAccessToken<GitHubToken> {
         if (tokenResponse.getStatusCode().value() == 201) {
             JsonNode rootNode = objectMapper.readTree(tokenResponse.getBody());
             token = rootNode.path("token").asText();
-            expiresAt = Instant.parse(rootNode.path("expires_at").asText());
+            String expiresAtText = rootNode.path("expires_at").asText();
+            expiresAt = expiresAtText.isEmpty() ? null : Instant.parse(expiresAtText);
         }
         return new GitHubAppInstallationToken(token, expiresAt);
     }

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenService.java
@@ -264,7 +264,7 @@ public class GitHubTokenService implements GetAccessToken<GitHubToken> {
     // (e.g. repository discovery, where the installation is picked from /app/installations)
     public String getInstallationToken(String installationId, String apiUrl, String jws, String owner)
             throws JsonMappingException, JsonProcessingException {
-        return fetchGitHubAppInstallationToken(installationId, apiUrl, jws, owner);
+        return fetchGitHubAppInstallationToken(installationId, apiUrl, jws, owner).token();
     }
 
     // Calls a GitHub API endpoint authenticated with the app JWT (used for /app/installations)

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookResultTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookResultTest.java
@@ -59,6 +59,13 @@ public class WebhookResultTest {
     }
 
     @Test
+    public void normalizedEventNullDoesNotThrow() {
+        WebhookResult result = new WebhookResult();
+        assertNull(result.getEvent());
+        assertEquals("unknown", result.getNormalizedEvent());
+    }
+
+    @Test
     public void prCommentFieldsAreSetCorrectly() {
         WebhookResult result = new WebhookResult();
         result.setPrComment(true);

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenServiceTest.java
@@ -58,6 +58,7 @@ public class GitHubTokenServiceTest {
     private AtomicInteger installationHits;
     private String tokenToReturn;
     private String expiresAtToReturn;
+    private boolean includeExpiresAt;
 
     @BeforeEach
     public void setup() throws Exception {
@@ -82,6 +83,7 @@ public class GitHubTokenServiceTest {
         installationHits = new AtomicInteger(0);
         tokenToReturn = "ghs_refreshed-token";
         expiresAtToReturn = Instant.now().plus(1, ChronoUnit.HOURS).toString();
+        includeExpiresAt = true;
 
         httpServer = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
         httpServer.createContext("/repos/" + OWNER + "/" + REPO + "/installation", exchange -> {
@@ -90,8 +92,10 @@ public class GitHubTokenServiceTest {
         });
         httpServer.createContext("/app/installations/" + INSTALLATION_ID + "/access_tokens", exchange -> {
             accessTokenHits.incrementAndGet();
-            writeJson(exchange, 201,
-                    "{\"token\":\"" + tokenToReturn + "\",\"expires_at\":\"" + expiresAtToReturn + "\"}");
+            String body = includeExpiresAt
+                    ? "{\"token\":\"" + tokenToReturn + "\",\"expires_at\":\"" + expiresAtToReturn + "\"}"
+                    : "{\"token\":\"" + tokenToReturn + "\"}";
+            writeJson(exchange, 201, body);
         });
         httpServer.start();
     }
@@ -211,6 +215,21 @@ public class GitHubTokenServiceTest {
 
         assertNull(result);
         verify(gitHubAppTokenRepository, times(1)).delete(orphaned);
+    }
+
+    // Repository discovery calls getInstallationToken directly, without ever caching or
+    // checking expiry - a response with no expires_at (or a caller/mock that omits it) must
+    // not blow up the whole call with a DateTimeParseException.
+    @Test
+    public void getInstallationToken_missingExpiresAt_doesNotThrow() throws Exception {
+        Vcs vcs = createVcs();
+        includeExpiresAt = false;
+        String jws = subject.generateAppJwt(vcs);
+
+        String result = subject.getInstallationToken(INSTALLATION_ID, vcs.getApiUrl(), jws, OWNER);
+
+        assertEquals(tokenToReturn, result);
+        assertEquals(1, accessTokenHits.get());
     }
 
     @Test


### PR DESCRIPTION
- Null-check the event field in getNormalizedEvent() before switching on it; event can be unset (e.g. new WebhookResult()) and the switch threw an NPE (SonarCloud javabugs:S2259)
- Fix getInstallationToken() returning the GitHubAppInstallationToken record instead of its token string, which broke compilation on main


Resolves https://sonarcloud.io/project/issues?id=AzBuilder_azb-server&open=AZ-aUDn718-5KNpa15cY&tab=code