### PR TITLE
feat(api): Add soft-delete to Jobs

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -40,6 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.text.ParseException;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.terrakube.api.plugin.scheduler.ScheduleJobService.PREFIX_JOB_CONTEXT;
@@ -195,11 +196,15 @@ public class ScheduleJob implements org.quartz.Job {
     private void deleteOldJobs(Job job) {
         AtomicInteger keepHistory = new AtomicInteger();
         keepHistory.set(0);
+        AtomicBoolean softDelete = new AtomicBoolean(false);
 
         Optional<List<Globalvar>> globalsList = Optional.ofNullable(globalVarRepository.findByOrganization(job.getOrganization()));
         globalsList.ifPresent(variableList -> variableList.forEach(variable -> {
             if (variable.getKey().equals("KEEP_JOB_HISTORY") && variable.getCategory() == Category.ENV) {
                 keepHistory.set(Integer.parseInt(variable.getValue()));
+            }
+            if (variable.getKey().equals("KEEP_JOB_HISTORY_SOFT_DELETE") && variable.getCategory() == Category.ENV) {
+                softDelete.set(Boolean.parseBoolean(variable.getValue()));
             }
         }));
 
@@ -208,10 +213,13 @@ public class ScheduleJob implements org.quartz.Job {
             if (variable.getKey().equals("KEEP_JOB_HISTORY") && variable.getCategory() == Category.ENV) {
                 keepHistory.set(Integer.parseInt(variable.getValue()));
             }
+            if (variable.getKey().equals("KEEP_JOB_HISTORY_SOFT_DELETE") && variable.getCategory() == Category.ENV) {
+                softDelete.set(Boolean.parseBoolean(variable.getValue()));
+            }
         }));
 
         if (keepHistory.get() > 0) {
-            log.info("Keeping history of {} jobs", keepHistory);
+            log.info("Keeping history of {} jobs (softDelete={})", keepHistory, softDelete.get());
             Optional<List<Job>> previousJobs = jobRepository.findByWorkspaceAndStatusInAndIdLessThanOrderByIdDesc(
                     job.getWorkspace(),
                     Arrays.asList(JobStatus.failed, JobStatus.completed, JobStatus.rejected, JobStatus.cancelled, JobStatus.noChanges),
@@ -221,9 +229,15 @@ public class ScheduleJob implements org.quartz.Job {
                 for (int i = 0; i < previousJobs.get().size(); i++) {
                     if (i >= keepHistory.get()) {
                         Job previousJob = previousJobs.get().get(i);
-                        log.info("Deleting Job {} with Status {}", previousJob.getId(), previousJob.getStatus());
-                        stepRepository.deleteAll(stepRepository.findByJobId(previousJob.getId()));
-                        jobRepository.delete(previousJob);
+                        if (softDelete.get()) {
+                            log.info("Soft deleting Job {} with Status {}", previousJob.getId(), previousJob.getStatus());
+                            previousJob.setDeleted(true);
+                            jobRepository.save(previousJob);
+                        } else {
+                            log.info("Deleting Job {} with Status {}", previousJob.getId(), previousJob.getStatus());
+                            stepRepository.deleteAll(stepRepository.findByJobId(previousJob.getId()));
+                            jobRepository.delete(previousJob);
+                        }
                     }
                 }
             }

--- a/api/src/main/java/io/terrakube/api/plugin/softdelete/SoftDeleteService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/softdelete/SoftDeleteService.java
@@ -7,17 +7,16 @@ import org.springframework.stereotype.Service;
 import io.terrakube.api.plugin.scheduler.ScheduleJobService;
 import io.terrakube.api.plugin.scheduler.module.ModuleRefreshService;
 import io.terrakube.api.plugin.scheduler.workspace.DeleteStorageBackendJob;
+import io.terrakube.api.repository.JobRepository;
 import io.terrakube.api.repository.ModuleRepository;
 import io.terrakube.api.repository.ScheduleRepository;
 import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.rs.Organization;
-import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.module.Module;
 import io.terrakube.api.rs.workspace.Workspace;
 import io.terrakube.api.rs.workspace.schedule.Schedule;
 
 import java.text.ParseException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -38,6 +37,8 @@ public class SoftDeleteService {
 
     WorkspaceRepository workspaceRepository;
 
+    JobRepository jobRepository;
+
     Scheduler scheduler;
 
     public void disableWorkspaceSchedules(Workspace workspace){
@@ -55,11 +56,11 @@ public class SoftDeleteService {
     }
 
     public void deleteWorkspaceStorage(Workspace workspace){
-        List<Job> jobList = workspace.getJob();
-        List<Integer> jobIdList = new ArrayList();
-        jobList.forEach(job -> jobIdList.add(job.getId()));
         String workspaceId = workspace.getId().toString();
         String organizationId = workspace.getOrganization().getId().toString();
+        // Use a native query so soft-deleted jobs are also included, otherwise the
+        // @SQLRestriction on Job would hide them and leave their output data orphaned.
+        List<Integer> jobIdList = jobRepository.findAllJobIdsByWorkspaceIncludingDeleted(workspaceId);
 
         try {
             log.info("Setup job to delete storage for organization {} workspace {} jobs {}", organizationId, workspaceId, jobIdList);

--- a/api/src/main/java/io/terrakube/api/repository/JobRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/JobRepository.java
@@ -41,4 +41,7 @@ public interface JobRepository extends JpaRepository<Job, Integer> {
     @Modifying(flushAutomatically = true)
     @Query("update job j set j.status = :status where j.id = :jobId")
     int updateStatusById(@Param("status") JobStatus status, @Param("jobId") int jobId);
+
+    @Query(value = "SELECT id FROM job WHERE workspace_id = :workspaceId", nativeQuery = true)
+    List<Integer> findAllJobIdsByWorkspaceIncludingDeleted(@Param("workspaceId") String workspaceId);
 }

--- a/api/src/main/java/io/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/Job.java
@@ -16,6 +16,8 @@ import com.yahoo.elide.annotation.LifeCycleHookBinding;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -38,6 +40,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity(name = "job")
+@SQLRestriction(value = "deleted = false")
 public class Job extends GenericAuditFields {
 
     @Id
@@ -60,6 +63,10 @@ public class Job extends GenericAuditFields {
     @Exclude
     @Column(name = "auto_apply")
     private boolean autoApply = false;
+
+    @Exclude
+    @Column(name = "deleted")
+    private boolean deleted = false;
 
     @Column(name = "terraform_plan")
     private String terraformPlan;

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -113,4 +113,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-pr-apply-enabled-fix.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-job-pr-apply-enabled.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-job-command-comment-id.xml"/>
+    <include file="/db/changelog/local/changelog-2.33.0-job-soft-delete.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-job-soft-delete.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-job-soft-delete.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-33-0-job-soft-delete" author="ivar">
+        <addColumn tableName="job">
+            <column name="deleted" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="2-33-0-job-soft-delete-backfill" author="ivar">
+        <update tableName="job">
+            <column name="deleted" valueBoolean="false"/>
+            <where>deleted IS NULL</where>
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
@@ -625,6 +625,54 @@ public class ScheduleJobTest {
     }
 
     @Test
+    public void completedJobWithHistorySoftDelete() {
+        Job job = job(JobStatus.completed);
+        Job prev1 = job(JobStatus.completed);
+        prev1.setId(4710);
+        Job prev2 = job(JobStatus.completed);
+        prev2.setId(4709);
+
+        Globalvar keepHistory = new Globalvar();
+        keepHistory.setKey("KEEP_JOB_HISTORY");
+        keepHistory.setCategory(Category.ENV);
+        keepHistory.setValue("1");
+
+        Globalvar softDelete = new Globalvar();
+        softDelete.setKey("KEEP_JOB_HISTORY_SOFT_DELETE");
+        softDelete.setCategory(Category.ENV);
+        softDelete.setValue("true");
+
+        doReturn(List.of(keepHistory, softDelete)).when(globalVarRepository).findByOrganization(any());
+        doReturn(Optional.of(Collections.emptyList())).when(variableRepository).findByWorkspace(any());
+
+        doReturn(false).when(tclService).isTemplatePlanOnly(any());
+        doReturn(Optional.of(Collections.emptyList()))
+                .when(jobRepository)
+                .findByWorkspaceAndStatusNotInAndIdLessThan(
+                        any(Workspace.class),
+                        anyList(),
+                        anyInt());
+        doReturn(Optional.of(List.of(prev1, prev2)))
+                .when(jobRepository)
+                .findByWorkspaceAndStatusInAndIdLessThanOrderByIdDesc(
+                        any(Workspace.class),
+                        anyList(),
+                        anyInt());
+        doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+        doReturn(Collections.emptyList()).when(stepRepository).findByJobId(anyInt());
+
+        Assert.assertTrue(subject().runExecution(job));
+
+        // prev2 should be soft deleted (flagged), never hard deleted
+        verify(jobRepository, never()).delete(any());
+        verify(jobRepository, times(1)).save(prev2);
+        Assertions.assertTrue(prev2.isDeleted());
+        Assertions.assertFalse(prev1.isDeleted());
+    }
+
+    @Test
     public void completedJob() {
         Job job = job(JobStatus.completed);
 


### PR DESCRIPTION
We noticed a massive slowdown of the API if there's a lot of jobs in the database. Rather than removing them outright and losing the history, this change allows jobs to be "soft deleted" similar to workspaces.

In the interest of transparency I had Claude Opus 4.8 generate the code for this change.