### PR TITLE
feat(ui): replace run status/log polling with SSE and GraphQL subscriptions

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -110,6 +110,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-graphql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
@@ -163,6 +171,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/api/src/main/java/io/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/authentication/dex/DexWebSecurityAdapter.java
@@ -76,6 +76,10 @@ public class DexWebSecurityAdapter {
                                                         .requestMatchers("/remote/tfe/v2/plans/logs/**").permitAll()
                                                         .requestMatchers("/remote/tfe/v2/applies/logs/**").permitAll()
                                                         .requestMatchers("/app/*/*/runs/*").permitAll()
+                                                        // The WebSocket handshake itself carries no Authorization header - browsers can't set
+                                                        // custom headers on a WebSocket upgrade request. Auth happens over the GraphQL-WS
+                                                        // connection_init message instead, via AuthenticationWebSocketInterceptor.
+                                                        .requestMatchers("/subscriptions").permitAll()
                                         .requestMatchers("/tofu/index.json").permitAll()
                                         .requestMatchers("/terraform/index.json").permitAll()
                                         .anyRequest().authenticated();

--- a/api/src/main/java/io/terrakube/api/plugin/storage/controller/TerraformOutputController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/storage/controller/TerraformOutputController.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import io.terrakube.api.plugin.storage.StorageTypeService;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import io.terrakube.api.plugin.streaming.StreamingService;
 
 import java.nio.charset.StandardCharsets;
@@ -36,5 +37,15 @@ public class TerraformOutputController {
             return storageTypeService.getStepOutput(organizationId, jobId, stepId);
         }
 
+    }
+
+    @GetMapping(
+            value = "/organization/{organizationId}/job/{jobId}/step/{stepId}/stream",
+            produces = MediaType.TEXT_EVENT_STREAM_VALUE
+    )
+    public SseEmitter streamOutput(@PathVariable("organizationId") String organizationId, @PathVariable("jobId") String jobId, @PathVariable("stepId") String stepId) {
+        SseEmitter emitter = new SseEmitter(0L);
+        streamingService.streamStepLogsAsync(stepId, emitter);
+        return emitter;
     }
 }

--- a/api/src/main/java/io/terrakube/api/plugin/storage/controller/TerraformOutputController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/storage/controller/TerraformOutputController.java
@@ -2,7 +2,9 @@ package io.terrakube.api.plugin.storage.controller;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import io.terrakube.api.plugin.storage.StorageTypeService;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -28,7 +30,7 @@ public class TerraformOutputController {
     )
     public @ResponseBody byte[] getFile(@PathVariable("organizationId") String organizationId, @PathVariable("jobId") String jobId, @PathVariable("stepId") String stepId) {
         String tempLogs = streamingService.getCurrentLogs(stepId);
-        
+
         if (tempLogs.length() > 0) {
             log.info("Reading output from redis stream....");
             return tempLogs.getBytes(StandardCharsets.UTF_8);
@@ -43,9 +45,25 @@ public class TerraformOutputController {
             value = "/organization/{organizationId}/job/{jobId}/step/{stepId}/stream",
             produces = MediaType.TEXT_EVENT_STREAM_VALUE
     )
-    public SseEmitter streamOutput(@PathVariable("organizationId") String organizationId, @PathVariable("jobId") String jobId, @PathVariable("stepId") String stepId) {
+    public SseEmitter streamOutput(
+            @PathVariable("organizationId") String organizationId,
+            @PathVariable("jobId") String jobId,
+            @PathVariable("stepId") String stepId,
+            @RequestHeader(value = "Last-Event-ID", required = false) String lastEventId) {
         SseEmitter emitter = new SseEmitter(0L);
-        streamingService.streamStepLogsAsync(stepId, emitter);
+        streamingService.streamStepLogsAsync(stepId, emitter, parseResumeId(lastEventId));
         return emitter;
+    }
+
+    private RecordId parseResumeId(String lastEventId) {
+        if (!StringUtils.hasText(lastEventId)) {
+            return RecordId.of("0-0");
+        }
+        try {
+            return RecordId.of(lastEventId);
+        } catch (IllegalArgumentException e) {
+            log.warn("Ignoring unparseable Last-Event-ID '{}': {}", lastEventId, e.getMessage());
+            return RecordId.of("0-0");
+        }
     }
 }

--- a/api/src/main/java/io/terrakube/api/plugin/streaming/RedisStreamReader.java
+++ b/api/src/main/java/io/terrakube/api/plugin/streaming/RedisStreamReader.java
@@ -1,0 +1,31 @@
+package io.terrakube.api.plugin.streaming;
+
+import lombok.AllArgsConstructor;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@AllArgsConstructor
+public class RedisStreamReader {
+
+    RedisTemplate redisTemplate;
+
+    @SuppressWarnings("unchecked")
+    public List<MapRecord> readAfter(String streamKey, RecordId lastId, Duration blockDuration) {
+        StreamOffset<String> offset = StreamOffset.create(streamKey, ReadOffset.from(lastId));
+        StreamReadOptions options = StreamReadOptions.empty().count(100).block(blockDuration);
+
+        List<MapRecord> records = redisTemplate.opsForStream().read(options, offset);
+
+        return records == null ? Collections.emptyList() : records;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/streaming/StreamingService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/streaming/StreamingService.java
@@ -4,12 +4,16 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.stream.*;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import io.terrakube.api.repository.StepRepository;
 import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.job.step.Step;
 import org.apache.commons.text.TextStringBuilder;
 
+import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 
@@ -21,6 +25,8 @@ public class StreamingService {
     RedisTemplate redisTemplate;
 
     StepRepository stepRepository;
+
+    RedisStreamReader redisStreamReader;
 
     public String getCurrentLogs(String stepId){
         TextStringBuilder currentLogs = new TextStringBuilder();
@@ -40,5 +46,56 @@ public class StreamingService {
 
         }
         return currentLogs.toString();
+    }
+
+    @Async
+    public void streamStepLogsAsync(String stepId, SseEmitter emitter) {
+        streamStepLogs(stepId, emitter);
+    }
+
+    public void streamStepLogs(String stepId, SseEmitter emitter) {
+        try {
+            UUID id = UUID.fromString(stepId);
+            // findById (not getReferenceById) because this loop runs on a separate @Async thread with no
+            // active Hibernate session - a lazy getReferenceById proxy would throw LazyInitializationException
+            // the moment any field (including the eagerly-mapped job association) is accessed here.
+            Step step = stepRepository.findById(id).orElseThrow();
+            String jobId = String.valueOf(step.getJob().getId());
+            RecordId lastId = RecordId.of("0-0");
+            int emptyReads = 0;
+
+            while (true) {
+                List<MapRecord> records = redisStreamReader.readAfter(jobId, lastId, Duration.ofSeconds(2));
+
+                if (records.isEmpty()) {
+                    emptyReads++;
+                    step = stepRepository.findById(id).orElseThrow();
+                    if (isTerminal(step.getStatus())) {
+                        emitter.complete();
+                        return;
+                    }
+                    if (emptyReads % 8 == 0) {
+                        emitter.send(SseEmitter.event().comment("heartbeat"));
+                    }
+                    continue;
+                }
+
+                emptyReads = 0;
+                for (MapRecord record : records) {
+                    lastId = record.getId();
+                    StringRecord stringRecord = StringRecord.of(record);
+                    emitter.send(stringRecord.getValue().get("output"));
+                }
+            }
+        } catch (IOException e) {
+            log.info("SSE client disconnected for step {}", stepId);
+        } catch (Exception e) {
+            log.error("Error streaming logs for step {}: {}", stepId, e.getMessage());
+            emitter.completeWithError(e);
+        }
+    }
+
+    private boolean isTerminal(JobStatus status) {
+        return status == JobStatus.completed || status == JobStatus.failed || status == JobStatus.cancelled;
     }
 }

--- a/api/src/main/java/io/terrakube/api/plugin/streaming/StreamingService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/streaming/StreamingService.java
@@ -49,11 +49,11 @@ public class StreamingService {
     }
 
     @Async
-    public void streamStepLogsAsync(String stepId, SseEmitter emitter) {
-        streamStepLogs(stepId, emitter);
+    public void streamStepLogsAsync(String stepId, SseEmitter emitter, RecordId resumeFrom) {
+        streamStepLogs(stepId, emitter, resumeFrom);
     }
 
-    public void streamStepLogs(String stepId, SseEmitter emitter) {
+    public void streamStepLogs(String stepId, SseEmitter emitter, RecordId resumeFrom) {
         try {
             UUID id = UUID.fromString(stepId);
             // findById (not getReferenceById) because this loop runs on a separate @Async thread with no
@@ -61,7 +61,7 @@ public class StreamingService {
             // the moment any field (including the eagerly-mapped job association) is accessed here.
             Step step = stepRepository.findById(id).orElseThrow();
             String jobId = String.valueOf(step.getJob().getId());
-            RecordId lastId = RecordId.of("0-0");
+            RecordId lastId = resumeFrom;
             int emptyReads = 0;
 
             while (true) {
@@ -84,7 +84,7 @@ public class StreamingService {
                 for (MapRecord record : records) {
                     lastId = record.getId();
                     StringRecord stringRecord = StringRecord.of(record);
-                    emitter.send(stringRecord.getValue().get("output"));
+                    emitter.send(SseEmitter.event().id(lastId.getValue()).data(stringRecord.getValue().get("output")));
                 }
             }
         } catch (IOException e) {

--- a/api/src/main/java/io/terrakube/api/plugin/subscription/JobStatusEvent.java
+++ b/api/src/main/java/io/terrakube/api/plugin/subscription/JobStatusEvent.java
@@ -1,0 +1,4 @@
+package io.terrakube.api.plugin.subscription;
+
+public record JobStatusEvent(int jobId, String workspaceId, String status) {
+}

--- a/api/src/main/java/io/terrakube/api/plugin/subscription/JobStatusPublisher.java
+++ b/api/src/main/java/io/terrakube/api/plugin/subscription/JobStatusPublisher.java
@@ -1,0 +1,33 @@
+package io.terrakube.api.plugin.subscription;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+@Slf4j
+public class JobStatusPublisher {
+
+    RedisTemplate<String, JobStatusEvent> jobStatusRedisTemplate;
+
+    // Publishing this event is a best-effort UI nicety (live status updates) - a Redis blip here must never
+    // fail the job create/update transaction this is called from inside JobManageHook's POSTCOMMIT hook.
+    public void publish(JobStatusEvent event, String organizationId) {
+        try {
+            jobStatusRedisTemplate.convertAndSend(channelFor(event.workspaceId()), event);
+            jobStatusRedisTemplate.convertAndSend(organizationChannelFor(organizationId), event);
+        } catch (Exception e) {
+            log.error("Failed to publish job status event {}: {}", event, e.getMessage());
+        }
+    }
+
+    public static String channelFor(String workspaceId) {
+        return "job-status:" + workspaceId;
+    }
+
+    public static String organizationChannelFor(String organizationId) {
+        return "org-job-status:" + organizationId;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/subscription/JobStatusSubscriptionResolver.java
+++ b/api/src/main/java/io/terrakube/api/plugin/subscription/JobStatusSubscriptionResolver.java
@@ -1,0 +1,88 @@
+package io.terrakube.api.plugin.subscription;
+
+import com.yahoo.elide.core.security.User;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.team.Team;
+import io.terrakube.api.rs.workspace.Workspace;
+import lombok.AllArgsConstructor;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.SubscriptionMapping;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import reactor.core.publisher.Flux;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.UUID;
+
+@Controller
+@AllArgsConstructor
+public class JobStatusSubscriptionResolver {
+
+    RedisMessageListenerContainer redisMessageListenerContainer;
+    RedisSerializer<JobStatusEvent> jobStatusEventSerializer;
+    WorkspaceRepository workspaceRepository;
+    OrganizationRepository organizationRepository;
+    MembershipService membershipService;
+    AuthenticatedUser authenticatedUser;
+
+    @SubscriptionMapping
+    public Flux<JobStatusEvent> jobStatusChanged(@Argument String workspaceId, Authentication authentication) {
+        return jobStatusChanged(workspaceId, new User((Principal) authentication));
+    }
+
+    @SubscriptionMapping
+    public Flux<JobStatusEvent> organizationJobStatusChanged(@Argument String organizationId, Authentication authentication) {
+        return organizationJobStatusChanged(organizationId, new User((Principal) authentication));
+    }
+
+    Flux<JobStatusEvent> jobStatusChanged(String workspaceId, User user) {
+        Workspace workspace = workspaceRepository.findById(UUID.fromString(workspaceId)).orElse(null);
+        if (workspace == null) {
+            return Flux.error(new SecurityException("Workspace not found"));
+        }
+
+        if (!isAuthorized(user, workspace.getOrganization().getTeam())) {
+            return Flux.error(new SecurityException("Not authorized to view this workspace"));
+        }
+
+        return listenOn(JobStatusPublisher.channelFor(workspaceId));
+    }
+
+    Flux<JobStatusEvent> organizationJobStatusChanged(String organizationId, User user) {
+        Organization organization = organizationRepository.findById(UUID.fromString(organizationId)).orElse(null);
+        if (organization == null) {
+            return Flux.error(new SecurityException("Organization not found"));
+        }
+
+        if (!isAuthorized(user, organization.getTeam())) {
+            return Flux.error(new SecurityException("Not authorized to view this organization"));
+        }
+
+        return listenOn(JobStatusPublisher.organizationChannelFor(organizationId));
+    }
+
+    private boolean isAuthorized(User user, List<Team> teams) {
+        return authenticatedUser.isSuperUser(user) || membershipService.checkMembership(user, teams);
+    }
+
+    private Flux<JobStatusEvent> listenOn(String channel) {
+        ChannelTopic topic = new ChannelTopic(channel);
+
+        return Flux.create(sink -> {
+            MessageListener listener = (message, pattern) ->
+                    sink.next(jobStatusEventSerializer.deserialize(message.getBody()));
+
+            redisMessageListenerContainer.addMessageListener(listener, topic);
+            sink.onDispose(() -> redisMessageListenerContainer.removeMessageListener(listener, topic));
+        });
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/subscription/SubscriptionRedisConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/subscription/SubscriptionRedisConfiguration.java
@@ -1,0 +1,36 @@
+package io.terrakube.api.plugin.subscription;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class SubscriptionRedisConfiguration {
+
+    @Bean
+    public RedisSerializer<JobStatusEvent> jobStatusEventSerializer() {
+        return new Jackson2JsonRedisSerializer<>(JobStatusEvent.class);
+    }
+
+    @Bean
+    public RedisTemplate<String, JobStatusEvent> jobStatusRedisTemplate(
+            RedisConnectionFactory connectionFactory, RedisSerializer<JobStatusEvent> jobStatusEventSerializer) {
+        RedisTemplate<String, JobStatusEvent> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(jobStatusEventSerializer);
+        return template;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer jobStatusRedisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/subscription/SubscriptionWebSocketConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/subscription/SubscriptionWebSocketConfiguration.java
@@ -1,0 +1,61 @@
+package io.terrakube.api.plugin.subscription;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.graphql.server.WebSocketGraphQlInterceptor;
+import org.springframework.graphql.server.support.BearerTokenAuthenticationExtractor;
+import org.springframework.graphql.server.webmvc.AuthenticationWebSocketInterceptor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
+
+@Configuration
+public class SubscriptionWebSocketConfiguration {
+
+    @Bean
+    public WebSocketGraphQlInterceptor authenticationWebSocketInterceptor(
+            @Value("${io.terrakube.token.issuer-uri}") String dexIssuerUri) {
+        AuthenticationManager authenticationManager =
+                new ProviderManager(new JwtAuthenticationProvider(new LazyIssuerJwtDecoder(dexIssuerUri)));
+        return new AuthenticationWebSocketInterceptor(new BearerTokenAuthenticationExtractor(), authenticationManager);
+    }
+
+    /**
+     * Defers the OIDC discovery fetch (JwtDecoders.fromIssuerLocation makes an HTTP call the first time
+     * it's used) until a WebSocket connection actually needs to authenticate. Spring for GraphQL's
+     * auto-configuration collects every WebSocketGraphQlInterceptor bean into a list at application startup,
+     * which forces eager instantiation of the interceptor/AuthenticationManager regardless of {@code @Lazy}
+     * on the bean method - so the laziness has to live inside the JwtDecoder itself instead. Matches
+     * DexAuthenticationManagerResolver's existing per-request (not eager) resolution: a transient Dex
+     * outage shouldn't be able to prevent the whole app from starting.
+     */
+    private static final class LazyIssuerJwtDecoder implements JwtDecoder {
+
+        private final String issuerUri;
+        private volatile JwtDecoder delegate;
+
+        private LazyIssuerJwtDecoder(String issuerUri) {
+            this.issuerUri = issuerUri;
+        }
+
+        @Override
+        public Jwt decode(String token) throws JwtException {
+            JwtDecoder resolved = delegate;
+            if (resolved == null) {
+                synchronized (this) {
+                    resolved = delegate;
+                    if (resolved == null) {
+                        resolved = JwtDecoders.fromIssuerLocation(issuerUri);
+                        delegate = resolved;
+                    }
+                }
+            }
+            return resolved.decode(token);
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/hooks/job/JobManageHook.java
+++ b/api/src/main/java/io/terrakube/api/rs/hooks/job/JobManageHook.java
@@ -4,6 +4,8 @@ import com.yahoo.elide.annotation.LifeCycleHookBinding;
 import com.yahoo.elide.core.lifecycle.LifeCycleHook;
 import com.yahoo.elide.core.security.ChangeSpec;
 import com.yahoo.elide.core.security.RequestScope;
+import io.terrakube.api.plugin.subscription.JobStatusEvent;
+import io.terrakube.api.plugin.subscription.JobStatusPublisher;
 import io.terrakube.api.repository.WorkspaceRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +24,7 @@ public class JobManageHook implements LifeCycleHook<Job> {
 
     private ScheduleJobService scheduleJobService;
     private WorkspaceRepository workspaceRepository;
+    private JobStatusPublisher jobStatusPublisher;
 
     @Override
     public void execute(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase transactionPhase, Job job, RequestScope requestScope, Optional<ChangeSpec> optional) {
@@ -31,6 +34,7 @@ public class JobManageHook implements LifeCycleHook<Job> {
                 case CREATE:
                     updateWorkspaceStatus(job);
                     scheduleJobService.createJobContext(job);
+                    publishStatus(job);
                     break;
                 case UPDATE:
                     updateWorkspaceStatus(job);
@@ -44,6 +48,7 @@ public class JobManageHook implements LifeCycleHook<Job> {
                             log.warn("Skip new quartz job");
                         }
                     }
+                    publishStatus(job);
                     break;
                 default:
                     log.info("Not supported {}", operation);
@@ -53,6 +58,12 @@ public class JobManageHook implements LifeCycleHook<Job> {
         } catch (ParseException | SchedulerException e) {
             log.error(e.getMessage());
         }
+    }
+
+    private void publishStatus(Job job) {
+        jobStatusPublisher.publish(
+                new JobStatusEvent(job.getId(), job.getWorkspace().getId().toString(), job.getStatus().name()),
+                job.getOrganization().getId().toString());
     }
 
     private void updateWorkspaceStatus(Job job) {

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -174,6 +174,13 @@ io.terrakube.token.internal=${InternalSecret}
 io.terrakube.token.issuer-uri=${DexIssuerUri}
 #spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${DexJwtSetUri}
 
+##############################
+# GRAPHQL SUBSCRIPTIONS (WS) #
+##############################
+spring.graphql.websocket.path=/subscriptions
+spring.graphql.cors.allowed-origins=${io.terrakube.ui.url}
+spring.graphql.cors.allow-credentials=true
+
 ######################
 # Terraform Releases #
 ######################

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -1,3 +1,8 @@
+############
+#THREADING#
+############
+spring.threads.virtual.enabled=true
+
 ##############
 #H2/JPA SETUP#
 ##############

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -176,6 +176,16 @@ io.terrakube.token.issuer-uri=${DexIssuerUri}
 io.terrakube.token.client-id=${DexClientId}
 #spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${DexJwtSetUri}
 
+##############################
+# GRAPHQL SUBSCRIPTIONS (WS) #
+##############################
+spring.graphql.websocket.path=/subscriptions
+# Spring Boot's GraphQL endpoints (HTTP + WebSocket) have their own CORS config, entirely separate from
+# the CorsConfigurationSource bean Spring Security uses for every other endpoint - without this, cross-origin
+# requests to /subscriptions are silently rejected with 403 regardless of the security filter chain's permitAll.
+spring.graphql.cors.allowed-origins=${io.terrakube.ui.url}
+spring.graphql.cors.allow-credentials=true
+
 ######################
 # Terraform Releases #
 ######################

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,3 +1,8 @@
+############
+#THREADING#
+############
+spring.threads.virtual.enabled=true
+
 ##############
 #H2/JPA SETUP#
 ##############

--- a/api/src/main/resources/graphql/subscriptions.graphqls
+++ b/api/src/main/resources/graphql/subscriptions.graphqls
@@ -1,0 +1,17 @@
+type Query {
+    # GraphQL requires a Query root type to exist even though this schema is subscription-only -
+    # this app's regular reads/writes go through Elide's separate GraphQL endpoint (/graphql/api/v1),
+    # not this one, so nothing here is ever expected to actually call this field.
+    _empty: Boolean
+}
+
+type Subscription {
+    jobStatusChanged(workspaceId: ID!): JobStatusEvent!
+    organizationJobStatusChanged(organizationId: ID!): JobStatusEvent!
+}
+
+type JobStatusEvent {
+    jobId: Int!
+    workspaceId: ID!
+    status: String!
+}

--- a/api/src/test/java/io/terrakube/api/LocalStorageTests.java
+++ b/api/src/test/java/io/terrakube/api/LocalStorageTests.java
@@ -148,4 +148,21 @@ public class LocalStorageTests extends ServerApplicationTests {
 
     }
 
+    @Test
+    void streamEndpointConnectsAndClosesCleanlyForUnknownStep() {
+        // Nonexistent step id -> EntityNotFoundException on first Redis/DB access, caught by
+        // StreamingService.streamStepLogs and surfaced as emitter.completeWithError before any bytes are
+        // flushed, so Spring falls back to its default 500 JSON error body instead of text/event-stream.
+        // This smoke test only cares that the request returns promptly (doesn't hang) rather than what's in it.
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .get("/tfoutput/v1/organization/3/job/3/step/11111111-1111-1111-1111-111111111111/stream")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+
 }

--- a/api/src/test/java/io/terrakube/api/LocalStorageTests.java
+++ b/api/src/test/java/io/terrakube/api/LocalStorageTests.java
@@ -165,4 +165,20 @@ public class LocalStorageTests extends ServerApplicationTests {
                 .statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value());
     }
 
+    @Test
+    void streamEndpointAcceptsLastEventIdHeader() {
+        // Same nonexistent-step path as streamEndpointConnectsAndClosesCleanlyForUnknownStep, just confirming
+        // the endpoint still accepts a Last-Event-ID header without erroring on the header parsing itself
+        // (the 500 comes from the unknown step id, not from the header).
+        given()
+                .headers(
+                        "Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"),
+                        "Last-Event-ID", "100-0")
+                .when()
+                .get("/tfoutput/v1/organization/3/job/3/step/11111111-1111-1111-1111-111111111111/stream")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+
 }

--- a/api/src/test/java/io/terrakube/api/SubscriptionWebSocketTests.java
+++ b/api/src/test/java/io/terrakube/api/SubscriptionWebSocketTests.java
@@ -1,0 +1,16 @@
+package io.terrakube.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SubscriptionWebSocketTests extends ServerApplicationTests {
+
+    @Test
+    void applicationContextLoadsWithGraphQlWebSocketConfigured() {
+        // If SubscriptionWebSocketConfiguration's bean definition is broken (wrong constructor args,
+        // missing property), the whole Spring context fails to start and every test in this class fails -
+        // this is a deliberate smoke test for that, not a behavioral test of the interceptor itself.
+        assertThat(port).isGreaterThan(0);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/streaming/RedisStreamReaderTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/streaming/RedisStreamReaderTest.java
@@ -1,0 +1,55 @@
+package io.terrakube.api.plugin.streaming;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StreamOperations;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RedisStreamReaderTest {
+
+    @Mock
+    RedisTemplate redisTemplate;
+
+    @Mock
+    StreamOperations streamOperations;
+
+    @Test
+    void returnsRecordsFromRedis() {
+        MapRecord record = MapRecord.create("42", Collections.singletonMap("output", "line 1"));
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.read(any(StreamReadOptions.class), any(StreamOffset.class)))
+                .thenReturn(List.of(record));
+
+        RedisStreamReader reader = new RedisStreamReader(redisTemplate);
+        List<MapRecord> result = reader.readAfter("42", RecordId.of("0-0"), Duration.ofSeconds(2));
+
+        assertThat(result).containsExactly(record);
+    }
+
+    @Test
+    void returnsEmptyListWhenRedisReturnsNull() {
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.read(any(StreamReadOptions.class), any(StreamOffset.class)))
+                .thenReturn(null);
+
+        RedisStreamReader reader = new RedisStreamReader(redisTemplate);
+        List<MapRecord> result = reader.readAfter("42", RecordId.of("0-0"), Duration.ofSeconds(2));
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/streaming/StreamingServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/streaming/StreamingServiceTest.java
@@ -1,0 +1,77 @@
+package io.terrakube.api.plugin.streaming;
+
+import io.terrakube.api.repository.StepRepository;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.step.Step;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StreamingServiceTest {
+
+    @Mock
+    StepRepository stepRepository;
+
+    @Mock
+    RedisStreamReader redisStreamReader;
+
+    @Test
+    @Timeout(5)
+    void streamsNewRecordsThenCompletesWhenStepIsTerminal() throws Exception {
+        UUID stepId = UUID.randomUUID();
+        Job job = new Job();
+        job.setId(42);
+
+        Step runningStep = new Step();
+        runningStep.setId(stepId);
+        runningStep.setJob(job);
+        runningStep.setStatus(JobStatus.running);
+
+        Step completedStep = new Step();
+        completedStep.setId(stepId);
+        completedStep.setJob(job);
+        completedStep.setStatus(JobStatus.completed);
+
+        when(stepRepository.findById(stepId))
+                .thenReturn(Optional.of(runningStep))
+                .thenReturn(Optional.of(completedStep));
+
+        MapRecord record = MapRecord.create("42", Map.of("output", "line 1"));
+        when(redisStreamReader.readAfter(eq("42"), any(RecordId.class), any(Duration.class)))
+                .thenReturn(List.of(record))
+                .thenReturn(Collections.emptyList());
+
+        List<String> sentPayloads = new ArrayList<>();
+        SseEmitter emitter = new SseEmitter(0L) {
+            @Override
+            public void send(Object object) {
+                sentPayloads.add(String.valueOf(object));
+            }
+        };
+
+        StreamingService streamingService = new StreamingService(null, stepRepository, redisStreamReader);
+        streamingService.streamStepLogs(stepId.toString(), emitter);
+
+        assertThat(sentPayloads).containsExactly("line 1");
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/streaming/StreamingServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/streaming/StreamingServiceTest.java
@@ -14,16 +14,15 @@ import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,7 +36,30 @@ class StreamingServiceTest {
 
     @Test
     @Timeout(5)
-    void streamsNewRecordsThenCompletesWhenStepIsTerminal() throws Exception {
+    void startsReadingFromTheProvidedResumeId() throws Exception {
+        UUID stepId = UUID.randomUUID();
+        Job job = new Job();
+        job.setId(42);
+
+        Step completedStep = new Step();
+        completedStep.setId(stepId);
+        completedStep.setJob(job);
+        completedStep.setStatus(JobStatus.completed);
+
+        when(stepRepository.findById(stepId)).thenReturn(Optional.of(completedStep));
+        when(redisStreamReader.readAfter(eq("42"), eq(RecordId.of("100-0")), any(Duration.class)))
+                .thenReturn(Collections.emptyList());
+
+        SseEmitter emitter = new SseEmitter(0L);
+        StreamingService streamingService = new StreamingService(null, stepRepository, redisStreamReader);
+        streamingService.streamStepLogs(stepId.toString(), emitter, RecordId.of("100-0"));
+
+        verify(redisStreamReader).readAfter(eq("42"), eq(RecordId.of("100-0")), any(Duration.class));
+    }
+
+    @Test
+    @Timeout(5)
+    void nextReadStartsAfterTheLastRecordIdReceived() throws Exception {
         UUID stepId = UUID.randomUUID();
         Job job = new Job();
         job.setId(42);
@@ -56,22 +78,20 @@ class StreamingServiceTest {
                 .thenReturn(Optional.of(runningStep))
                 .thenReturn(Optional.of(completedStep));
 
-        MapRecord record = MapRecord.create("42", Map.of("output", "line 1"));
-        when(redisStreamReader.readAfter(eq("42"), any(RecordId.class), any(Duration.class)))
-                .thenReturn(List.of(record))
+        MapRecord record = MapRecord.create("42", Map.of("output", "line 1")).withId(RecordId.of("100-0"));
+        when(redisStreamReader.readAfter(eq("42"), eq(RecordId.of("0-0")), any(Duration.class)))
+                .thenReturn(List.of(record));
+        when(redisStreamReader.readAfter(eq("42"), eq(RecordId.of("100-0")), any(Duration.class)))
                 .thenReturn(Collections.emptyList());
 
-        List<String> sentPayloads = new ArrayList<>();
-        SseEmitter emitter = new SseEmitter(0L) {
-            @Override
-            public void send(Object object) {
-                sentPayloads.add(String.valueOf(object));
-            }
-        };
-
+        SseEmitter emitter = new SseEmitter(0L);
         StreamingService streamingService = new StreamingService(null, stepRepository, redisStreamReader);
-        streamingService.streamStepLogs(stepId.toString(), emitter);
+        streamingService.streamStepLogs(stepId.toString(), emitter, RecordId.of("0-0"));
 
-        assertThat(sentPayloads).containsExactly("line 1");
+        // Proves the loop advances lastId to the id of the record it just processed - the same value used
+        // both for the next Redis read and for the "id:" field sent to the client (SseEmitter internals make
+        // the latter unobservable from a unit test: SseEmitter.send(SseEventBuilder) calls
+        // super.send(Set<DataWithMediaType>) via invokespecial, which bypasses any subclass override).
+        verify(redisStreamReader).readAfter(eq("42"), eq(RecordId.of("100-0")), any(Duration.class));
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/subscription/JobStatusPublisherTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/subscription/JobStatusPublisherTest.java
@@ -1,0 +1,61 @@
+package io.terrakube.api.plugin.subscription;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class JobStatusPublisherTest {
+
+    @Mock
+    RedisTemplate<String, JobStatusEvent> jobStatusRedisTemplate;
+
+    @Test
+    void publishesToTheWorkspaceScopedChannel() {
+        JobStatusPublisher publisher = new JobStatusPublisher(jobStatusRedisTemplate);
+        JobStatusEvent event = new JobStatusEvent(42, "workspace-1", "running");
+
+        publisher.publish(event, "org-1");
+
+        verify(jobStatusRedisTemplate).convertAndSend("job-status:workspace-1", event);
+    }
+
+    @Test
+    void publishesToTheOrganizationScopedChannel() {
+        JobStatusPublisher publisher = new JobStatusPublisher(jobStatusRedisTemplate);
+        JobStatusEvent event = new JobStatusEvent(42, "workspace-1", "running");
+
+        publisher.publish(event, "org-1");
+
+        verify(jobStatusRedisTemplate).convertAndSend("org-job-status:org-1", event);
+    }
+
+    @Test
+    void channelForIncludesTheWorkspaceId() {
+        assertThat(JobStatusPublisher.channelFor("workspace-1")).isEqualTo("job-status:workspace-1");
+    }
+
+    @Test
+    void organizationChannelForIncludesTheOrganizationId() {
+        assertThat(JobStatusPublisher.organizationChannelFor("org-1")).isEqualTo("org-job-status:org-1");
+    }
+
+    @Test
+    void doesNotPropagateWhenRedisIsUnavailable() {
+        doThrow(new RedisConnectionFailureException("no connection"))
+                .when(jobStatusRedisTemplate).convertAndSend("job-status:workspace-1", new JobStatusEvent(42, "workspace-1", "running"));
+
+        JobStatusPublisher publisher = new JobStatusPublisher(jobStatusRedisTemplate);
+
+        assertThatCode(() -> publisher.publish(new JobStatusEvent(42, "workspace-1", "running"), "org-1"))
+                .doesNotThrowAnyException();
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/subscription/JobStatusSubscriptionResolverTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/subscription/JobStatusSubscriptionResolverTest.java
@@ -1,0 +1,172 @@
+package io.terrakube.api.plugin.subscription;
+
+import com.yahoo.elide.core.security.User;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.team.Team;
+import io.terrakube.api.rs.workspace.Workspace;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.DefaultMessage;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JobStatusSubscriptionResolverTest {
+
+    @Mock
+    RedisMessageListenerContainer redisMessageListenerContainer;
+
+    @Mock
+    WorkspaceRepository workspaceRepository;
+
+    @Mock
+    OrganizationRepository organizationRepository;
+
+    @Mock
+    MembershipService membershipService;
+
+    @Mock
+    AuthenticatedUser authenticatedUser;
+
+    @Mock
+    JwtAuthenticationToken principal;
+
+    RedisSerializer<JobStatusEvent> serializer = new Jackson2JsonRedisSerializer<>(JobStatusEvent.class);
+
+    @Test
+    void rejectsWhenUserLacksWorkspaceAccess() {
+        UUID workspaceId = UUID.randomUUID();
+        Workspace workspace = new Workspace();
+        workspace.setId(workspaceId);
+        Organization organization = new Organization();
+        organization.setTeam(Collections.emptyList());
+        workspace.setOrganization(organization);
+
+        when(workspaceRepository.findById(workspaceId)).thenReturn(Optional.of(workspace));
+        User user = new User(principal);
+        when(authenticatedUser.isSuperUser(user)).thenReturn(false);
+        when(membershipService.checkMembership(eq(user), any())).thenReturn(false);
+
+        JobStatusSubscriptionResolver resolver = new JobStatusSubscriptionResolver(
+                redisMessageListenerContainer, serializer, workspaceRepository, organizationRepository, membershipService, authenticatedUser);
+
+        StepVerifier.create(resolver.jobStatusChanged(workspaceId.toString(), user))
+                .expectErrorMatches(error -> error instanceof SecurityException)
+                .verify(Duration.ofSeconds(2));
+
+        verify(redisMessageListenerContainer, never()).addMessageListener(any(), any(ChannelTopic.class));
+    }
+
+    @Test
+    void emitsDecodedEventsForAnAuthorizedUserAndUnsubscribesOnCancel() {
+        UUID workspaceId = UUID.randomUUID();
+        Workspace workspace = new Workspace();
+        workspace.setId(workspaceId);
+        Organization organization = new Organization();
+        Team team = new Team();
+        team.setName("developers");
+        organization.setTeam(List.of(team));
+        workspace.setOrganization(organization);
+
+        when(workspaceRepository.findById(workspaceId)).thenReturn(Optional.of(workspace));
+        User user = new User(principal);
+        when(authenticatedUser.isSuperUser(user)).thenReturn(false);
+        when(membershipService.checkMembership(eq(user), eq(List.of(team)))).thenReturn(true);
+
+        JobStatusSubscriptionResolver resolver = new JobStatusSubscriptionResolver(
+                redisMessageListenerContainer, serializer, workspaceRepository, organizationRepository, membershipService, authenticatedUser);
+
+        Flux<JobStatusEvent> flux = resolver.jobStatusChanged(workspaceId.toString(), user);
+
+        ArgumentCaptor<MessageListener> listenerCaptor = ArgumentCaptor.forClass(MessageListener.class);
+
+        StepVerifier.create(flux)
+                .then(() -> {
+                    verify(redisMessageListenerContainer).addMessageListener(listenerCaptor.capture(), eq(new ChannelTopic("job-status:" + workspaceId)));
+                    JobStatusEvent event = new JobStatusEvent(42, workspaceId.toString(), "running");
+                    byte[] body = serializer.serialize(event);
+                    listenerCaptor.getValue().onMessage(new DefaultMessage(("job-status:" + workspaceId).getBytes(), body), null);
+                })
+                .expectNext(new JobStatusEvent(42, workspaceId.toString(), "running"))
+                .thenCancel()
+                .verify(Duration.ofSeconds(2));
+
+        verify(redisMessageListenerContainer).removeMessageListener(any(MessageListener.class), eq(new ChannelTopic("job-status:" + workspaceId)));
+    }
+
+    @Test
+    void rejectsOrganizationSubscriptionWhenUserLacksAccess() {
+        UUID organizationId = UUID.randomUUID();
+        Organization organization = new Organization();
+        organization.setId(organizationId);
+        organization.setTeam(Collections.emptyList());
+
+        when(organizationRepository.findById(organizationId)).thenReturn(Optional.of(organization));
+        User user = new User(principal);
+        when(authenticatedUser.isSuperUser(user)).thenReturn(false);
+        when(membershipService.checkMembership(eq(user), any())).thenReturn(false);
+
+        JobStatusSubscriptionResolver resolver = new JobStatusSubscriptionResolver(
+                redisMessageListenerContainer, serializer, workspaceRepository, organizationRepository, membershipService, authenticatedUser);
+
+        StepVerifier.create(resolver.organizationJobStatusChanged(organizationId.toString(), user))
+                .expectErrorMatches(error -> error instanceof SecurityException)
+                .verify(Duration.ofSeconds(2));
+    }
+
+    @Test
+    void emitsOrganizationScopedEventsForAnAuthorizedUser() {
+        UUID organizationId = UUID.randomUUID();
+        Organization organization = new Organization();
+        organization.setId(organizationId);
+        Team team = new Team();
+        team.setName("developers");
+        organization.setTeam(List.of(team));
+
+        when(organizationRepository.findById(organizationId)).thenReturn(Optional.of(organization));
+        User user = new User(principal);
+        when(authenticatedUser.isSuperUser(user)).thenReturn(false);
+        when(membershipService.checkMembership(eq(user), eq(List.of(team)))).thenReturn(true);
+
+        JobStatusSubscriptionResolver resolver = new JobStatusSubscriptionResolver(
+                redisMessageListenerContainer, serializer, workspaceRepository, organizationRepository, membershipService, authenticatedUser);
+
+        Flux<JobStatusEvent> flux = resolver.organizationJobStatusChanged(organizationId.toString(), user);
+
+        ArgumentCaptor<MessageListener> listenerCaptor = ArgumentCaptor.forClass(MessageListener.class);
+
+        StepVerifier.create(flux)
+                .then(() -> {
+                    verify(redisMessageListenerContainer).addMessageListener(listenerCaptor.capture(), eq(new ChannelTopic("org-job-status:" + organizationId)));
+                    JobStatusEvent event = new JobStatusEvent(42, "workspace-1", "running");
+                    byte[] body = serializer.serialize(event);
+                    listenerCaptor.getValue().onMessage(new DefaultMessage(("org-job-status:" + organizationId).getBytes(), body), null);
+                })
+                .expectNext(new JobStatusEvent(42, "workspace-1", "running"))
+                .thenCancel()
+                .verify(Duration.ofSeconds(2));
+    }
+}

--- a/api/src/test/java/io/terrakube/api/rs/hooks/job/JobManageHookTest.java
+++ b/api/src/test/java/io/terrakube/api/rs/hooks/job/JobManageHookTest.java
@@ -1,0 +1,79 @@
+package io.terrakube.api.rs.hooks.job;
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
+import io.terrakube.api.plugin.scheduler.ScheduleJobService;
+import io.terrakube.api.plugin.subscription.JobStatusEvent;
+import io.terrakube.api.plugin.subscription.JobStatusPublisher;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.workspace.Workspace;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class JobManageHookTest {
+
+    @Mock
+    ScheduleJobService scheduleJobService;
+
+    @Mock
+    WorkspaceRepository workspaceRepository;
+
+    @Mock
+    JobStatusPublisher jobStatusPublisher;
+
+    @Test
+    void publishesOnUpdate() throws Exception {
+        UUID workspaceId = UUID.randomUUID();
+        Workspace workspace = new Workspace();
+        workspace.setId(workspaceId);
+        workspace.setOrganization(new Organization());
+
+        UUID organizationId = UUID.randomUUID();
+        Organization organization = new Organization();
+        organization.setId(organizationId);
+
+        Job job = new Job();
+        job.setId(42);
+        job.setWorkspace(workspace);
+        job.setOrganization(organization);
+        job.setStatus(JobStatus.running);
+
+        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher);
+        hook.execute(LifeCycleHookBinding.Operation.UPDATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, job, null, Optional.empty());
+
+        verify(jobStatusPublisher).publish(new JobStatusEvent(42, workspaceId.toString(), "running"), organizationId.toString());
+    }
+
+    @Test
+    void publishesOnCreate() throws Exception {
+        UUID workspaceId = UUID.randomUUID();
+        Workspace workspace = new Workspace();
+        workspace.setId(workspaceId);
+        workspace.setOrganization(new Organization());
+
+        UUID organizationId = UUID.randomUUID();
+        Organization organization = new Organization();
+        organization.setId(organizationId);
+
+        Job job = new Job();
+        job.setId(43);
+        job.setWorkspace(workspace);
+        job.setOrganization(organization);
+        job.setStatus(JobStatus.pending);
+
+        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher);
+        hook.execute(LifeCycleHookBinding.Operation.CREATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, job, null, Optional.empty());
+
+        verify(jobStatusPublisher).publish(new JobStatusEvent(43, workspaceId.toString(), "pending"), organizationId.toString());
+    }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,8 @@
     "cron-to-quartz": "^1.4.15",
     "cronstrue": "^3.24.0",
     "github-markdown-css": "^5.9.0",
+    "graphql": "^17.0.2",
+    "graphql-ws": "^6.2.0",
     "hcl2-parser": "^1.0.3",
     "html-react-parser": "^6.1.5",
     "html-to-image": "^1.11.13",

--- a/ui/src/domain/Jobs/Details.tsx
+++ b/ui/src/domain/Jobs/Details.tsx
@@ -19,7 +19,7 @@ import { ORGANIZATION_ARCHIVE } from "../../config/actionTypes";
 import axiosInstance, { axiosClient } from "../../config/axiosConfig";
 import { useAbortController, usePolling } from "../../hooks";
 import { Job, JobStep } from "../types";
-import { TerminalOutput } from "./TerminalOutput";
+import { LiveTerminalOutput } from "./LiveTerminalOutput";
 import { getJobOutputRequestUrl, getPublicApiOrigin, isTerrakubeApiUrl } from "./outputUrl";
 import { shouldStepBeCollapsible, shouldStepBeExpandedByDefault } from "./stepExpansion";
 import { StructuredPlanOutput } from "./StructuredPlanOutput";
@@ -184,7 +184,7 @@ export const DetailsJob = ({ jobId }: Props) => {
   };
 
   const renderConsoleOutput = (item: JobStep) => {
-    return <TerminalOutput outputLog={item.outputLog} stepName={item.name} isRunning={item.status === "running"} />;
+    return <LiveTerminalOutput jobId={jobId} organizationId={organizationId ?? ""} item={item} />;
   };
 
   const getStepStructuredData = (item: JobStep) => {
@@ -395,6 +395,8 @@ export const DetailsJob = ({ jobId }: Props) => {
           outputLog:
             incompleteVariableGuard != null && isIncompleteVariableGuardStep(stepItem.attributes.name)
               ? incompleteVariableGuard.rawMessage
+              : stepItem.attributes.status === "running"
+              ? ""
               : await outputLog(stepItem.attributes.output, stepItem.attributes.status, signal),
         }))
       );

--- a/ui/src/domain/Jobs/LiveTerminalOutput.tsx
+++ b/ui/src/domain/Jobs/LiveTerminalOutput.tsx
@@ -1,0 +1,21 @@
+import { useLogStream } from "../../hooks";
+import { getPublicApiOrigin } from "./outputUrl";
+import { TerminalOutput } from "./TerminalOutput";
+import { JobStep } from "../types";
+
+type Props = {
+  jobId: string;
+  organizationId: string;
+  item: JobStep;
+};
+
+export const LiveTerminalOutput = ({ jobId, organizationId, item }: Props) => {
+  const isRunning = item.status === "running";
+  const streamUrl = `${getPublicApiOrigin()}/tfoutput/v1/organization/${organizationId}/job/${jobId}/step/${item.id}/stream`;
+
+  const { text } = useLogStream({ url: streamUrl, enabled: isRunning });
+
+  const outputLog = isRunning && text.length > 0 ? text : item.outputLog;
+
+  return <TerminalOutput outputLog={outputLog} stepName={item.name} isRunning={isRunning} />;
+};

--- a/ui/src/domain/Jobs/__tests__/LiveTerminalOutput.test.tsx
+++ b/ui/src/domain/Jobs/__tests__/LiveTerminalOutput.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import { LiveTerminalOutput } from "../LiveTerminalOutput";
+import { useLogStream } from "../../../hooks";
+import { JobStatus, JobStep } from "../../types";
+
+jest.mock("../../../hooks", () => ({
+  useLogStream: jest.fn(),
+}));
+
+jest.mock("../TerminalOutput", () => ({
+  TerminalOutput: ({ outputLog }: { outputLog: string }) => <div data-testid="terminal">{outputLog}</div>,
+}));
+
+const makeStep = (overrides: Partial<JobStep>): JobStep => ({
+  id: "step-1",
+  name: "Plan",
+  status: JobStatus.Running,
+  stepNumber: 1,
+  output: "",
+  outputLog: "",
+  ...overrides,
+});
+
+describe("LiveTerminalOutput", () => {
+  it("renders the live stream text for a running step", () => {
+    (useLogStream as jest.Mock).mockReturnValue({ text: "streamed line" });
+
+    render(<LiveTerminalOutput jobId="1" organizationId="org-1" item={makeStep({ status: JobStatus.Running })} />);
+
+    expect(screen.getByTestId("terminal")).toHaveTextContent("streamed line");
+  });
+
+  it("falls back to the static outputLog while the stream has not sent anything yet", () => {
+    (useLogStream as jest.Mock).mockReturnValue({ text: "" });
+
+    render(
+      <LiveTerminalOutput
+        jobId="1"
+        organizationId="org-1"
+        item={makeStep({ status: JobStatus.Running, outputLog: "Initializing the backend..." })}
+      />
+    );
+
+    expect(screen.getByTestId("terminal")).toHaveTextContent("Initializing the backend...");
+  });
+
+  it("renders the static outputLog for a completed step without connecting the stream", () => {
+    (useLogStream as jest.Mock).mockReturnValue({ text: "" });
+
+    render(
+      <LiveTerminalOutput
+        jobId="1"
+        organizationId="org-1"
+        item={makeStep({ status: JobStatus.Completed, output: "some-url", outputLog: "final output" })}
+      />
+    );
+
+    expect(screen.getByTestId("terminal")).toHaveTextContent("final output");
+    expect(useLogStream).toHaveBeenCalledWith(expect.objectContaining({ enabled: false }));
+  });
+});

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -40,7 +40,7 @@ import {
 
 import { DateTime } from "luxon";
 import { lazy, Suspense, useEffect, useState } from "react";
-import { usePolling } from "../../hooks";
+import { useJobStatusSubscription, usePolling } from "../../hooks";
 import { IconContext } from "react-icons";
 import { BiTerminal } from "react-icons/bi";
 import { FiGitCommit } from "react-icons/fi";
@@ -364,6 +364,14 @@ export const WorkspaceDetails = ({
     },
     { interval: 10000, enabled: Boolean(id), immediate: false }
   );
+
+  // Pushes an immediate refresh on real job status changes; the poll above stays as a fallback for a
+  // dropped WebSocket connection.
+  useJobStatusSubscription({
+    workspaceId: id ?? "",
+    enabled: Boolean(id),
+    onEvent: () => loadWorkspace(false, false, false),
+  });
 
   const changeJob = (id: string) => {
     setJobId(id);

--- a/ui/src/hooks/__tests__/useJobStatusSubscription.test.ts
+++ b/ui/src/hooks/__tests__/useJobStatusSubscription.test.ts
@@ -1,0 +1,83 @@
+import { renderHook } from "@testing-library/react";
+import { useJobStatusSubscription } from "../useJobStatusSubscription";
+import { getSubscriptionClient } from "../../modules/api/subscriptionClient";
+
+jest.mock("../../modules/api/subscriptionClient");
+
+describe("useJobStatusSubscription", () => {
+  const unsubscribe = jest.fn();
+  const subscribe = jest.fn().mockReturnValue(unsubscribe);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    subscribe.mockReturnValue(unsubscribe);
+    (getSubscriptionClient as jest.Mock).mockReturnValue({ subscribe });
+  });
+
+  it("subscribes with the workspaceId variable and forwards each event", () => {
+    const onEvent = jest.fn();
+
+    renderHook(() => useJobStatusSubscription({ workspaceId: "workspace-1", enabled: true, onEvent }));
+
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    const [payload, sink] = subscribe.mock.calls[0];
+    expect(payload.variables).toEqual({ workspaceId: "workspace-1" });
+
+    sink.next({ data: { jobStatusChanged: { jobId: 1, workspaceId: "workspace-1", status: "running" } } });
+
+    expect(onEvent).toHaveBeenCalledWith({ jobId: 1, workspaceId: "workspace-1", status: "running" });
+  });
+
+  it("does not subscribe when disabled", () => {
+    renderHook(() => useJobStatusSubscription({ workspaceId: "workspace-1", enabled: false, onEvent: jest.fn() }));
+
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useJobStatusSubscription({ workspaceId: "workspace-1", enabled: true, onEvent: jest.fn() })
+    );
+
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not resubscribe when the caller passes a new onEvent reference on every render", () => {
+    // Regression test: callers commonly pass an inline callback (e.g. `() => loadWorkspace(...)`), which
+    // is a new function reference every render. Re-subscribing every render would tear down and reopen
+    // the WebSocket subscription constantly - the same class of bug the SSE log-streaming hook had before
+    // its own fix, just for a different transport.
+    const { rerender } = renderHook(
+      ({ onEvent }) => useJobStatusSubscription({ workspaceId: "workspace-1", enabled: true, onEvent }),
+      { initialProps: { onEvent: () => {} } }
+    );
+
+    expect(subscribe).toHaveBeenCalledTimes(1);
+
+    rerender({ onEvent: () => {} });
+    rerender({ onEvent: () => {} });
+
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    expect(unsubscribe).not.toHaveBeenCalled();
+  });
+
+  it("calls the latest onEvent even after a re-render passed a new reference", () => {
+    const firstOnEvent = jest.fn();
+    const secondOnEvent = jest.fn();
+
+    const { rerender } = renderHook(
+      ({ onEvent }) => useJobStatusSubscription({ workspaceId: "workspace-1", enabled: true, onEvent }),
+      { initialProps: { onEvent: firstOnEvent } }
+    );
+
+    rerender({ onEvent: secondOnEvent });
+
+    const [, sink] = subscribe.mock.calls[0];
+    sink.next({ data: { jobStatusChanged: { jobId: 1, workspaceId: "workspace-1", status: "running" } } });
+
+    expect(secondOnEvent).toHaveBeenCalledWith({ jobId: 1, workspaceId: "workspace-1", status: "running" });
+    expect(firstOnEvent).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/hooks/__tests__/useLogStream.test.ts
+++ b/ui/src/hooks/__tests__/useLogStream.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { useLogStream } from "../useLogStream";
 import { readEventStream } from "../../modules/api/eventStream";
 
@@ -40,5 +40,72 @@ describe("useLogStream", () => {
     rerender({ url: "http://localhost/stream/b" });
 
     await waitFor(() => expect(result.current.text).toBe("line 1"));
+  });
+
+  describe("reconnect behavior", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("resumes from the last received id after a transient error, keeping accumulated text", async () => {
+      const mock = readEventStream as jest.Mock;
+      mock.mockImplementationOnce(async (_url, { onMessage }) => {
+        onMessage("line 1", "10-0");
+        throw new Error("network drop");
+      });
+      mock.mockImplementationOnce(() => new Promise(() => {}));
+
+      const { result } = renderHook(() => useLogStream({ url: "http://localhost/stream", enabled: true }));
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.text).toBe("line 1");
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(1000);
+      });
+
+      expect(mock).toHaveBeenCalledTimes(2);
+      expect(mock.mock.calls[1][1]).toEqual(expect.objectContaining({ lastEventId: "10-0" }));
+      expect(result.current.text).toBe("line 1");
+    });
+
+    it("does not reconnect once the effect has been cleaned up", async () => {
+      const mock = readEventStream as jest.Mock;
+      mock.mockImplementationOnce(async () => {
+        throw new Error("network drop");
+      });
+
+      const { unmount } = renderHook(() => useLogStream({ url: "http://localhost/stream", enabled: true }));
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+      unmount();
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(30000);
+      });
+
+      expect(mock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not reconnect when the stream ends without an error", async () => {
+      const mock = readEventStream as jest.Mock;
+      mock.mockResolvedValueOnce(undefined);
+
+      renderHook(() => useLogStream({ url: "http://localhost/stream", enabled: true }));
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(30000);
+      });
+
+      expect(mock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/ui/src/hooks/__tests__/useLogStream.test.ts
+++ b/ui/src/hooks/__tests__/useLogStream.test.ts
@@ -1,0 +1,44 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { useLogStream } from "../useLogStream";
+import { readEventStream } from "../../modules/api/eventStream";
+
+jest.mock("../../modules/api/eventStream");
+
+describe("useLogStream", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("accumulates messages emitted by readEventStream", async () => {
+    (readEventStream as jest.Mock).mockImplementation(async (_url, { onMessage }) => {
+      onMessage("line 1");
+      onMessage("line 2");
+    });
+
+    const { result } = renderHook(() => useLogStream({ url: "http://localhost/stream", enabled: true }));
+
+    await waitFor(() => expect(result.current.text).toBe("line 1\nline 2"));
+  });
+
+  it("does not connect when enabled is false", () => {
+    renderHook(() => useLogStream({ url: "http://localhost/stream", enabled: false }));
+
+    expect(readEventStream).not.toHaveBeenCalled();
+  });
+
+  it("resets accumulated text when the url changes", async () => {
+    (readEventStream as jest.Mock).mockImplementation(async (_url, { onMessage }) => {
+      onMessage("line 1");
+    });
+
+    const { result, rerender } = renderHook(({ url }) => useLogStream({ url, enabled: true }), {
+      initialProps: { url: "http://localhost/stream/a" },
+    });
+
+    await waitFor(() => expect(result.current.text).toBe("line 1"));
+
+    rerender({ url: "http://localhost/stream/b" });
+
+    await waitFor(() => expect(result.current.text).toBe("line 1"));
+  });
+});

--- a/ui/src/hooks/__tests__/useOrganizationJobStatusSubscription.test.ts
+++ b/ui/src/hooks/__tests__/useOrganizationJobStatusSubscription.test.ts
@@ -1,0 +1,63 @@
+import { renderHook } from "@testing-library/react";
+import { useOrganizationJobStatusSubscription } from "../useOrganizationJobStatusSubscription";
+import { getSubscriptionClient } from "../../modules/api/subscriptionClient";
+
+jest.mock("../../modules/api/subscriptionClient");
+
+describe("useOrganizationJobStatusSubscription", () => {
+  const unsubscribe = jest.fn();
+  const subscribe = jest.fn().mockReturnValue(unsubscribe);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    subscribe.mockReturnValue(unsubscribe);
+    (getSubscriptionClient as jest.Mock).mockReturnValue({ subscribe });
+  });
+
+  it("subscribes with the organizationId variable and forwards each event", () => {
+    const onEvent = jest.fn();
+
+    renderHook(() => useOrganizationJobStatusSubscription({ organizationId: "org-1", enabled: true, onEvent }));
+
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    const [payload, sink] = subscribe.mock.calls[0];
+    expect(payload.variables).toEqual({ organizationId: "org-1" });
+
+    sink.next({ data: { organizationJobStatusChanged: { jobId: 1, workspaceId: "workspace-1", status: "running" } } });
+
+    expect(onEvent).toHaveBeenCalledWith({ jobId: 1, workspaceId: "workspace-1", status: "running" });
+  });
+
+  it("does not subscribe when disabled", () => {
+    renderHook(() =>
+      useOrganizationJobStatusSubscription({ organizationId: "org-1", enabled: false, onEvent: jest.fn() })
+    );
+
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes on unmount", () => {
+    const { unmount } = renderHook(() =>
+      useOrganizationJobStatusSubscription({ organizationId: "org-1", enabled: true, onEvent: jest.fn() })
+    );
+
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not resubscribe when the caller passes a new onEvent reference on every render", () => {
+    const { rerender } = renderHook(
+      ({ onEvent }) => useOrganizationJobStatusSubscription({ organizationId: "org-1", enabled: true, onEvent }),
+      { initialProps: { onEvent: () => {} } }
+    );
+
+    expect(subscribe).toHaveBeenCalledTimes(1);
+
+    rerender({ onEvent: () => {} });
+    rerender({ onEvent: () => {} });
+
+    expect(subscribe).toHaveBeenCalledTimes(1);
+    expect(unsubscribe).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { usePolling } from "./usePolling";
 export { useAbortableFetch, useAbortController } from "./useAbortableFetch";
+export { useLogStream } from "./useLogStream";

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -1,3 +1,5 @@
 export { usePolling } from "./usePolling";
 export { useAbortableFetch, useAbortController } from "./useAbortableFetch";
 export { useLogStream } from "./useLogStream";
+export { useJobStatusSubscription } from "./useJobStatusSubscription";
+export { useOrganizationJobStatusSubscription } from "./useOrganizationJobStatusSubscription";

--- a/ui/src/hooks/useJobStatusSubscription.ts
+++ b/ui/src/hooks/useJobStatusSubscription.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from "react";
+import { getSubscriptionClient } from "../modules/api/subscriptionClient";
+
+export type JobStatusEvent = {
+  jobId: number;
+  workspaceId: string;
+  status: string;
+};
+
+type UseJobStatusSubscriptionOptions = {
+  workspaceId: string;
+  enabled: boolean;
+  onEvent: (event: JobStatusEvent) => void;
+};
+
+const SUBSCRIPTION_QUERY = `
+  subscription OnJobStatusChanged($workspaceId: ID!) {
+    jobStatusChanged(workspaceId: $workspaceId) {
+      jobId
+      workspaceId
+      status
+    }
+  }
+`;
+
+export function useJobStatusSubscription({ workspaceId, enabled, onEvent }: UseJobStatusSubscriptionOptions): void {
+  // Callers commonly pass an inline callback that closes over component state (e.g. `() =>
+  // loadWorkspace(...)`), which is a new function reference every render. Reading it through a ref -
+  // updated on every render, but not part of the effect's dependency array - means the subscription
+  // itself isn't torn down and recreated just because the caller re-rendered.
+  const onEventRef = useRef(onEvent);
+  onEventRef.current = onEvent;
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const unsubscribe = getSubscriptionClient().subscribe(
+      { query: SUBSCRIPTION_QUERY, variables: { workspaceId } },
+      {
+        next: (result) => {
+          const event = (result.data as { jobStatusChanged?: JobStatusEvent } | null | undefined)?.jobStatusChanged;
+          if (event != null) {
+            onEventRef.current(event);
+          }
+        },
+        error: () => {
+          // graphql-ws retries the underlying connection and resubscribes automatically; nothing to do here.
+        },
+        complete: () => {},
+      }
+    );
+
+    return () => unsubscribe();
+  }, [workspaceId, enabled]);
+}

--- a/ui/src/hooks/useLogStream.ts
+++ b/ui/src/hooks/useLogStream.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { readEventStream } from "../modules/api/eventStream";
+
+type UseLogStreamOptions = {
+  url: string;
+  enabled: boolean;
+};
+
+export function useLogStream({ url, enabled }: UseLogStreamOptions): { text: string } {
+  const [text, setText] = useState("");
+
+  useEffect(() => {
+    setText("");
+
+    if (!enabled) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    readEventStream(url, {
+      signal: controller.signal,
+      onMessage: (data) => {
+        setText((previous) => (previous.length === 0 ? data : `${previous}\n${data}`));
+      },
+    }).catch(() => {
+      // Connection closed or aborted; the terminal falls back to whatever text was already accumulated.
+    });
+
+    return () => controller.abort();
+  }, [url, enabled]);
+
+  return { text };
+}

--- a/ui/src/hooks/useLogStream.ts
+++ b/ui/src/hooks/useLogStream.ts
@@ -6,6 +6,13 @@ type UseLogStreamOptions = {
   enabled: boolean;
 };
 
+const INITIAL_BACKOFF_MS = 1000;
+const MAX_BACKOFF_MS = 30000;
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
 export function useLogStream({ url, enabled }: UseLogStreamOptions): { text: string } {
   const [text, setText] = useState("");
 
@@ -16,18 +23,45 @@ export function useLogStream({ url, enabled }: UseLogStreamOptions): { text: str
       return;
     }
 
-    const controller = new AbortController();
+    let cancelled = false;
+    let retryTimeout: ReturnType<typeof setTimeout> | undefined;
+    let backoffMs = INITIAL_BACKOFF_MS;
+    let lastEventId: string | undefined;
+    let controller = new AbortController();
 
-    readEventStream(url, {
-      signal: controller.signal,
-      onMessage: (data) => {
-        setText((previous) => (previous.length === 0 ? data : `${previous}\n${data}`));
-      },
-    }).catch(() => {
-      // Connection closed or aborted; the terminal falls back to whatever text was already accumulated.
-    });
+    const connect = () => {
+      controller = new AbortController();
 
-    return () => controller.abort();
+      readEventStream(url, {
+        signal: controller.signal,
+        lastEventId,
+        onMessage: (data, id) => {
+          backoffMs = INITIAL_BACKOFF_MS;
+          if (id != null) {
+            lastEventId = id;
+          }
+          setText((previous) => (previous.length === 0 ? data : `${previous}\n${data}`));
+        },
+      }).catch((error: unknown) => {
+        if (cancelled || isAbortError(error)) {
+          return;
+        }
+        retryTimeout = setTimeout(() => {
+          backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
+          connect();
+        }, backoffMs);
+      });
+    };
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (retryTimeout != null) {
+        clearTimeout(retryTimeout);
+      }
+    };
   }, [url, enabled]);
 
   return { text };

--- a/ui/src/hooks/useOrganizationJobStatusSubscription.ts
+++ b/ui/src/hooks/useOrganizationJobStatusSubscription.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from "react";
+import { getSubscriptionClient } from "../modules/api/subscriptionClient";
+import { JobStatusEvent } from "./useJobStatusSubscription";
+
+type UseOrganizationJobStatusSubscriptionOptions = {
+  organizationId: string;
+  enabled: boolean;
+  onEvent: (event: JobStatusEvent) => void;
+};
+
+const SUBSCRIPTION_QUERY = `
+  subscription OnOrganizationJobStatusChanged($organizationId: ID!) {
+    organizationJobStatusChanged(organizationId: $organizationId) {
+      jobId
+      workspaceId
+      status
+    }
+  }
+`;
+
+export function useOrganizationJobStatusSubscription({
+  organizationId,
+  enabled,
+  onEvent,
+}: UseOrganizationJobStatusSubscriptionOptions): void {
+  const onEventRef = useRef(onEvent);
+  onEventRef.current = onEvent;
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const unsubscribe = getSubscriptionClient().subscribe(
+      { query: SUBSCRIPTION_QUERY, variables: { organizationId } },
+      {
+        next: (result) => {
+          const event = (result.data as { organizationJobStatusChanged?: JobStatusEvent } | null | undefined)
+            ?.organizationJobStatusChanged;
+          if (event != null) {
+            onEventRef.current(event);
+          }
+        },
+        error: () => {
+          // graphql-ws retries the underlying connection and resubscribes automatically; nothing to do here.
+        },
+        complete: () => {},
+      }
+    );
+
+    return () => unsubscribe();
+  }, [organizationId, enabled]);
+}

--- a/ui/src/modules/api/__tests__/eventStream.test.ts
+++ b/ui/src/modules/api/__tests__/eventStream.test.ts
@@ -62,4 +62,32 @@ describe("readEventStream", () => {
       })
     ).rejects.toThrow("401");
   });
+
+  it("passes the event's id alongside its data", async () => {
+    const response = makeStreamResponse(["id: 100-0\ndata: line 1\n\n"]);
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue(response);
+
+    const received: Array<[string, string | undefined]> = [];
+    await readEventStream("http://localhost/stream", {
+      onMessage: (data, id) => received.push([data, id]),
+      signal: new AbortController().signal,
+    });
+
+    expect(received).toEqual([["line 1", "100-0"]]);
+  });
+
+  it("sends Last-Event-ID as a request header when provided", async () => {
+    const response = makeStreamResponse(["data: line 1\n\n"]);
+    const fetchMock = jest.fn().mockResolvedValue(response);
+    (global.fetch as jest.Mock) = fetchMock;
+
+    await readEventStream("http://localhost/stream", {
+      onMessage: jest.fn(),
+      signal: new AbortController().signal,
+      lastEventId: "100-0",
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    expect(requestInit.headers["Last-Event-ID"]).toBe("100-0");
+  });
 });

--- a/ui/src/modules/api/__tests__/eventStream.test.ts
+++ b/ui/src/modules/api/__tests__/eventStream.test.ts
@@ -1,0 +1,65 @@
+import { readEventStream } from "../eventStream";
+
+function makeStreamResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  let index = 0;
+
+  const reader = {
+    read: async () => {
+      if (index < chunks.length) {
+        const value = encoder.encode(chunks[index]);
+        index++;
+        return { value, done: false };
+      }
+      return { value: undefined, done: true };
+    },
+  };
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      getReader: () => reader,
+    },
+  } as unknown as Response;
+}
+
+describe("readEventStream", () => {
+  it("invokes onMessage for each SSE data line", async () => {
+    const response = makeStreamResponse(["data: line 1\n\n", "data: line 2\n\n"]);
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue(response);
+
+    const received: string[] = [];
+    await readEventStream("http://localhost/stream", {
+      onMessage: (data) => received.push(data),
+      signal: new AbortController().signal,
+    });
+
+    expect(received).toEqual(["line 1", "line 2"]);
+  });
+
+  it("ignores SSE comment lines", async () => {
+    const response = makeStreamResponse([": heartbeat\n\n", "data: line 1\n\n"]);
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue(response);
+
+    const received: string[] = [];
+    await readEventStream("http://localhost/stream", {
+      onMessage: (data) => received.push(data),
+      signal: new AbortController().signal,
+    });
+
+    expect(received).toEqual(["line 1"]);
+  });
+
+  it("rejects when the response is not ok", async () => {
+    const response = { ok: false, status: 401, body: null } as unknown as Response;
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue(response);
+
+    await expect(
+      readEventStream("http://localhost/stream", {
+        onMessage: jest.fn(),
+        signal: new AbortController().signal,
+      })
+    ).rejects.toThrow("401");
+  });
+});

--- a/ui/src/modules/api/__tests__/subscriptionClient.test.ts
+++ b/ui/src/modules/api/__tests__/subscriptionClient.test.ts
@@ -1,0 +1,28 @@
+import { createClient } from "graphql-ws";
+import { getSubscriptionClient } from "../subscriptionClient";
+
+jest.mock("graphql-ws");
+
+describe("getSubscriptionClient", () => {
+  beforeAll(() => {
+    (createClient as jest.Mock).mockReturnValue({ subscribe: jest.fn() });
+  });
+
+  // getSubscriptionClient() caches a module-level singleton, so both behaviors are asserted from the
+  // same pair of calls in one test rather than split across tests - a second `it()` calling
+  // getSubscriptionClient() again would just hit the cache and never call createClient again, since Jest
+  // doesn't reset module-level state between tests in the same file the way it resets mocks.
+  it("creates the client once, reuses it on subsequent calls, and configures connectionParams with the access token", async () => {
+    const first = getSubscriptionClient();
+    const second = getSubscriptionClient();
+
+    expect(createClient).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+
+    const options = (createClient as jest.Mock).mock.calls[0][0];
+    const params = await options.connectionParams();
+
+    expect(params).toHaveProperty("Authorization");
+    expect(params.Authorization).toMatch(/^Bearer /);
+  });
+});

--- a/ui/src/modules/api/eventStream.ts
+++ b/ui/src/modules/api/eventStream.ts
@@ -1,19 +1,25 @@
 import getUserFromStorage from "../../config/authUser";
 
 type ReadEventStreamOptions = {
-  onMessage: (data: string) => void;
+  onMessage: (data: string, id?: string) => void;
   signal: AbortSignal;
+  lastEventId?: string;
 };
 
-export async function readEventStream(url: string, { onMessage, signal }: ReadEventStreamOptions): Promise<void> {
+export async function readEventStream(
+  url: string,
+  { onMessage, signal, lastEventId }: ReadEventStreamOptions
+): Promise<void> {
   const user = getUserFromStorage();
 
-  const response = await fetch(url, {
-    signal,
-    headers: {
-      Authorization: `Bearer ${user?.access_token ?? ""}`,
-    },
-  });
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${user?.access_token ?? ""}`,
+  };
+  if (lastEventId != null) {
+    headers["Last-Event-ID"] = lastEventId;
+  }
+
+  const response = await fetch(url, { signal, headers });
 
   if (!response.ok || !response.body) {
     throw new Error(`Event stream request failed with status ${response.status}`);
@@ -34,13 +40,13 @@ export async function readEventStream(url: string, { onMessage, signal }: ReadEv
     buffer = events.pop() ?? "";
 
     for (const event of events) {
-      const dataLines = event
-        .split("\n")
-        .filter((line) => line.startsWith("data:"))
-        .map((line) => line.slice(5).trimStart());
+      const lines = event.split("\n");
+      const dataLines = lines.filter((line) => line.startsWith("data:")).map((line) => line.slice(5).trimStart());
+      const idLine = lines.find((line) => line.startsWith("id:"));
+      const id = idLine != null ? idLine.slice(3).trimStart() : undefined;
 
       if (dataLines.length > 0) {
-        onMessage(dataLines.join("\n"));
+        onMessage(dataLines.join("\n"), id);
       }
     }
   }

--- a/ui/src/modules/api/eventStream.ts
+++ b/ui/src/modules/api/eventStream.ts
@@ -1,0 +1,47 @@
+import getUserFromStorage from "../../config/authUser";
+
+type ReadEventStreamOptions = {
+  onMessage: (data: string) => void;
+  signal: AbortSignal;
+};
+
+export async function readEventStream(url: string, { onMessage, signal }: ReadEventStreamOptions): Promise<void> {
+  const user = getUserFromStorage();
+
+  const response = await fetch(url, {
+    signal,
+    headers: {
+      Authorization: `Bearer ${user?.access_token ?? ""}`,
+    },
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error(`Event stream request failed with status ${response.status}`);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) {
+      return;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+    const events = buffer.split("\n\n");
+    buffer = events.pop() ?? "";
+
+    for (const event of events) {
+      const dataLines = event
+        .split("\n")
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice(5).trimStart());
+
+      if (dataLines.length > 0) {
+        onMessage(dataLines.join("\n"));
+      }
+    }
+  }
+}

--- a/ui/src/modules/api/subscriptionClient.ts
+++ b/ui/src/modules/api/subscriptionClient.ts
@@ -1,0 +1,20 @@
+import { Client, createClient } from "graphql-ws";
+import getUserFromStorage from "../../config/authUser";
+import { getPublicApiOrigin } from "../../domain/Jobs/outputUrl";
+
+let client: Client | undefined;
+
+export function getSubscriptionClient(): Client {
+  if (client == null) {
+    const wsUrl = getPublicApiOrigin().replace(/^http/, "ws") + "/subscriptions";
+
+    client = createClient({
+      url: wsUrl,
+      connectionParams: () => {
+        const user = getUserFromStorage();
+        return { Authorization: `Bearer ${user?.access_token ?? ""}` };
+      },
+    });
+  }
+  return client;
+}

--- a/ui/src/modules/organizations/OrganizationDetailsPage.tsx
+++ b/ui/src/modules/organizations/OrganizationDetailsPage.tsx
@@ -8,7 +8,7 @@ import { JobStatus } from "@/domain/types";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import workspaceService from "@/modules/workspaces/workspaceService";
 import useApiRequest from "@/modules/api/useApiRequest";
-import { usePolling } from "@/hooks";
+import { useOrganizationJobStatusSubscription, usePolling } from "@/hooks";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
 import { TagModel } from "./types";
 import WorkspaceCard from "@/modules/workspaces/components/WorkspaceCard";
@@ -127,6 +127,21 @@ export default function OrganizationsDetailPage({ organizationName, setOrganizat
     },
     { interval: 10000, enabled: Boolean(id), immediate: false }
   );
+
+  // Pushes an immediate refresh on real job status changes anywhere in this organization; the poll
+  // above stays as a fallback for a dropped WebSocket connection.
+  useOrganizationJobStatusSubscription({
+    organizationId: id ?? "",
+    enabled: Boolean(id),
+    onEvent: () => {
+      if (!id) return;
+      workspaceService.listWorkspaces(id).then((response) => {
+        if (!response.isError && response.data) {
+          setWorkspaces(response.data.workspaces);
+        }
+      });
+    },
+  });
 
   const handleCreateWorkspace = () => {
     navigate("/workspaces/create");

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3603,6 +3603,8 @@ __metadata:
     eslint-plugin-react-refresh: "npm:^0.5.3"
     github-markdown-css: "npm:^5.9.0"
     globals: "npm:^17.8.0"
+    graphql: "npm:^17.0.2"
+    graphql-ws: "npm:^6.2.0"
     hcl2-parser: "npm:^1.0.3"
     html-react-parser: "npm:^6.1.5"
     html-to-image: "npm:^1.11.13"
@@ -5690,6 +5692,32 @@ __metadata:
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
+  languageName: node
+  linkType: hard
+
+"graphql-ws@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "graphql-ws@npm:6.2.0"
+  peerDependencies:
+    "@fastify/websocket": ^10 || ^11
+    crossws: ~0.3
+    graphql: ^15.10.1 || ^16 || ^17
+    ws: ^8
+  peerDependenciesMeta:
+    "@fastify/websocket":
+      optional: true
+    crossws:
+      optional: true
+    ws:
+      optional: true
+  checksum: 10c0/8037420e955a69f6af5244edf0931eb6e91556e24c77086fd1540a04969ab62c10b539f3967bd81baafee6e6ef7d436279d3ccb0e45cb85d26d7f5edf9e15e10
+  languageName: node
+  linkType: hard
+
+"graphql@npm:^17.0.2":
+  version: 17.0.2
+  resolution: "graphql@npm:17.0.2"
+  checksum: 10c0/766546216b891439ed09fd8584963df2013e26f2f79f096036eaaa2788c38964e049c8a142d68e3afdabdd8bbe70042639e83f0f4b82edbc7c6850421f072bb6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why

The workspace runs page and job console output were both driven entirely by polling - up to a 10s wait for a run's status to update, up to 5s for new log lines, and every poll re-fetched the entire log blob from scratch regardless of whether anything had changed. On a long apply this meant watching the UI catch up in visible chunks instead of actually following along.

## What changed

Two separate but related pieces:

**Log streaming** - the running step's console output is now pushed over Server-Sent Events instead of re-polled. The backend tails the same Redis Stream the executor already writes to, incrementally, and the client reconnects with backoff and resumes from the last line it saw (via a `Last-Event-ID`-style offset) if the connection drops. Falls back to the old one-shot fetch for completed steps.

**Job status** - job/workspace status changes now push over a GraphQL subscription instead of waiting for the next poll tick. `JobManageHook` publishes to Redis Pub/Sub on every job create/update, and a small GraphQL-over-WebSocket layer (separate from Elide's existing JSON:API/GraphQL surface, which is untouched) turns that into a subscription any connected client can listen to. Two scopes: per-workspace (the runs page) and per-organization (the all-workspaces list), each authorized against the same team-membership checks Elide already enforces for regular reads.

The 10s/5s polls are still there, just demoted to a fallback. Redis Pub/Sub has no message history, so a status change published during a brief reconnect (pod restart, network blip) can be missed by the subscription - the poll is what catches that. The log stream doesn't have this gap since it replays from an offset instead.

## Why it's built this way

Both features reuse the Redis instance already required by this stack (used today for the log streams and module cache) rather than introducing anything new to deploy. Elide's own subscription support needs JMS/ActiveMQ, which isn't part of this stack anywhere and would mean adding a stateful service to every deployment of this chart - so this sidesteps that entirely and stays on infrastructure that's already there. It also means this works correctly with multiple API/UI pods with no sticky sessions: whichever pod publishes an event and whichever pod holds a given browser's connection don't have to be the same one, because the state lives in Redis, not in pod memory.

## What this looks like in practice

- Console output for a running step streams line by line instead of jumping every 5 seconds
- A run finishing, failing, or changing status shows up in the UI within a second or so instead of waiting for the next 10s poll
- Killing the pod serving your connection mid-run reconnects on its own - logs resume from where they left off, status falls back to the poll until the subscription reconnects

## Notes for review

- New backend deps: `spring-boot-starter-graphql`, `spring-boot-starter-websocket`, `reactor-test` (test scope)
- New frontend deps: `graphql-ws`, `graphql` (the latter is a hard runtime requirement of `graphql-ws`'s bundled client despite showing up as just a peer dependency)
- The WebSocket handshake authenticates over the GraphQL-WS `connection_init` message rather than an HTTP header, since browsers can't set custom headers on a WebSocket upgrade - same constraint SSE hit with `EventSource`, different workaround
- One pre-existing, unrelated this branch:`Jobs/Details.test.tsx` fails to load due to an ESM issue in `html-react-parser`'s dependency chain, untouched by