### PR TITLE
fix(api): evaluate federated membership outside the groups loop

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/security/groups/dex/DexGroupServiceImpl.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/groups/dex/DexGroupServiceImpl.java
@@ -56,10 +56,13 @@ public class DexGroupServiceImpl implements GroupService {
         boolean isMember = principal.getTokenAttributes().get("iss").equals("TerrakubeInternal")? true: false;
         boolean isFederated = isFederatedAccount(user);
         if(!isMember) {
+            // Federated tokens are issued by an external provider and usually carry no
+            // "groups" claim, so this check cannot live inside the loop below.
+            if (isFederated && isFederatedMember(user, group))
+                isMember = true;
+
             for (String groupName : toStringArray((java.util.ArrayList) principal.getTokenAttributes().get("groups"))) {
                 if (groupName.equals(group))
-                    isMember = true;
-                if (isFederated && isFederatedMember(user, group))
                     isMember = true;
             }
             log.debug("{} is member {} {}", principal.getTokenAttributes().get("name"), group, isMember);

--- a/api/src/test/java/io/terrakube/api/DexGroupServiceTests.java
+++ b/api/src/test/java/io/terrakube/api/DexGroupServiceTests.java
@@ -1,0 +1,94 @@
+package io.terrakube.api;
+
+import com.yahoo.elide.core.security.User;
+import io.terrakube.api.plugin.security.groups.dex.DexGroupServiceImpl;
+import io.terrakube.api.repository.FederatedRepository;
+import io.terrakube.api.rs.federated.Federated;
+import io.terrakube.api.rs.federated.claim.FederatedClaim;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DexGroupServiceTests {
+
+    private static final String ISSUER = "https://token.actions.githubusercontent.com";
+    private static final String AUDIENCE = "terrakube";
+    private static final String GROUP = "ci-trigger";
+
+    @Test
+    void federatedTokenWithoutGroupsClaimIsMember() {
+        DexGroupServiceImpl groupService = groupServiceWith(federated(GROUP, Map.of("repository", "acme/infra")));
+
+        User user = userWith(Map.of(
+                "iss", ISSUER,
+                "aud", AUDIENCE,
+                "repository", "acme/infra"));
+
+        assertTrue(groupService.isServiceMember(user, GROUP));
+    }
+
+    @Test
+    void federatedTokenWithClaimMismatchIsNotMember() {
+        DexGroupServiceImpl groupService = groupServiceWith(federated(GROUP, Map.of("repository", "acme/infra")));
+
+        User user = userWith(Map.of(
+                "iss", ISSUER,
+                "aud", AUDIENCE,
+                "repository", "someone-else/infra"));
+
+        assertFalse(groupService.isServiceMember(user, GROUP));
+    }
+
+    @Test
+    void tokenWithGroupsClaimIsStillMember() {
+        FederatedRepository federatedRepository = mock(FederatedRepository.class);
+        when(federatedRepository.findByIssuerUrlAndAudience(anyString(), anyString())).thenReturn(Optional.empty());
+        DexGroupServiceImpl groupService = new DexGroupServiceImpl(null, null, null, federatedRepository);
+
+        User user = userWith(Map.of(
+                "iss", "https://dex.example.com",
+                "aud", "terrakube",
+                "groups", new java.util.ArrayList<>(List.of("TERRAKUBE_ADMIN"))));
+
+        assertTrue(groupService.isServiceMember(user, "TERRAKUBE_ADMIN"));
+        assertFalse(groupService.isServiceMember(user, "other-group"));
+    }
+
+    private DexGroupServiceImpl groupServiceWith(Federated federated) {
+        FederatedRepository federatedRepository = mock(FederatedRepository.class);
+        when(federatedRepository.findByIssuerUrlAndAudience(ISSUER, AUDIENCE)).thenReturn(Optional.of(federated));
+        return new DexGroupServiceImpl(null, null, null, federatedRepository);
+    }
+
+    private Federated federated(String name, Map<String, String> claims) {
+        Federated federated = new Federated();
+        federated.setName(name);
+        federated.setIssuerUrl(ISSUER);
+        federated.setAudience(AUDIENCE);
+        federated.setClaims(claims.entrySet().stream().map(entry -> {
+            FederatedClaim claim = new FederatedClaim();
+            claim.setClaimKey(entry.getKey());
+            claim.setClaimValue(entry.getValue());
+            return claim;
+        }).toList());
+        return federated;
+    }
+
+    private User userWith(Map<String, Object> claims) {
+        Jwt jwt = Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .claims(jwtClaims -> jwtClaims.putAll(claims))
+                .build();
+        return new User(new JwtAuthenticationToken(jwt));
+    }
+}


### PR DESCRIPTION
Fixes #3378

### Problem

A federated identity can authenticate and read, but gets denied when creating a job.

In `DexGroupServiceImpl.isServiceMember` the federated check sits inside the loop over the `groups` claim:

```java
for (String groupName : toStringArray((ArrayList) principal.getTokenAttributes().get("groups"))) {
    if (groupName.equals(group))
        isMember = true;
    if (isFederated && isFederatedMember(user, group))
        isMember = true;
}
```

Tokens issued by an external provider usually have no `groups` claim, and a GitHub Actions OIDC token never has one. `toStringArray(null)` returns an empty array, the loop body never runs, so the federated check never executes and membership resolves to false.

Read paths work because `MembershipService.checkMembership` calls `isFederatedMember` directly, outside any loop. That is why the identity looks half working: it lists workspaces and templates, then fails on `POST /organization/{id}/job`.

### Fix

Move the federated check out of the loop. The loop keeps behaving the same for tokens that do carry `groups`.

### Test

`DexGroupServiceTests` covers three cases:

- federated token with no `groups` claim and matching claims is a member. This one fails without the fix.
- federated token whose claims do not match the registered ones is not a member.
- token carrying a `groups` claim still resolves membership the same way.

The last two are there on purpose. For an authorization fix, the risk is not that it keeps denying, it is that it starts allowing too much.

Result with the fix, and with the fix reverted:

```
Tests run: 3, Failures: 0   (with fix)
Tests run: 3, Failures: 1   (without fix)
  DexGroupServiceTests.federatedTokenWithoutGroupsClaimIsMember:37 expected: <true> but was: <false>
```

### Notes

`isMember` has a similar shape but no federated branch at all, so it is left unchanged. Federated principals reach `isServiceMember` because `isServiceAccount` already returns true for them.

Reproduced on 2.32.2 with a federated identity using issuer `https://token.actions.githubusercontent.com` and claim matchers on `repository` and `repository_owner`. As a workaround until this lands, a federated caller can mint a short lived team token through `POST /access-token/v1/teams`, since `getCurrentGroups` handles federation correctly, and use that token for the job APIs.
