### PR TITLE
fix: update ANSI escape sequence regex to correctly identify terminal color codes

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
@@ -32,7 +32,7 @@ public class PrCommentService {
     private static final Pattern PLAN_SUMMARY_PATTERN = Pattern.compile(
             "(Plan: \\d+ to add, \\d+ to change, \\d+ to destroy\\.|No changes\\. Your infrastructure matches the configuration\\.)");
     private static final Pattern ANSI_PATTERN = Pattern.compile(
-            "[\\u001b\\u009b][\\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nq-uy=><~]");
+            "[\\u001b\\u009b][\\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{1,4})*)?[0-9A-ORZcf-nq-uy=><~]");
 
     GitHubWebhookService gitHubWebhookService;
     GitLabWebhookService gitLabWebhookService;


### PR DESCRIPTION
The issue is that [0-9]{0,4} can match an empty string, which combined with the outer * quantifier creates ambiguity the regex engine must explore through backtracking. The fix is to change {0,4} to {1,4} — each iteration of the * loop must then consume at least one digit (in addition to the ;), eliminating the catastrophic backtracking risk. This doesn't affect practical behavior since ANSI escape sequences always have digits between semicolons.

Changed {0,4} → {1,4} on line 35.

This ensures each iteration of the (?:;[0-9]{1,4})* loop must consume at least one digit plus the semicolon, eliminating the backtracking ambiguity that SonarQube flagged.