### PR TITLE
fix(webhook): sync shared repo webhook on WebhookEvent mutations

### DIFF
--- a/api/src/main/java/io/terrakube/api/rs/hooks/webhook/WebhookEventManageHook.java
+++ b/api/src/main/java/io/terrakube/api/rs/hooks/webhook/WebhookEventManageHook.java
@@ -1,0 +1,68 @@
+package io.terrakube.api.rs.hooks.webhook;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding.Operation;
+import com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase;
+import com.yahoo.elide.core.lifecycle.LifeCycleHook;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+
+import io.terrakube.api.plugin.scheduler.webhook.RepoWebhookSyncScheduler;
+import io.terrakube.api.plugin.vcs.RepoUrlNormalizer;
+import io.terrakube.api.rs.vcs.VcsType;
+import io.terrakube.api.rs.webhook.Webhook;
+import io.terrakube.api.rs.webhook.WebhookEvent;
+import io.terrakube.api.rs.workspace.Workspace;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Reconciles the repository-level v2 webhook after an individual workspace
+ * event changes. The parent webhook hook can run before Terraform (or another
+ * API client) has created its events, so event mutations must independently
+ * request a sync.
+ */
+@Slf4j
+public class WebhookEventManageHook implements LifeCycleHook<WebhookEvent> {
+
+    @Autowired
+    RepoWebhookSyncScheduler repoWebhookSyncScheduler;
+
+    @Override
+    public void execute(Operation operation, TransactionPhase phase, WebhookEvent webhookEvent,
+            RequestScope requestScope, Optional<ChangeSpec> changes) {
+        if (phase != TransactionPhase.POSTCOMMIT) {
+            return;
+        }
+
+        Webhook webhook = webhookEvent.getWebhook();
+        if (webhook == null || !webhook.isMigratedV2() || !isSharedWebhookProvider(webhook)) {
+            return;
+        }
+
+        try {
+            Workspace workspace = webhook.getWorkspace();
+            String normalizedUrl = RepoUrlNormalizer.normalize(workspace.getSource());
+            if (normalizedUrl == null) {
+                log.warn("Skipping repo webhook sync after {} webhook event: workspace {} has no source URL",
+                        operation, workspace.getId());
+                return;
+            }
+            String workspaceId = workspace.getId() == null ? null : workspace.getId().toString();
+            repoWebhookSyncScheduler.scheduleSync(normalizedUrl, workspaceId);
+        } catch (Exception e) {
+            // The event change is already committed. Log the failure and let a
+            // later workspace/event mutation retry the idempotent reconciliation.
+            log.error("Failed to schedule repo webhook sync after {} webhook event", operation, e);
+        }
+    }
+
+    private boolean isSharedWebhookProvider(Webhook webhook) {
+        VcsType vcsType = webhook.getWorkspace().getVcs() == null
+                ? null
+                : webhook.getWorkspace().getVcs().getVcsType();
+        return vcsType == VcsType.GITHUB || vcsType == VcsType.GITLAB;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/webhook/WebhookEvent.java
+++ b/api/src/main/java/io/terrakube/api/rs/webhook/WebhookEvent.java
@@ -6,8 +6,10 @@ import java.util.UUID;
 import org.hibernate.annotations.JdbcTypeCode;
 import io.terrakube.api.plugin.security.audit.GenericAuditFields;
 import io.terrakube.api.rs.IdConverter;
+import io.terrakube.api.rs.hooks.webhook.WebhookEventManageHook;
 
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -23,6 +25,9 @@ import lombok.Setter;
 @Getter
 @Setter
 @Include
+@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = WebhookEventManageHook.class)
+@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = WebhookEventManageHook.class)
+@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.DELETE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = WebhookEventManageHook.class)
 @Entity(name = "webhook_event")
 public class WebhookEvent extends GenericAuditFields {
     @Id

--- a/api/src/test/java/io/terrakube/api/rs/hooks/webhook/WebhookEventManageHookTest.java
+++ b/api/src/test/java/io/terrakube/api/rs/hooks/webhook/WebhookEventManageHookTest.java
@@ -1,0 +1,81 @@
+package io.terrakube.api.rs.hooks.webhook;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding.Operation;
+import com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase;
+
+import io.terrakube.api.plugin.scheduler.webhook.RepoWebhookSyncScheduler;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.vcs.VcsType;
+import io.terrakube.api.rs.webhook.Webhook;
+import io.terrakube.api.rs.webhook.WebhookEvent;
+import io.terrakube.api.rs.workspace.Workspace;
+
+@ExtendWith(MockitoExtension.class)
+class WebhookEventManageHookTest {
+
+    @Mock
+    RepoWebhookSyncScheduler repoWebhookSyncScheduler;
+
+    @InjectMocks
+    WebhookEventManageHook subject;
+
+    @Test
+    void execute_v2GithubEventChangeSchedulesSync() {
+        WebhookEvent event = eventFor(VcsType.GITHUB, true, "https://github.com/owner/repo.git");
+
+        subject.execute(Operation.CREATE, TransactionPhase.POSTCOMMIT, event, null, Optional.empty());
+
+        verify(repoWebhookSyncScheduler).scheduleSync(
+                "https://github.com/owner/repo", "11111111-1111-1111-1111-111111111111");
+    }
+
+    @Test
+    void execute_v2GitlabEventChangeSchedulesSync() {
+        WebhookEvent event = eventFor(VcsType.GITLAB, true, "https://gitlab.com/owner/repo.git");
+
+        subject.execute(Operation.DELETE, TransactionPhase.POSTCOMMIT, event, null, Optional.empty());
+
+        verify(repoWebhookSyncScheduler).scheduleSync(
+                "https://gitlab.com/owner/repo", "11111111-1111-1111-1111-111111111111");
+    }
+
+    @Test
+    void execute_nonV2OrNonSharedEventChangeDoesNotScheduleSync() {
+        WebhookEvent v1Event = eventFor(VcsType.GITHUB, false, "https://github.com/owner/repo");
+        WebhookEvent bitbucketEvent = eventFor(VcsType.BITBUCKET, true, "https://bitbucket.org/owner/repo");
+
+        subject.execute(Operation.UPDATE, TransactionPhase.POSTCOMMIT, v1Event, null, Optional.empty());
+        subject.execute(Operation.UPDATE, TransactionPhase.POSTCOMMIT, bitbucketEvent, null, Optional.empty());
+
+        verifyNoInteractions(repoWebhookSyncScheduler);
+    }
+
+    private WebhookEvent eventFor(VcsType vcsType, boolean migratedV2, String source) {
+        Workspace workspace = new Workspace();
+        workspace.setId(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        workspace.setSource(source);
+        Vcs vcs = new Vcs();
+        vcs.setVcsType(vcsType);
+        workspace.setVcs(vcs);
+
+        Webhook webhook = new Webhook();
+        webhook.setWorkspace(workspace);
+        webhook.setMigratedV2(migratedV2);
+
+        WebhookEvent event = new WebhookEvent();
+        event.setWebhook(webhook);
+        return event;
+    }
+}

--- a/api/src/test/java/io/terrakube/api/rs/webhook/WebhookEventLifeCycleHookBindingTest.java
+++ b/api/src/test/java/io/terrakube/api/rs/webhook/WebhookEventLifeCycleHookBindingTest.java
@@ -1,0 +1,32 @@
+package io.terrakube.api.rs.webhook;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
+
+import io.terrakube.api.rs.hooks.webhook.WebhookEventManageHook;
+
+class WebhookEventLifeCycleHookBindingTest {
+
+    private record Binding(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase phase) {
+    }
+
+    @Test
+    void registersEventHookForPostCommitMutations() {
+        Set<Binding> registered = java.util.Arrays.stream(
+                WebhookEvent.class.getAnnotationsByType(LifeCycleHookBinding.class))
+                .filter(binding -> binding.hook() == WebhookEventManageHook.class)
+                .map(binding -> new Binding(binding.operation(), binding.phase()))
+                .collect(Collectors.toSet());
+
+        assertThat(registered).containsExactlyInAnyOrder(
+                new Binding(LifeCycleHookBinding.Operation.CREATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT),
+                new Binding(LifeCycleHookBinding.Operation.UPDATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT),
+                new Binding(LifeCycleHookBinding.Operation.DELETE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT));
+    }
+}


### PR DESCRIPTION
## What

Adds a lifecycle hook on `WebhookEvent` so that creating, updating, or deleting an event row schedules a resync of the shared v2 repo webhook — the same resync that previously only fired off mutations to the parent `Webhook` entity.

## Why

The v2 shared webhook (one VCS-side webhook per repo, covering all workspaces on GitHub/GitLab) is built from each workspace's `WebhookEvent` rows. Only `Webhook` had a `@LifeCycleHookBinding` wired to trigger a resync, so any client that mutates `WebhookEvent` directly without touching the parent `Webhook` — notably `terraform-provider-terrakube` — left the actual VCS-side webhook stale and out of sync with the events actually configured in Terrakube.

## How

- Added `WebhookEventManageHook`, a `LifeCycleHook<WebhookEvent>` bound via `@LifeCycleHookBinding` on `WebhookEvent` for `CREATE`/`UPDATE`/`DELETE` at `POSTCOMMIT` — mirroring the existing binding pattern already used on `Webhook` itself.
- On each post-commit mutation, the hook:
  - No-ops unless the parent `Webhook` is `migratedV2` and the workspace's VCS provider uses a shared webhook (`GITHUB` or `GITLAB`; `BITBUCKET` is excluded since it doesn't share this model).
  - Normalizes the workspace's source URL via `RepoUrlNormalizer` and calls `RepoWebhookSyncScheduler.scheduleSync(normalizedUrl, workspaceId)`.
  - Logs and swallows scheduling failures rather than throwing, since the event change is already committed by this point — a later mutation will retry the (idempotent) reconciliation.

## Tests

- `WebhookEventManageHookTest`: v2 GitHub event schedules a sync, v2 GitLab event schedules a sync, and both a v1 event and a Bitbucket event schedule nothing
- `WebhookEventLifeCycleHookBindingTest`: reflection-based assertion that `WebhookEvent` registers `WebhookEventManageHook` for exactly `CREATE`/`UPDATE`/`DELETE` at `POSTCOMMIT`