### PR TITLE
feat(api): add GitLab webhooks support for shared repository-level workflows

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
@@ -20,12 +20,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import io.terrakube.api.plugin.scheduler.ScheduleJobService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
+import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
 import io.terrakube.api.repository.JobRepository;
 import io.terrakube.api.repository.RepoWebhookRepository;
 import io.terrakube.api.repository.WebhookEventRepository;
 import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.vcs.VcsType;
 import io.terrakube.api.rs.webhook.RepoWebhook;
 import io.terrakube.api.rs.webhook.WebhookEvent;
 import io.terrakube.api.rs.webhook.WebhookEventType;
@@ -43,8 +45,17 @@ public class RepoWebhookService {
     WorkspaceRepository workspaceRepository;
     WebhookEventRepository webhookEventRepository;
     GitHubWebhookService gitHubWebhookService;
+    GitLabWebhookService gitLabWebhookService;
     JobRepository jobRepository;
     ScheduleJobService scheduleJobService;
+
+    private boolean isGitLab(RepoWebhook repoWebhook) {
+        return repoWebhook.getVcs() != null && repoWebhook.getVcs().getVcsType() == VcsType.GITLAB;
+    }
+
+    private boolean isGitLab(Workspace workspace) {
+        return workspace.getVcs() != null && workspace.getVcs().getVcsType() == VcsType.GITLAB;
+    }
 
     // Callers reach this exclusively through RepoWebhookSyncJob, which is
     // @DisallowConcurrentExecution and keyed by a hash of the normalized
@@ -97,7 +108,9 @@ public class RepoWebhookService {
             return;
         }
 
-        String remoteHookId = gitHubWebhookService.createOrUpdateRepoWebhook(repoWebhook, eventTypes);
+        String remoteHookId = isGitLab(repoWebhook)
+                ? gitLabWebhookService.createOrUpdateRepoWebhook(repoWebhook, eventTypes)
+                : gitHubWebhookService.createOrUpdateRepoWebhook(repoWebhook, eventTypes);
         repoWebhook.setRemoteHookId(remoteHookId);
         repoWebhookRepository.save(repoWebhook);
     }
@@ -108,7 +121,11 @@ public class RepoWebhookService {
                 .findByNormalizedSourceWithMigratedWebhook(repoWebhook.getRepositoryUrl());
 
         if (workspaces.isEmpty()) {
-            gitHubWebhookService.deleteRepoWebhook(repoWebhook);
+            if (isGitLab(repoWebhook)) {
+                gitLabWebhookService.deleteRepoWebhook(repoWebhook);
+            } else {
+                gitHubWebhookService.deleteRepoWebhook(repoWebhook);
+            }
             repoWebhookRepository.delete(repoWebhook);
             log.info("Deleted orphan repo webhook {} for {}", repoWebhook.getId(), repoWebhook.getRepositoryUrl());
         } else {
@@ -121,12 +138,20 @@ public class RepoWebhookService {
         RepoWebhook repoWebhook = repoWebhookRepository.findById(UUID.fromString(repoWebhookId))
                 .orElseThrow(() -> new IllegalArgumentException("Repo webhook not found: " + repoWebhookId));
 
-        if (!verifyHmacSignature(headers, repoWebhook.getWebhookSecret(), jsonPayload)) {
+        boolean gitlab = isGitLab(repoWebhook);
+        if (gitlab) {
+            if (!verifyGitlabToken(headers, repoWebhook.getWebhookSecret())) {
+                log.error("Token verification failed for repo webhook {}", repoWebhookId);
+                throw new SecurityException("GitLab token verification failed");
+            }
+        } else if (!verifyHmacSignature(headers, repoWebhook.getWebhookSecret(), jsonPayload)) {
             log.error("Signature verification failed for repo webhook {}", repoWebhookId);
             throw new SecurityException("HMAC signature verification failed");
         }
 
-        WebhookResult webhookResult = gitHubWebhookService.parseGitHubPayload(jsonPayload, headers);
+        WebhookResult webhookResult = gitlab
+                ? gitLabWebhookService.parseGitLabPayload(jsonPayload, headers)
+                : gitHubWebhookService.parseGitHubPayload(jsonPayload, headers);
 
         if (webhookResult.getEvent() != null && webhookResult.getEvent().equals("ping")) {
             log.info("Received ping for repo webhook {}", repoWebhookId);
@@ -161,8 +186,11 @@ public class RepoWebhookService {
 
         if (webhookResult.getPrFilesUrl() != null) {
             if (workspace.getVcs() != null) {
-                List<String> prFiles = gitHubWebhookService.fetchPrFileChanges(
-                        workspace.getVcs(), workspace.getSource(), webhookResult.getPrFilesUrl());
+                List<String> prFiles = isGitLab(workspace)
+                        ? gitLabWebhookService.fetchPrFileChanges(
+                                workspace.getVcs(), workspace.getSource(), webhookResult.getPrFilesUrl())
+                        : gitHubWebhookService.fetchPrFileChanges(
+                                workspace.getVcs(), workspace.getSource(), webhookResult.getPrFilesUrl());
                 webhookResult.setFileChanges(prFiles);
             } else {
                 log.warn("Workspace {} has no VCS, cannot fetch PR file changes", workspace.getName());
@@ -199,7 +227,11 @@ public class RepoWebhookService {
             job.setCommitId(webhookResult.getCommit());
             Job savedJob = jobRepository.save(job);
             if (!webhookResult.isRelease() && workspace.getVcs() != null) {
-                gitHubWebhookService.sendCommitStatus(savedJob, JobStatus.pending, null);
+                if (isGitLab(workspace)) {
+                    gitLabWebhookService.sendCommitStatus(savedJob, JobStatus.pending, null);
+                } else {
+                    gitHubWebhookService.sendCommitStatus(savedJob, JobStatus.pending, null);
+                }
             }
             scheduleJobService.createJobContext(savedJob);
         } catch (IllegalArgumentException e) {
@@ -208,6 +240,17 @@ public class RepoWebhookService {
         } catch (Exception e) {
             log.error("Error creating job for workspace {}", workspace.getName(), e);
         }
+    }
+
+    private boolean verifyGitlabToken(Map<String, String> headers, String secret) {
+        String tokenHeader = headers.get("x-gitlab-token");
+        if (tokenHeader == null) {
+            log.error("x-gitlab-token header is missing!");
+            return false;
+        }
+        return MessageDigest.isEqual(
+                tokenHeader.getBytes(StandardCharsets.UTF_8),
+                secret.getBytes(StandardCharsets.UTF_8));
     }
 
     private boolean verifyHmacSignature(Map<String, String> headers, String secret, String payload) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -14,7 +14,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.JobVia;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.webhook.RepoWebhook;
 import io.terrakube.api.rs.webhook.Webhook;
+import io.terrakube.api.rs.webhook.WebhookEventType;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -787,5 +791,248 @@ public class GitLabWebhookService extends WebhookServiceBase {
             log.error("Error sending commit status to GitLab", e);
         }
 
+    }
+
+    /**
+     * Parses a GitLab webhook payload for the shared (v2) repository-level flow, mirroring
+     * {@code GitHubWebhookService#parseGitHubPayload}. Unlike the per-workspace v1
+     * {@link #processWebhook}, this does not perform any workspace-scoped API calls: merge
+     * request/note events store the MR iid in {@code prFilesUrl} so that file changes can be
+     * resolved later, per workspace, through {@link #fetchPrFileChanges}.
+     */
+    public WebhookResult parseGitLabPayload(String jsonPayload, Map<String, String> headers) {
+        WebhookResult result = new WebhookResult();
+        result.setBranch("");
+        result.setVia(JobVia.GITLAB.getValue());
+        result.setValid(true);
+        try {
+            JsonNode rootNode = objectMapper.readTree(jsonPayload);
+            String event = rootNode.path("object_kind").asText();
+            result.setEvent(event);
+
+            switch (event) {
+                case "push":
+                    parsePushEvent(result, jsonPayload, rootNode);
+                    break;
+                case "merge_request":
+                    parseMergeRequestEvent(result, jsonPayload, rootNode);
+                    break;
+                case "release":
+                    handleReleaseEvent(result, jsonPayload);
+                    break;
+                case "note":
+                    parseNoteEvent(result, rootNode);
+                    break;
+                default:
+                    result.setValid(false);
+                    log.error("No valid gitlab event {}", event);
+                    break;
+            }
+        } catch (Exception e) {
+            log.error("Error parsing GitLab payload", e);
+            result.setValid(false);
+        }
+        return result;
+    }
+
+    private void parsePushEvent(WebhookResult result, String jsonPayload, JsonNode rootNode) {
+        String[] ref = rootNode.path("ref").asText().split("/");
+        if (ref.length >= 3) {
+            String[] extractedBranch = Arrays.copyOfRange(ref, 2, ref.length);
+            result.setBranch(String.join("/", extractedBranch));
+        }
+        result.setCreatedBy(rootNode.path("user_username").asText());
+
+        List<String> fileChanges = new ArrayList<>();
+        try {
+            GitlabWebhookModel gitlabWebhookModel = objectMapper.readValue(jsonPayload, GitlabWebhookModel.class);
+            result.setCommit(gitlabWebhookModel.getCheckoutSha());
+            if (gitlabWebhookModel.getCommits() != null) {
+                gitlabWebhookModel.getCommits().forEach(commitData -> {
+                    fileChanges.addAll(commitData.getAdded());
+                    fileChanges.addAll(commitData.getModified());
+                    fileChanges.addAll(commitData.getRemoved());
+                });
+            }
+        } catch (JsonProcessingException e) {
+            log.error("Error parsing GitLab push payload: {}", e.getMessage());
+        }
+        result.setFileChanges(fileChanges);
+    }
+
+    private void parseMergeRequestEvent(WebhookResult result, String jsonPayload, JsonNode rootNode) {
+        try {
+            GitlabMergeRequestModel mrModel = objectMapper.readValue(jsonPayload, GitlabMergeRequestModel.class);
+            String action = mrModel.getObjectAttributes().getAction();
+
+            // Ignore update events triggered by resolving blocking discussions
+            if ("update".equals(action) && rootNode.has("blocking_discussions_resolved")) {
+                log.info("Ignoring GitLab MR update event: blocking discussions resolved");
+                result.setValid(false);
+                return;
+            }
+
+            if ("open".equals(action) || "update".equals(action) || "reopen".equals(action)) {
+                result.setBranch(mrModel.getObjectAttributes().getSourceBranch());
+                result.setCreatedBy("system");
+                result.setPrNumber(mrModel.getObjectAttributes().getIid());
+                if (mrModel.getObjectAttributes().getLastCommit() != null) {
+                    result.setCommit(mrModel.getObjectAttributes().getLastCommit().getId());
+                }
+                // Defer file-change resolution to fetchPrFileChanges (per workspace), mirroring
+                // GitHub's prFilesUrl mechanism. The MR iid is the marker used to fetch the diff.
+                if (mrModel.getObjectAttributes().getIid() != null) {
+                    result.setPrFilesUrl(mrModel.getObjectAttributes().getIid().toString());
+                }
+            } else {
+                result.setValid(false);
+                log.info("Merge request action '{}' not supported for shared webhook", action);
+            }
+        } catch (JsonProcessingException e) {
+            log.error("Error parsing merge request event payload: {}", e.getMessage());
+            result.setValid(false);
+        }
+    }
+
+    private void parseNoteEvent(WebhookResult result, JsonNode rootNode) {
+        JsonNode noteNode = rootNode.path("object_attributes");
+        if (!"MergeRequest".equals(noteNode.path("noteable_type").asText())) {
+            result.setValid(false);
+            return;
+        }
+
+        String commentBody = noteNode.path("note").asText().trim();
+        String command = parseTerrakubeCommand(commentBody);
+        if (command == null) {
+            result.setValid(false);
+            return;
+        }
+
+        result.setPrComment(true);
+        result.setCommentBody(commentBody);
+        result.setCommentCommand(command);
+        result.setCommentId(noteNode.path("id").asText());
+        result.setCreatedBy(rootNode.path("user").path("username").asText());
+
+        JsonNode mrNode = rootNode.path("merge_request");
+        result.setBranch(mrNode.path("source_branch").asText());
+        result.setPrNumber(mrNode.path("iid").asInt());
+        if (mrNode.has("last_commit")) {
+            result.setCommit(mrNode.path("last_commit").path("id").asText());
+        }
+        result.setPrFilesUrl(String.valueOf(mrNode.path("iid").asInt()));
+    }
+
+    /**
+     * Resolves the changed files of a GitLab merge request for the shared (v2) flow. The
+     * {@code mergeRequestIid} is the marker stored in {@code WebhookResult.prFilesUrl} by
+     * {@link #parseGitLabPayload}. Kept signature-compatible with
+     * {@code GitHubWebhookService#fetchPrFileChanges} so {@code RepoWebhookService} can dispatch
+     * uniformly.
+     */
+    public List<String> fetchPrFileChanges(Vcs vcs, String source, String mergeRequestIid) {
+        try {
+            String ownerAndRepo = extractOwnerAndRepoGitlab(source);
+            String projectId = getGitlabProjectId(ownerAndRepo, vcs.getAccessToken(), vcs.getApiUrl());
+            return getFileChanges(mergeRequestIid, projectId, vcs.getAccessToken(), vcs.getApiUrl());
+        } catch (IOException e) {
+            log.error("Error fetching GitLab MR file changes for MR {}: {}", mergeRequestIid, e.getMessage());
+        } catch (InterruptedException e) {
+            log.error("Interrupted fetching GitLab MR file changes for MR {}: {}", mergeRequestIid, e.getMessage());
+            Thread.currentThread().interrupt();
+        }
+        return new ArrayList<>();
+    }
+
+    /**
+     * Creates or updates the single shared GitLab webhook for a repository, mirroring
+     * {@code GitHubWebhookService#createOrUpdateRepoWebhook}. The aggregated {@code eventTypes}
+     * (across every migrated workspace sharing this repository) decide which GitLab event flags
+     * are enabled.
+     */
+    public String createOrUpdateRepoWebhook(RepoWebhook repoWebhook, Set<WebhookEventType> eventTypes) {
+        String remoteHookId = repoWebhook.getRemoteHookId();
+        Vcs vcs = repoWebhook.getVcs();
+        String token = vcs.getAccessToken();
+        String ownerAndRepo = extractOwnerAndRepoGitlab(repoWebhook.getRepositoryUrl());
+        String webhookUrl = String.format("https://%s/webhook/v2/%s", hostname, repoWebhook.getId().toString());
+
+        boolean pushEvents = eventTypes.contains(WebhookEventType.PUSH);
+        boolean mergeRequestsEvents = eventTypes.contains(WebhookEventType.PULL_REQUEST);
+        boolean releasesEvents = eventTypes.contains(WebhookEventType.RELEASE);
+        boolean noteEvents = eventTypes.contains(WebhookEventType.PR_COMMENT);
+
+        String body = "{\"url\":\"" + webhookUrl
+                + "\",\"push_events\":" + pushEvents
+                + ",\"merge_requests_events\":" + mergeRequestsEvents
+                + ",\"releases_events\":" + releasesEvents
+                + ",\"note_events\":" + noteEvents
+                + ",\"enable_ssl_verification\":false,\"token\":\"" + repoWebhook.getWebhookSecret() + "\"}";
+
+        String projectId;
+        try {
+            projectId = getGitlabProjectId(ownerAndRepo, token, vcs.getApiUrl());
+        } catch (IOException e) {
+            log.error("Error resolving GitLab project id for {}: {}", ownerAndRepo, e.getMessage());
+            return remoteHookId;
+        } catch (InterruptedException e) {
+            log.error("Interrupted resolving GitLab project id for {}: {}", ownerAndRepo, e.getMessage());
+            Thread.currentThread().interrupt();
+            return remoteHookId;
+        }
+
+        ResponseEntity<String> response;
+        if (remoteHookId == null || remoteHookId.isEmpty()) {
+            String apiUrl = vcs.getApiUrl() + "/projects/" + projectId + "/hooks";
+            response = callGitlabApi(token, body, apiUrl, HttpMethod.POST);
+            if (response != null && response.getStatusCode().value() == 201) {
+                try {
+                    JsonNode rootNode = objectMapper.readTree(response.getBody());
+                    remoteHookId = rootNode.path("id").asText();
+                } catch (Exception e) {
+                    log.error("Error parsing JSON response", e);
+                }
+                log.info("GitLab repo webhook created successfully with id {}", remoteHookId);
+            }
+        } else {
+            String apiUrl = vcs.getApiUrl() + "/projects/" + projectId + "/hooks/" + remoteHookId;
+            response = callGitlabApi(token, body, apiUrl, HttpMethod.PUT);
+            log.info("GitLab repo webhook updated with status {} and id {}",
+                    response != null ? response.getStatusCode() : "no response", remoteHookId);
+        }
+
+        return remoteHookId;
+    }
+
+    /**
+     * Deletes the shared GitLab webhook of an orphaned repository, mirroring
+     * {@code GitHubWebhookService#deleteRepoWebhook}.
+     */
+    public void deleteRepoWebhook(RepoWebhook repoWebhook) {
+        if (repoWebhook.getRemoteHookId() == null || repoWebhook.getRemoteHookId().isEmpty()) {
+            log.warn("No remote hook id found for repo webhook {}, skipping deletion", repoWebhook.getId());
+            return;
+        }
+        Vcs vcs = repoWebhook.getVcs();
+        try {
+            String ownerAndRepo = extractOwnerAndRepoGitlab(repoWebhook.getRepositoryUrl());
+            String projectId = getGitlabProjectId(ownerAndRepo, vcs.getAccessToken(), vcs.getApiUrl());
+            String apiUrl = vcs.getApiUrl() + "/projects/" + projectId + "/hooks/" + repoWebhook.getRemoteHookId();
+
+            ResponseEntity<String> response = callGitlabApi(vcs.getAccessToken(), "", apiUrl, HttpMethod.DELETE);
+            if (response != null && response.getStatusCode().value() == 204) {
+                log.info("Repo webhook with remote hook id {} deleted successfully", repoWebhook.getRemoteHookId());
+            } else {
+                log.warn("Failed to delete repo webhook with remote hook id {}, message {}",
+                        repoWebhook.getRemoteHookId(), response != null ? response.getBody() : "no response");
+            }
+        } catch (IOException e) {
+            log.error("Failed to delete repo webhook with remote hook id {}: {}",
+                    repoWebhook.getRemoteHookId(), e.getMessage());
+        } catch (InterruptedException e) {
+            log.error("Interrupted deleting repo webhook with remote hook id {}: {}",
+                    repoWebhook.getRemoteHookId(), e.getMessage());
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/api/src/main/java/io/terrakube/api/rs/hooks/webhook/WebhookManageHook.java
+++ b/api/src/main/java/io/terrakube/api/rs/hooks/webhook/WebhookManageHook.java
@@ -9,6 +9,7 @@ import io.terrakube.api.plugin.scheduler.webhook.RepoWebhookSyncScheduler;
 import io.terrakube.api.plugin.vcs.RepoUrlNormalizer;
 import io.terrakube.api.plugin.vcs.WebhookService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
+import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
 import io.terrakube.api.rs.vcs.VcsType;
 import io.terrakube.api.rs.webhook.Webhook;
 import io.terrakube.api.rs.webhook.WebhookEvent;
@@ -30,6 +31,9 @@ public class WebhookManageHook implements LifeCycleHook<Webhook> {
     GitHubWebhookService gitHubWebhookService;
 
     @Autowired
+    GitLabWebhookService gitLabWebhookService;
+
+    @Autowired
     RepoWebhookSyncScheduler repoWebhookSyncScheduler;
 
     @Override
@@ -41,12 +45,12 @@ public class WebhookManageHook implements LifeCycleHook<Webhook> {
                 switch (phase) {
                     case PRECOMMIT:
                         try {
-                            if (isMigratedV2GitHub(elideEntity)) {
+                            if (isMigratedV2Shared(elideEntity)) {
                                 // Delete the old per-workspace hook, if any — this is
                                 // workspace-specific cleanup, not the shared-repo setup
                                 // that used to race, so it stays inline here.
                                 if (elideEntity.getRemoteHookId() != null && !elideEntity.getRemoteHookId().isEmpty()) {
-                                    gitHubWebhookService.deleteWebhook(elideEntity.getWorkspace(), elideEntity.getRemoteHookId());
+                                    deleteWorkspaceHook(elideEntity);
                                     elideEntity.setRemoteHookId(null);
                                 }
                             } else {
@@ -65,16 +69,17 @@ public class WebhookManageHook implements LifeCycleHook<Webhook> {
                         // Only now is the workspace's migrated Webhook/WebhookEvent
                         // data durably committed and visible to the job's own query.
                         //
-                        // Scheduled whenever the workspace is GitHub-backed at all,
-                        // not just when currently migrated-v2: a revert (migratedV2
-                        // true -> false) needs this too, so the job can notice this
-                        // workspace no longer shares the URL and either resync the
-                        // remaining migrated workspaces' event types or, if this was
-                        // the last one, clean up the now-orphaned shared webhook. The
-                        // job itself is cheap and already a no-op when there's
-                        // nothing to do, so this isn't gated on isMigratedV2GitHub.
+                        // Scheduled whenever the workspace is backed by a shared
+                        // webhook provider (GitHub or GitLab) at all, not just when
+                        // currently migrated-v2: a revert (migratedV2 true -> false)
+                        // needs this too, so the job can notice this workspace no
+                        // longer shares the URL and either resync the remaining
+                        // migrated workspaces' event types or, if this was the last
+                        // one, clean up the now-orphaned shared webhook. The job
+                        // itself is cheap and already a no-op when there's nothing to
+                        // do, so this isn't gated on isMigratedV2Shared.
                         try {
-                            if (isGitHub(elideEntity)) {
+                            if (isSharedWebhookProvider(elideEntity)) {
                                 scheduleSync(elideEntity);
                             }
                         } catch (Exception e) {
@@ -90,7 +95,7 @@ public class WebhookManageHook implements LifeCycleHook<Webhook> {
                 switch (phase) {
                     case POSTCOMMIT:
                         try {
-                            if (isMigratedV2GitHub(elideEntity)) {
+                            if (isMigratedV2Shared(elideEntity)) {
                                 scheduleSync(elideEntity);
                             } else {
                                 webhookService.deleteWorkspaceWebhook(elideEntity);
@@ -110,13 +115,29 @@ public class WebhookManageHook implements LifeCycleHook<Webhook> {
         }
     }
 
-    private boolean isMigratedV2GitHub(Webhook elideEntity) {
-        return elideEntity.isMigratedV2() && isGitHub(elideEntity);
+    private boolean isMigratedV2Shared(Webhook elideEntity) {
+        return elideEntity.isMigratedV2() && isSharedWebhookProvider(elideEntity);
     }
 
-    private boolean isGitHub(Webhook elideEntity) {
+    // Both GitHub and GitLab participate in the shared, repository-level (v2)
+    // webhook flow reconciled asynchronously by RepoWebhookSyncJob.
+    private boolean isSharedWebhookProvider(Webhook elideEntity) {
+        VcsType vcsType = vcsType(elideEntity);
+        return vcsType == VcsType.GITHUB || vcsType == VcsType.GITLAB;
+    }
+
+    private VcsType vcsType(Webhook elideEntity) {
         return elideEntity.getWorkspace().getVcs() != null
-                && elideEntity.getWorkspace().getVcs().getVcsType() == VcsType.GITHUB;
+                ? elideEntity.getWorkspace().getVcs().getVcsType()
+                : null;
+    }
+
+    private void deleteWorkspaceHook(Webhook elideEntity) {
+        if (vcsType(elideEntity) == VcsType.GITLAB) {
+            gitLabWebhookService.deleteWebhook(elideEntity.getWorkspace(), elideEntity.getRemoteHookId());
+        } else {
+            gitHubWebhookService.deleteWebhook(elideEntity.getWorkspace(), elideEntity.getRemoteHookId());
+        }
     }
 
     private void scheduleSync(Webhook elideEntity) {

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
@@ -32,6 +32,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 
 import io.terrakube.api.plugin.scheduler.ScheduleJobService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
+import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
 import io.terrakube.api.repository.JobRepository;
 import io.terrakube.api.repository.RepoWebhookRepository;
 import io.terrakube.api.repository.WebhookEventRepository;
@@ -54,6 +55,7 @@ class RepoWebhookServiceTest {
     WorkspaceRepository workspaceRepository;
     WebhookEventRepository webhookEventRepository;
     GitHubWebhookService gitHubWebhookService;
+    GitLabWebhookService gitLabWebhookService;
     JobRepository jobRepository;
     ScheduleJobService scheduleJobService;
 
@@ -65,6 +67,7 @@ class RepoWebhookServiceTest {
         workspaceRepository = mock(WorkspaceRepository.class);
         webhookEventRepository = mock(WebhookEventRepository.class);
         gitHubWebhookService = mock(GitHubWebhookService.class);
+        gitLabWebhookService = mock(GitLabWebhookService.class);
         jobRepository = mock(JobRepository.class);
         scheduleJobService = mock(ScheduleJobService.class);
 
@@ -73,6 +76,7 @@ class RepoWebhookServiceTest {
                 workspaceRepository,
                 webhookEventRepository,
                 gitHubWebhookService,
+                gitLabWebhookService,
                 jobRepository,
                 scheduleJobService);
     }
@@ -94,6 +98,20 @@ class RepoWebhookServiceTest {
         rw.setRepositoryUrl(url);
         rw.setWebhookSecret(secret);
         rw.setVcs(new Vcs());
+        return rw;
+    }
+
+    private Workspace gitlabWorkspaceWithSource(String source) {
+        Workspace ws = workspaceWithSource(source);
+        ws.getVcs().setVcsType(VcsType.GITLAB);
+        return ws;
+    }
+
+    private RepoWebhook gitlabRepoWebhookWith(String url, String secret) {
+        RepoWebhook rw = repoWebhookWith(url, secret);
+        Vcs vcs = new Vcs();
+        vcs.setVcsType(VcsType.GITLAB);
+        rw.setVcs(vcs);
         return rw;
     }
 
@@ -890,6 +908,258 @@ class RepoWebhookServiceTest {
 
             assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), payload, headers))
                     .isInstanceOf(SecurityException.class);
+        }
+    }
+
+    @Nested
+    class GitLabRepoWebhook {
+
+        @Test
+        void createOrUpdateSharedWebhookDispatchesToGitLab() {
+            RepoWebhook rw = gitlabRepoWebhookWith("https://gitlab.com/owner/repo", "secret");
+
+            Workspace ws1 = gitlabWorkspaceWithSource("https://gitlab.com/owner/repo");
+            Webhook wh1 = new Webhook();
+            WebhookEvent pushEvent = new WebhookEvent();
+            pushEvent.setEvent(WebhookEventType.PUSH);
+            wh1.setEvents(List.of(pushEvent));
+            ws1.setWebhook(wh1);
+
+            Workspace ws2 = gitlabWorkspaceWithSource("https://gitlab.com/owner/repo");
+            Webhook wh2 = new Webhook();
+            WebhookEvent mrEvent = new WebhookEvent();
+            mrEvent.setEvent(WebhookEventType.PULL_REQUEST);
+            wh2.setEvents(List.of(mrEvent));
+            ws2.setWebhook(wh2);
+
+            when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(rw.getRepositoryUrl()))
+                    .thenReturn(List.of(ws1, ws2));
+            when(gitLabWebhookService.createOrUpdateRepoWebhook(eq(rw), any()))
+                    .thenReturn("gl-999");
+
+            subject.createOrUpdateSharedWebhook(rw);
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Set<WebhookEventType>> captor = ArgumentCaptor.forClass(Set.class);
+            verify(gitLabWebhookService).createOrUpdateRepoWebhook(eq(rw), captor.capture());
+            assertThat(captor.getValue()).containsExactlyInAnyOrder(WebhookEventType.PUSH, WebhookEventType.PULL_REQUEST);
+            assertThat(rw.getRemoteHookId()).isEqualTo("gl-999");
+            verify(gitHubWebhookService, never()).createOrUpdateRepoWebhook(any(), any());
+            verify(repoWebhookRepository).save(rw);
+        }
+
+        @Test
+        void cleanupDeletesGitLabRepoWebhookWhenOrphan() {
+            RepoWebhook rw = gitlabRepoWebhookWith("https://gitlab.com/owner/repo", "secret");
+            when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(rw.getRepositoryUrl()))
+                    .thenReturn(Collections.emptyList());
+
+            subject.cleanupIfOrphan(rw);
+
+            verify(gitLabWebhookService).deleteRepoWebhook(rw);
+            verify(gitHubWebhookService, never()).deleteRepoWebhook(any());
+            verify(repoWebhookRepository).delete(rw);
+        }
+
+        @Test
+        void processV2WebhookGitLabPushFansOutAndVerifiesToken() {
+            String repoUrl = "https://gitlab.com/owner/repo";
+            String secret = "gitlab-token-secret";
+            String payload = "{\"object_kind\":\"push\"}";
+            RepoWebhook rw = gitlabRepoWebhookWith(repoUrl, secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            Map<String, String> headers = Map.of("x-gitlab-token", secret);
+
+            WebhookResult pushResult = new WebhookResult();
+            pushResult.setEvent("push");
+            pushResult.setValid(true);
+            pushResult.setBranch("main");
+            pushResult.setCommit("abc123");
+            pushResult.setFileChanges(List.of("main.tf"));
+            when(gitLabWebhookService.parseGitLabPayload(eq(payload), any())).thenReturn(pushResult);
+
+            Workspace ws = gitlabWorkspaceWithSource(repoUrl);
+            ws.setName("gl-ws");
+            Webhook wh = new Webhook();
+            WebhookEvent event = new WebhookEvent();
+            event.setEvent(WebhookEventType.PUSH);
+            event.setBranch("main");
+            event.setPath("*");
+            event.setPathType(WebhookEventPathType.PATTERN);
+            event.setTemplateId("gl-template");
+            wh.setEvents(List.of(event));
+            ws.setWebhook(wh);
+
+            when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(repoUrl))
+                    .thenReturn(List.of(ws));
+            when(webhookEventRepository.findByWebhookAndEventOrderByPriorityAsc(wh, WebhookEventType.PUSH))
+                    .thenReturn(List.of(event));
+            when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+
+            ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
+            verify(jobRepository).save(jobCaptor.capture());
+            assertThat(jobCaptor.getValue().getTemplateReference()).isEqualTo("gl-template");
+            // GitLab parser used, not GitHub, and commit status sent via GitLab
+            verify(gitHubWebhookService, never()).parseGitHubPayload(any(), any());
+            verify(gitLabWebhookService).sendCommitStatus(any(Job.class), any(), any());
+            verify(gitHubWebhookService, never()).sendCommitStatus(any(), any(), any());
+        }
+
+        @Test
+        void processV2WebhookGitLabMergeRequestFetchesFileChanges() {
+            String repoUrl = "https://gitlab.com/owner/repo";
+            String secret = "mr-token-secret";
+            String payload = "{\"object_kind\":\"merge_request\"}";
+            RepoWebhook rw = gitlabRepoWebhookWith(repoUrl, secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            Map<String, String> headers = Map.of("x-gitlab-token", secret);
+
+            WebhookResult mrResult = new WebhookResult();
+            mrResult.setEvent("merge_request");
+            mrResult.setValid(true);
+            mrResult.setBranch("feature-branch");
+            mrResult.setCommit("def456");
+            mrResult.setPrNumber(42);
+            // GitLab stores the MR iid marker in prFilesUrl (mirrors GitHub's PR files URL)
+            mrResult.setPrFilesUrl("42");
+            when(gitLabWebhookService.parseGitLabPayload(eq(payload), any())).thenReturn(mrResult);
+            when(gitLabWebhookService.fetchPrFileChanges(any(), eq(repoUrl), eq("42")))
+                    .thenReturn(List.of("variables.tf"));
+
+            Workspace ws = gitlabWorkspaceWithSource(repoUrl);
+            ws.setName("gl-mr-ws");
+            Webhook wh = new Webhook();
+            WebhookEvent event = new WebhookEvent();
+            event.setEvent(WebhookEventType.PULL_REQUEST);
+            event.setBranch("feature-branch");
+            event.setPath("*.tf");
+            event.setPathType(WebhookEventPathType.PATTERN);
+            event.setTemplateId("gl-mr-template");
+            wh.setEvents(List.of(event));
+            ws.setWebhook(wh);
+
+            when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(repoUrl))
+                    .thenReturn(List.of(ws));
+            when(webhookEventRepository.findByWebhookAndEventOrderByPriorityAsc(wh, WebhookEventType.PULL_REQUEST))
+                    .thenReturn(List.of(event));
+            when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+
+            verify(gitLabWebhookService).fetchPrFileChanges(any(), eq(repoUrl), eq("42"));
+            verify(gitHubWebhookService, never()).fetchPrFileChanges(any(), any(), any());
+            ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
+            verify(jobRepository).save(jobCaptor.capture());
+            assertThat(jobCaptor.getValue().getTemplateReference()).isEqualTo("gl-mr-template");
+            assertThat(jobCaptor.getValue().getCommitId()).isEqualTo("def456");
+            assertThat(jobCaptor.getValue().getOverrideBranch()).isEqualTo("feature-branch");
+        }
+
+        @Test
+        void processV2WebhookGitLabReleaseCreatesJobs() {
+            String repoUrl = "https://gitlab.com/owner/repo";
+            String secret = "release-token-secret";
+            String payload = "{\"object_kind\":\"release\"}";
+            RepoWebhook rw = gitlabRepoWebhookWith(repoUrl, secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            Map<String, String> headers = Map.of("x-gitlab-token", secret);
+
+            WebhookResult releaseResult = new WebhookResult();
+            releaseResult.setEvent("release");
+            releaseResult.setValid(true);
+            releaseResult.setBranch("v1.0.0");
+            releaseResult.setCommit("tag-sha-123");
+            releaseResult.setRelease(true);
+            when(gitLabWebhookService.parseGitLabPayload(eq(payload), any())).thenReturn(releaseResult);
+
+            Workspace ws = gitlabWorkspaceWithSource(repoUrl);
+            ws.setName("gl-release-ws");
+            Webhook wh = new Webhook();
+            WebhookEvent event = new WebhookEvent();
+            event.setEvent(WebhookEventType.RELEASE);
+            event.setBranch("v1.*");
+            event.setTemplateId("gl-release-template");
+            wh.setEvents(List.of(event));
+            ws.setWebhook(wh);
+
+            when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(repoUrl))
+                    .thenReturn(List.of(ws));
+            when(webhookEventRepository.findByWebhookAndEventOrderByPriorityAsc(wh, WebhookEventType.RELEASE))
+                    .thenReturn(List.of(event));
+            when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+
+            ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
+            verify(jobRepository).save(jobCaptor.capture());
+            assertThat(jobCaptor.getValue().getTemplateReference()).isEqualTo("gl-release-template");
+            assertThat(jobCaptor.getValue().getOverrideBranch()).isEqualTo("refs/tags/v1.0.0");
+            // Releases don't send a commit status
+            verify(gitLabWebhookService, never()).sendCommitStatus(any(), any(), any());
+        }
+
+        @Test
+        void processV2WebhookGitLabRejectsWrongToken() {
+            String secret = "correct-token";
+            RepoWebhook rw = gitlabRepoWebhookWith("https://gitlab.com/owner/repo", secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            Map<String, String> headers = Map.of("x-gitlab-token", "wrong-token");
+
+            assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), "{}", headers))
+                    .isInstanceOf(SecurityException.class)
+                    .hasMessageContaining("GitLab token verification failed");
+
+            verify(jobRepository, never()).save(any());
+        }
+
+        @Test
+        void processV2WebhookGitLabRejectsMissingToken() {
+            RepoWebhook rw = gitlabRepoWebhookWith("https://gitlab.com/owner/repo", "secret");
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), "{}", Map.of()))
+                    .isInstanceOf(SecurityException.class);
+
+            verify(jobRepository, never()).save(any());
+        }
+
+        @Test
+        void v2WebhookMigrationRemovalScenarioGitLab() {
+            String repoUrl = "https://gitlab.com/owner/repo";
+
+            Workspace workspace = gitlabWorkspaceWithSource(repoUrl);
+            workspace.setName("gl-workspace-v1");
+
+            Webhook webhook = new Webhook();
+            webhook.setWorkspace(workspace);
+            webhook.setMigratedV2(true);
+            webhook.setRemoteHookId("old-gl-v1-hook-id");
+            workspace.setWebhook(webhook);
+
+            RepoWebhook repoWebhook = gitlabRepoWebhookWith(repoUrl, "new-secret");
+            when(repoWebhookRepository.findByRepositoryUrl(anyString())).thenReturn(Optional.of(repoWebhook));
+
+            // This mirrors the logic in WebhookManageHook for a migrated GitLab webhook
+            if (webhook.isMigratedV2() && workspace.getVcs() != null
+                    && workspace.getVcs().getVcsType() == VcsType.GITLAB) {
+                subject.getOrCreateRepoWebhook(workspace);
+                subject.createOrUpdateSharedWebhook(repoWebhook);
+
+                if (webhook.getRemoteHookId() != null && !webhook.getRemoteHookId().isEmpty()) {
+                    gitLabWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
+                    webhook.setRemoteHookId(null);
+                }
+            }
+
+            verify(gitLabWebhookService).deleteWebhook(workspace, "old-gl-v1-hook-id");
+            verify(gitHubWebhookService, never()).deleteRepoWebhook(any());
+            assertThat(webhook.getRemoteHookId()).isNull();
         }
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookServiceTest.java
@@ -1,12 +1,80 @@
 package io.terrakube.api.plugin.vcs.provider.gitlab;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.terrakube.api.plugin.vcs.WebhookResult;
 import io.terrakube.api.rs.job.JobStatus;
 
 public class GitLabWebhookServiceTest {
+
+    private GitLabWebhookService newService() {
+        return new GitLabWebhookService(new ObjectMapper(), "localhost", "http://localhost",
+                WebClient.builder(), 30, 25);
+    }
+
+    @Test
+    public void parseGitLabPayloadParsesPushEvent() {
+        String payload = "{\"object_kind\":\"push\",\"ref\":\"refs/heads/main\",\"checkout_sha\":\"abc123\","
+                + "\"user_username\":\"jdoe\",\"commits\":[{\"added\":[\"main.tf\"],"
+                + "\"modified\":[\"variables.tf\"],\"removed\":[]}]}";
+
+        WebhookResult result = newService().parseGitLabPayload(payload, Map.of());
+
+        assertEquals("push", result.getEvent());
+        assertEquals("main", result.getBranch());
+        assertEquals("abc123", result.getCommit());
+        assertTrue(result.isValid());
+        assertTrue(result.getFileChanges().contains("main.tf"));
+        assertTrue(result.getFileChanges().contains("variables.tf"));
+    }
+
+    @Test
+    public void parseGitLabPayloadStoresMergeRequestIidForFileFetch() {
+        String payload = "{\"object_kind\":\"merge_request\",\"object_attributes\":{\"iid\":42,"
+                + "\"action\":\"open\",\"source_branch\":\"feature\",\"last_commit\":{\"id\":\"def456\"}}}";
+
+        WebhookResult result = newService().parseGitLabPayload(payload, Map.of());
+
+        assertEquals("merge_request", result.getEvent());
+        assertEquals("feature", result.getBranch());
+        assertEquals("def456", result.getCommit());
+        assertEquals(42L, result.getPrNumber());
+        // The MR iid is the marker used later to resolve the changed files per workspace
+        assertEquals("42", result.getPrFilesUrl());
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void parseGitLabPayloadParsesReleaseCreate() {
+        String payload = "{\"object_kind\":\"release\",\"action\":\"create\",\"tag\":\"v1.0.0\","
+                + "\"name\":\"Release 1.0.0\"}";
+
+        WebhookResult result = newService().parseGitLabPayload(payload, Map.of());
+
+        assertEquals("release", result.getEvent());
+        assertTrue(result.isRelease());
+        assertTrue(result.isValid());
+        assertEquals("Release 1.0.0", result.getBranch());
+    }
+
+    @Test
+    public void parseGitLabPayloadMarksUnknownEventInvalid() {
+        String payload = "{\"object_kind\":\"pipeline\"}";
+
+        WebhookResult result = newService().parseGitLabPayload(payload, Map.of());
+
+        assertEquals("pipeline", result.getEvent());
+        assertFalse(result.isValid());
+    }
 
     @Test
     public void buildCommitStatusDescriptionAppendsRunSummaryOnSuccess() {

--- a/api/src/test/java/io/terrakube/api/rs/hooks/webhook/WebhookManageHookTest.java
+++ b/api/src/test/java/io/terrakube/api/rs/hooks/webhook/WebhookManageHookTest.java
@@ -3,6 +3,7 @@ package io.terrakube.api.rs.hooks.webhook;
 import io.terrakube.api.plugin.scheduler.webhook.RepoWebhookSyncScheduler;
 import io.terrakube.api.plugin.vcs.WebhookService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
+import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
 import io.terrakube.api.rs.vcs.Vcs;
 import io.terrakube.api.rs.vcs.VcsType;
 import io.terrakube.api.rs.webhook.Webhook;
@@ -38,6 +39,9 @@ class WebhookManageHookTest {
 
     @Mock
     GitHubWebhookService gitHubWebhookService;
+
+    @Mock
+    GitLabWebhookService gitLabWebhookService;
 
     @Mock
     RepoWebhookSyncScheduler repoWebhookSyncScheduler;
@@ -122,11 +126,11 @@ class WebhookManageHookTest {
     }
 
     @Test
-    void execute_nonGitHub_postcommitDoesNotScheduleSync() {
+    void execute_nonSharedProvider_postcommitDoesNotScheduleSync() {
         Workspace workspace = new Workspace();
-        workspace.setSource("https://gitlab.com/owner/repo");
+        workspace.setSource("https://bitbucket.org/owner/repo");
         Vcs vcs = new Vcs();
-        vcs.setVcsType(VcsType.GITLAB);
+        vcs.setVcsType(VcsType.BITBUCKET);
         workspace.setVcs(vcs);
 
         Webhook webhook = new Webhook();
@@ -135,6 +139,46 @@ class WebhookManageHookTest {
 
         subject.execute(Operation.UPDATE, TransactionPhase.POSTCOMMIT, webhook, requestScope, Optional.empty());
 
+        verifyNoInteractions(repoWebhookSyncScheduler);
+    }
+
+    @Test
+    void execute_gitlab_postcommitSchedulesSync() {
+        Workspace workspace = new Workspace();
+        workspace.setId(java.util.UUID.fromString("44444444-4444-4444-4444-444444444444"));
+        workspace.setSource("https://gitlab.com/owner/repo");
+        Vcs vcs = new Vcs();
+        vcs.setVcsType(VcsType.GITLAB);
+        workspace.setVcs(vcs);
+
+        Webhook webhook = new Webhook();
+        webhook.setWorkspace(workspace);
+        webhook.setMigratedV2(true);
+
+        subject.execute(Operation.UPDATE, TransactionPhase.POSTCOMMIT, webhook, requestScope, Optional.empty());
+
+        verify(repoWebhookSyncScheduler).scheduleSync(
+                "https://gitlab.com/owner/repo", "44444444-4444-4444-4444-444444444444");
+    }
+
+    @Test
+    void execute_gitlab_migrationV2_precommitRemovesV1WebhookButDoesNotSyncYet() {
+        Workspace workspace = new Workspace();
+        workspace.setSource("https://gitlab.com/owner/repo");
+        Vcs vcs = new Vcs();
+        vcs.setVcsType(VcsType.GITLAB);
+        workspace.setVcs(vcs);
+
+        Webhook webhook = new Webhook();
+        webhook.setWorkspace(workspace);
+        webhook.setMigratedV2(true);
+        webhook.setRemoteHookId("gl-v1-hook-id");
+
+        subject.execute(Operation.UPDATE, TransactionPhase.PRECOMMIT, webhook, requestScope, Optional.empty());
+
+        verify(gitLabWebhookService).deleteWebhook(workspace, "gl-v1-hook-id");
+        verifyNoInteractions(gitHubWebhookService);
+        assertNull(webhook.getRemoteHookId());
         verifyNoInteractions(repoWebhookSyncScheduler);
     }
 


### PR DESCRIPTION
## Creating some dummy workspaces with version 1

<img width="1226" height="754" alt="imagen" src="https://github.com/user-attachments/assets/9557a643-2242-47b0-8e25-bb8a2c1d23d5" />

## Independent webhooks for v1

<img width="1532" height="448" alt="imagen" src="https://github.com/user-attachments/assets/3b975ee8-408f-4550-8e61-fd37f2292782" />

## Migrate gitlab1

<img width="1111" height="720" alt="imagen" src="https://github.com/user-attachments/assets/24590df6-bf37-406e-8f7d-f26f6ecfffa7" />


## Migrate gitlab2

<img width="1111" height="720" alt="imagen" src="https://github.com/user-attachments/assets/a7d00491-2888-4391-a6ad-7ac3b3b49d9b" />

## Shared webhook in gitlab 

<img width="1499" height="405" alt="imagen" src="https://github.com/user-attachments/assets/1675767b-1813-4da8-878b-7703c03a48d3" />

## Job Trigger by shared webhook


<img width="1530" height="474" alt="imagen" src="https://github.com/user-attachments/assets/cd84c444-dea2-4d64-87c7-0ffa58ed6bdc" />

