### PR TITLE
fix(streaming): stop dropping unparseable apply -json lines and SSE i…

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/service/terraform/ApplyJsonEventParser.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/ApplyJsonEventParser.java
@@ -19,8 +19,9 @@ public class ApplyJsonEventParser {
     /**
      * Parses one line of `terraform apply -json` output, updating the matching entry in
      * {@code changes} (matched by "address") in place. Returns the human-readable @message
-     * for the caller to feed into the existing plain-text console log, or null if the line
-     * wasn't parseable JSON.
+     * for the caller to feed into the existing plain-text console log. Plain-text lines can
+     * still be emitted by Terraform or provisioners while JSON output is enabled, so preserve
+     * those lines even though they cannot update structured apply progress.
      */
     public String parseLine(String jsonLine, List<Map<String, Object>> changes) {
         Map<String, Object> event;
@@ -28,8 +29,8 @@ public class ApplyJsonEventParser {
             event = objectMapper.readValue(jsonLine, new TypeReference<>() {
             });
         } catch (Exception e) {
-            log.warn("Unable to parse apply JSON line: {}", jsonLine, e);
-            return null;
+            log.debug("Unable to parse apply JSON line; forwarding it as plain text: {}", jsonLine);
+            return jsonLine;
         }
 
         Object message = event.get("@message");

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -314,6 +314,10 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         return TerraformClient.builder()
                 .jsonOutput(true)
                 .showColor(false)
+                // The normal client merges stderr before every Terraform operation. Keep that
+                // behaviour for the JSON client too: runJsonApply has no separate stderr
+                // listener, so otherwise diagnostics are silently discarded.
+                .redirectErrorStream(true)
                 .terraformReleasesUrl(terraformClient.getTerraformReleasesUrl())
                 .tofuReleasesUrl(terraformClient.getTofuReleasesUrl())
                 .build();

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/ApplyJsonEventParserTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/ApplyJsonEventParserTest.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 class ApplyJsonEventParserTest {
 
@@ -68,7 +67,7 @@ class ApplyJsonEventParserTest {
     }
 
     @Test
-    void returnsMessageForNonHookEventsAndNullForUnparsableLines() {
+    void returnsMessageForNonHookEventsAndOriginalLineForUnparsableLines() {
         List<Map<String, Object>> changes = oneChange("aws_instance.foo");
 
         String message = subject().parseLine(
@@ -76,6 +75,6 @@ class ApplyJsonEventParserTest {
                 changes);
 
         assertEquals("Apply complete! Resources: 1 added, 0 changed, 0 destroyed.", message);
-        assertNull(subject().parseLine("not valid json", changes));
+        assertEquals("not valid json", subject().parseLine("not valid json", changes));
     }
 }

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
@@ -150,6 +150,14 @@ class TerraformExecutorServiceImplTest {
     }
 
     @Test
+    void jsonApplyClientMergesErrorStream() {
+        TerraformClient jsonApplyClient = subject().buildJsonEnabledApplyClient();
+
+        assertTrue(jsonApplyClient.isJsonOutput());
+        assertTrue(jsonApplyClient.isRedirectErrorStream());
+    }
+
+    @Test
     void fallsBackToSharedClientWhenThereIsNoSeedData() throws Exception {
         TerraformExecutorServiceImpl subject = subject();
         TerraformJob terraformJob = createJob();

--- a/ui/src/domain/Jobs/StructuredPlanOutput.tsx
+++ b/ui/src/domain/Jobs/StructuredPlanOutput.tsx
@@ -97,6 +97,7 @@ type PreparedChangeRow = {
   visibleChanges: number;
   hiddenCount: number;
   applyStatus?: ApplyChange["status"];
+  applyError?: ApplyChange["error"];
 };
 
 type SummarySegment = {
@@ -1116,6 +1117,7 @@ export const StructuredPlanOutput = ({ changes, outputLog, applyMode = false, ou
       const providerName = getProviderName(change);
       const diff = buildResourceDiff(change, normalizedAction);
       const applyStatus = "status" in change ? (change as ApplyChange).status : undefined;
+      const applyError = "error" in change ? (change as ApplyChange).error : undefined;
 
       return {
         key: `${resourceLabel}-${normalizedAction}-${index}`,
@@ -1129,6 +1131,7 @@ export const StructuredPlanOutput = ({ changes, outputLog, applyMode = false, ou
         visibleChanges: countVisibleLeaves(diff.rows),
         hiddenCount: diff.hiddenCount,
         applyStatus,
+        applyError,
       };
     });
   }, [changes]);
@@ -1459,6 +1462,7 @@ export const StructuredPlanOutput = ({ changes, outputLog, applyMode = false, ou
                       {rowApplyStatusMeta ? (
                         <span
                           className={`structured-plan-applyStatus structured-plan-applyStatus--${rowApplyStatusMeta.className}`}
+                          title={row.applyStatus === "errored" && row.applyError ? row.applyError : undefined}
                         >
                           {rowApplyStatusMeta.label}
                         </span>

--- a/ui/src/domain/Jobs/__tests__/StructuredPlanOutput.test.tsx
+++ b/ui/src/domain/Jobs/__tests__/StructuredPlanOutput.test.tsx
@@ -192,6 +192,31 @@ describe("StructuredPlanOutput", () => {
     expect(screen.getByText("imported", { selector: ".structured-plan-applyStatus" })).toBeInTheDocument();
   });
 
+  it("surfaces the diagnostic error message as a tooltip on the errored badge", () => {
+    render(
+      <StructuredPlanOutput
+        applyMode
+        changes={[
+          {
+            address: "null_resource.fails",
+            action: "create",
+            actions: ["create"],
+            after: {},
+            status: "errored",
+            error: "local-exec provisioner error",
+          },
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /null_resource\.fails/i }));
+
+    expect(screen.getByText("create failed", { selector: ".structured-plan-applyStatus" })).toHaveAttribute(
+      "title",
+      "local-exec provisioner error"
+    );
+  });
+
   it("filters rows by address", () => {
     render(
       <StructuredPlanOutput

--- a/ui/src/modules/api/__tests__/eventStream.test.ts
+++ b/ui/src/modules/api/__tests__/eventStream.test.ts
@@ -76,6 +76,19 @@ describe("readEventStream", () => {
     expect(received).toEqual([["line 1", "100-0"]]);
   });
 
+  it("preserves indentation beyond the single SSE-spec leading space", async () => {
+    const response = makeStreamResponse(["data:      + arn = (known after apply)\n\n"]);
+    (global.fetch as jest.Mock) = jest.fn().mockResolvedValue(response);
+
+    const received: string[] = [];
+    await readEventStream("http://localhost/stream", {
+      onMessage: (data) => received.push(data),
+      signal: new AbortController().signal,
+    });
+
+    expect(received).toEqual(["     + arn = (known after apply)"]);
+  });
+
   it("sends Last-Event-ID as a request header when provided", async () => {
     const response = makeStreamResponse(["data: line 1\n\n"]);
     const fetchMock = jest.fn().mockResolvedValue(response);

--- a/ui/src/modules/api/eventStream.ts
+++ b/ui/src/modules/api/eventStream.ts
@@ -41,7 +41,12 @@ export async function readEventStream(
 
     for (const event of events) {
       const lines = event.split("\n");
-      const dataLines = lines.filter((line) => line.startsWith("data:")).map((line) => line.slice(5).trimStart());
+      // Per the SSE spec, only a single leading space after "data:" is stripped -
+      // any further indentation is part of the value and must be preserved.
+      const dataLines = lines
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice(5))
+        .map((line) => (line.startsWith(" ") ? line.slice(1) : line));
       const idLine = lines.find((line) => line.startsWith("id:"));
       const id = idLine != null ? idLine.slice(3).trimStart() : undefined;
 


### PR DESCRIPTION
## Summary

Three related fixes to apply/plan streaming, found while chasing reports of the apply console going silent partway through a run and plan output losing its indentation while streaming live:

- **`ApplyJsonEventParser`**: `terraform apply -json` isn't guaranteed to emit valid JSON on every line (e.g. plain-text lines from provisioners or long-running resource progress ticks). Previously any unparseable line was silently dropped — no console output, no structured-status update, and the resource stuck on "pending" indefinitely. It's now forwarded to the console as raw text instead of vanishing.
- **`buildJsonEnabledApplyClient`**: the JSON-mode apply client never merged stderr into stdout (unlike every other Terraform operation in this codebase, which sets `redirectErrorStream(true)` in `prepareTerraformOperation`), and `runJsonApply` passes no separate stderr listener — so any real stderr output during a JSON apply was being silently discarded. Now merged, consistent with the rest of the client's operations.
- **`eventStream.ts`**: the SSE client was stripping *all* leading whitespace from `data:` lines instead of the single spec-mandated leading space, which flattened `terraform plan`'s indentation (nested attributes, closing braces) while it streamed live. Fixed to strip at most one leading space.
- **`StructuredPlanOutput.tsx`**: the backend already captured a per-resource failure reason (`ApplyChange.error`, from the `diagnostic` JSON event's summary) and it was already parsed into the frontend model, but never rendered. Now shown as a tooltip on the "errored" status badge.

## Test plan

- [x] `ApplyJsonEventParserTest` — new coverage for the raw-line fallback and the `redirectErrorStream`/`jsonOutput` client config
- [x] `TerraformExecutorServiceImplTest` — new `jsonApplyClientMergesErrorStream` test
- [x] `eventStream.test.ts` — new coverage asserting indentation beyond the single SSE-spec leading space is preserved
- [x] `StructuredPlanOutput.test.tsx` — new coverage asserting the diagnostic message renders as a tooltip on the errored badge
- [x] Manually reproduced the original bug against a local minikube deployment using a throwaway repo with a nested `time_sleep`/`aws_secretsmanager_secret_version` resource (matching the original report's module depth) to trigger OpenTofu's "Still creating... [Ns elapsed]" ticker; confirmed the console went silent on the pre-fix build and stayed live on the post-fix build