### PR TITLE
fix(redis): enable Jedis connection pooling

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -139,6 +139,10 @@
             <type>jar</type>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.yahoo.elide</groupId>
             <artifactId>elide-spring-boot-starter</artifactId>
             <version>${elide.version}</version>

--- a/api/src/main/java/io/terrakube/api/plugin/streaming/StreamingConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/streaming/StreamingConfiguration.java
@@ -57,6 +57,7 @@ public class StreamingConfiguration {
     @Bean
     JedisConnectionFactory jedisConnectionFactory(StreamingProperties props, SSLSocketFactory sslSocketFactory) {
         JedisClientConfiguration.JedisClientConfigurationBuilder clientConfigBuilder = JedisClientConfiguration.builder();
+        clientConfigBuilder.usePooling();
 
         if (props.isSsl()) {
             log.info("Setup Redis connection using SSL");

--- a/api/src/test/java/io/terrakube/api/plugin/streaming/StreamingConfigurationTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/streaming/StreamingConfigurationTest.java
@@ -1,0 +1,25 @@
+package io.terrakube.api.plugin.streaming;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.net.ssl.SSLContext;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+
+class StreamingConfigurationTest {
+
+    @Test
+    void jedisConnectionFactoryUsesPoolingWithSsl() throws Exception {
+        StreamingProperties properties = new StreamingProperties();
+        properties.setHostname("localhost");
+        properties.setPort(6379);
+        properties.setSsl(true);
+
+        JedisConnectionFactory connectionFactory = new StreamingConfiguration()
+                .jedisConnectionFactory(properties, SSLContext.getDefault().getSocketFactory());
+
+        assertThat(connectionFactory.getClientConfiguration().isUsePooling()).isTrue();
+        assertThat(connectionFactory.getClientConfiguration().isUseSsl()).isTrue();
+    }
+}

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -74,6 +74,10 @@
 			<type>jar</type>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-pool2</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>

--- a/executor/src/main/java/io/terrakube/executor/configuration/RedisAutoConfiguration.java
+++ b/executor/src/main/java/io/terrakube/executor/configuration/RedisAutoConfiguration.java
@@ -58,6 +58,7 @@ public class RedisAutoConfiguration {
     @Bean
     JedisConnectionFactory jedisConnectionFactory(RedisProperties redisProperties, SSLSocketFactory sslSocketFactory) {
         JedisClientConfiguration.JedisClientConfigurationBuilder clientConfigBuilder = JedisClientConfiguration.builder();
+        clientConfigBuilder.usePooling();
 
         if (redisProperties.isSsl()) {
             log.info("Redis connection with SSL configuration");

--- a/executor/src/test/java/io/terrakube/executor/configuration/RedisAutoConfigurationTest.java
+++ b/executor/src/test/java/io/terrakube/executor/configuration/RedisAutoConfigurationTest.java
@@ -1,0 +1,25 @@
+package io.terrakube.executor.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.net.ssl.SSLContext;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+
+class RedisAutoConfigurationTest {
+
+    @Test
+    void jedisConnectionFactoryUsesPoolingWithSsl() throws Exception {
+        RedisProperties properties = new RedisProperties();
+        properties.setHostname("localhost");
+        properties.setPort(6379);
+        properties.setSsl(true);
+
+        JedisConnectionFactory connectionFactory = new RedisAutoConfiguration()
+                .jedisConnectionFactory(properties, SSLContext.getDefault().getSocketFactory());
+
+        assertThat(connectionFactory.getClientConfiguration().isUsePooling()).isTrue();
+        assertThat(connectionFactory.getClientConfiguration().isUseSsl()).isTrue();
+    }
+}


### PR DESCRIPTION
Enable Jedis pooling for the API and executor Redis connection factories and add the required pool dependency.

Fixes #3363

Tests:
- mvn -pl executor -Dtest=RedisAutoConfigurationTest,RedisPropertiesTest,SpringAsyncAutoConfigurationTest test
- mvn -pl api -Dtest=StreamingConfigurationTest,StreamingPropertiesTest,StreamingServiceTest,RedisStreamReaderTest test