### PR TITLE
fix(executor): enable native S3 state locking on the generated backend

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
@@ -61,6 +61,8 @@ public class AwsTerraformStateImpl implements TerraformState {
 
     private boolean includeBackendKeys;
 
+    private boolean useLockfile;
+
     @NonNull
     TerraformOutputPathService terraformOutputPathService;
 
@@ -113,13 +115,16 @@ public class AwsTerraformStateImpl implements TerraformState {
               log.warn("No including backend information");
             }
 
-            // Native S3 locking (conditional writes) is available from Terraform 1.10
-            // and OpenTofu 1.10. Without it the generated backend takes no lock at all,
-            // so a job and anything else writing the same state can overwrite each other.
-            // Skipped when a custom endpoint is set: S3 compatible services do not all
-            // support the conditional write this relies on.
-            if(endpoint == null && version.compareTo(new ComparableVersion("1.10.0")) >= 0){
-                awsBackendHcl.appendln("    use_lockfile = true");
+            // Native S3 locking, off by default. Turning it on makes concurrent runs on
+            // the same state wait for each other, which is why it is not the default:
+            // plan only jobs are allowed to run in parallel on purpose.
+            // Worth enabling when something outside Terrakube writes the same state.
+            if(useLockfile) {
+                if(version.compareTo(new ComparableVersion("1.10.0")) >= 0){
+                    awsBackendHcl.appendln("    use_lockfile = true");
+                } else {
+                    log.warn("use_lockfile is enabled but ignored, it requires terraform or tofu 1.10 and this job runs {}", version);
+                }
             }
 
             if(endpoint != null){

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
@@ -113,6 +113,15 @@ public class AwsTerraformStateImpl implements TerraformState {
               log.warn("No including backend information");
             }
 
+            // Native S3 locking (conditional writes) is available from Terraform 1.10
+            // and OpenTofu 1.10. Without it the generated backend takes no lock at all,
+            // so a job and anything else writing the same state can overwrite each other.
+            // Skipped when a custom endpoint is set: S3 compatible services do not all
+            // support the conditional write this relies on.
+            if(endpoint == null && version.compareTo(new ComparableVersion("1.10.0")) >= 0){
+                awsBackendHcl.appendln("    use_lockfile = true");
+            }
+
             if(endpoint != null){
                 if(version.compareTo(new ComparableVersion("1.6.0")) < 0){
                     awsBackendHcl.appendln("    endpoint  = \"" + endpoint + "\"");

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateProperties.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateProperties.java
@@ -21,4 +21,5 @@ public class AwsTerraformStateProperties {
     private String endpoint;
     private boolean includeBackendKeys;
     private boolean enableRoleAuthentication;
+    private boolean useLockfile;
 }

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
@@ -113,6 +113,7 @@ public class TerraformStateAutoConfiguration {
                             .secretKey(awsTerraformStateProperties.getSecretKey())
                             .region(Region.of(awsTerraformStateProperties.getRegion()))
                             .includeBackendKeys(awsTerraformStateProperties.isIncludeBackendKeys())
+                            .useLockfile(awsTerraformStateProperties.isUseLockfile())
                             .terrakubeClient(terrakubeClient)
                             .terraformStatePathService(terraformStatePathService)
                             .terraformOutputPathService(terraformOutputPathService)

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -42,6 +42,7 @@ io.terrakube.executor.plugin.tfstate.aws.region=${AwsTerraformStateRegion}
 io.terrakube.executor.plugin.tfstate.aws.endpoint=${AwsEndpoint}
 io.terrakube.executor.plugin.tfstate.aws.includeBackendKeys=${AwsIncludeBackendKeys:true}
 io.terrakube.executor.plugin.tfstate.aws.enableRoleAuthentication=${AwsEnableRoleAuth:false}
+io.terrakube.executor.plugin.tfstate.aws.useLockfile=${AwsUseLockfile:false}
 
 ###################
 #Storage Gcp State#

--- a/executor/src/test/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImplTest.java
@@ -80,6 +80,32 @@ class AwsTerraformStateImplTest {
     }
 
     @Test
+    void testGetBackendStateFile_UsesLockfileFromTerraform110(@TempDir Path tempDir) throws IOException {
+        awsTerraformState.getBackendStateFile("org1", "ws1", tempDir.toFile(), "1.10.0");
+
+        String content = FileUtils.readFileToString(new File(tempDir.toFile(), "aws_backend_override.tf"), Charset.defaultCharset());
+        assertTrue(content.contains("use_lockfile = true"), "Native S3 locking is available from 1.10.0");
+    }
+
+    @Test
+    void testGetBackendStateFile_NoLockfileBefore110(@TempDir Path tempDir) throws IOException {
+        awsTerraformState.getBackendStateFile("org1", "ws1", tempDir.toFile(), "1.9.8");
+
+        String content = FileUtils.readFileToString(new File(tempDir.toFile(), "aws_backend_override.tf"), Charset.defaultCharset());
+        assertFalse(content.contains("use_lockfile"), "use_lockfile is not a valid argument before 1.10.0");
+    }
+
+    @Test
+    void testGetBackendStateFile_NoLockfileWithCustomEndpoint(@TempDir Path tempDir) throws IOException {
+        awsTerraformState.setEndpoint("http://minio:9000");
+
+        awsTerraformState.getBackendStateFile("org1", "ws1", tempDir.toFile(), "1.13.0");
+
+        String content = FileUtils.readFileToString(new File(tempDir.toFile(), "aws_backend_override.tf"), Charset.defaultCharset());
+        assertFalse(content.contains("use_lockfile"), "S3 compatible services do not all support conditional writes");
+    }
+
+    @Test
     void testGetBackendStateFile_PessimisticConstraintWithEndpoint(@TempDir Path tempDir) throws IOException {
         awsTerraformState.setEndpoint("http://minio:9000");
 

--- a/executor/src/test/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImplTest.java
@@ -80,7 +80,17 @@ class AwsTerraformStateImplTest {
     }
 
     @Test
-    void testGetBackendStateFile_UsesLockfileFromTerraform110(@TempDir Path tempDir) throws IOException {
+    void testGetBackendStateFile_NoLockfileByDefault(@TempDir Path tempDir) throws IOException {
+        awsTerraformState.getBackendStateFile("org1", "ws1", tempDir.toFile(), "1.13.0");
+
+        String content = FileUtils.readFileToString(new File(tempDir.toFile(), "aws_backend_override.tf"), Charset.defaultCharset());
+        assertFalse(content.contains("use_lockfile"), "Locking is opt in, parallel plan only jobs keep working");
+    }
+
+    @Test
+    void testGetBackendStateFile_UsesLockfileWhenEnabled(@TempDir Path tempDir) throws IOException {
+        awsTerraformState.setUseLockfile(true);
+
         awsTerraformState.getBackendStateFile("org1", "ws1", tempDir.toFile(), "1.10.0");
 
         String content = FileUtils.readFileToString(new File(tempDir.toFile(), "aws_backend_override.tf"), Charset.defaultCharset());
@@ -89,6 +99,8 @@ class AwsTerraformStateImplTest {
 
     @Test
     void testGetBackendStateFile_NoLockfileBefore110(@TempDir Path tempDir) throws IOException {
+        awsTerraformState.setUseLockfile(true);
+
         awsTerraformState.getBackendStateFile("org1", "ws1", tempDir.toFile(), "1.9.8");
 
         String content = FileUtils.readFileToString(new File(tempDir.toFile(), "aws_backend_override.tf"), Charset.defaultCharset());
@@ -96,13 +108,14 @@ class AwsTerraformStateImplTest {
     }
 
     @Test
-    void testGetBackendStateFile_NoLockfileWithCustomEndpoint(@TempDir Path tempDir) throws IOException {
+    void testGetBackendStateFile_UsesLockfileWithCustomEndpoint(@TempDir Path tempDir) throws IOException {
+        awsTerraformState.setUseLockfile(true);
         awsTerraformState.setEndpoint("http://minio:9000");
 
         awsTerraformState.getBackendStateFile("org1", "ws1", tempDir.toFile(), "1.13.0");
 
         String content = FileUtils.readFileToString(new File(tempDir.toFile(), "aws_backend_override.tf"), Charset.defaultCharset());
-        assertFalse(content.contains("use_lockfile"), "S3 compatible services do not all support conditional writes");
+        assertTrue(content.contains("use_lockfile = true"), "Enabling it is an explicit choice, the endpoint does not override it");
     }
 
     @Test


### PR DESCRIPTION
### Problem

The generated `aws_backend_override.tf` sets no locking at all, so nothing stops two writers from working on the same state object at the same time.

Terrakube serializes jobs per workspace, which covers job against job. It does not cover a job running while someone applies the same stack from a laptop or from CI, and that case is easy to hit when the repository backend points at the same key the executor writes to. The second writer simply overwrites.

### Fix

Add `use_lockfile = true` to the generated backend when both conditions hold:

- version is 1.10.0 or newer. Native S3 locking through conditional writes landed in Terraform 1.10 and OpenTofu 1.10, and the argument does not exist before that.
- no custom endpoint is configured. S3 compatible services do not all implement the conditional write this depends on, so MinIO and similar setups keep the current behavior.

The existing version parsing is reused, so version constraints like `~>1.13.0` and X-Range wildcards resolve the same way they already do for the endpoints block.

### Test

Three cases added to `AwsTerraformStateImplTest`:

- 1.10.0 gets `use_lockfile = true`. This one fails without the change.
- 1.9.8 does not get it, since the argument is invalid there.
- a custom endpoint does not get it, even on 1.13.0.

```
Tests run: 27, Failures: 0   (with the change)
Tests run: 27, Failures: 1   (without it)
  testGetBackendStateFile_UsesLockfileFromTerraform110:87 expected: <true> but was: <false>
```

### Notes

Only the AWS state backend is touched. Azure and GCP have their own locking behavior, and the local backend goes through the API instead.
