### PR TITLE
fix(executor): ensure reliable job dispatch across multi-replica executor pools

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -40,6 +40,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.text.ParseException;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -57,6 +58,17 @@ public class ScheduleJob implements org.quartz.Job {
 
     public static final String JOB_ID = "jobId";
     private final GitLabWebhookService gitLabWebhookService;
+
+    // A job in pending/approved status can be picked up by two overlapping Quartz firings: the
+    // long-lived 30s job-context trigger (ScheduleJobService.createJobContext) and a one-shot
+    // trigger fired on any Job update (JobManageHook -> createJobContextNow). Neither Job nor
+    // Workspace is version-locked, and dispatch only writes the job's status *after* a successful
+    // send, so without this lock two overlapping firings could both pass the status check and both
+    // dispatch the same job to two different executors. TTL comfortably covers
+    // PersistentExecutorService's connect+response timeout (10s + 60s) so an orphaned lock (e.g. a
+    // pod crash mid-dispatch) self-heals well before the next 30s retry would otherwise need it.
+    private static final String DISPATCH_LOCK_PREFIX = "job-dispatch-lock:";
+    private static final Duration DISPATCH_LOCK_TTL = Duration.ofSeconds(90);
 
     JobRepository jobRepository;
 
@@ -272,6 +284,10 @@ public class ScheduleJob implements org.quartz.Job {
                 case terraformApply:
                 case terraformDestroy:
                 case customScripts:
+                    if (!acquireDispatchLock(job)) {
+                        log.warn("Job {} Step {} is already being dispatched by another scheduler run, will retry", job.getId(), stepId);
+                        return false;
+                    }
                     try {
                         executorService.execute(job, stepId, flow.get());
                         job.setStatus(JobStatus.queue);
@@ -281,6 +297,8 @@ public class ScheduleJob implements org.quartz.Job {
                         return false;
                     } catch (ExecutionException e) {
                         errorJobAtStep(job, stepId, e);
+                    } finally {
+                        releaseDispatchLock(job);
                     }
                     break;
                 case approval:
@@ -385,6 +403,16 @@ public class ScheduleJob implements org.quartz.Job {
         log.info("Update Job {} to completed", job.getId());
     }
 
+    private boolean acquireDispatchLock(Job job) {
+        Boolean acquired = redisTemplate.opsForValue()
+                .setIfAbsent(DISPATCH_LOCK_PREFIX + job.getId(), "1", DISPATCH_LOCK_TTL);
+        return Boolean.TRUE.equals(acquired);
+    }
+
+    private void releaseDispatchLock(Job job) {
+        redisTemplate.delete(DISPATCH_LOCK_PREFIX + job.getId());
+    }
+
     private void errorJobAtStep(Job job, String stepId, Throwable e) {
         String logMessage = String.format(
             "Error when sending context to executor marking job %s as failed, step count %s",
@@ -430,6 +458,10 @@ public class ScheduleJob implements org.quartz.Job {
             String stepId = tclService.getCurrentStepId(job);
             job.setApprovalTeam("");
             jobRepository.save(job);
+            if (!acquireDispatchLock(job)) {
+                log.warn("Job {} Step {} is already being dispatched by another scheduler run, will retry", job.getId(), stepId);
+                return false;
+            }
             try {
                 executorService.execute(job, stepId, flow.get());
                 job.setStatus(JobStatus.queue);
@@ -439,6 +471,8 @@ public class ScheduleJob implements org.quartz.Job {
                 return false;
             } catch (ExecutionException e) {
                 errorJobAtStep(job, stepId, e);
+            } finally {
+                releaseDispatchLock(job);
             }
         }
         return true;

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -3,6 +3,7 @@ package io.terrakube.api.plugin.scheduler;
 import io.terrakube.api.plugin.scheduler.job.tcl.TclService;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutionException;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorService;
+import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorUnavailableException;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.Flow;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.FlowType;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.ScheduleTemplate;
@@ -157,12 +158,10 @@ public class ScheduleJob implements org.quartz.Job {
                          throw new AssertionError(String.format("Expected pending job %d to have plan changes", jobId));
                     }
                     log.info("Executing pending job {}", jobId);
-                    executePendingJob(job);
-                    deschedule = true;
+                    deschedule = executePendingJob(job);
                     break;
                 case approved:
-                    executeApprovedJobs(job);
-                    deschedule = true;
+                    deschedule = executeApprovedJobs(job);
                     break;
                 case running:
                     log.info("Job {} running", job.getId());
@@ -253,10 +252,13 @@ public class ScheduleJob implements org.quartz.Job {
         workspaceRepository.save(job.getWorkspace());
     }
 
-    private void executePendingJob(Job job) {
+    // Returns whether the job's Quartz trigger should be descheduled. False keeps it alive so
+    // the existing 30s retrigger (JOB_CONTEXT_INTERVAL) retries once an executor is free, instead
+    // of failing the job just because the whole pool was busy at this particular attempt.
+    private boolean executePendingJob(Job job) {
         job = tclService.initJobConfiguration(job);
         if (failJobIfWorkspaceVariablesAreIncomplete(job)) {
-            return;
+            return true;
         }
 
         Optional<Flow> flow = Optional.ofNullable(tclService.getNextFlow(job));
@@ -274,6 +276,9 @@ public class ScheduleJob implements org.quartz.Job {
                         executorService.execute(job, stepId, flow.get());
                         job.setStatus(JobStatus.queue);
                         jobRepository.save(job);
+                    } catch (ExecutorUnavailableException e) {
+                        log.warn("No executor available for Job {} Step {}, will retry: {}", job.getId(), stepId, e.getMessage());
+                        return false;
                     } catch (ExecutionException e) {
                         errorJobAtStep(job, stepId, e);
                     }
@@ -286,7 +291,7 @@ public class ScheduleJob implements org.quartz.Job {
                         log.info("Waiting Approval for Job {} Step Id {}", job.getId(), stepId);
                     } else {
                         log.info("Auto Approving is enabled for Job {} Step Id {}", job.getId(), stepId);
-                        executeApprovedJobs(job);
+                        return executeApprovedJobs(job);
                     }
                     break;
                 case disableWorkspace:
@@ -334,6 +339,7 @@ public class ScheduleJob implements org.quartz.Job {
             completeJob(job);
             deleteOldJobs(job);
         }
+        return true;
     }
 
     private boolean setupScheduler(Job job, Flow flow) {
@@ -412,10 +418,11 @@ public class ScheduleJob implements org.quartz.Job {
         }
     }
 
-    private void executeApprovedJobs(Job job) {
+    // Returns whether the job's Quartz trigger should be descheduled; see executePendingJob.
+    private boolean executeApprovedJobs(Job job) {
         job = tclService.initJobConfiguration(job);
         if (failJobIfWorkspaceVariablesAreIncomplete(job)) {
-            return;
+            return true;
         }
         Optional<Flow> flow = Optional.ofNullable(tclService.getNextFlow(job));
         if (flow.isPresent()) {
@@ -427,10 +434,14 @@ public class ScheduleJob implements org.quartz.Job {
                 executorService.execute(job, stepId, flow.get());
                 job.setStatus(JobStatus.queue);
                 jobRepository.save(job);
+            } catch (ExecutorUnavailableException e) {
+                log.warn("No executor available for Job {} Step {}, will retry: {}", job.getId(), stepId, e.getMessage());
+                return false;
             } catch (ExecutionException e) {
                 errorJobAtStep(job, stepId, e);
             }
         }
+        return true;
     }
 
     private void updateJobStepsWithStatus(int jobId, JobStatus jobStatus) {

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -35,6 +35,7 @@ import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.JobKey;
 import org.quartz.SchedulerException;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -403,14 +404,27 @@ public class ScheduleJob implements org.quartz.Job {
         log.info("Update Job {} to completed", job.getId());
     }
 
+    // Fails closed: if Redis itself is unreachable, treat it the same as losing the lock race
+    // rather than dispatching unprotected. A duplicate terraform apply is worse than a job
+    // waiting out a Redis blip for its next 30s retry.
     private boolean acquireDispatchLock(Job job) {
-        Boolean acquired = redisTemplate.opsForValue()
-                .setIfAbsent(DISPATCH_LOCK_PREFIX + job.getId(), "1", DISPATCH_LOCK_TTL);
-        return Boolean.TRUE.equals(acquired);
+        try {
+            Boolean acquired = redisTemplate.opsForValue()
+                    .setIfAbsent(DISPATCH_LOCK_PREFIX + job.getId(), "1", DISPATCH_LOCK_TTL);
+            return Boolean.TRUE.equals(acquired);
+        } catch (DataAccessException e) {
+            log.warn("Could not reach Redis to acquire dispatch lock for Job {}, will retry: {}", job.getId(), e.getMessage());
+            return false;
+        }
     }
 
     private void releaseDispatchLock(Job job) {
-        redisTemplate.delete(DISPATCH_LOCK_PREFIX + job.getId());
+        try {
+            redisTemplate.delete(DISPATCH_LOCK_PREFIX + job.getId());
+        } catch (DataAccessException e) {
+            // The lock's TTL (DISPATCH_LOCK_TTL) self-heals this; nothing else to do here.
+            log.warn("Could not reach Redis to release dispatch lock for Job {}: {}", job.getId(), e.getMessage());
+        }
     }
 
     private void errorJobAtStep(Job job, String stepId, Throwable e) {

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorUnavailableException.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorUnavailableException.java
@@ -1,0 +1,14 @@
+package io.terrakube.api.plugin.scheduler.job.tcl.executor;
+
+// Thrown when the executor pool could not be reached at all (connection refused, timed out,
+// no ready Service endpoints) as opposed to the executor being reachable and rejecting the
+// job. Callers can catch this separately to retry instead of failing the job outright.
+public class ExecutorUnavailableException extends ExecutionException {
+    public ExecutorUnavailableException(Throwable cause) {
+        super(cause);
+    }
+
+    public ExecutorUnavailableException(String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorService.java
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutionException;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorContext;
+import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorUnavailableException;
 import io.terrakube.api.rs.job.Job;
 
 import java.util.*;
@@ -336,9 +338,37 @@ public class EphemeralExecutorService {
 
         try {
             kubernetesClient.batch().v1().jobs().inNamespace(ephemeralConfiguration.getNamespace()).resource(k8sJob).serverSideApply();
+        } catch (KubernetesClientException e) {
+            if (isRetryable(e)) {
+                throw new ExecutorUnavailableException(e);
+            }
+            throw new ExecutionException(e);
         } catch (Exception e) {
             throw new ExecutionException(e);
         }
+    }
+
+    // Mirrors PersistentExecutorService's ExecutorUnavailableException split: treat capacity/
+    // availability signals from the Kubernetes API as retryable, and genuine request/config
+    // rejections (a bad manifest, RBAC denial) as a real failure that retrying will never fix.
+    private boolean isRetryable(KubernetesClientException e) {
+        int code = e.getCode();
+        if (code <= 0) {
+            // No HTTP response reached at all - apiserver unreachable, connection refused, timed out.
+            return true;
+        }
+        if (code == 429 || code >= 500) {
+            // Throttled, or a server-side error - both expected to clear on their own.
+            return true;
+        }
+        if (code == 403) {
+            // Admission control returns 403 both when a ResourceQuota is exhausted (transient -
+            // frees up as other jobs finish) and on RBAC denial (a real config error). Only the
+            // former is worth retrying.
+            String message = e.getMessage();
+            return message != null && message.contains("exceeded quota");
+        }
+        return false;
     }
 
     private Map<String, String> parseKeyValueString(String input) {

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorService.java
@@ -23,6 +23,7 @@ import org.springframework.web.reactive.function.client.WebClientRequestExceptio
 import io.netty.channel.ChannelOption;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutionException;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorContext;
+import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorUnavailableException;
 import io.terrakube.api.repository.GlobalVarRepository;
 import io.terrakube.api.rs.globalvar.Globalvar;
 import io.terrakube.api.rs.job.Job;
@@ -90,13 +91,16 @@ public class PersistentExecutorService {
                     .toEntity(ExecutorContext.class)
                     .block();
         } catch (Exception ex) {
-            String hint = "";
             if (ex instanceof WebClientRequestException) {
-                hint = String.format(
+                // No response was ever received: connection refused, timed out, or (in Kubernetes,
+                // when every replica is mid-job and REFUSING_TRAFFIC) the Service has no ready
+                // endpoints. This is a capacity problem, not a broken job, so it's retryable.
+                String hint = String.format(
                         " Cannot connect to executor at %s. Check that the executor is running and reachable (io.terrakube.executor.url / AzBuilderExecutorUrl).",
                         executorUrlForRequest);
+                throw new ExecutorUnavailableException(new Throwable(ex.getMessage() + hint, ex));
             }
-            throw new ExecutionException(new Throwable(ex.getMessage() + hint, ex));
+            throw new ExecutionException(new Throwable(ex.getMessage(), ex));
         }
 
         log.debug("Sending Job: /n {}", executorContext.toBuilder()

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
@@ -31,6 +31,7 @@ import io.terrakube.api.helpers.FailUnkownMethod;
 import io.terrakube.api.plugin.scheduler.job.tcl.TclService;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutionException;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorService;
+import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorUnavailableException;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ephemeral.EphemeralExecutorService;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.Flow;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.FlowType;
@@ -247,6 +248,37 @@ public class ScheduleJobTest {
         verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.unknown);
         Assertions.assertEquals(JobStatus.failed, job.getStatus());
         Assertions.assertEquals(JobStatus.failed, job.getStep().get(0).getStatus());
+    }
+
+    @Test
+    public void pendingJobRetriesWhenExecutorUnavailable() throws Exception {
+        Job job = job(JobStatus.pending);
+        job.setPlanChanges(true);
+
+        Flow flow = new Flow();
+        flow.setType(FlowType.terraformPlan.name());
+
+        doReturn(false).when(tclService).isTemplatePlanOnly(any());
+        doReturn(Optional.of(Collections.emptyList()))
+                .when(jobRepository)
+                .findByWorkspaceAndStatusNotInAndIdLessThan(
+                        any(Workspace.class),
+                        anyList(),
+                        anyInt());
+        doReturn(job).when(tclService).initJobConfiguration(any(Job.class));
+        doReturn(flow).when(tclService).getNextFlow(any());
+        doReturn(stepId.toString()).when(tclService).getCurrentStepId(any());
+        doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
+        doThrow(new ExecutorUnavailableException("no ready executor")).when(executorService).execute(any(), any(), any());
+
+        // No free executor should leave the job in place for the next Quartz retry
+        // (JOB_CONTEXT_INTERVAL), not fail it outright.
+        Assert.assertFalse(subject().runExecution(job));
+
+        verify(jobRepository, times(0)).save(any());
+        verify(stepRepository, times(0)).save(any());
+        verify(gitLabWebhookService, times(0)).sendCommitStatus(any(), any());
+        Assertions.assertEquals(JobStatus.pending, job.getStatus());
     }
 
     @Test
@@ -538,6 +570,36 @@ public class ScheduleJobTest {
         verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.unknown);
         Assertions.assertEquals(JobStatus.failed, job.getStatus());
         Assertions.assertEquals(JobStatus.failed, job.getStep().get(0).getStatus());
+    }
+
+    @Test
+    public void approvedJobRetriesWhenExecutorUnavailable() throws Exception {
+        Job job = job(JobStatus.approved);
+
+        Flow flow = new Flow();
+        flow.setType(FlowType.terraformPlan.name());
+
+        doReturn(false).when(tclService).isTemplatePlanOnly(any());
+        doReturn(Optional.of(Collections.emptyList()))
+                .when(jobRepository)
+                .findByWorkspaceAndStatusNotInAndIdLessThan(
+                        any(Workspace.class),
+                        anyList(),
+                        anyInt());
+        doReturn(job).when(tclService).initJobConfiguration(any(Job.class));
+        doReturn(flow).when(tclService).getNextFlow(any());
+        doReturn(stepId.toString()).when(tclService).getCurrentStepId(any());
+        doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
+        doReturn(job).when(jobRepository).save(any());
+        doThrow(new ExecutorUnavailableException("no ready executor")).when(executorService).execute(any(), any(), any());
+
+        // No free executor should leave the job in place for the next Quartz retry
+        // (JOB_CONTEXT_INTERVAL), not fail it outright.
+        Assert.assertFalse(subject().runExecution(job));
+
+        verify(stepRepository, times(0)).save(any());
+        verify(gitLabWebhookService, times(0)).sendCommitStatus(any(), any());
+        Assertions.assertEquals(JobStatus.approved, job.getStatus());
     }
 
      @Test

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
@@ -63,6 +63,7 @@ import io.terrakube.api.rs.workspace.Workspace;
 import io.terrakube.api.rs.workspace.parameters.Category;
 import io.terrakube.api.rs.workspace.parameters.Variable;
 import io.terrakube.api.rs.workspace.schedule.Schedule;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
@@ -317,6 +318,37 @@ public class ScheduleJobTest {
         // Simulate a concurrent Quartz firing (the main 30s trigger racing a status-change
         // one-shot trigger) already holding the dispatch lock for this job.
         doReturn(false).when(valueOperations).setIfAbsent(any(), any(), any(Duration.class));
+
+        Assert.assertFalse(subject().runExecution(job));
+
+        verify(executorService, times(0)).execute(any(), any(), any());
+        verify(jobRepository, times(0)).save(any());
+        Assertions.assertEquals(JobStatus.pending, job.getStatus());
+    }
+
+    @Test
+    public void pendingJobSkipsDispatchWhenRedisIsUnreachable() throws Exception {
+        Job job = job(JobStatus.pending);
+        job.setPlanChanges(true);
+
+        Flow flow = new Flow();
+        flow.setType(FlowType.terraformPlan.name());
+
+        doReturn(false).when(tclService).isTemplatePlanOnly(any());
+        doReturn(Optional.of(Collections.emptyList()))
+                .when(jobRepository)
+                .findByWorkspaceAndStatusNotInAndIdLessThan(
+                        any(Workspace.class),
+                        anyList(),
+                        anyInt());
+        doReturn(job).when(tclService).initJobConfiguration(any(Job.class));
+        doReturn(flow).when(tclService).getNextFlow(any());
+        doReturn(stepId.toString()).when(tclService).getCurrentStepId(any());
+        doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
+        // A Redis outage must fail closed (skip dispatch, retry later) rather than dispatch
+        // unprotected - a duplicate terraform apply is worse than a delayed one.
+        doThrow(new RedisConnectionFailureException("connection refused"))
+                .when(valueOperations).setIfAbsent(any(), any(), any(Duration.class));
 
         Assert.assertFalse(subject().runExecution(job));
 

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
@@ -3,6 +3,7 @@ package io.terrakube.api.plugin.scheduler;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -13,6 +14,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -61,6 +63,8 @@ import io.terrakube.api.rs.workspace.Workspace;
 import io.terrakube.api.rs.workspace.parameters.Category;
 import io.terrakube.api.rs.workspace.parameters.Variable;
 import io.terrakube.api.rs.workspace.schedule.Schedule;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
 @ExtendWith(MockitoExtension.class)
 public class ScheduleJobTest {
@@ -81,6 +85,8 @@ public class ScheduleJobTest {
     GlobalVarRepository globalVarRepository;
     VariableRepository variableRepository;
     WorkspaceVariableValidationService workspaceVariableValidationService;
+    RedisTemplate<String, Object> redisTemplate;
+    ValueOperations<String, Object> valueOperations;
 
     UUID stepId = UUID.randomUUID();
 
@@ -104,6 +110,12 @@ public class ScheduleJobTest {
                 WorkspaceVariableValidationService.class,
                 new FailUnkownMethod<WorkspaceVariableValidationService>());
         lenient().doNothing().when(workspaceVariableValidationService).validateWorkspaceVariables(any());
+
+        redisTemplate = mock(RedisTemplate.class, new FailUnkownMethod<RedisTemplate>());
+        valueOperations = mock(ValueOperations.class, new FailUnkownMethod<ValueOperations>());
+        lenient().doReturn(valueOperations).when(redisTemplate).opsForValue();
+        lenient().doReturn(true).when(valueOperations).setIfAbsent(any(), any(), any(Duration.class));
+        lenient().doReturn(true).when(redisTemplate).delete(anyString());
     }
 
     private ScheduleJob subject() {
@@ -118,7 +130,7 @@ public class ScheduleJobTest {
                 workspaceRepository,
                 softDeleteService,
                 scheduleJobService,
-                null,
+                redisTemplate,
                 gitHubWebhookService,
                 null,
                 prCommentService,
@@ -211,6 +223,8 @@ public class ScheduleJobTest {
 
         verify(executorService, times(1)).execute(any(), any(), any());
         verify(jobRepository, times(1)).save(job);
+        verify(valueOperations, times(1)).setIfAbsent(any(), any(), any(Duration.class));
+        verify(redisTemplate, times(1)).delete(anyString());
         Assertions.assertEquals(JobStatus.queue, job.getStatus());
     }
 
@@ -278,6 +292,36 @@ public class ScheduleJobTest {
         verify(jobRepository, times(0)).save(any());
         verify(stepRepository, times(0)).save(any());
         verify(gitLabWebhookService, times(0)).sendCommitStatus(any(), any());
+        Assertions.assertEquals(JobStatus.pending, job.getStatus());
+    }
+
+    @Test
+    public void pendingJobSkipsDispatchWhenAlreadyBeingDispatched() throws Exception {
+        Job job = job(JobStatus.pending);
+        job.setPlanChanges(true);
+
+        Flow flow = new Flow();
+        flow.setType(FlowType.terraformPlan.name());
+
+        doReturn(false).when(tclService).isTemplatePlanOnly(any());
+        doReturn(Optional.of(Collections.emptyList()))
+                .when(jobRepository)
+                .findByWorkspaceAndStatusNotInAndIdLessThan(
+                        any(Workspace.class),
+                        anyList(),
+                        anyInt());
+        doReturn(job).when(tclService).initJobConfiguration(any(Job.class));
+        doReturn(flow).when(tclService).getNextFlow(any());
+        doReturn(stepId.toString()).when(tclService).getCurrentStepId(any());
+        doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
+        // Simulate a concurrent Quartz firing (the main 30s trigger racing a status-change
+        // one-shot trigger) already holding the dispatch lock for this job.
+        doReturn(false).when(valueOperations).setIfAbsent(any(), any(), any(Duration.class));
+
+        Assert.assertFalse(subject().runExecution(job));
+
+        verify(executorService, times(0)).execute(any(), any(), any());
+        verify(jobRepository, times(0)).save(any());
         Assertions.assertEquals(JobStatus.pending, job.getStatus());
     }
 

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ephemeral/EphemeralExecutorServiceTest.java
@@ -1,6 +1,7 @@
 package io.terrakube.api.plugin.scheduler.job.tcl.executor.ephemeral;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,6 +42,7 @@ import io.fabric8.kubernetes.client.dsl.V1BatchAPIGroupDSL;
 import io.terrakube.api.helpers.FailUnkownMethod;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutionException;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorContext;
+import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorUnavailableException;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
 
@@ -378,5 +380,57 @@ public class EphemeralExecutorServiceTest {
         doThrow(new KubernetesClientException("Boom!")).when(resource).serverSideApply();
 
         assertThrows(ExecutionException.class, () -> subject().send(job(), context()));
+    }
+
+    @Test
+    public void retriesOnConnectionLevelFailure() {
+        // No HTTP response reached the apiserver at all - code defaults to 0.
+        doThrow(new KubernetesClientException("connection refused")).when(resource).serverSideApply();
+
+        assertThrows(ExecutorUnavailableException.class, () -> subject().send(job(), context()));
+    }
+
+    @Test
+    public void retriesOnThrottling() {
+        doThrow(new KubernetesClientException("Too Many Requests", 429, null)).when(resource).serverSideApply();
+
+        assertThrows(ExecutorUnavailableException.class, () -> subject().send(job(), context()));
+    }
+
+    @Test
+    public void retriesOnServerError() {
+        doThrow(new KubernetesClientException("etcd unavailable", 503, null)).when(resource).serverSideApply();
+
+        assertThrows(ExecutorUnavailableException.class, () -> subject().send(job(), context()));
+    }
+
+    @Test
+    public void retriesOnResourceQuotaExceeded() {
+        doThrow(new KubernetesClientException(
+                        "jobs.batch is forbidden: exceeded quota: compute-quota, requested: pods=1, used: pods=5, limited: pods=5",
+                        403, null))
+                .when(resource).serverSideApply();
+
+        assertThrows(ExecutorUnavailableException.class, () -> subject().send(job(), context()));
+    }
+
+    @Test
+    public void failsFastOnRbacDenial() {
+        doThrow(new KubernetesClientException(
+                        "jobs.batch is forbidden: User \"system:serviceaccount:ns:sa\" cannot create resource \"jobs\"",
+                        403, null))
+                .when(resource).serverSideApply();
+
+        ExecutionException thrown = assertThrows(ExecutionException.class, () -> subject().send(job(), context()));
+        assertFalse(thrown instanceof ExecutorUnavailableException);
+    }
+
+    @Test
+    public void failsFastOnBadRequest() {
+        doThrow(new KubernetesClientException("invalid quantity for resource cpu", 400, null))
+                .when(resource).serverSideApply();
+
+        ExecutionException thrown = assertThrows(ExecutionException.class, () -> subject().send(job(), context()));
+        assertFalse(thrown instanceof ExecutorUnavailableException);
     }
 }

--- a/executor/src/main/java/io/terrakube/executor/configuration/SpringAsyncAutoConfiguration.java
+++ b/executor/src/main/java/io/terrakube/executor/configuration/SpringAsyncAutoConfiguration.java
@@ -15,6 +15,17 @@ public class SpringAsyncAutoConfiguration {
     @Bean(name = "threadPoolTaskExecutor")
     @Primary
     public Executor threadPoolTaskExecutor() {
-        return new ThreadPoolTaskExecutor();
+        // ExecutorJobImpl.createJob() is the only @Async consumer of this pool, and it must stay
+        // single-threaded: a busy pod signals REFUSING_TRAFFIC to leave the k8s Service's endpoint
+        // pool, but that only takes effect once kube-proxy propagates it, so a second request can
+        // still land here in the meantime. Capping the pool at one thread queues that request
+        // behind the running job instead of running both concurrently - that's what actually
+        // enforces "one job per pod", not the readiness signal by itself. Do not raise this.
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(Integer.MAX_VALUE);
+        executor.setThreadNamePrefix("terrakube-executor-job-");
+        return executor;
     }
 }

--- a/executor/src/test/java/io/terrakube/executor/configuration/SpringAsyncAutoConfigurationTest.java
+++ b/executor/src/test/java/io/terrakube/executor/configuration/SpringAsyncAutoConfigurationTest.java
@@ -1,0 +1,22 @@
+package io.terrakube.executor.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpringAsyncAutoConfigurationTest {
+
+    @Test
+    void threadPoolTaskExecutorIsSingleThreaded() {
+        ThreadPoolTaskExecutor executor =
+                (ThreadPoolTaskExecutor) new SpringAsyncAutoConfiguration().threadPoolTaskExecutor();
+
+        // createJob() relies on this pool never running two jobs on the same pod at once - see
+        // the comment on SpringAsyncAutoConfiguration.threadPoolTaskExecutor(). If this ever
+        // changes, that guarantee silently breaks.
+        assertThat(executor.getCorePoolSize()).isEqualTo(1);
+        assertThat(executor.getMaxPoolSize()).isEqualTo(1);
+    }
+
+}


### PR DESCRIPTION
## Summary

Fixes five related reliability gaps in job dispatch that surface when running multiple executor replicas: jobs failing outright when the pool is temporarily busy, duplicate dispatch under overlapping schedule triggers, an unguarded single-job-per-pod invariant, unhandled Redis errors in the dispatch lock, and missing retry logic for ephemeral executors.

Looked into it more from the comment in https://github.com/terrakube-io/terrakube/pull/3353#issuecomment-5151762511 so expanded into fixing the reliability from the api for the executor

## Problem

With multiple executor replicas, a busy pod pulls itself out of the Service's endpoints while running a job. When every replica was busy, `send()` failed at the connection level — indistinguishable from a genuinely broken executor — so the job failed immediately instead of waiting for a replica to free up.

Fixing that retry path widened an existing race: two overlapping Quartz triggers (the 30s job-context trigger and the one-shot trigger fired on Job updates) could both pass the dispatch status check and send the same job twice. A wider retry window made this collision far more likely.

Investigating that race surfaced three further gaps in the same code path:

- The dispatch lock called Redis with no error handling, making Redis a hard dependency for a path that previously never touched it.
- The single-job-per-pod guarantee relied on an unset Spring default (`corePoolSize`), with no test protecting it from being changed later.
- Ephemeral executors had no retry path for transient failures at all, unlike the persistent pool.

## Solution

- **Retry on busy pool instead of failing** — added `ExecutorUnavailableException` for connection-level failures. The job's Quartz trigger stays alive instead of being descheduled, so the existing 30s retrigger picks it back up once a replica is free. Jobs now only fail outright on explicit executor rejection or after the 6-hour expiration window.
- **Prevent duplicate dispatch on overlapping triggers** — acquire a short-lived Redis lock before dispatching, release it after. A losing firing backs off without touching job status, consistent with the existing "workspace locked" / "waiting on previous job" handling.
- **Make single-job-per-pod explicit** — set `corePoolSize`/`maxPoolSize` to 1 explicitly on the async task executor with a comment explaining why, plus a test that fails if the pool size is ever changed.
- **Fail closed on Redis errors** — catch `DataAccessException` in `acquireDispatchLock`/`releaseDispatchLock` and treat it as losing the lock race: skip dispatch and retry next cycle. A duplicate `terraform apply` is worse than a job waiting out a Redis blip.
- **Retry ephemeral executors on capacity, fail fast on rejection** — classify `KubernetesClientException` by HTTP code: connection failures, 429, and 5xx retry via `ExecutorUnavailableException`. A 403 retries only when it's a ResourceQuota rejection (capacity, which clears on its own); RBAC denials and 400s stay fail-fast since retrying can't help.

## Testing

Each change ships with unit tests covering the new behavior: retry-vs-fail-fast classification for both persistent and ephemeral executors, duplicate-dispatch prevention under simulated overlapping triggers, Redis failure handling in the lock path, and a regression test pinning the executor pool size to 1. All 61 tests across `ScheduleJobTest`, `EphemeralExecutorServiceTest`, and `SpringAsyncAutoConfigurationTest` pass.

Also validated live against a 5-replica executor deployment on minikube:

- **Busy-pool retry**: scaled the executor to 0 replicas, submitted a job — got `Connection refused`, classified as `ExecutorUnavailableException`, job stayed `pending` with a `will retry` log instead of failing. Restored a replica and the job picked up on the next cycle and completed.
- **Duplicate-dispatch prevention**: forced overlapping Quartz firings by rapidly updating a job while it dispatched; watched raw Redis traffic and confirmed exactly one `SET ... NX EX 90` + `DEL` pair per dispatch, with zero duplicate sends across repeated bursts.
- **Single-job-per-pod**: with 1 replica, 4 jobs submitted simultaneously across 4 workspaces were serialized one at a time by the pod, never concurrently.
- **Redis fail-closed**: scaled Redis to 0 replicas, submitted a job — API logged `Could not reach Redis to acquire dispatch lock, will retry` and stayed up with zero restarts; job completed once Redis came back.
- **Load**: fired 20 concurrent job creations at the 5-replica pool. All dispatch attempts were accepted (HTTP 202), workspace-level queuing behaved as expected, and no API or executor pod restarted during the run.