### PR TITLE
fix(vcs): tolerate clock drift in GitHub App JWTs

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubTokenService.java
@@ -20,7 +20,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -235,11 +234,15 @@ public class GitHubTokenService implements GetAccessToken<GitHubToken> {
         KeyFactory keyFactory = KeyFactory.getInstance("RSA");
         PrivateKey key = keyFactory.generatePrivate(keySpec);
 
+        // GitHub rejects a JWT if, from its own clock, "iat" looks like it's in the
+        // future or "exp" is more than 10 minutes out. Backdating "iat" by 60 seconds
+        // and keeping "exp" a bit under the 10-minute cap gives room for clock drift
+        // between this server and GitHub's, as GitHub's own docs recommend.
         Instant now = Instant.now();
         String jws = Jwts.builder()
                 .setIssuer(clientId)
-                .setIssuedAt(Date.from(now))
-                .setExpiration(Date.from(now.plus(10, ChronoUnit.MINUTES)))
+                .setIssuedAt(Date.from(now.minus(60, ChronoUnit.SECONDS)))
+                .setExpiration(Date.from(now.plus(9, ChronoUnit.MINUTES)))
                 .signWith(key, SignatureAlgorithm.RS256)
                 .compact();
         return jws;
@@ -274,17 +277,22 @@ public class GitHubTokenService implements GetAccessToken<GitHubToken> {
     }
 
     public RestTemplate getRestTemplateWithProxy() {
+        // JdkClientHttpRequestFactory (java.net.http.HttpClient) is used instead of the
+        // legacy SimpleClientHttpRequestFactory (java.net.HttpURLConnection): the latter
+        // was observed to intermittently return an empty error body even when the server
+        // sent one (e.g. GitHub's actual "'Expiration time' claim..." message came back
+        // as "[no body]"), which made failures from this client impossible to diagnose.
         if (System.getProperty("http.proxyHost") != null) {
             log.info("RestTemplate proxy host: {} port: {}", System.getProperty("http.proxyHost"), System.getProperty("http.proxyPort"));
-            SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
             String proxyHost = System.getProperty("http.proxyHost");
             int proxyPort = Integer.parseInt(System.getProperty("http.proxyPort"));
-            Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
-            requestFactory.setProxy(proxy);
-            return new RestTemplate(requestFactory);
+            java.net.http.HttpClient httpClient = java.net.http.HttpClient.newBuilder()
+                    .proxy(java.net.ProxySelector.of(new InetSocketAddress(proxyHost, proxyPort)))
+                    .build();
+            return new RestTemplate(new org.springframework.http.client.JdkClientHttpRequestFactory(httpClient));
         } else {
             log.info("No proxy setup");
-            return new RestTemplate();
+            return new RestTemplate(new org.springframework.http.client.JdkClientHttpRequestFactory());
         }
     }
 }


### PR DESCRIPTION
## Issue

Jobs got stuck in `pending` forever. The api log showed a `401 Unauthorized` from GitHub on `POST /app/installations/{id}/access_tokens`, thrown on every 30-second Quartz retry, with no visible reason since Spring's exception logging showed `[no body]`.

Root cause: `GitHubTokenService.generateJWT()` set the JWT's `iat` to exactly `now()` and `exp` to exactly `now() + 10 minutes` — GitHub's hard maximum, with zero margin. GitHub validates that window against its own clock, and any small clock drift between the app server and GitHub pushes `exp` past GitHub's limit, so every token request gets rejected. GitHub's own docs recommend backdating `iat` by 60 seconds and keeping `exp` under the 10-minute cap specifically to guard against this.

The real GitHub error (`'Expiration time' claim ('exp') is too far in the future`) only surfaced after bypassing Spring's RestTemplate error handling entirely and hitting the endpoint with a raw `HttpURLConnection`, which uncovered a second bug: the default `SimpleClientHttpRequestFactory` (legacy `HttpURLConnection`) was silently losing the response body on error, showing `[no body]` even when GitHub sent a real message.

Because the pending job never got the actual error, and Quartz's own `HttpClientErrorException` is unchecked and wasn't caught in `ScheduleJob.executePendingJob()`, the `@Transactional` execution rolled back before the job status could ever change — so it sat in `pending` indefinitely with no path to failure or retry visibility.

## Fix

- `generateJWT()`: set `iat = now - 60s` and `exp = now + 9m`, matching GitHub's documented recommendation for tolerating clock drift.
- `getRestTemplateWithProxy()`: switched from `SimpleClientHttpRequestFactory` to `JdkClientHttpRequestFactory` (backed by `java.net.http.HttpClient`, already part of the JDK — no new dependency). This reliably surfaces error response bodies, so future failures from this client will show GitHub's actual message in the existing "unhandled Exception" log lines instead of `[no body]`.

## Verification

- Reproduced the original 401 in a live devcontainer and confirmed the exact GitHub error message via raw socket-level testing.
- Applied the fix, restarted the api process, and confirmed `Unauthorized` no longer appears in the logs.
- Triggered fresh jobs and confirmed they pass the token-fetch stage and reach the Terraform executor (they now fail later on an unrelated, pre-existing Terraform config syntax error, unrelated to this change).
- Confirmed `JdkClientHttpRequestFactory` correctly returns both success (`201`) and error bodies via a standalone reproduction against GitHub's API.

## References

- [Generating a JSON Web Token (JWT) for a GitHub App](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app)