### PR TITLE
fix(executor): restrict the shallow clone to the requested ref

### DIFF
--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -141,6 +141,12 @@
 			<version>${jgit.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.jgit</groupId>
+			<artifactId>org.eclipse.jgit.junit.ssh</artifactId>
+			<version>${jgit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
 			<version>${groovy.version}</version>

--- a/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -10,6 +10,7 @@ import java.security.PublicKey;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -28,10 +29,12 @@ import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.TransportCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.errors.MissingObjectException;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.transport.CredentialsProvider;
@@ -163,6 +166,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
 
     private void downloadWorkspaceGit(File gitCloneFolder, TerraformJob terraformJob)
             throws GitAPIException, IOException {
+        String branchRef = resolveBranchRef(terraformJob);
         if (terraformJob.getVcsType().startsWith("SSH")) {
             CloneCommand cloneCommand = Git.cloneRepository()
                     .setURI(terraformJob.getSource())
@@ -179,7 +183,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
                     .setCloneSubmodules(true);
 
             cloneCommand.setDepth(1);
-            cloneCommand.setBranchesToClone(List.of(Constants.R_HEADS + terraformJob.getBranch()));
+            cloneCommand.setBranchesToClone(List.of(branchRef));
             cloneCommand.call();
         } else {
             CloneCommand cloneCommand = Git.cloneRepository()
@@ -191,7 +195,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
                     .setCloneSubmodules(true);
 
             cloneCommand.setDepth(1);
-            cloneCommand.setBranchesToClone(List.of(Constants.R_HEADS + terraformJob.getBranch()));
+            cloneCommand.setBranchesToClone(List.of(branchRef));
             cloneCommand.call();
         }
 
@@ -204,6 +208,58 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
 
         log.info("Git clone: {} Branch: {} Folder {}", terraformJob.getSource(), terraformJob.getBranch(),
                 gitCloneFolder.getPath());
+    }
+
+    /**
+     * The branch field also accepts a tag name, so the namespace has to be resolved before the
+     * fetch can be restricted to a single ref.
+     */
+    private String resolveBranchRef(TerraformJob terraformJob) throws IOException {
+        String headRef = Constants.R_HEADS + terraformJob.getBranch();
+        String tagRef = Constants.R_TAGS + terraformJob.getBranch();
+
+        // Key material has to land outside the clone folder: CloneCommand refuses a destination
+        // that is not empty.
+        File sshFolder = Files.createTempDirectory("terrakube-ls-remote").toFile();
+        SshdSessionFactory sshSessionFactory = sshSessionFactory(sshFolder, terraformJob);
+        try {
+            Map<String, Ref> remoteRefs = configureTransport(
+                    Git.lsRemoteRepository().setRemote(terraformJob.getSource()), sshSessionFactory, terraformJob)
+                    .setHeads(true)
+                    .setTags(true)
+                    .callAsMap();
+            return !remoteRefs.containsKey(headRef) && remoteRefs.containsKey(tagRef) ? tagRef : headRef;
+        } catch (GitAPIException e) {
+            // Narrowing is an optimisation, so a failed probe defers to the clone, which reports
+            // transport and credential problems in the terms callers already expect.
+            log.warn("Unable to list refs for {}: {}", terraformJob.getSource(), e.getMessage());
+            return headRef;
+        } finally {
+            if (sshSessionFactory != null) {
+                sshSessionFactory.close();
+            }
+            FileUtils.deleteDirectory(sshFolder);
+        }
+    }
+
+    private SshdSessionFactory sshSessionFactory(File sshFolder, TerraformJob terraformJob) throws IOException {
+        return terraformJob.getVcsType().startsWith("SSH")
+                ? getSshdSessionFactory(sshFolder, terraformJob.getAccessToken())
+                : null;
+    }
+
+    private <C extends TransportCommand<C, ?>> C configureTransport(C command,
+            SshdSessionFactory sshSessionFactory, TerraformJob terraformJob) {
+        if (sshSessionFactory != null) {
+            return command.setTransportConfigCallback(
+                    transport -> ((SshTransport) transport).setSshSessionFactory(sshSessionFactory));
+        }
+        CredentialsProvider credentialsProvider = setupCredentials(terraformJob.getVcsType(),
+                terraformJob.getConnectionType(), terraformJob.getAccessToken());
+        if (credentialsProvider != null) {
+            command.setCredentialsProvider(credentialsProvider);
+        }
+        return command;
     }
 
     private void checkoutCommitId(File gitCloneFolder, TerraformJob terraformJob) throws GitAPIException, IOException {
@@ -261,23 +317,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
     private FetchCommand configureFetchCommand(FetchCommand fetchCommand, File gitCloneFolder,
             TerraformJob terraformJob) throws IOException {
         fetchCommand.setRemote("origin");
-        if (terraformJob.getVcsType().startsWith("SSH")) {
-            fetchCommand.setTransportConfigCallback(transport -> {
-                try {
-                    ((SshTransport) transport).setSshSessionFactory(
-                            getSshdSessionFactory(gitCloneFolder, terraformJob.getAccessToken()));
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-        } else {
-            CredentialsProvider credentialsProvider = setupCredentials(terraformJob.getVcsType(),
-                    terraformJob.getConnectionType(), terraformJob.getAccessToken());
-            if (credentialsProvider != null) {
-                fetchCommand.setCredentialsProvider(credentialsProvider);
-            }
-        }
-        return fetchCommand;
+        return configureTransport(fetchCommand, sshSessionFactory(gitCloneFolder, terraformJob), terraformJob);
     }
 
     private void downloadWorkspaceTarGz(File tarGzFolder, String organizationId, String jobId) throws IOException, URISyntaxException {

--- a/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -30,6 +30,7 @@ import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.errors.MissingObjectException;
+import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
@@ -178,6 +179,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
                     .setCloneSubmodules(true);
 
             cloneCommand.setDepth(1);
+            cloneCommand.setBranchesToClone(List.of(Constants.R_HEADS + terraformJob.getBranch()));
             cloneCommand.call();
         } else {
             CloneCommand cloneCommand = Git.cloneRepository()
@@ -189,6 +191,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
                     .setCloneSubmodules(true);
 
             cloneCommand.setDepth(1);
+            cloneCommand.setBranchesToClone(List.of(Constants.R_HEADS + terraformJob.getBranch()));
             cloneCommand.call();
         }
 

--- a/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -166,8 +166,11 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
 
     private void downloadWorkspaceGit(File gitCloneFolder, TerraformJob terraformJob)
             throws GitAPIException, IOException {
-        String branchRef = resolveBranchRef(terraformJob);
-        if (terraformJob.getVcsType().startsWith("SSH")) {
+        // Resolved once and shared with the ref probe: for AZURE_SP_MI this acquires a token
+        // over the network, and nothing caches it between calls.
+        CredentialsProvider credentialsProvider = credentialsProvider(terraformJob);
+        String branchRef = resolveBranchRef(terraformJob, credentialsProvider);
+        if (isSsh(terraformJob)) {
             CloneCommand cloneCommand = Git.cloneRepository()
                     .setURI(terraformJob.getSource())
                     .setDirectory(gitCloneFolder)
@@ -189,8 +192,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
             CloneCommand cloneCommand = Git.cloneRepository()
                     .setURI(terraformJob.getSource())
                     .setDirectory(gitCloneFolder)
-                    .setCredentialsProvider(setupCredentials(terraformJob.getVcsType(),
-                            terraformJob.getConnectionType(), terraformJob.getAccessToken()))
+                    .setCredentialsProvider(credentialsProvider)
                     .setBranch(terraformJob.getBranch())
                     .setCloneSubmodules(true);
 
@@ -214,7 +216,8 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
      * The branch field also accepts a tag name, so the namespace has to be resolved before the
      * fetch can be restricted to a single ref.
      */
-    private String resolveBranchRef(TerraformJob terraformJob) throws IOException {
+    private String resolveBranchRef(TerraformJob terraformJob, CredentialsProvider credentialsProvider)
+            throws IOException {
         String headRef = Constants.R_HEADS + terraformJob.getBranch();
         String tagRef = Constants.R_TAGS + terraformJob.getBranch();
 
@@ -224,7 +227,8 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
         SshdSessionFactory sshSessionFactory = sshSessionFactory(sshFolder, terraformJob);
         try {
             Map<String, Ref> remoteRefs = configureTransport(
-                    Git.lsRemoteRepository().setRemote(terraformJob.getSource()), sshSessionFactory, terraformJob)
+                    Git.lsRemoteRepository().setRemote(terraformJob.getSource()), sshSessionFactory,
+                    credentialsProvider)
                     .setHeads(true)
                     .setTags(true)
                     .callAsMap();
@@ -242,20 +246,26 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
         }
     }
 
+    private static boolean isSsh(TerraformJob terraformJob) {
+        return terraformJob.getVcsType().startsWith("SSH");
+    }
+
     private SshdSessionFactory sshSessionFactory(File sshFolder, TerraformJob terraformJob) throws IOException {
-        return terraformJob.getVcsType().startsWith("SSH")
-                ? getSshdSessionFactory(sshFolder, terraformJob.getAccessToken())
-                : null;
+        return isSsh(terraformJob) ? getSshdSessionFactory(sshFolder, terraformJob.getAccessToken()) : null;
+    }
+
+    private CredentialsProvider credentialsProvider(TerraformJob terraformJob) {
+        return isSsh(terraformJob) ? null
+                : setupCredentials(terraformJob.getVcsType(), terraformJob.getConnectionType(),
+                        terraformJob.getAccessToken());
     }
 
     private <C extends TransportCommand<C, ?>> C configureTransport(C command,
-            SshdSessionFactory sshSessionFactory, TerraformJob terraformJob) {
+            SshdSessionFactory sshSessionFactory, CredentialsProvider credentialsProvider) {
         if (sshSessionFactory != null) {
             return command.setTransportConfigCallback(
                     transport -> ((SshTransport) transport).setSshSessionFactory(sshSessionFactory));
         }
-        CredentialsProvider credentialsProvider = setupCredentials(terraformJob.getVcsType(),
-                terraformJob.getConnectionType(), terraformJob.getAccessToken());
         if (credentialsProvider != null) {
             command.setCredentialsProvider(credentialsProvider);
         }
@@ -317,7 +327,8 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
     private FetchCommand configureFetchCommand(FetchCommand fetchCommand, File gitCloneFolder,
             TerraformJob terraformJob) throws IOException {
         fetchCommand.setRemote("origin");
-        return configureTransport(fetchCommand, sshSessionFactory(gitCloneFolder, terraformJob), terraformJob);
+        return configureTransport(fetchCommand, sshSessionFactory(gitCloneFolder, terraformJob),
+                credentialsProvider(terraformJob));
     }
 
     private void downloadWorkspaceTarGz(File tarGzFolder, String organizationId, String jobId) throws IOException, URISyntaxException {

--- a/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -311,24 +311,27 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
     void fetchCommitById(Git git, File gitCloneFolder, TerraformJob terraformJob, String commitId)
             throws GitAPIException, IOException {
         log.info("Fetching missing commit id {} with depth 1", commitId);
-        configureFetchCommand(git.fetch(), gitCloneFolder, terraformJob)
-                .setRefSpecs(new RefSpec(commitId))
-                .setDepth(1)
-                .call();
+        try (SshdSessionFactory sshSessionFactory = sshSessionFactory(gitCloneFolder, terraformJob)) {
+            configureFetchCommand(git.fetch(), sshSessionFactory, terraformJob)
+                    .setRefSpecs(new RefSpec(commitId))
+                    .setDepth(1)
+                    .call();
+        }
     }
 
     void unshallowRepository(Git git, File gitCloneFolder, TerraformJob terraformJob)
             throws GitAPIException, IOException {
-        configureFetchCommand(git.fetch(), gitCloneFolder, terraformJob)
-                .setUnshallow(true)
-                .call();
+        try (SshdSessionFactory sshSessionFactory = sshSessionFactory(gitCloneFolder, terraformJob)) {
+            configureFetchCommand(git.fetch(), sshSessionFactory, terraformJob)
+                    .setUnshallow(true)
+                    .call();
+        }
     }
 
-    private FetchCommand configureFetchCommand(FetchCommand fetchCommand, File gitCloneFolder,
-            TerraformJob terraformJob) throws IOException {
+    private FetchCommand configureFetchCommand(FetchCommand fetchCommand,
+            SshdSessionFactory sshSessionFactory, TerraformJob terraformJob) {
         fetchCommand.setRemote("origin");
-        return configureTransport(fetchCommand, sshSessionFactory(gitCloneFolder, terraformJob),
-                credentialsProvider(terraformJob));
+        return configureTransport(fetchCommand, sshSessionFactory, credentialsProvider(terraformJob));
     }
 
     private void downloadWorkspaceTarGz(File tarGzFolder, String organizationId, String jobId) throws IOException, URISyntaxException {

--- a/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
@@ -422,11 +422,7 @@ public class SetupWorkspaceTest {
                     sourceGit.getRepository(), generateRsaKeyPair());
             int port = server.start();
             try {
-                TerraformJob job = baseGitJob();
-                job.setVcsType("SSH~id_rsa");
-                job.setSource("ssh://git@localhost:" + port + "/terrakube-source");
-                job.setBranch(requestedBranch);
-                job.setAccessToken(privateKeyPem(clientKey));
+                TerraformJob job = sshJob(port, requestedBranch, clientKey);
 
                 File workspaceDir = standardSetupWorkspaceImpl(job).prepareWorkspace(job);
 
@@ -446,6 +442,85 @@ public class SetupWorkspaceTest {
         } finally {
             FileUtils.deleteDirectory(sourceRepository);
         }
+    }
+
+    @Test
+    public void fetchesAMissingCommitOverSsh() throws Exception {
+        File sourceRepository = Files.createTempDirectory("terrakube-source").toFile();
+        KeyPair clientKey = generateRsaKeyPair();
+        try (Git sourceGit = Git.init().setDirectory(sourceRepository).call()) {
+            commitFile(sourceGit, "main.tf", "requested");
+            String requestedBranch = sourceGit.getRepository().getBranch();
+
+            sourceGit.checkout().setCreateBranch(true).setName("unrelated").call();
+            RevCommit unrelatedCommit = commitFile(sourceGit, "main.tf", "unrelated");
+            sourceGit.checkout().setName(requestedBranch).call();
+
+            SshTestGitServer server = new SshTestGitServer("git", clientKey.getPublic(),
+                    sourceGit.getRepository(), generateRsaKeyPair());
+            int port = server.start();
+            try {
+                TerraformJob job = sshJob(port, requestedBranch, clientKey);
+                job.setCommitId(unrelatedCommit.getName());
+
+                UnshallowRecordingSetupWorkspace setup = new UnshallowRecordingSetupWorkspace();
+                File workspaceDir = setup.prepareWorkspace(job);
+
+                Assertions.assertFalse(setup.unshallowRepositoryCalled);
+                Assertions.assertTrue(FileUtils.getFile(workspaceDir, ".git", "shallow").exists());
+                try (Git workspaceGit = Git.open(workspaceDir)) {
+                    Assertions.assertEquals(unrelatedCommit.getName(),
+                            workspaceGit.getRepository().resolve("HEAD").getName());
+                }
+            } finally {
+                server.stop();
+            }
+        } finally {
+            FileUtils.deleteDirectory(sourceRepository);
+        }
+    }
+
+    @Test
+    public void unshallowsOverSshWhenTheShaFetchIsRejected() throws Exception {
+        File sourceRepository = Files.createTempDirectory("terrakube-source").toFile();
+        KeyPair clientKey = generateRsaKeyPair();
+        try (Git sourceGit = Git.init().setDirectory(sourceRepository).call()) {
+            RevCommit plannedCommit = commitFile(sourceGit, "main.tf", "planned");
+            String requestedBranch = sourceGit.getRepository().getBranch();
+            commitFile(sourceGit, "main.tf", "advanced");
+
+            SshTestGitServer server = new SshTestGitServer("git", clientKey.getPublic(),
+                    sourceGit.getRepository(), generateRsaKeyPair());
+            int port = server.start();
+            try {
+                TerraformJob job = sshJob(port, requestedBranch, clientKey);
+                job.setCommitId(plannedCommit.getName());
+
+                RejectingShaFetchSetupWorkspace setup = new RejectingShaFetchSetupWorkspace();
+                File workspaceDir = setup.prepareWorkspace(job);
+
+                Assertions.assertTrue(setup.unshallowRepositoryCalled);
+                try (Git workspaceGit = Git.open(workspaceDir)) {
+                    Assertions.assertEquals(plannedCommit.getName(),
+                            workspaceGit.getRepository().resolve("HEAD").getName());
+                }
+                Assertions.assertEquals("planned", FileUtils.readFileToString(
+                        FileUtils.getFile(workspaceDir, "main.tf"), StandardCharsets.UTF_8));
+            } finally {
+                server.stop();
+            }
+        } finally {
+            FileUtils.deleteDirectory(sourceRepository);
+        }
+    }
+
+    private TerraformJob sshJob(int port, String branch, KeyPair clientKey) throws IOException {
+        TerraformJob job = baseGitJob();
+        job.setVcsType("SSH~id_rsa");
+        job.setSource("ssh://git@localhost:" + port + "/terrakube-source");
+        job.setBranch(branch);
+        job.setAccessToken(privateKeyPem(clientKey));
+        return job;
     }
 
     private static KeyPair generateRsaKeyPair() throws Exception {

--- a/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
@@ -4,8 +4,11 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.StringWriter;
 import java.lang.reflect.Proxy;
 import java.net.URI;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -22,11 +25,13 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.tools.tar.TarEntry;
 import org.apache.tools.tar.TarOutputStream;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.InvalidRemoteException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.api.errors.TransportException;
+import org.eclipse.jgit.junit.ssh.SshTestGitServer;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -399,6 +404,63 @@ public class SetupWorkspaceTest {
         } finally {
             FileUtils.deleteDirectory(sourceRepository);
         }
+    }
+
+    @Test
+    public void clonesOverSshAndLeavesTheKeyInTheWorkspace() throws Exception {
+        File sourceRepository = Files.createTempDirectory("terrakube-source").toFile();
+        KeyPair clientKey = generateRsaKeyPair();
+        try (Git sourceGit = Git.init().setDirectory(sourceRepository).call()) {
+            commitFile(sourceGit, "main.tf", "over-ssh");
+            String requestedBranch = sourceGit.getRepository().getBranch();
+
+            sourceGit.checkout().setCreateBranch(true).setName("unrelated").call();
+            commitFile(sourceGit, "main.tf", "unrelated");
+            sourceGit.checkout().setName(requestedBranch).call();
+
+            SshTestGitServer server = new SshTestGitServer("git", clientKey.getPublic(),
+                    sourceGit.getRepository(), generateRsaKeyPair());
+            int port = server.start();
+            try {
+                TerraformJob job = baseGitJob();
+                job.setVcsType("SSH~id_rsa");
+                job.setSource("ssh://git@localhost:" + port + "/terrakube-source");
+                job.setBranch(requestedBranch);
+                job.setAccessToken(privateKeyPem(clientKey));
+
+                File workspaceDir = standardSetupWorkspaceImpl(job).prepareWorkspace(job);
+
+                // TerraformExecutorServiceImpl.getSshFile reads the key back out of the
+                // workspace, so the clone has to be what puts it there.
+                Assertions.assertTrue(FileUtils.getFile(workspaceDir, ".ssh", "id_rsa").exists());
+                Assertions.assertTrue(FileUtils.getFile(workspaceDir, ".git", "shallow").exists());
+                try (Git workspaceGit = Git.open(workspaceDir)) {
+                    Assertions.assertEquals(List.of(Constants.R_REMOTES + "origin/" + requestedBranch),
+                            refNames(workspaceGit, Constants.R_REMOTES));
+                }
+                Assertions.assertEquals("over-ssh", FileUtils.readFileToString(
+                        FileUtils.getFile(workspaceDir, "main.tf"), StandardCharsets.UTF_8));
+            } finally {
+                server.stop();
+            }
+        } finally {
+            FileUtils.deleteDirectory(sourceRepository);
+        }
+    }
+
+    private static KeyPair generateRsaKeyPair() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        return generator.generateKeyPair();
+    }
+
+    /** PKCS#1, since that is the format the executor keys its file naming off. */
+    private static String privateKeyPem(KeyPair keyPair) throws IOException {
+        StringWriter pem = new StringWriter();
+        try (JcaPEMWriter writer = new JcaPEMWriter(pem)) {
+            writer.writeObject(keyPair.getPrivate());
+        }
+        return pem.toString();
     }
 
     @Test

--- a/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
@@ -204,6 +204,22 @@ public class SetupWorkspaceTest {
                 .toList();
     }
 
+    private static class UnshallowRecordingSetupWorkspace extends SetupWorkspaceImpl {
+        boolean unshallowRepositoryCalled;
+
+        UnshallowRecordingSetupWorkspace() {
+            super(new NoopWorkspaceSecurity(), false, new NoopTerraformExecutor(),
+                    "https://terrakube-api.example.com", terrakubeClient(null));
+        }
+
+        @Override
+        void unshallowRepository(Git git, File gitCloneFolder, TerraformJob terraformJob)
+                throws GitAPIException, IOException {
+            unshallowRepositoryCalled = true;
+            super.unshallowRepository(git, gitCloneFolder, terraformJob);
+        }
+    }
+
     private static class RejectingShaFetchSetupWorkspace extends SetupWorkspaceImpl {
         boolean unshallowRepositoryCalled;
 
@@ -347,6 +363,38 @@ public class SetupWorkspaceTest {
                 Assertions.assertEquals(List.of(Constants.R_TAGS + "v1.0.0"),
                         refNames(workspaceGit, Constants.R_TAGS));
                 Assertions.assertEquals(List.of(), refNames(workspaceGit, Constants.R_REMOTES));
+            }
+        } finally {
+            FileUtils.deleteDirectory(sourceRepository);
+        }
+    }
+
+    @Test
+    public void checksOutARecordedCommitThatLivesOnAnotherBranch() throws Exception {
+        File sourceRepository = Files.createTempDirectory("terrakube-source").toFile();
+        try (Git sourceGit = Git.init().setDirectory(sourceRepository).call()) {
+            commitFile(sourceGit, "main.tf", "requested");
+            String requestedBranch = sourceGit.getRepository().getBranch();
+
+            sourceGit.checkout().setCreateBranch(true).setName("unrelated").call();
+            RevCommit unrelatedCommit = commitFile(sourceGit, "main.tf", "unrelated");
+            sourceGit.checkout().setName(requestedBranch).call();
+
+            TerraformJob job = localGitJob(sourceRepository, requestedBranch);
+            job.setCommitId(unrelatedCommit.getName());
+
+            UnshallowRecordingSetupWorkspace setup = new UnshallowRecordingSetupWorkspace();
+            File workspaceDir = setup.prepareWorkspace(job);
+
+            // The commit is an advertised ref tip, so the narrowed clone can fetch it by sha
+            // rather than falling back to pulling the whole history.
+            Assertions.assertFalse(setup.unshallowRepositoryCalled);
+            Assertions.assertTrue(FileUtils.getFile(workspaceDir, ".git", "shallow").exists());
+            try (Git workspaceGit = Git.open(workspaceDir)) {
+                Assertions.assertEquals(unrelatedCommit.getName(),
+                        workspaceGit.getRepository().resolve("HEAD").getName());
+                Assertions.assertEquals(List.of(Constants.R_REMOTES + "origin/" + requestedBranch),
+                        refNames(workspaceGit, Constants.R_REMOTES));
             }
         } finally {
             FileUtils.deleteDirectory(sourceRepository);

--- a/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
@@ -482,6 +482,15 @@ public class SetupWorkspaceTest {
     }
 
     @Test
+    public void reportsFailureWhenTheBranchDoesNotExist() throws Exception {
+        TerraformJob job = successfulGitJob();
+        job.setBranch("does-not-exist");
+        SetupWorkspace setup = standardSetupWorkspaceImpl(job);
+        WorkspaceException e = Assertions.assertThrows(WorkspaceException.class, () -> setup.prepareWorkspace(job));
+        Assertions.assertEquals(TransportException.class, e.getCause().getClass());
+    }
+
+    @Test
     public void reportsFailureOnBadRepository() throws Exception {
         TerraformJob job = successfulGitJob();
         SetupWorkspace setup = standardSetupWorkspaceImpl(job);

--- a/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 
 import io.terrakube.client.TerrakubeClient;
 import io.terrakube.client.model.organization.job.Job;
@@ -26,6 +27,8 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.InvalidRemoteException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.api.errors.TransportException;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -194,6 +197,13 @@ public class SetupWorkspaceTest {
                 .call();
     }
 
+    private static List<String> refNames(Git git, String prefix) throws IOException {
+        return git.getRepository().getRefDatabase().getRefsByPrefix(prefix).stream()
+                .map(Ref::getName)
+                .sorted()
+                .toList();
+    }
+
     private static class RejectingShaFetchSetupWorkspace extends SetupWorkspaceImpl {
         boolean unshallowRepositoryCalled;
 
@@ -285,6 +295,58 @@ public class SetupWorkspaceTest {
             Assertions.assertTrue(FileUtils.getFile(workspaceDir, ".git", "shallow").exists());
             try (Git workspaceGit = Git.open(workspaceDir)) {
                 Assertions.assertEquals(branchTip.getName(), workspaceGit.getRepository().resolve("HEAD").getName());
+            }
+        } finally {
+            FileUtils.deleteDirectory(sourceRepository);
+        }
+    }
+
+    @Test
+    public void fetchesOnlyTheRequestedBranch() throws Exception {
+        File sourceRepository = Files.createTempDirectory("terrakube-source").toFile();
+        try (Git sourceGit = Git.init().setDirectory(sourceRepository).call()) {
+            commitFile(sourceGit, "main.tf", "requested");
+            String requestedBranch = sourceGit.getRepository().getBranch();
+
+            // The tag sits on the unrelated branch so a narrowed fetch cannot reach it:
+            // AUTO_FOLLOW would still pull a tag pointing at the requested branch's tip.
+            sourceGit.checkout().setCreateBranch(true).setName("unrelated").call();
+            commitFile(sourceGit, "main.tf", "unrelated");
+            sourceGit.tag().setName("v1.0.0").call();
+            sourceGit.checkout().setName(requestedBranch).call();
+
+            TerraformJob job = localGitJob(sourceRepository, requestedBranch);
+            File workspaceDir = standardSetupWorkspaceImpl(job).prepareWorkspace(job);
+
+            try (Git workspaceGit = Git.open(workspaceDir)) {
+                Assertions.assertEquals(List.of(Constants.R_REMOTES + "origin/" + requestedBranch),
+                        refNames(workspaceGit, Constants.R_REMOTES));
+                Assertions.assertEquals(List.of(), refNames(workspaceGit, Constants.R_TAGS));
+            }
+        } finally {
+            FileUtils.deleteDirectory(sourceRepository);
+        }
+    }
+
+    @Test
+    public void checksOutWhenBranchFieldNamesATag() throws Exception {
+        File sourceRepository = Files.createTempDirectory("terrakube-source").toFile();
+        try (Git sourceGit = Git.init().setDirectory(sourceRepository).call()) {
+            RevCommit tagged = commitFile(sourceGit, "main.tf", "tagged");
+            sourceGit.tag().setName("v1.0.0").call();
+
+            sourceGit.checkout().setCreateBranch(true).setName("unrelated").call();
+            commitFile(sourceGit, "main.tf", "unrelated");
+
+            TerraformJob job = localGitJob(sourceRepository, "v1.0.0");
+            File workspaceDir = standardSetupWorkspaceImpl(job).prepareWorkspace(job);
+
+            try (Git workspaceGit = Git.open(workspaceDir)) {
+                Assertions.assertEquals(tagged.getName(),
+                        workspaceGit.getRepository().resolve("HEAD").getName());
+                Assertions.assertEquals(List.of(Constants.R_TAGS + "v1.0.0"),
+                        refNames(workspaceGit, Constants.R_TAGS));
+                Assertions.assertEquals(List.of(), refNames(workspaceGit, Constants.R_REMOTES));
             }
         } finally {
             FileUtils.deleteDirectory(sourceRepository);


### PR DESCRIPTION
currently, even with `setDepth(1)`, jgit defaults to fetching all branches. tested when fetching against `torvalds/linux` I see the following results:

| Clone | Wall | `.git` |
| --- | --- | --- |
| full, all branches | 22.9 min | 6.77 GB |
| `depth=1`, all branches (today) | 9.1 min | 3.32 GB |
| `depth=1`, one branch (this PR) | **50 s** | **306 MB** |

tests run from a macbook pro (m4)

# changes in this pr
* fetch just one ref (using `setBranchesToClone()`)
* if provided with a tag, triggers an `ls-remote` round trip to resolve it to a branch or a tag
  * this is best effort - a failed probe assumes it's a branch, and if that fails the clone reports it
* credentials are resolved only once per job. without some refactoring that would have been duplicated
* the ssh session factory for fetch is closed, the clone factories are left open
  * fixing the clone factory close would ideally involve changing where the key is placed as `CloneCommand` only works on an empty directory

# risk
the checkout now only has a single branch and no tags. if anything (git hooks, etc.) depends on more being present it will be broken.

# tests
added `org.eclipse.jgit.junit.ssh` at matching jgit version for offline ssh tests. wrote tests for various failure cases this change could introduce as well as some pre-existing behavior. if you don't want the new test dep, we can remove it and associated tests.

i did not add tests for http paths (github, etc.) or submodules

