### PR TITLE
fix(ui): avoid double v-prefix on module/provider/workspace versions

### DIFF
--- a/ui/src/domain/Modules/components/ModuleTable.tsx
+++ b/ui/src/domain/Modules/components/ModuleTable.tsx
@@ -1,6 +1,7 @@
 import { DownloadOutlined } from "@ant-design/icons";
 import { Table, Typography } from "antd";
 import { useNavigate, useParams } from "react-router-dom";
+import formatVersion from "@/modules/utils/formatVersion";
 import { FlatModule } from "../../types";
 
 type Params = {
@@ -52,7 +53,7 @@ export default function ModuleTable({ modules, searchFilter }: Props) {
       dataIndex: "latestVersion",
       key: "latestVersion",
       width: 140,
-      render: (version: string | undefined) => (version ? `v${version}` : "—"),
+      render: (version: string | undefined) => (version ? formatVersion(version) : "—"),
     },
     {
       title: "Downloads",

--- a/ui/src/domain/Providers/ProviderList.tsx
+++ b/ui/src/domain/Providers/ProviderList.tsx
@@ -2,6 +2,7 @@ import { CloudOutlined, LinkOutlined } from "@ant-design/icons";
 import { Card, Empty, List, Space, Typography } from "antd";
 import { useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import formatVersion from "@/modules/utils/formatVersion";
 import { FlatProvider } from "./types";
 import "../Modules/Module.css";
 
@@ -110,7 +111,9 @@ export const ProviderList = ({ providers, searchFilter }: Props) => {
               >
                 <Space size={16}>
                   {item.latestVersion && (
-                    <Typography.Text style={{ fontSize: 13, color: "#8c97a8" }}>v{item.latestVersion}</Typography.Text>
+                    <Typography.Text style={{ fontSize: 13, color: "#8c97a8" }}>
+                      {formatVersion(item.latestVersion)}
+                    </Typography.Text>
                   )}
                 </Space>
                 <Space size={6}>

--- a/ui/src/domain/Providers/components/ProviderTable.tsx
+++ b/ui/src/domain/Providers/components/ProviderTable.tsx
@@ -1,5 +1,6 @@
 import { Table, Typography } from "antd";
 import { useNavigate, useParams } from "react-router-dom";
+import formatVersion from "@/modules/utils/formatVersion";
 import { FlatProvider } from "../types";
 
 type Params = {
@@ -44,7 +45,7 @@ export default function ProviderTable({ providers, searchFilter }: Props) {
       dataIndex: "latestVersion",
       key: "latestVersion",
       width: 160,
-      render: (version: string | undefined) => (version ? `v${version}` : "—"),
+      render: (version: string | undefined) => (version ? formatVersion(version) : "—"),
     },
   ];
 

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -907,7 +907,7 @@ export const WorkspaceDetails = ({
                     <Typography.Text>
                       {getIaCNameById(workspace.attributes?.iacType)}{" "}
                       <a onClick={handleClickSettings} className="workspace-button">
-                        v{workspace.attributes.terraformVersion}
+                        {workspace.attributes.terraformVersion}
                       </a>
                     </Typography.Text>
                   </Space>

--- a/ui/src/modules/utils/formatVersion.spec.ts
+++ b/ui/src/modules/utils/formatVersion.spec.ts
@@ -1,0 +1,25 @@
+import formatVersion from "./formatVersion";
+
+describe("formatVersion", () => {
+  describe("plain exact versions get a v prefix", () => {
+    it.each([
+      ["1.2.3", "v1.2.3"],
+      ["1", "v1"],
+      ["0.15.0", "v0.15.0"],
+      [" 1.2.3 ", "v1.2.3"],
+    ])("%s -> %s", (input, expected) => expect(formatVersion(input)).toBe(expected));
+  });
+
+  describe("already v-prefixed exact versions are normalized, not doubled", () => {
+    it.each([
+      ["v1.2.3", "v1.2.3"],
+      ["V1.2.3", "v1.2.3"],
+    ])("%s -> %s", (input, expected) => expect(formatVersion(input)).toBe(expected));
+  });
+
+  describe("constraints are returned unchanged", () => {
+    it.each([">=1", "~>1.11.0", "^1.2.3", "1.2.3 - 2.3.4", "*", "1.x", "latest"])("leaves %s as-is", (input) =>
+      expect(formatVersion(input)).toBe(input)
+    );
+  });
+});

--- a/ui/src/modules/utils/formatVersion.ts
+++ b/ui/src/modules/utils/formatVersion.ts
@@ -1,0 +1,7 @@
+const EXACT_VERSION = /^\d+(\.\d+)*$/;
+
+export default function formatVersion(version: string) {
+  const trimmed = version.trim();
+  const stripped = trimmed.replace(/^v/i, "");
+  return EXACT_VERSION.test(stripped) ? `v${stripped}` : trimmed;
+}


### PR DESCRIPTION
## What

Fixes a `vv` double-prefix bug on version displays in the module/provider registry, and removes an incorrect `v` prefix on the workspace Terraform version.

## Why

`ModuleTable`, `ProviderTable`, and `ProviderList` each hardcoded `` `v${version}` ``, but the underlying version can already be a raw git tag like `v1.2.3` (module versions are stored as-is from the repo's tags), so it rendered as `vv1.2.3`.

The workspace details page had the same `v${terraformVersion}` pattern, but that field is a user-entered version *constraint*, not a resolved single version — it accepts the same syntax Terraform itself uses for `required_version` (`>=1.5.7`, `~>1.11.0`, `1.9.0`, etc.), and none of that syntax uses a `v` prefix. Prefixing `v` there is misleading, not just cosmetic: it implies one specific version even when the value is a range. The registry tables are different — `latestVersion` there is always a single resolved version, so a `v` prefix matches convention (npm, GitHub releases, `terraform version`'s own CLI banner) and stays unambiguous.

## How

- Added `ui/src/modules/utils/formatVersion.ts`, a shared util that strips any existing `v`/`V` prefix and re-adds `v` only when the value is an exact numeric version (`^\d+(\.\d+)*$`); constraint strings pass through unchanged.
- Wired it into `ModuleTable.tsx`, `ProviderTable.tsx`, and `ProviderList.tsx`, replacing the duplicated inline template.
- `Workspaces/Details.tsx` now renders `terraformVersion` raw with no `v` prefix at all, matching the constraint syntax as typed.
- Added `formatVersion.spec.ts` covering exact versions, already-prefixed versions (no double `v`), and constraints (left untouched), following the existing `versionValidation.spec.ts` pattern.

## Testing

`yarn jest src/modules/utils/formatVersion.spec.ts` — 13/13 passing. Verified manually against a local docker-compose stack (module/provider registry tables and a workspace with a constraint-based Terraform version).