### PR TITLE
fix(ui): trim whitespace from key, value, and description fields when saving variables

### DIFF
--- a/ui/src/domain/Settings/CreateEditCollection.tsx
+++ b/ui/src/domain/Settings/CreateEditCollection.tsx
@@ -252,12 +252,12 @@ export const CreateEditCollection = ({
               ? {
                   ...v,
                   attributes: {
-                    key: values.key,
-                    value: values.value,
-                    category: values.category,
-                    description: values.description,
-                    hcl: values.hcl,
+                    key: values.key?.trim(),
+                    value: typeof values.value === "string" ? values.value.trim() : values.value,
                     sensitive: values.sensitive,
+                    description: values.description?.trim(),
+                    hcl: values.hcl,
+                    category: values.category,
                   },
                 }
               : v
@@ -274,10 +274,10 @@ export const CreateEditCollection = ({
                 type: "item",
                 id: editingVariableId,
                 attributes: {
-                  key: values.key,
-                  value: values.value,
+                  key: values.key?.trim(),
+                  value: typeof values.value === "string" ? values.value.trim() : values.value,
                   sensitive: values.sensitive,
-                  description: values.description,
+                  description: values.description?.trim(),
                   hcl: values.hcl,
                   category: values.category,
                 },
@@ -317,10 +317,10 @@ export const CreateEditCollection = ({
       const newVariable = {
         id: `temp-${Date.now()}`,
         attributes: {
-          key: values.key,
-          value: values.value,
+          key: values.key?.trim(),
+          value: typeof values.value === "string" ? values.value.trim() : values.value,
           category: values.category,
-          description: values.description,
+          description: values.description?.trim(),
           hcl: values.hcl,
           sensitive: values.sensitive,
         },
@@ -337,10 +337,10 @@ export const CreateEditCollection = ({
               data: {
                 type: "item",
                 attributes: {
-                  key: values.key,
-                  value: values.value,
+                  key: values.key?.trim(),
+                  value: typeof values.value === "string" ? values.value.trim() : values.value,
                   sensitive: values.sensitive,
-                  description: values.description,
+                  description: values.description?.trim(),
                   hcl: values.hcl,
                   category: values.category,
                 },
@@ -378,10 +378,10 @@ export const CreateEditCollection = ({
     setEditingVariableId(record.id);
     setAddingVariable(true);
     variableForm.setFieldsValue({
-      key: record.attributes.key,
-      value: record.attributes.value,
+      key: record.attributes.key?.trim(),
+      value: typeof record.attributes.value === "string" ? record.attributes.value.trim() : record.attributes.value,
       category: record.attributes.category,
-      description: record.attributes.description,
+      description: record.attributes.description?.trim(),
       hcl: record.attributes.hcl,
       sensitive: record.attributes.sensitive,
     });

--- a/ui/src/domain/Settings/GlobalVariables.tsx
+++ b/ui/src/domain/Settings/GlobalVariables.tsx
@@ -143,10 +143,10 @@ export const GlobalVariablesSettings = ({ managePermission = true }: Props) => {
       data: {
         type: "globalvar",
         attributes: {
-          key: values.key,
-          value: values.value,
+          key: values.key?.trim(),
+          value: typeof values.value === "string" ? values.value.trim() : values.value,
           sensitive: values.sensitive,
-          description: values.description,
+          description: values.description?.trim(),
           hcl: values.hcl,
           category: values.category,
         },
@@ -176,9 +176,9 @@ export const GlobalVariablesSettings = ({ managePermission = true }: Props) => {
         type: "globalvar",
         id: variableId,
         attributes: {
-          key: values.key,
-          value: values.value,
-          description: values.description,
+          key: values.key?.trim(),
+          value: typeof values.value === "string" ? values.value.trim() : values.value,
+          description: values.description?.trim(),
           hcl: values.hcl,
           category: values.category,
         },

--- a/ui/src/domain/Workspaces/Variables.tsx
+++ b/ui/src/domain/Workspaces/Variables.tsx
@@ -289,12 +289,12 @@ export const Variables = ({
       data: {
         type: "variable",
         attributes: {
-          key: values.key,
-          value: values.value,
+          key: values.key?.trim(),
+          value: typeof values.value === "string" ? values.value.trim() : values.value,
           sensitive: values.sensitive,
-          description: values.description,
+          description: values.description?.trim(),
           hcl: values.hcl,
-          category: category,
+          category: values.category,
         },
       },
     };
@@ -322,12 +322,12 @@ export const Variables = ({
         type: "variable",
         id: variableId,
         attributes: {
-          key: values.key,
-          value: values.value,
+          key: values.key?.trim(),
+          value: typeof values.value === "string" ? values.value.trim() : values.value,
           sensitive: values.sensitive,
-          description: values.description,
+          description: values.description?.trim(),
           hcl: values.hcl,
-          category: category,
+          category: values.category,
         },
       },
     };


### PR DESCRIPTION
Closes #3352 

### Summary
Normalizes string input fields (`key`, `value`, and `description`) by stripping leading and trailing whitespaces before submitting payloads when creating or editing variables across the UI.

### Problem
Accidental leading or trailing spaces entered into variable fields were saved directly to the database. This could cause subtle, difficult-to-diagnose execution failures during Terraform/Tofu runs (e.g. environment variable keys containing trailing spaces like `"XXXXXXXXX    "`).

### Changes
Added `.trim()` normalization across all variable creation and edit handlers:
- **Global Variables** (`GlobalVariables.tsx`): Updated `onCreate` and `onUpdate` handlers.
- **Workspace Variables** (`Variables.tsx`): Updated `onCreate` and `onUpdate` handlers.
- **Variable Collections** (`CreateEditCollection.tsx`): Updated `handleAddVariable` and `handleUpdateVariable` handlers.

### Verification
- Tested creating and updating variables containing leading and trailing spaces in Global Variables, Workspace Variables, and Variable Collections.
- Verified that saved values are cleanly trimmed in API payloads and UI table displays.
