### PR TITLE
feat(vcs): include plan/apply summary in commit status descriptions

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -503,7 +503,7 @@ public class ScheduleJob implements org.quartz.Job {
         }
     }
 
-    private void updateJobStatusOnVcs(Job job, JobStatus jobStatus) {
+    void updateJobStatusOnVcs(Job job, JobStatus jobStatus) {
         if (job.getVia().equals(JobVia.UI.getValue()) || job.getVia().equals(JobVia.CLI.getValue()) || job.getVia().equals(JobVia.SCHEDULE.getValue())) {
             return;
         }
@@ -512,16 +512,17 @@ public class ScheduleJob implements org.quartz.Job {
         // (expired token, provider outage, rate limit, missing commit) must never abort the
         // job itself, since callers here include the job-completion path.
         try {
+            String runSummary = prCommentService.extractRunSummary(job).orElse(null);
             switch (job.getWorkspace().getVcs().getVcsType()) {
                 case GITHUB:
-                    gitHubWebhookService.sendCommitStatus(job, jobStatus);
+                    gitHubWebhookService.sendCommitStatus(job, jobStatus, runSummary);
                     break;
                 case GITLAB:
-                    gitLabWebhookService.sendCommitStatus(job, jobStatus);
+                    gitLabWebhookService.sendCommitStatus(job, jobStatus, runSummary);
                     break;
                 case AZURE_DEVOPS:
                 case AZURE_SP_MI:
-                    azDevOpsWebhookService.sendCommitStatus(job, jobStatus);
+                    azDevOpsWebhookService.sendCommitStatus(job, jobStatus, runSummary);
                     break;
                 default:
                     break;

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/inactive/InactiveJobs.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/inactive/InactiveJobs.java
@@ -97,16 +97,16 @@ public class InactiveJobs implements org.quartz.Job {
         switch (workspaceVcs.getVcsType()) {
             case GITHUB:
                 log.info("Updating VCS information for GITHUB on job {}", job.getId());
-                gitHubWebhookService.sendCommitStatus(job, JobStatus.unknown);
+                gitHubWebhookService.sendCommitStatus(job, JobStatus.unknown, null);
                 break;
             case GITLAB:
                 log.info("Updating VCS information for GITLAB on job {}", job.getId());
-                gitLabWebhookService.sendCommitStatus(job, JobStatus.unknown);
+                gitLabWebhookService.sendCommitStatus(job, JobStatus.unknown, null);
                 break;
             case AZURE_DEVOPS:
             case AZURE_SP_MI:
                 log.info("Updating VCS information for AZURE_DEVOPS on job {}", job.getId());
-                azDevOpsWebhookService.sendCommitStatus(job, JobStatus.unknown);
+                azDevOpsWebhookService.sendCommitStatus(job, JobStatus.unknown, null);
                 break;
             default:
                 break;

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -29,8 +30,10 @@ public class PrCommentService {
 
     private static final int MAX_COMMENT_LENGTH = 60000;
     private static final Set<VcsType> PR_COMMENT_SUPPORTED_VCS = EnumSet.of(VcsType.GITHUB, VcsType.GITLAB, VcsType.BITBUCKET);
-    private static final Pattern PLAN_SUMMARY_PATTERN = Pattern.compile(
-            "(Plan: \\d+ to add, \\d+ to change, \\d+ to destroy\\.|No changes\\. Your infrastructure matches the configuration\\.)");
+    private static final Pattern RUN_SUMMARY_PATTERN = Pattern.compile(
+            "(Plan: \\d+ to add, \\d+ to change, \\d+ to destroy\\."
+            + "|No changes\\. Your infrastructure matches the configuration\\."
+            + "|Apply complete! Resources: \\d+ added, \\d+ changed, \\d+ destroyed\\.)");
     private static final Pattern ANSI_PATTERN = Pattern.compile(
             "[\\u001b\\u009b][\\[()#;?]*(?:\\d{1,4}(?:;\\d{1,4})*)?[0-9A-ORZcf-nq-uy=><~]");
 
@@ -183,6 +186,18 @@ public class PrCommentService {
         return ANSI_PATTERN.matcher(text).replaceAll("");
     }
 
+    private String matchRunSummary(String output) {
+        if (output == null || output.isEmpty()) {
+            return null;
+        }
+        Matcher matcher = RUN_SUMMARY_PATTERN.matcher(output);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
+    public Optional<String> extractRunSummary(Job job) {
+        return Optional.ofNullable(matchRunSummary(fetchStepOutputText(job)));
+    }
+
     public void postApplyDisabledNotice(Workspace workspace, Integer prNumber) {
         if (prNumber == null || prNumber == 0) return;
 
@@ -279,9 +294,9 @@ public class PrCommentService {
         String icon = statusIcon(job.getStatus());
 
         if (planOutput != null && !planOutput.isEmpty()) {
-            Matcher summaryMatcher = PLAN_SUMMARY_PATTERN.matcher(planOutput);
-            if (summaryMatcher.find()) {
-                sb.append(icon).append(" ").append(summaryMatcher.group(1)).append("\n\n");
+            String summary = matchRunSummary(planOutput);
+            if (summary != null) {
+                sb.append(icon).append(" ").append(summary).append("\n\n");
             }
 
             String content = planOutput;

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
@@ -199,7 +199,7 @@ public class RepoWebhookService {
             job.setCommitId(webhookResult.getCommit());
             Job savedJob = jobRepository.save(job);
             if (!webhookResult.isRelease() && workspace.getVcs() != null) {
-                gitHubWebhookService.sendCommitStatus(savedJob, JobStatus.pending);
+                gitHubWebhookService.sendCommitStatus(savedJob, JobStatus.pending, null);
             }
             scheduleJobService.createJobContext(savedJob);
         } catch (IllegalArgumentException e) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
@@ -404,14 +404,14 @@ public class WebhookService {
     private void sendCommitStatus(Job job) {
         switch (job.getWorkspace().getVcs().getVcsType()) {
             case GITHUB:
-                gitHubWebhookService.sendCommitStatus(job, JobStatus.pending);
+                gitHubWebhookService.sendCommitStatus(job, JobStatus.pending, null);
                 break;
             case GITLAB:
-                gitLabWebhookService.sendCommitStatus(job, JobStatus.pending);
+                gitLabWebhookService.sendCommitStatus(job, JobStatus.pending, null);
                 break;
             case AZURE_DEVOPS:
             case AZURE_SP_MI:
-                azDevOpsWebhookService.sendCommitStatus(job, JobStatus.pending);
+                azDevOpsWebhookService.sendCommitStatus(job, JobStatus.pending, null);
                 break;
             default:
                 break;

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookServiceBase.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookServiceBase.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
+import io.terrakube.api.rs.job.JobStatus;
+
 import org.apache.commons.lang3.function.TriFunction;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -114,6 +116,30 @@ public class WebhookServiceBase {
         if (lower.equals("terrakube plan") || lower.startsWith("terrakube plan ")) return "plan";
         if (lower.equals("terrakube apply") || lower.startsWith("terrakube apply ")) return "apply";
         return null;
+    }
+
+    public static String buildCommitStatusDescription(JobStatus jobStatus, String runSummary) {
+        String description;
+        switch (jobStatus) {
+            case completed:
+                description = "Your task has been completed successfully.";
+                break;
+            case failed:
+            case rejected:
+            case cancelled:
+                description = "Your task has failed.";
+                break;
+            case unknown:
+                description = "Your task ran into errors.";
+                break;
+            default:
+                description = "Your task is in Terrakube queue.";
+                break;
+        }
+        if (runSummary != null && !runSummary.isBlank()) {
+            description = description + " " + runSummary;
+        }
+        return description;
     }
 
     protected String escapeJsonString(String input) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookService.java
@@ -436,30 +436,6 @@ public class AzDevOpsWebhookService extends WebhookServiceBase {
         }
     }
 
-    static String buildCommitStatusDescription(JobStatus jobStatus, String runSummary) {
-        String description;
-        switch (jobStatus) {
-            case completed:
-                description = "Your task has been completed successfully.";
-                break;
-            case failed:
-            case rejected:
-            case cancelled:
-                description = "Your task has failed.";
-                break;
-            case unknown:
-                description = "Your task ran into errors.";
-                break;
-            default:
-                description = "Your task is in Terrakube queue.";
-                break;
-        }
-        if (runSummary != null && !runSummary.isBlank()) {
-            description = description + " " + runSummary;
-        }
-        return description;
-    }
-
     /**
      * Returns the current tip commit id of {@code branch}, or null if it cannot be resolved.
      * Used by outbound polling so new commits can be detected without an inbound webhook endpoint

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookService.java
@@ -369,7 +369,7 @@ public class AzDevOpsWebhookService extends WebhookServiceBase {
         }
     }
 
-    public void sendCommitStatus(Job job, JobStatus jobStatus) {
+    public void sendCommitStatus(Job job, JobStatus jobStatus, String runSummary) {
         Workspace workspace = job.getWorkspace();
         if (job.getCommitId() == null || job.getCommitId().isBlank()) {
             log.warn("No commit id available for job {}, skipping Azure DevOps commit status", job.getId());
@@ -390,27 +390,23 @@ public class AzDevOpsWebhookService extends WebhookServiceBase {
         String jobUrl = String.format("%s/organizations/%s/workspaces/%s/runs/%s", uiUrl,
                 workspace.getOrganization().getId(), workspace.getId(), job.getId());
         String state;
-        String description;
         switch (jobStatus) {
             case completed:
                 state = "succeeded";
-                description = "Your task has been completed successfully.";
                 break;
             case failed:
             case rejected:
             case cancelled:
                 state = "failed";
-                description = "Your task has failed.";
                 break;
             case unknown:
                 state = "error";
-                description = "Your task ran into errors.";
                 break;
             default:
                 state = "pending";
-                description = "Your task is in Terrakube queue.";
                 break;
         }
+        String description = buildCommitStatusDescription(jobStatus, runSummary);
 
         Map<String, Object> context = new LinkedHashMap<>();
         context.put("name", workspace.getOrganization().getName() + "-" + workspace.getName());
@@ -438,6 +434,30 @@ public class AzDevOpsWebhookService extends WebhookServiceBase {
         } catch (Exception e) {
             log.error("Error sending commit status to Azure DevOps", e);
         }
+    }
+
+    static String buildCommitStatusDescription(JobStatus jobStatus, String runSummary) {
+        String description;
+        switch (jobStatus) {
+            case completed:
+                description = "Your task has been completed successfully.";
+                break;
+            case failed:
+            case rejected:
+            case cancelled:
+                description = "Your task has failed.";
+                break;
+            case unknown:
+                description = "Your task ran into errors.";
+                break;
+            default:
+                description = "Your task is in Terrakube queue.";
+                break;
+        }
+        if (runSummary != null && !runSummary.isBlank()) {
+            description = description + " " + runSummary;
+        }
+        return description;
     }
 
     /**

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -203,7 +203,7 @@ public class GitHubWebhookService extends WebhookServiceBase {
         return result;
     }
 
-    public void sendCommitStatus(Job job, JobStatus jobStatus) {
+    public void sendCommitStatus(Job job, JobStatus jobStatus, String runSummary) {
         Workspace workspace = job.getWorkspace();
         String jobUrl = String.format("%s/organizations/%s/workspaces/%s/runs/%s", uiUrl,
                 workspace.getOrganization().getId(), workspace.getId(), job.getId());
@@ -212,27 +212,24 @@ public class GitHubWebhookService extends WebhookServiceBase {
         GithubCommitStatus commitStatus = GithubCommitStatus.pending;
         String commitStatusContext = "Terrakube - " + workspace.getOrganization().getName() + " - "
                 + workspace.getName();
-        String commitStatusDescription = "Your task is in Terrakube queue.";
 
         // Determine the commit status based on jobStatus
         switch (jobStatus) {
             case completed:
                 commitStatus = GithubCommitStatus.success;
-                commitStatusDescription = "Your task has been completed successfully.";
                 break;
             case failed:
             case rejected:
             case cancelled:
                 commitStatus = GithubCommitStatus.failure;
-                commitStatusDescription = "Your task has failed.";
                 break;
             case unknown:
                 commitStatus = GithubCommitStatus.error;
-                commitStatusDescription = "Your task ran into errors.";
                 break;
             default:
                 break;
         }
+        String commitStatusDescription = buildCommitStatusDescription(jobStatus, runSummary);
 
         // API URL for commit status
         String apiUrl = workspace.getVcs().getApiUrl() + "/repos/" + String.join("/", ownerAndRepos) + "/statuses/"
@@ -288,6 +285,34 @@ public class GitHubWebhookService extends WebhookServiceBase {
         } catch (Exception e) {
             log.error("Error occurred while checking PRs for commit {}: {}", job.getCommitId(), e.getMessage());
         }
+    }
+
+    // GitHub's commit-status description has a hard 140-character API limit.
+    static String buildCommitStatusDescription(JobStatus jobStatus, String runSummary) {
+        String description;
+        switch (jobStatus) {
+            case completed:
+                description = "Your task has been completed successfully.";
+                break;
+            case failed:
+            case rejected:
+            case cancelled:
+                description = "Your task has failed.";
+                break;
+            case unknown:
+                description = "Your task ran into errors.";
+                break;
+            default:
+                description = "Your task is in Terrakube queue.";
+                break;
+        }
+        if (runSummary != null && !runSummary.isBlank()) {
+            description = description + " " + runSummary;
+        }
+        if (description.length() > 140) {
+            description = description.substring(0, 140);
+        }
+        return description;
     }
 
     private List<Integer> getPullRequestNumbersForCommit(Workspace workspace, String commitId) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -288,31 +288,9 @@ public class GitHubWebhookService extends WebhookServiceBase {
     }
 
     // GitHub's commit-status description has a hard 140-character API limit.
-    static String buildCommitStatusDescription(JobStatus jobStatus, String runSummary) {
-        String description;
-        switch (jobStatus) {
-            case completed:
-                description = "Your task has been completed successfully.";
-                break;
-            case failed:
-            case rejected:
-            case cancelled:
-                description = "Your task has failed.";
-                break;
-            case unknown:
-                description = "Your task ran into errors.";
-                break;
-            default:
-                description = "Your task is in Terrakube queue.";
-                break;
-        }
-        if (runSummary != null && !runSummary.isBlank()) {
-            description = description + " " + runSummary;
-        }
-        if (description.length() > 140) {
-            description = description.substring(0, 140);
-        }
-        return description;
+    public static String buildCommitStatusDescription(JobStatus jobStatus, String runSummary) {
+        String description = WebhookServiceBase.buildCommitStatusDescription(jobStatus, runSummary);
+        return description.length() > 140 ? description.substring(0, 140) : description;
     }
 
     private List<Integer> getPullRequestNumbersForCommit(Workspace workspace, String commitId) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -723,7 +723,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
         }
     }
 
-    public void sendCommitStatus(Job job, JobStatus jobStatus) {
+    public void sendCommitStatus(Job job, JobStatus jobStatus, String runSummary) {
         Workspace workspace = job.getWorkspace();
         String jobUrl = String.format("%s/organizations/%s/workspaces/%s/runs/%s", uiUrl,
                 workspace.getOrganization().getId(), workspace.getId(), job.getId());
@@ -734,27 +734,24 @@ public class GitLabWebhookService extends WebhookServiceBase {
             GitlabCommitStatus commitStatus = GitlabCommitStatus.pending;
             String commitStatusContext = "Terrakube - " + workspace.getOrganization().getName() + " - "
                     + workspace.getName();
-            String commitStatusDescription = "Your task is in Terrakube queue.";
 
             // Determine the commit status based on jobStatus
             switch (jobStatus) {
                 case completed:
                     commitStatus = GitlabCommitStatus.success;
-                    commitStatusDescription = "Your task has been completed successfully.";
                     break;
                 case failed:
                 case rejected:
                 case cancelled:
                     commitStatus = GitlabCommitStatus.failed;
-                    commitStatusDescription = "Your task has failed.";
                     break;
                 case unknown:
                     commitStatus = GitlabCommitStatus.failed;
-                    commitStatusDescription = "Your task ran into errors.";
                     break;
                 default:
                     break;
             }
+            String commitStatusDescription = buildCommitStatusDescription(jobStatus, runSummary);
 
             // Create WebClient instance
             WebClient webClient = webClientBuilder
@@ -790,5 +787,29 @@ public class GitLabWebhookService extends WebhookServiceBase {
             log.error("Error sending commit status to GitLab", e);
         }
 
+    }
+
+    static String buildCommitStatusDescription(JobStatus jobStatus, String runSummary) {
+        String description;
+        switch (jobStatus) {
+            case completed:
+                description = "Your task has been completed successfully.";
+                break;
+            case failed:
+            case rejected:
+            case cancelled:
+                description = "Your task has failed.";
+                break;
+            case unknown:
+                description = "Your task ran into errors.";
+                break;
+            default:
+                description = "Your task is in Terrakube queue.";
+                break;
+        }
+        if (runSummary != null && !runSummary.isBlank()) {
+            description = description + " " + runSummary;
+        }
+        return description;
     }
 }

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -788,28 +788,4 @@ public class GitLabWebhookService extends WebhookServiceBase {
         }
 
     }
-
-    static String buildCommitStatusDescription(JobStatus jobStatus, String runSummary) {
-        String description;
-        switch (jobStatus) {
-            case completed:
-                description = "Your task has been completed successfully.";
-                break;
-            case failed:
-            case rejected:
-            case cancelled:
-                description = "Your task has failed.";
-                break;
-            case unknown:
-                description = "Your task ran into errors.";
-                break;
-            default:
-                description = "Your task is in Terrakube queue.";
-                break;
-        }
-        if (runSummary != null && !runSummary.isBlank()) {
-            description = description + " " + runSummary;
-        }
-        return description;
-    }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
@@ -293,7 +293,7 @@ public class ScheduleJobTest {
 
         verify(jobRepository, times(0)).save(any());
         verify(stepRepository, times(0)).save(any());
-        verify(gitLabWebhookService, times(0)).sendCommitStatus(any(), any());
+        verify(gitLabWebhookService, times(0)).sendCommitStatus(any(), any(), any());
         Assertions.assertEquals(JobStatus.pending, job.getStatus());
     }
 
@@ -675,7 +675,7 @@ public class ScheduleJobTest {
         Assert.assertFalse(subject().runExecution(job));
 
         verify(stepRepository, times(0)).save(any());
-        verify(gitLabWebhookService, times(0)).sendCommitStatus(any(), any());
+        verify(gitLabWebhookService, times(0)).sendCommitStatus(any(), any(), any());
         Assertions.assertEquals(JobStatus.approved, job.getStatus());
     }
 

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
@@ -103,6 +103,7 @@ public class ScheduleJobTest {
                 WorkspaceVariableValidationService.class,
                 new FailUnkownMethod<WorkspaceVariableValidationService>());
         lenient().doNothing().when(workspaceVariableValidationService).validateWorkspaceVariables(any());
+        lenient().doReturn(Optional.empty()).when(prCommentService).extractRunSummary(any());
     }
 
     private ScheduleJob subject() {
@@ -162,11 +163,11 @@ public class ScheduleJobTest {
         doReturn(job).when(jobRepository).save(any());
         doReturn(job.getStep()).when(stepRepository).findByJobId(anyInt());
         doReturn(null).when(stepRepository).save(any());
-        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
 
         Assertions.assertTrue(subject().runExecution(job));
 
-        verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.unknown);
+        verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.unknown, null);
         Assertions.assertEquals(JobStatus.failed, job.getStatus());
     }
 
@@ -178,7 +179,7 @@ public class ScheduleJobTest {
         doReturn(job).when(jobRepository).save(any());
         doReturn(job.getStep()).when(stepRepository).findByJobId(anyInt());
         doReturn(null).when(stepRepository).save(any());
-        doThrow(new RuntimeException("Boom!")).when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doThrow(new RuntimeException("Boom!")).when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
 
         Assertions.assertTrue(subject().runExecution(job));
 
@@ -237,14 +238,14 @@ public class ScheduleJobTest {
         doReturn(job.getStep()).when(stepRepository).findByJobId(anyInt());
         doReturn(null).when(stepRepository).save(any());
         doThrow(new ExecutionException(new Exception("Boom!"))).when(executorService).execute(any(), any(), any());
-        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
 
         // Seems odd that we do not remove the job from the scheduler?
         Assert.assertTrue(subject().runExecution(job));
 
         verify(jobRepository, times(1)).save(job);
         verify(workspaceRepository, times(1)).save(job.getWorkspace());
-        verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.unknown);
+        verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.unknown, null);
         Assertions.assertEquals(JobStatus.failed, job.getStatus());
         Assertions.assertEquals(JobStatus.failed, job.getStep().get(0).getStatus());
     }
@@ -435,11 +436,11 @@ public class ScheduleJobTest {
         doReturn(job).when(jobRepository).save(any());
         doReturn(job.getStep()).when(stepRepository).findByJobId(anyInt());
         doReturn(null).when(stepRepository).save(any());
-        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
 
         Assert.assertTrue(subject().runExecution(job));
 
-        verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.unknown);
+        verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.unknown, null);
         Assertions.assertEquals(JobStatus.failed, job.getStatus());
         Assertions.assertEquals(JobStatus.failed, job.getStep().get(0).getStatus());
     }
@@ -467,14 +468,14 @@ public class ScheduleJobTest {
         doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
         doReturn(job).when(jobRepository).save(any());
 
-        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
 
         // Seems odd that we do not remove the job from the scheduler?
         Assert.assertTrue(subject().runExecution(job));
 
         verify(jobRepository, times(1)).save(job);
         verify(workspaceRepository, times(2)).save(job.getWorkspace());
-        verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.completed);
+        verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.completed, null);
         Assertions.assertEquals(JobStatus.completed, job.getStatus());
     }
 
@@ -529,13 +530,13 @@ public class ScheduleJobTest {
         doReturn(job.getStep()).when(stepRepository).findByJobId(anyInt());
         doReturn(null).when(stepRepository).save(any());
         doThrow(new ExecutionException(new Exception("Boom!"))).when(executorService).execute(any(), any(), any());
-        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
 
         // TODO Could be true with no extra scheduling, because we know we are done
         Assert.assertTrue(subject().runExecution(job));
 
         verify(workspaceRepository, times(1)).save(job.getWorkspace());
-        verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.unknown);
+        verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.unknown, null);
         Assertions.assertEquals(JobStatus.failed, job.getStatus());
         Assertions.assertEquals(JobStatus.failed, job.getStep().get(0).getStatus());
     }
@@ -570,7 +571,7 @@ public class ScheduleJobTest {
                          anyList(),
                          anyInt());
          doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
-         doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+         doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
          doNothing().when(jobRepository).delete(any());
           // Passed directly to other mock, so list does not matter
          doReturn(Collections.emptyList()).when(stepRepository).findByJobId(anyInt());
@@ -612,7 +613,7 @@ public class ScheduleJobTest {
                         anyList(),
                         anyInt());
         doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
-        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
         doNothing().when(jobRepository).delete(any());
         // Passed directly to other mock, so list does not matter
         doReturn(Collections.emptyList()).when(stepRepository).findByJobId(anyInt());
@@ -659,7 +660,7 @@ public class ScheduleJobTest {
                         anyList(),
                         anyInt());
         doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
-        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
         doReturn(job).when(jobRepository).save(any());
         doReturn(Collections.emptyList()).when(stepRepository).findByJobId(anyInt());
 
@@ -670,6 +671,19 @@ public class ScheduleJobTest {
         verify(jobRepository, times(1)).save(prev2);
         Assertions.assertTrue(prev2.isDeleted());
         Assertions.assertFalse(prev1.isDeleted());
+    }
+
+    @Test
+    public void completedJobIncludesRunSummaryInCommitStatus() {
+        Job job = job(JobStatus.completed);
+        doReturn(Optional.of("Plan: 2 to add, 0 to change, 1 to destroy."))
+                .when(prCommentService).extractRunSummary(job);
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
+
+        subject().updateJobStatusOnVcs(job, JobStatus.completed);
+
+        verify(gitLabWebhookService, times(1))
+                .sendCommitStatus(job, JobStatus.completed, "Plan: 2 to add, 0 to change, 1 to destroy.");
     }
 
     @Test
@@ -689,12 +703,12 @@ public class ScheduleJobTest {
         doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
         doReturn(job.getStep()).when(stepRepository).findByJobId(anyInt());
         doReturn(null).when(stepRepository).save(any());
-        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
 
         Assert.assertTrue(subject().runExecution(job));
 
         verify(workspaceRepository, times(1)).save(job.getWorkspace());
-        verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.completed);
+        verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.completed, null);
         Assertions.assertEquals(JobStatus.notExecuted, job.getStep().get(0).getStatus());
     }
 
@@ -716,11 +730,11 @@ public class ScheduleJobTest {
         doReturn(null).when(stepRepository).save(any());
         doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
 
-        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
 
         Assert.assertTrue(subject().runExecution(job));
 
-        verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.failed);
+        verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.failed, null);
         Assertions.assertEquals(JobStatus.failed, job.getStep().get(0).getStatus());
     }
 
@@ -945,7 +959,7 @@ public class ScheduleJobTest {
         doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
         doReturn(job.getStep()).when(stepRepository).findByJobId(anyInt());
         doReturn(null).when(stepRepository).save(any());
-        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
         doNothing().when(prCommentService).postApplyResult(any());
         doNothing().when(prCommentService).acknowledgeCompletion(any());
 
@@ -979,7 +993,7 @@ public class ScheduleJobTest {
         doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
         doReturn(job.getStep()).when(stepRepository).findByJobId(anyInt());
         doReturn(null).when(stepRepository).save(any());
-        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
         doNothing().when(prCommentService).postPlanResult(any());
         doNothing().when(prCommentService).acknowledgeCompletion(any());
 

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
@@ -107,6 +107,53 @@ public class PrCommentServiceTest {
     }
 
     @Test
+    public void extractRunSummaryReturnsPlanLine() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        stubStepOutput("Some preamble\n\nPlan: 2 to add, 1 to change, 0 to destroy.\n");
+
+        Optional<String> summary = subject.extractRunSummary(job);
+
+        assertTrue(summary.isPresent());
+        assertEquals("Plan: 2 to add, 1 to change, 0 to destroy.", summary.get());
+    }
+
+    @Test
+    public void extractRunSummaryReturnsNoChangesLine() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        stubStepOutput("No changes. Your infrastructure matches the configuration.\n");
+
+        Optional<String> summary = subject.extractRunSummary(job);
+
+        assertEquals("No changes. Your infrastructure matches the configuration.", summary.get());
+    }
+
+    @Test
+    public void extractRunSummaryReturnsApplyCompleteLine() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        stubStepOutput("Some preamble\n\nApply complete! Resources: 3 added, 0 changed, 1 destroyed.\n");
+
+        Optional<String> summary = subject.extractRunSummary(job);
+
+        assertEquals("Apply complete! Resources: 3 added, 0 changed, 1 destroyed.", summary.get());
+    }
+
+    @Test
+    public void extractRunSummaryReturnsEmptyWhenNoStepOutput() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        stubStepOutput(null);
+
+        assertTrue(subject.extractRunSummary(job).isEmpty());
+    }
+
+    @Test
+    public void extractRunSummaryReturnsEmptyWhenNoMatch() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        stubStepOutput("Some unusual output with no recognizable summary");
+
+        assertTrue(subject.extractRunSummary(job).isEmpty());
+    }
+
+    @Test
     public void postPlanResultSkipsWhenPrNumberIsNull() {
         Job job = createJob(VcsType.GITHUB, null, JobStatus.completed);
 

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookServiceTest.java
@@ -1,0 +1,56 @@
+package io.terrakube.api.plugin.vcs.provider.azdevops;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.terrakube.api.rs.job.JobStatus;
+
+public class AzDevOpsWebhookServiceTest {
+
+    @Test
+    public void buildCommitStatusDescriptionAppendsRunSummaryOnSuccess() {
+        String description = AzDevOpsWebhookService.buildCommitStatusDescription(JobStatus.completed,
+                "Plan: 2 to add, 0 to change, 1 to destroy.");
+
+        assertEquals("Your task has been completed successfully. Plan: 2 to add, 0 to change, 1 to destroy.",
+                description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionOmitsSummaryWhenNull() {
+        String description = AzDevOpsWebhookService.buildCommitStatusDescription(JobStatus.completed, null);
+
+        assertEquals("Your task has been completed successfully.", description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionOmitsSummaryWhenBlank() {
+        String description = AzDevOpsWebhookService.buildCommitStatusDescription(JobStatus.completed, "   ");
+
+        assertEquals("Your task has been completed successfully.", description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionAppendsRunSummaryOnFailure() {
+        String description = AzDevOpsWebhookService.buildCommitStatusDescription(JobStatus.failed,
+                "Plan: 1 to add, 0 to change, 0 to destroy.");
+
+        assertEquals("Your task has failed. Plan: 1 to add, 0 to change, 0 to destroy.", description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionAppendsRunSummaryOnError() {
+        String description = AzDevOpsWebhookService.buildCommitStatusDescription(JobStatus.unknown,
+                "Plan: 1 to add, 0 to change, 0 to destroy.");
+
+        assertEquals("Your task ran into errors. Plan: 1 to add, 0 to change, 0 to destroy.", description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionDefaultsToQueueMessage() {
+        String description = AzDevOpsWebhookService.buildCommitStatusDescription(JobStatus.queue, null);
+
+        assertEquals("Your task is in Terrakube queue.", description);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookServiceTest.java
@@ -1,0 +1,67 @@
+package io.terrakube.api.plugin.vcs.provider.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.terrakube.api.rs.job.JobStatus;
+
+public class GitHubWebhookServiceTest {
+
+    @Test
+    public void buildCommitStatusDescriptionAppendsRunSummaryOnSuccess() {
+        String description = GitHubWebhookService.buildCommitStatusDescription(JobStatus.completed,
+                "Plan: 2 to add, 0 to change, 1 to destroy.");
+
+        assertEquals("Your task has been completed successfully. Plan: 2 to add, 0 to change, 1 to destroy.",
+                description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionOmitsSummaryWhenNull() {
+        String description = GitHubWebhookService.buildCommitStatusDescription(JobStatus.completed, null);
+
+        assertEquals("Your task has been completed successfully.", description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionOmitsSummaryWhenBlank() {
+        String description = GitHubWebhookService.buildCommitStatusDescription(JobStatus.completed, "   ");
+
+        assertEquals("Your task has been completed successfully.", description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionAppendsRunSummaryOnFailure() {
+        String description = GitHubWebhookService.buildCommitStatusDescription(JobStatus.failed,
+                "Plan: 1 to add, 0 to change, 0 to destroy.");
+
+        assertEquals("Your task has failed. Plan: 1 to add, 0 to change, 0 to destroy.", description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionAppendsRunSummaryOnError() {
+        String description = GitHubWebhookService.buildCommitStatusDescription(JobStatus.unknown,
+                "Plan: 1 to add, 0 to change, 0 to destroy.");
+
+        assertEquals("Your task ran into errors. Plan: 1 to add, 0 to change, 0 to destroy.", description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionDefaultsToQueueMessage() {
+        String description = GitHubWebhookService.buildCommitStatusDescription(JobStatus.queue, null);
+
+        assertEquals("Your task is in Terrakube queue.", description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionTruncatesAt140Characters() {
+        String longSummary = "Plan: " + "1".repeat(200) + " to add, 0 to change, 0 to destroy.";
+
+        String description = GitHubWebhookService.buildCommitStatusDescription(JobStatus.completed, longSummary);
+
+        assertEquals(140, description.length());
+        assertTrue(description.startsWith("Your task has been completed successfully. Plan:"));
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookServiceTest.java
@@ -1,0 +1,56 @@
+package io.terrakube.api.plugin.vcs.provider.gitlab;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import io.terrakube.api.rs.job.JobStatus;
+
+public class GitLabWebhookServiceTest {
+
+    @Test
+    public void buildCommitStatusDescriptionAppendsRunSummaryOnSuccess() {
+        String description = GitLabWebhookService.buildCommitStatusDescription(JobStatus.completed,
+                "Plan: 2 to add, 0 to change, 1 to destroy.");
+
+        assertEquals("Your task has been completed successfully. Plan: 2 to add, 0 to change, 1 to destroy.",
+                description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionOmitsSummaryWhenNull() {
+        String description = GitLabWebhookService.buildCommitStatusDescription(JobStatus.completed, null);
+
+        assertEquals("Your task has been completed successfully.", description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionOmitsSummaryWhenBlank() {
+        String description = GitLabWebhookService.buildCommitStatusDescription(JobStatus.completed, "   ");
+
+        assertEquals("Your task has been completed successfully.", description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionAppendsRunSummaryOnFailure() {
+        String description = GitLabWebhookService.buildCommitStatusDescription(JobStatus.failed,
+                "Plan: 1 to add, 0 to change, 0 to destroy.");
+
+        assertEquals("Your task has failed. Plan: 1 to add, 0 to change, 0 to destroy.", description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionAppendsRunSummaryOnError() {
+        String description = GitLabWebhookService.buildCommitStatusDescription(JobStatus.unknown,
+                "Plan: 1 to add, 0 to change, 0 to destroy.");
+
+        assertEquals("Your task ran into errors. Plan: 1 to add, 0 to change, 0 to destroy.", description);
+    }
+
+    @Test
+    public void buildCommitStatusDescriptionDefaultsToQueueMessage() {
+        String description = GitLabWebhookService.buildCommitStatusDescription(JobStatus.queue, null);
+
+        assertEquals("Your task is in Terrakube queue.", description);
+    }
+}


### PR DESCRIPTION
## What

GitHub, GitLab, and Azure DevOps commit statuses now include a resource-change summary instead of always saying the generic "Your task has been completed successfully." A completed plan now shows something like `Your task has been completed successfully. Plan: 2 to add, 0 to change, 1 to destroy.`, matching what `terraform plan` itself prints

Closes #3297

## Why

The status message gave no indication of what actually happened, so you had to click through to the job to see if anything changed. The issue discussion floated pulling this from the structured plan JSON output, but there's already a working extractor for exactly this text — `PrCommentService` regex-matches terraform's own summary line out of the step console output for PR comments. Reusing that was simpler and guarantees the wording matches what people already see in PR comments, so I widened it slightly instead of writing a second parser against the JSON.

## How

`PrCommentService.extractRunSummary(Job)` is the new entry point — it fetches the last step's console output and matches the plan/no-changes/apply-complete line out of it (the pattern now also catches `Apply complete! Resources: ...`, which it didn't before, so apply jobs get a summary too, not just plans). `ScheduleJob.updateJobStatusOnVcs` calls this once and threads the result through to whichever provider handles the job.

Each provider's `sendCommitStatus` picks up a `runSummary` param and appends it to the description if present. The description-building logic itself (the queue/success/failure/error text) got pulled out of all three provider classes into one `WebhookServiceBase.buildCommitStatusDescription` — they were about to become three copies of the same switch statement, which would've been an easy target for the SonarCloud duplication check. GitHub keeps a thin wrapper on top since it's the only one of the three with a hard 140-character API limit on the description field.

Scope note: the linked issue only mentions GitHub, but GitLab and Azure DevOps have the identical pattern, so I did all three rather than leaving a gap for a follow-up issue.

## Testing

`mvn -pl api test` — full suite green. Added coverage for the new extraction (plan/no-changes/apply-complete/no-match cases), the description builder per provider including GitHub's truncation, and a `ScheduleJobTest` case proving the extracted summary actually reaches `sendCommitStatus`