### PR TITLE
feat(executor): support running multiple executor replicas, fix VCS-status crash & plan-only completion, add Queued filter

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -494,19 +494,26 @@ public class ScheduleJob implements org.quartz.Job {
             return;
         }
 
-        switch (job.getWorkspace().getVcs().getVcsType()) {
-            case GITHUB:
-                gitHubWebhookService.sendCommitStatus(job, jobStatus);
-                break;
-            case GITLAB:
-                gitLabWebhookService.sendCommitStatus(job, jobStatus);
-                break;
-            case AZURE_DEVOPS:
-            case AZURE_SP_MI:
-                azDevOpsWebhookService.sendCommitStatus(job, jobStatus);
-                break;
-            default:
-                break;
+        // Notifying the VCS is a side effect of the job, not part of it: a VCS-side failure
+        // (expired token, provider outage, rate limit, missing commit) must never abort the
+        // job itself, since callers here include the job-completion path.
+        try {
+            switch (job.getWorkspace().getVcs().getVcsType()) {
+                case GITHUB:
+                    gitHubWebhookService.sendCommitStatus(job, jobStatus);
+                    break;
+                case GITLAB:
+                    gitLabWebhookService.sendCommitStatus(job, jobStatus);
+                    break;
+                case AZURE_DEVOPS:
+                case AZURE_SP_MI:
+                    azDevOpsWebhookService.sendCommitStatus(job, jobStatus);
+                    break;
+                default:
+                    break;
+            }
+        } catch (Exception e) {
+            log.error("Failed to update VCS commit status for job {}: {}", job.getId(), e.getMessage());
         }
     }
 

--- a/executor/src/main/java/io/terrakube/executor/service/executor/ExecutorJobImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/executor/ExecutorJobImpl.java
@@ -13,6 +13,9 @@ import io.terrakube.executor.service.workspace.WorkspaceException;
 import io.terrakube.executor.service.shutdown.ShutdownServiceImpl;
 import io.terrakube.executor.service.status.UpdateJobStatus;
 import io.terrakube.executor.service.terraform.TerraformExecutor;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.availability.ReadinessState;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -31,11 +34,17 @@ public class ExecutorJobImpl implements ExecutorJob {
     ExecutorFlagsProperties executorFlagsProperties;
     ShutdownServiceImpl shutdownService;
     ScriptEngineService scriptEngineService;
+    ApplicationEventPublisher eventPublisher;
+    JobExecutionWatchdog jobExecutionWatchdog;
 
     @Async
     @Override
     public void createJob(TerraformJob terraformJob) {
         log.info("Create Job for Organization {} Workspace {} ", terraformJob.getOrganizationId(), terraformJob.getWorkspaceId());
+        // Pulls this pod out of the executor Service's endpoints while a job is running,
+        // since the pool underneath this @Async method only runs one job at a time.
+        publishReadiness(ReadinessState.REFUSING_TRAFFIC);
+        jobExecutionWatchdog.markBusy();
         File terraformWorkingDir = null;
         try {
             try {
@@ -55,9 +64,22 @@ public class ExecutorJobImpl implements ExecutorJob {
                 log.error(e.getMessage());
             }
 
+            jobExecutionWatchdog.markFree();
             if (executorFlagsProperties.isEphemeral()) {
                 shutdownService.shutdownApplication();
+            } else {
+                publishReadiness(ReadinessState.ACCEPTING_TRAFFIC);
             }
+        }
+    }
+
+    private void publishReadiness(ReadinessState state) {
+        try {
+            AvailabilityChangeEvent.publish(eventPublisher, this, state);
+        } catch (Exception e) {
+            // A misbehaving listener must never block a job from starting, and must never
+            // leave this method's finally block before the pod is marked free again.
+            log.error("Failed to publish readiness state {}: {}", state, e.getMessage());
         }
     }
 

--- a/executor/src/main/java/io/terrakube/executor/service/executor/JobExecutionWatchdog.java
+++ b/executor/src/main/java/io/terrakube/executor/service/executor/JobExecutionWatchdog.java
@@ -1,0 +1,50 @@
+package io.terrakube.executor.service.executor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.availability.LivenessState;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Detects a job that never reaches ExecutorJobImpl's finally block (hung terraform process,
+ * infinite-looping hook script, etc). Without this, a wedged pod stays REFUSING_TRAFFIC
+ * forever with nothing else noticing, silently shrinking cluster capacity.
+ */
+@Slf4j
+@Component
+public class JobExecutionWatchdog {
+
+    private final ApplicationEventPublisher eventPublisher;
+    private final Duration maxJobDuration;
+    private final AtomicReference<Instant> busySince = new AtomicReference<>();
+
+    public JobExecutionWatchdog(ApplicationEventPublisher eventPublisher,
+            @Value("${io.terrakube.executor.job.maxDurationMinutes}") long maxDurationMinutes) {
+        this.eventPublisher = eventPublisher;
+        this.maxJobDuration = Duration.ofMinutes(maxDurationMinutes);
+    }
+
+    void markBusy() {
+        busySince.set(Instant.now());
+    }
+
+    void markFree() {
+        busySince.set(null);
+    }
+
+    @Scheduled(fixedDelay = 60_000)
+    void checkForWedgedJob() {
+        Instant since = busySince.get();
+        if (since != null && Duration.between(since, Instant.now()).compareTo(maxJobDuration) > 0) {
+            log.error("Job has been running for longer than {} without completing, marking pod unhealthy so it gets restarted", maxJobDuration);
+            AvailabilityChangeEvent.publish(eventPublisher, this, LivenessState.BROKEN);
+        }
+    }
+}

--- a/executor/src/main/java/io/terrakube/executor/service/status/UpdateJobStatusImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/status/UpdateJobStatusImpl.java
@@ -94,7 +94,11 @@ public class UpdateJobStatusImpl implements UpdateJobStatus {
                         planChanges = false;
                         break;
                     case 2:
-                        status = "pending";
+                        // A plan that finds changes normally waits "pending" for an approval/apply
+                        // step. But if this plan is the job's only step (a plan-only template),
+                        // there's nothing left to run it against - leaving it "pending" forever
+                        // misreports a finished job as still in progress.
+                        status = job.getRelationships().getStep().getData().size() > 1 ? "pending" : "completed";
                         break;
                 }
             }

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -17,6 +17,9 @@ io.terrakube.executor.flags.ephemeral=${EphemeralFlagBatch:false}
 io.terrakube.executor.flags.ephemeralJobData=${EphemeralJobData:}
 io.terrakube.executor.flags.disableAcknowledge=${ExecutorFlagDisableAcknowledge:false}
 
+## Ceiling for a single job before the pod is marked unhealthy (watchdog for a wedged terraform/hook process)
+io.terrakube.executor.job.maxDurationMinutes=${ExecutorJobMaxDurationMinutes:360}
+
 ###################
 #State/Output Type#
 ###################

--- a/executor/src/test/java/io/terrakube/executor/service/executor/ExecutorJobImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/executor/ExecutorJobImplTest.java
@@ -1,0 +1,144 @@
+package io.terrakube.executor.service.executor;
+
+import io.terrakube.executor.configuration.ExecutorFlagsProperties;
+import io.terrakube.executor.service.mode.TerraformJob;
+import io.terrakube.executor.service.scripts.ScriptEngineService;
+import io.terrakube.executor.service.shutdown.ShutdownServiceImpl;
+import io.terrakube.executor.service.status.UpdateJobStatus;
+import io.terrakube.executor.service.terraform.TerraformExecutor;
+import io.terrakube.executor.service.workspace.SetupWorkspace;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.availability.ReadinessState;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+class ExecutorJobImplTest {
+
+    @TempDir
+    Path tempDir;
+
+    private final SetupWorkspace setupWorkspace = Mockito.mock(SetupWorkspace.class);
+    private final TerraformExecutor terraformExecutor = Mockito.mock(TerraformExecutor.class);
+    private final UpdateJobStatus updateJobStatus = Mockito.mock(UpdateJobStatus.class);
+    private final ExecutorFlagsProperties executorFlagsProperties = new ExecutorFlagsProperties();
+    private final ShutdownServiceImpl shutdownService = Mockito.mock(ShutdownServiceImpl.class);
+    private final ScriptEngineService scriptEngineService = Mockito.mock(ScriptEngineService.class);
+    private final JobExecutionWatchdog jobExecutionWatchdog = Mockito.mock(JobExecutionWatchdog.class);
+    private final List<Object> publishedEvents = new ArrayList<>();
+    private final ApplicationEventPublisher eventPublisher = publishedEvents::add;
+
+    private ExecutorJobImpl subject(ApplicationEventPublisher publisher) {
+        return new ExecutorJobImpl(setupWorkspace, terraformExecutor, updateJobStatus, executorFlagsProperties,
+                shutdownService, scriptEngineService, publisher, jobExecutionWatchdog);
+    }
+
+    private TerraformJob createJob(String type) {
+        TerraformJob job = new TerraformJob();
+        job.setJobId("42");
+        job.setStepId("1");
+        job.setOrganizationId("org");
+        job.setWorkspaceId("workspace");
+        job.setType(type);
+        // Skips commitHash.info lookup so the test doesn't need a real git working dir.
+        job.setBranch("remote-content");
+        job.setEnvironmentVariables(new HashMap<>());
+        job.setVariables(new HashMap<>());
+        return job;
+    }
+
+    @SuppressWarnings("unchecked")
+    private ReadinessState stateAt(int index) {
+        return ((AvailabilityChangeEvent<ReadinessState>) publishedEvents.get(index)).getState();
+    }
+
+    @Test
+    void togglesReadinessAndWatchdogAroundASuccessfulJob() throws Exception {
+        TerraformJob job = createJob("terraformPlan");
+        File workDir = tempDir.toFile();
+        when(setupWorkspace.prepareWorkspace(job)).thenReturn(workDir);
+        ExecutorJobResult result = new ExecutorJobResult();
+        result.setSuccessfulExecution(true);
+        when(terraformExecutor.plan(eq(job), eq(workDir), eq(false))).thenReturn(result);
+
+        subject(eventPublisher).createJob(job);
+
+        assertEquals(2, publishedEvents.size());
+        assertEquals(ReadinessState.REFUSING_TRAFFIC, stateAt(0));
+        assertEquals(ReadinessState.ACCEPTING_TRAFFIC, stateAt(1));
+
+        InOrder inOrder = inOrder(jobExecutionWatchdog, updateJobStatus);
+        inOrder.verify(jobExecutionWatchdog).markBusy();
+        inOrder.verify(updateJobStatus).setCompletedStatus(eq(true), anyBoolean(), anyInt(), eq(job), any(), any(), any(), any());
+        inOrder.verify(jobExecutionWatchdog).markFree();
+    }
+
+    @Test
+    void doesNotRestoreReadinessInEphemeralModeSinceThePodIsShuttingDownAnyway() throws Exception {
+        executorFlagsProperties.setEphemeral(true);
+        TerraformJob job = createJob("terraformPlan");
+        File workDir = tempDir.toFile();
+        when(setupWorkspace.prepareWorkspace(job)).thenReturn(workDir);
+        when(terraformExecutor.plan(any(), any(), anyBoolean())).thenReturn(new ExecutorJobResult());
+
+        subject(eventPublisher).createJob(job);
+
+        assertEquals(1, publishedEvents.size());
+        assertEquals(ReadinessState.REFUSING_TRAFFIC, stateAt(0));
+        verify(jobExecutionWatchdog).markFree();
+        verify(shutdownService).shutdownApplication();
+    }
+
+    @Test
+    void aReadinessListenerThrowingNeverBlocksJobExecutionOrLeavesThePodMarkedBusy() throws Exception {
+        ApplicationEventPublisher throwingPublisher = event -> {
+            throw new RuntimeException("listener exploded");
+        };
+        TerraformJob job = createJob("terraformPlan");
+        File workDir = tempDir.toFile();
+        when(setupWorkspace.prepareWorkspace(job)).thenReturn(workDir);
+        ExecutorJobResult result = new ExecutorJobResult();
+        result.setSuccessfulExecution(true);
+        when(terraformExecutor.plan(any(), any(), anyBoolean())).thenReturn(result);
+
+        subject(throwingPublisher).createJob(job);
+
+        verify(jobExecutionWatchdog).markBusy();
+        verify(jobExecutionWatchdog).markFree();
+        verify(updateJobStatus).setCompletedStatus(eq(true), anyBoolean(), anyInt(), eq(job), any(), any(), any(), any());
+    }
+
+    @Test
+    void marksBusyBeforeWorkspaceSetupSoAFailureStillCountsAsBusyThenFree() throws Exception {
+        TerraformJob job = createJob("terraformPlan");
+        when(setupWorkspace.prepareWorkspace(job)).thenThrow(new io.terrakube.executor.service.workspace.WorkspaceException(new RuntimeException("boom")));
+
+        subject(eventPublisher).createJob(job);
+
+        assertEquals(2, publishedEvents.size());
+        InOrder inOrder = inOrder(jobExecutionWatchdog, updateJobStatus);
+        inOrder.verify(jobExecutionWatchdog).markBusy();
+        inOrder.verify(updateJobStatus).setCompletedStatus(eq(false), eq(false), eq(-1), eq(job), any(), any(), any(), any());
+        inOrder.verify(jobExecutionWatchdog).markFree();
+        verifyNoMoreInteractions(terraformExecutor);
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/executor/JobExecutionWatchdogTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/executor/JobExecutionWatchdogTest.java
@@ -1,0 +1,61 @@
+package io.terrakube.executor.service.executor;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.availability.LivenessState;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JobExecutionWatchdogTest {
+
+    private final List<Object> publishedEvents = new ArrayList<>();
+    private final ApplicationEventPublisher eventPublisher = publishedEvents::add;
+
+    @Test
+    void doesNothingWhenNeverMarkedBusy() {
+        JobExecutionWatchdog watchdog = new JobExecutionWatchdog(eventPublisher, 360);
+
+        watchdog.checkForWedgedJob();
+
+        assertTrue(publishedEvents.isEmpty());
+    }
+
+    @Test
+    void doesNothingWhileWithinTheAllowedDuration() {
+        JobExecutionWatchdog watchdog = new JobExecutionWatchdog(eventPublisher, 360);
+
+        watchdog.markBusy();
+        watchdog.checkForWedgedJob();
+
+        assertTrue(publishedEvents.isEmpty());
+    }
+
+    @Test
+    void marksThePodUnhealthyOnceBusyLongerThanTheConfiguredCeiling() throws InterruptedException {
+        JobExecutionWatchdog watchdog = new JobExecutionWatchdog(eventPublisher, 0);
+
+        watchdog.markBusy();
+        Thread.sleep(5);
+        watchdog.checkForWedgedJob();
+
+        assertEquals(1, publishedEvents.size());
+        assertEquals(LivenessState.BROKEN, ((AvailabilityChangeEvent<?>) publishedEvents.get(0)).getState());
+    }
+
+    @Test
+    void markFreeResetsTheWatchdogSoAFinishedJobIsNeverFlaggedAsWedged() throws InterruptedException {
+        JobExecutionWatchdog watchdog = new JobExecutionWatchdog(eventPublisher, 0);
+
+        watchdog.markBusy();
+        Thread.sleep(5);
+        watchdog.markFree();
+        watchdog.checkForWedgedJob();
+
+        assertTrue(publishedEvents.isEmpty());
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/status/UpdateJobStatusImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/status/UpdateJobStatusImplTest.java
@@ -1,0 +1,106 @@
+package io.terrakube.executor.service.status;
+
+import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.generic.Resource;
+import io.terrakube.client.model.organization.job.Job;
+import io.terrakube.client.model.organization.job.JobAttributes;
+import io.terrakube.client.model.organization.job.OrganizationData;
+import io.terrakube.client.model.organization.job.Relationships;
+import io.terrakube.client.model.organization.job.StepData;
+import io.terrakube.client.model.response.ResponseWithInclude;
+import io.terrakube.executor.configuration.ExecutorFlagsProperties;
+import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
+import io.terrakube.executor.plugin.tfstate.TerraformState;
+import io.terrakube.executor.service.mode.TerraformJob;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class UpdateJobStatusImplTest {
+
+    private Job jobWithSteps(int stepCount) {
+        Job job = new Job();
+        job.setId("42");
+
+        JobAttributes attributes = new JobAttributes();
+        attributes.setStatus("queue");
+        job.setAttributes(attributes);
+
+        Resource organizationResource = new Resource();
+        organizationResource.setId("org-1");
+        OrganizationData organizationData = new OrganizationData();
+        organizationData.setData(organizationResource);
+
+        List<Resource> steps = new java.util.ArrayList<>();
+        for (int i = 0; i < stepCount; i++) {
+            steps.add(new Resource());
+        }
+        StepData stepData = new StepData();
+        stepData.setData(steps);
+
+        Relationships relationships = new Relationships();
+        relationships.setOrganization(organizationData);
+        relationships.setStep(stepData);
+        job.setRelationships(relationships);
+
+        return job;
+    }
+
+    private UpdateJobStatusImpl newService(Job job) {
+        TerrakubeClient terrakubeClient = mock(TerrakubeClient.class);
+        ResponseWithInclude<Job, ?> response = new ResponseWithInclude<>();
+        response.setData(job);
+        when(terrakubeClient.getJobById(anyString(), anyString())).thenReturn((ResponseWithInclude) response);
+
+        TerraformState terraformState = mock(TerraformState.class);
+        when(terraformState.saveOutput(any(), any(), any(), any(), any())).thenReturn("output-path");
+
+        ExecutorFlagsProperties flags = mock(ExecutorFlagsProperties.class);
+        when(flags.isDisableAcknowledge()).thenReturn(false);
+
+        TerraformOutputPathService pathService = mock(TerraformOutputPathService.class);
+
+        return new UpdateJobStatusImpl(terrakubeClient, terraformState, flags, pathService);
+    }
+
+    private TerraformJob terraformJob() {
+        TerraformJob terraformJob = new TerraformJob();
+        terraformJob.setOrganizationId("org-1");
+        terraformJob.setJobId("42");
+        terraformJob.setStepId("step-1");
+        return terraformJob;
+    }
+
+    @Test
+    void planWithChangesAndNoFurtherSteps_marksJobCompleted() {
+        // A plan-only template has exactly one step. When that plan finds changes
+        // (exitCode 2) there is nothing left in the template to run, so the job
+        // should be marked completed rather than left pending forever.
+        Job job = jobWithSteps(1);
+        UpdateJobStatusImpl service = newService(job);
+
+        service.setCompletedStatus(true, true, 2, terraformJob(), "plan output", "", "plan-file", "commit-1");
+
+        assertEquals("completed", job.getAttributes().getStatus());
+        assertEquals(true, job.getAttributes().isPlanChanges());
+    }
+
+    @Test
+    void planWithChangesAndFurtherSteps_marksJobPending() {
+        // A "Plan and Apply" template has two steps. A plan finding changes should
+        // still wait "pending" for the apply step that follows it.
+        Job job = jobWithSteps(2);
+        UpdateJobStatusImpl service = newService(job);
+
+        service.setCompletedStatus(true, true, 2, terraformJob(), "plan output", "", "plan-file", "commit-1");
+
+        assertEquals("pending", job.getAttributes().getStatus());
+        assertEquals(true, job.getAttributes().isPlanChanges());
+    }
+}

--- a/ui/src/modules/organizations/OrganizationDetailsPage.tsx
+++ b/ui/src/modules/organizations/OrganizationDetailsPage.tsx
@@ -60,6 +60,7 @@ export default function OrganizationsDetailPage({ organizationName, setOrganizat
       [WorkspaceStatusFilter.NeverExecuted]: 0,
       [JobStatus.WaitingApproval]: 0,
       [JobStatus.Failed]: 0,
+      [JobStatus.Queue]: 0,
       [JobStatus.Running]: 0,
       [JobStatus.Completed]: 0,
     };

--- a/ui/src/modules/workspaces/components/WorkspaceStatusTag.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceStatusTag.tsx
@@ -16,6 +16,8 @@ export default function WorkspaceStatusTag({ status }: Props) {
         return "No Changes";
       case JobStatus.Running:
         return JobStatus.Running;
+      case JobStatus.Queue:
+        return "Queued";
       case JobStatus.WaitingApproval:
         return "Waiting Approval";
       case "NeverExecuted":

--- a/ui/src/modules/workspaces/utils/workspaceStatusColors.ts
+++ b/ui/src/modules/workspaces/utils/workspaceStatusColors.ts
@@ -3,6 +3,7 @@ import { JobStatus } from "../../../domain/types";
 export const statusColors: Record<string, string> = {
   [JobStatus.Completed]: "#2eb039",
   [JobStatus.Running]: "#108ee9",
+  [JobStatus.Queue]: "#8c8c8c",
   [JobStatus.WaitingApproval]: "#fa8f37",
   [JobStatus.Rejected]: "#FB0136",
   [JobStatus.Failed]: "#FB0136",

--- a/ui/src/modules/workspaces/utils/workspaceStatusIcon.tsx
+++ b/ui/src/modules/workspaces/utils/workspaceStatusIcon.tsx
@@ -25,6 +25,8 @@ export function getWorkspaceStatusIcon(status?: string) {
     case JobStatus.Cancelled:
     case JobStatus.Failed:
       return <StopOutlined />;
+    case JobStatus.Queue:
+      return <ClockCircleOutlined />;
     default:
       return <ClockCircleOutlined />;
   }

--- a/ui/src/modules/workspaces/utils/workspaceStatusPalette.tsx
+++ b/ui/src/modules/workspaces/utils/workspaceStatusPalette.tsx
@@ -5,6 +5,7 @@ import {
   SyncOutlined,
   CheckCircleOutlined,
   InfoCircleOutlined,
+  ClockCircleOutlined,
 } from "@ant-design/icons";
 import { JobStatus } from "@/domain/types";
 import { WorkspaceStatusFilter } from "./workspaceFilter";
@@ -27,6 +28,7 @@ export const WORKSPACE_STATUS_PALETTE: WorkspaceStatusPaletteEntry[] = [
     color: "#fa8f37",
   },
   { value: JobStatus.Failed, label: "Failed", icon: <StopOutlined />, color: "#FB0136" },
+  { value: JobStatus.Queue, label: "Queued", icon: <ClockCircleOutlined />, color: "#8c8c8c" },
   { value: JobStatus.Running, label: "Running", icon: <SyncOutlined />, color: "#108ee9" },
   { value: JobStatus.Completed, label: "Completed", icon: <CheckCircleOutlined />, color: "#2eb039" },
   { value: WorkspaceStatusFilter.NeverExecuted, label: "Never Executed", icon: <InfoCircleOutlined /> },


### PR DESCRIPTION
### What was added and why

Terrakube's executor only processes one job at a time internally, but nothing stopped a busy pod from still receiving new job dispatches when `executor.replicaCount > 1` — the Service just round-robins across all pods regardless of load. 
Alternatively people were instructed to have ephemeral agents, but people may want to have a pool of 'warm ready' agents, and this could ultimately be extended in the future to do autoscaling with KEDA in future improvements

This adds readiness gating so a busy pod drops out of rotation, making it safe to actually run multiple executor replicas concurrently. Also adds a "Queued" filter to the workspace list, since `JobStatus.Queue` already existed in the data model but wasn't exposed anywhere in the UI.

### How it was done

- `ExecutorJobImpl.createJob()` publishes `REFUSING_TRAFFIC` for the duration of a job and `ACCEPTING_TRAFFIC` once it's free, so the k8s readiness probe pulls a busy pod out of the Service's endpoints. Ephemeral executors skip the restore step since the pod shuts down right after.
- `JobExecutionWatchdog` is a scheduled backstop (60s interval): if a job never reaches the `finally` block (hung terraform process, looping hook script), it marks the pod's liveness `BROKEN` after `io.terrakube.executor.job.maxDurationMinutes` (default 360) so k8s restarts it instead of the pool silently shrinking forever.
- UI: added `JobStatus.Queue` to the shared status palette, color map, icon switch, and tag label — the same places every other status is already wired through.

### Any tests added

- `UpdateJobStatusImplTest.java` (new): asserts a plan-only job (single step) with detected changes now reaches `completed`; asserts a Plan+Apply job's plan step still correctly stays `pending`.
- `JobExecutionWatchdogTest.java` / `ExecutorJobImplTest.java`: cover the readiness-toggling and watchdog-scheduling behavior.
- No new test needed for the `ScheduleJob` fix — `ScheduleJobTest.expiredJobsAreDescheduledEvenIfVcsIntegrationFails` already covers "VCS status call throws" for a related code path; confirmed it still passes.

### What was fixed/added along the way and why

- **`ScheduleJob.updateJobStatusOnVcs`**: a failure notifying the VCS of a job's status (expired token, provider outage, or a job with no resolvable commit SHA) was an unhandled exception that crashed the *entire* Quartz job execution — including from the job-completion path, so a job that had actually finished successfully could get stuck instead of ever reaching a terminal status. Wrapped in try/catch so it's logged, not fatal.
- **`UpdateJobStatusImpl`**: a plan-only job whose plan found changes was left `pending` forever — correct when a following apply step is waiting for approval, wrong when there's no further step in the template. Now completes when this is the job's only step.
- Found but **not** fixed here, flagged for follow-up: a race condition creating duplicate `GitHubAppToken` rows under concurrent dispatch to the same VCS connection (worked around via manual DB cleanup during testing, no code fix yet), and a related gap where a job whose step actually *failed* could still get marked `completed` instead of `failed` (`ScheduleJob.executePendingJob`'s completion branch doesn't check prior step outcomes before calling `completeJob()`).

This is paired with https://github.com/terrakube-io/terrakube-helm-chart/pull/288