### PR TITLE
fix: remove sparse field filtering from registry, workspace, and job API requests

### DIFF
--- a/ui/src/domain/Jobs/Details.tsx
+++ b/ui/src/domain/Jobs/Details.tsx
@@ -18,7 +18,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { ORGANIZATION_ARCHIVE } from "../../config/actionTypes";
 import axiosInstance, { axiosClient } from "../../config/axiosConfig";
 import { useAbortController, usePolling, useStructuredOutputStream } from "../../hooks";
-import { IncludedItem, Job, JobStep, sparseFields, SparseOf, Workspace } from "../types";
+import { IncludedItem, Job, JobStep, Workspace } from "../types";
 import { LiveTerminalOutput } from "./LiveTerminalOutput";
 import { getJobOutputRequestUrl, getPublicApiOrigin, isTerrakubeApiUrl } from "./outputUrl";
 import { shouldStepBeCollapsible, shouldStepBeExpandedByDefault } from "./stepExpansion";
@@ -39,8 +39,6 @@ type Props = {
   jobId: string;
 };
 
-const WORKSPACE_FIELDS = sparseFields<Workspace>("workspace")("source", "branch");
-type SparseWorkspace = SparseOf<typeof WORKSPACE_FIELDS>;
 
 const TERMINAL_JOB_STATUSES = new Set(["completed", "noChanges", "failed", "cancelled", "rejected", "notExecuted"]);
 const INCOMPLETE_VARIABLE_GUARD_STEP_NAME = "Incomplete sensitive variables";
@@ -436,7 +434,7 @@ export const DetailsJob = ({ jobId }: Props) => {
 
     try {
       const response = await axiosInstance.get(
-        `organization/${organizationId}/job/${jobId}?include=step,workspace&${WORKSPACE_FIELDS}`,
+        `organization/${organizationId}/job/${jobId}?include=step,workspace`,
         { signal }
       );
       if (requestId !== jobRequestRef.current) {
@@ -447,8 +445,8 @@ export const DetailsJob = ({ jobId }: Props) => {
 
       const included = response.data.included ?? [];
       const stepEntries = included.filter((item: any) => item.type === "step");
-      const workspaceEntry: SparseWorkspace | undefined = included.find(
-        (item: IncludedItem<SparseWorkspace>) => item.type === "workspace"
+      const workspaceEntry: Workspace | undefined = included.find(
+        (item: IncludedItem<Workspace>) => item.type === "workspace"
       );
       const incompleteVariableGuard = parseIncompleteVariableGuard(response.data.data.attributes.output);
 

--- a/ui/src/domain/Modules/PublicRegistrySearch.tsx
+++ b/ui/src/domain/Modules/PublicRegistrySearch.tsx
@@ -16,10 +16,8 @@ import { useNavigate, useParams } from "react-router-dom";
 import PageWrapper from "@/modules/layout/PageWrapper/PageWrapper";
 import { importProvider, getProviderVersions, listProviders } from "../Providers/providerService";
 import { ProviderModel } from "../Providers/types";
-import { ModuleModel, Organization, sparseFields } from "../types";
+import { ModuleModel } from "../types";
 
-/** The registry search reads no organization attributes; the fieldset is here to suppress its relationship fanout. */
-const ORGANIZATION_FIELDS = sparseFields<Organization>("organization")("name");
 import axiosInstance, { axiosRegistry } from "../../config/axiosConfig";
 
 const { Search } = Input;
@@ -156,8 +154,7 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
         );
         setExistingProviders(providerNames);
 
-        // Fetch existing modules
-        const modulesResponse = await axiosInstance.get(`organization/${orgid}?include=module&${ORGANIZATION_FIELDS}`);
+        const modulesResponse = await axiosInstance.get(`organization/${orgid}?include=module`);
         const moduleNames = new Set<string>();
         if (modulesResponse.data.included) {
           modulesResponse.data.included

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -60,8 +60,6 @@ import {
   IncludedItem,
   Organization,
   Resource,
-  sparseFields,
-  SparseOf,
   VcsType,
   Workspace,
 } from "../types.js";
@@ -106,8 +104,6 @@ const WORKSPACE_SETTINGS_SECTION_LABELS: Record<string, string> = {
   advanced: "Destruction and Deletion",
 };
 
-const ORGANIZATION_FIELDS = sparseFields<Organization>("organization")("name");
-type SparseOrganization = SparseOf<typeof ORGANIZATION_FIELDS>;
 
 type Props = {
   setOrganizationName: React.Dispatch<React.SetStateAction<string>>;
@@ -425,7 +421,7 @@ export const WorkspaceDetails = ({
         setTemplates(template.data.data);
         axiosInstance
           .get(
-            `organization/${organizationId}/workspace/${id}?include=job,variable,history,schedule,vcs,agent,organization,webhook,reference,project&${ORGANIZATION_FIELDS}`
+            `organization/${organizationId}/workspace/${id}?include=job,variable,history,schedule,vcs,agent,organization,webhook,reference,project`
           )
           .then(async (response) => {
             if (_loadPermissionSet) loadPermissionSet();
@@ -458,8 +454,8 @@ export const WorkspaceDetails = ({
               );
             }
 
-            const organization: SparseOrganization | undefined = response.data.included?.find(
-              (item: IncludedItem<SparseOrganization>) => item.type === "organization"
+            const organization: Organization | undefined = response.data.included?.find(
+              (item: IncludedItem<Organization>) => item.type === "organization"
             );
             if (organization) {
               const organizationName = organization.attributes.name;


### PR DESCRIPTION
In a recent commit (7852e0186), sparse fieldset query parameters (such as ORGANIZATION_FIELDS = fields[organization]=name and WORKSPACE_FIELDS = fields[workspace]=source,branch) were appended to axiosInstance.get requests for compound endpoints using ?include=....

In Elide (JSON:API framework):

- When a fields[type] query parameter is present in a request, Elide activates sparse fieldset filtering for all resource types in the request.
- For any resource type in the primary response or included array that does not have its own fields[type] specified in the query string, Elide projects 0 fields (strips all attributes).
- In Workspaces/Details.tsx, querying organization/${orgId}/workspace/${id}?include=...&fields[organization]=name caused Elide to return the primary resource workspace without an attributes property.
- When WorkspaceDetails attempted to access response.data.data.attributes.name, JavaScript threw: TypeError: can't access property "name", response.data.data.attributes is undefined.

related to #3381 