### PR TITLE
feat(executor): carry plan-built artifacts through to apply

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorContext.java
@@ -16,6 +16,8 @@ import java.util.List;
 public class ExecutorContext {
     private List<Command> commandList;
     private List<Command> onFailureList;
+    private List<String> artifactPatterns;
+    private boolean multiStepJob;
     private String type;
     private String organizationId;
     private String workspaceId;

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -143,6 +143,8 @@ public class ExecutorService {
 
         executorContext.setCommandList(flow.getCommands());
         executorContext.setOnFailureList(flow.getOnFailure());
+        executorContext.setArtifactPatterns(flow.getArtifacts());
+        executorContext.setMultiStepJob(job.getStep() != null && job.getStep().size() > 1);
         executorContext.setType(flow.getType());
         executorContext.setIgnoreError(flow.isIgnoreError());
         executorContext.setTerraformVersion(job.getWorkspace().getTerraformVersion());

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/model/Flow.java
@@ -19,6 +19,7 @@ public class Flow {
     private int step;
     List<Command> commands;
     List<Command> onFailure;
+    List<String> artifacts;
 
     List<ScheduleTemplate> templates;
 

--- a/api/src/main/java/io/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/Job.java
@@ -71,6 +71,12 @@ public class Job extends GenericAuditFields {
     @Column(name = "terraform_plan")
     private String terraformPlan;
 
+    @Column(name = "terraform_plan_artifacts")
+    private String terraformPlanArtifacts;
+
+    @Column(name = "terraform_plan_artifacts_checksum")
+    private String terraformPlanArtifactsChecksum;
+
     @CreatePermission(expression = "user is a super service")
     @UpdatePermission(expression = "user is a super service")
     @Column(name = "approval_team")

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -115,4 +115,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-job-command-comment-id.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-job-soft-delete.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-job-status-index.xml"/>
+    <include file="/db/changelog/local/changelog-2.33.0-plan-artifacts.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-plan-artifacts.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-plan-artifacts.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="1" author="terrakube">
+        <addColumn tableName="job">
+            <column name="terraform_plan_artifacts" type="varchar(1024)"/>
+        </addColumn>
+        <addColumn tableName="job">
+            <column name="terraform_plan_artifacts_checksum" type="varchar(64)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/model/FlowArtifactsTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/model/FlowArtifactsTest.java
@@ -1,0 +1,18 @@
+package io.terrakube.api.plugin.scheduler.job.tcl.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FlowArtifactsTest {
+
+    @Test
+    void artifactsRoundTrips() {
+        Flow flow = new Flow();
+        flow.setArtifacts(List.of("${ARTIFACT_PATHS}"));
+
+        assertEquals(List.of("${ARTIFACT_PATHS}"), flow.getArtifacts());
+    }
+}

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -19,7 +19,7 @@
 		<msal4j.version>1.25.1</msal4j.version>
 		<commons-text.version>1.15.0</commons-text.version>
 		<terraform-spring-boot-starter.version>1.5.0</terraform-spring-boot-starter.version>
-		<terrakube-client-starter.version>1.6.0</terrakube-client-starter.version>
+		<terrakube-client-starter.version>1.9.0</terrakube-client-starter.version>
 		<commons-io.version>2.22.0</commons-io.version>
 		<commons-codec>1.22.1</commons-codec>
 		<azure-storage-blob.version>12.33.2</azure-storage-blob.version>

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/ArtifactVerificationException.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/ArtifactVerificationException.java
@@ -1,0 +1,8 @@
+package io.terrakube.executor.plugin.tfstate;
+
+public class ArtifactVerificationException extends RuntimeException {
+
+    public ArtifactVerificationException(String message) {
+        super(message);
+    }
+}

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/TerraformState.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/TerraformState.java
@@ -12,6 +12,11 @@ public interface TerraformState {
 
     boolean downloadTerraformPlan(String organizationId, String workspaceId, String jobId, String stepId, File workingDirectory);
 
+    String saveArtifacts(String organizationId, String workspaceId, String jobId, String stepId, File workingDirectory);
+
+    boolean downloadArtifacts(String organizationId, String workspaceId, String jobId, String stepId, File workingDirectory)
+            throws ArtifactVerificationException;
+
     void saveStateJson(TerraformJob terraformJob, String applyJSON, String rawState);
 
     String saveOutput(String organizationId, String jobId, String stepId, String output, String outputError);

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
@@ -11,12 +11,16 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.text.TextStringBuilder;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.organization.job.JobAttributes;
 import io.terrakube.client.model.organization.workspace.history.History;
 import io.terrakube.client.model.organization.workspace.history.HistoryAttributes;
 import io.terrakube.client.model.organization.workspace.history.HistoryRequest;
+import io.terrakube.executor.plugin.tfstate.ArtifactVerificationException;
 import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
 import io.terrakube.executor.plugin.tfstate.TerraformState;
 import io.terrakube.executor.plugin.tfstate.TerraformStatePathService;
+import io.terrakube.executor.service.artifact.ArtifactPackagingService;
+import io.terrakube.executor.service.artifact.ArtifactVerifier;
 import io.terrakube.executor.service.mode.TerraformJob;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -44,6 +48,10 @@ public class AwsTerraformStateImpl implements TerraformState {
 
     private static final String TERRAFORM_PLAN_FILE = "terraformLibrary.tfPlan";
     private static final String BACKEND_FILE_NAME = "aws_backend_override.tf";
+    // Deliberately a separate top-level prefix from "tfstate/" (where the plan file and state
+    // live) rather than nested alongside them, so a bucket lifecycle rule can expire artifacts
+    // - which can be far larger than a plan file - without touching plan/state history.
+    private static final String ARTIFACTS_PREFIX = "plan-artifacts/";
 
     @NonNull
     private S3Client s3client;
@@ -71,6 +79,9 @@ public class AwsTerraformStateImpl implements TerraformState {
 
     @NonNull
     TerraformStatePathService terraformStatePathService;
+
+    @NonNull
+    ArtifactVerifier artifactVerifier;
 
     // Matches X-Range wildcards: * or major.wildcard (e.g. 1.x, 1.*, 1.X).
     // Bare x/X are intentionally excluded: TerraformDownloader rejects them as invalid.
@@ -212,6 +223,53 @@ public class AwsTerraformStateImpl implements TerraformState {
                     }
                 });
         return planExists.get();
+    }
+
+    @Override
+    public String saveArtifacts(String organizationId, String workspaceId, String jobId, String stepId, File workingDirectory) {
+        String blobKey = ARTIFACTS_PREFIX + organizationId + "/" + workspaceId + "/" + jobId + "/" + stepId + "/" + ArtifactPackagingService.ARTIFACTS_FILE_NAME;
+        log.info("terraformArtifactsFile: {}", blobKey);
+
+        File artifactsTarGz = new File(workingDirectory.getAbsolutePath() + "/" + ArtifactPackagingService.ARTIFACTS_FILE_NAME);
+        if (artifactsTarGz.exists()) {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(blobKey)
+                    .build();
+
+            s3client.putObject(putObjectRequest, RequestBody.fromFile(artifactsTarGz));
+
+            GetUrlRequest getUrlRequest = GetUrlRequest.builder()
+                    .bucket(bucketName)
+                    .key(blobKey)
+                    .build();
+
+            return s3client.utilities().getUrl(getUrlRequest).toExternalForm();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean downloadArtifacts(String organizationId, String workspaceId, String jobId, String stepId, File workingDirectory)
+            throws ArtifactVerificationException {
+        JobAttributes attributes = terrakubeClient.getJobById(organizationId, jobId).getData().getAttributes();
+        String artifactsUrl = attributes.getTerraformPlanArtifacts();
+        if (artifactsUrl == null || artifactsUrl.isBlank()) {
+            return false;
+        }
+
+        byte[] artifactBytes;
+        try {
+            log.info("Downloading plan artifacts from {}", artifactsUrl);
+            String objectKey = ARTIFACTS_PREFIX + new URL(artifactsUrl).getPath().split("/" + ARTIFACTS_PREFIX)[1];
+            artifactBytes = downloadObjectFromBucket(bucketName, objectKey);
+        } catch (IOException e) {
+            throw new ArtifactVerificationException("Failed to download plan artifacts bundle from " + artifactsUrl + ": " + e.getMessage());
+        }
+
+        artifactVerifier.verifyAndExtract(artifactBytes, attributes.getTerraformPlanArtifactsChecksum(), workingDirectory);
+        return true;
     }
 
     @Override

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/azure/AzureTerraformStateImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/azure/AzureTerraformStateImpl.java
@@ -17,16 +17,22 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.text.TextStringBuilder;
 import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.organization.job.JobAttributes;
 import io.terrakube.client.model.organization.workspace.history.History;
 import io.terrakube.client.model.organization.workspace.history.HistoryAttributes;
 import io.terrakube.client.model.organization.workspace.history.HistoryRequest;
+import io.terrakube.executor.plugin.tfstate.ArtifactVerificationException;
 import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
 import io.terrakube.executor.plugin.tfstate.TerraformState;
 import io.terrakube.executor.plugin.tfstate.TerraformStatePathService;
+import io.terrakube.executor.service.artifact.ArtifactPackagingService;
+import io.terrakube.executor.service.artifact.ArtifactVerifier;
 import io.terrakube.executor.service.mode.TerraformJob;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.time.OffsetDateTime;
@@ -45,6 +51,10 @@ public class AzureTerraformStateImpl implements TerraformState {
     private static final String BACKEND_FILE_NAME = "azure_backend_override.tf";
     private static final String CONTAINER_OUTPUT_NAME = "tfoutput";
     private static final String CONTAINER_BINARY_NAME = "tfbinary";
+    // A separate container from "tfstate" (not just a blob-name prefix within it), mirroring how
+    // "tfoutput" is already its own container - so a lifecycle policy can expire artifacts, which
+    // can be far larger than a plan file, without touching plan/state history.
+    private static final String CONTAINER_ARTIFACTS_NAME = "plan-artifacts";
     private String resourceGroupName;
     private String storageAccountName;
     private String storageContainerName;
@@ -60,6 +70,9 @@ public class AzureTerraformStateImpl implements TerraformState {
 
     @NonNull
     TerraformStatePathService terraformStatePathService;
+
+    @NonNull
+    ArtifactVerifier artifactVerifier;
 
     @Override
     public String getBackendStateFile(String organizationId, String workspaceId, File workingDirectory, String terraformVersion) {
@@ -111,6 +124,60 @@ public class AzureTerraformStateImpl implements TerraformState {
         } else {
             return null;
         }
+    }
+
+    @Override
+    public String saveArtifacts(String organizationId, String workspaceId, String jobId, String stepId, File workingDirectory) {
+        BlobContainerClient blobContainerClient = blobServiceClient.getBlobContainerClient(CONTAINER_ARTIFACTS_NAME);
+        if (!blobContainerClient.exists()) {
+            blobContainerClient.create();
+        }
+        String blobName = organizationId + "/" + workspaceId + "/" + jobId + "/" + stepId + "/" + ArtifactPackagingService.ARTIFACTS_FILE_NAME;
+        log.info("terraformArtifactsFile: {}", blobName);
+        BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
+
+        File artifactsTarGz = new File(workingDirectory.getAbsolutePath() + "/" + ArtifactPackagingService.ARTIFACTS_FILE_NAME);
+        if (artifactsTarGz.exists()) {
+            blobClient.uploadFromFile(artifactsTarGz.getAbsolutePath());
+            return blobClient.getBlobUrl();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean downloadArtifacts(String organizationId, String workspaceId, String jobId, String stepId, File workingDirectory)
+            throws ArtifactVerificationException {
+        JobAttributes attributes = terrakubeClient.getJobById(organizationId, jobId).getData().getAttributes();
+        String artifactsUrl = attributes.getTerraformPlanArtifacts();
+        if (artifactsUrl == null || artifactsUrl.isBlank()) {
+            return false;
+        }
+
+        byte[] artifactBytes;
+        try {
+            log.info("Downloading plan artifacts from {}", artifactsUrl);
+            URL blobURL = new URL(artifactsUrl);
+            String blobName = blobURL.getPath().replace("/" + CONTAINER_ARTIFACTS_NAME + "/", "").replace("%2F", "/");
+
+            BlobContainerClient blobContainerClient = blobServiceClient.getBlobContainerClient(CONTAINER_ARTIFACTS_NAME);
+            BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
+
+            BlobSasPermission blobSasPermission = new BlobSasPermission().setReadPermission(true);
+            BlobServiceSasSignatureValues builder = new BlobServiceSasSignatureValues(OffsetDateTime.now().plusMinutes(5), blobSasPermission)
+                    .setProtocol(SasProtocol.HTTPS_ONLY);
+
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            try (InputStream in = new URL(String.format("%s?%s", blobClient.getBlobUrl(), blobClient.generateSas(builder))).openStream()) {
+                in.transferTo(buffer);
+            }
+            artifactBytes = buffer.toByteArray();
+        } catch (IOException e) {
+            throw new ArtifactVerificationException("Failed to download plan artifacts bundle from " + artifactsUrl + ": " + e.getMessage());
+        }
+
+        artifactVerifier.verifyAndExtract(artifactBytes, attributes.getTerraformPlanArtifactsChecksum(), workingDirectory);
+        return true;
     }
 
     @Override

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
@@ -17,6 +17,7 @@ import io.terrakube.executor.plugin.tfstate.azure.AzureTerraformStateProperties;
 import io.terrakube.executor.plugin.tfstate.gcp.GcpTerraformStateImpl;
 import io.terrakube.executor.plugin.tfstate.gcp.GcpTerraformStateProperties;
 import io.terrakube.executor.plugin.tfstate.local.LocalTerraformStateImpl;
+import io.terrakube.executor.service.artifact.ArtifactVerifier;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Base64;
@@ -49,7 +50,7 @@ import java.net.URI;
 public class TerraformStateAutoConfiguration {
 
     @Bean
-    public TerraformState terraformState(TerrakubeClient terrakubeClient, TerraformStateProperties terraformStateProperties, AzureTerraformStateProperties azureTerraformStateProperties, AwsTerraformStateProperties awsTerraformStateProperties, GcpTerraformStateProperties gcpTerraformStateProperties, TerraformStatePathService terraformStatePathService, TerraformOutputPathService terraformOutputPathService) {
+    public TerraformState terraformState(TerrakubeClient terrakubeClient, TerraformStateProperties terraformStateProperties, AzureTerraformStateProperties azureTerraformStateProperties, AwsTerraformStateProperties awsTerraformStateProperties, GcpTerraformStateProperties gcpTerraformStateProperties, TerraformStatePathService terraformStatePathService, TerraformOutputPathService terraformOutputPathService, ArtifactVerifier artifactVerifier) {
         TerraformState terraformState = null;
 
         if (terraformStateProperties != null)
@@ -71,6 +72,7 @@ public class TerraformStateAutoConfiguration {
                             .terrakubeClient(terrakubeClient)
                             .terraformOutputPathService(terraformOutputPathService)
                             .terraformStatePathService(terraformStatePathService)
+                            .artifactVerifier(artifactVerifier)
                             .build();
                     break;
                 case AwsTerraformStateImpl:
@@ -117,6 +119,7 @@ public class TerraformStateAutoConfiguration {
                             .terrakubeClient(terrakubeClient)
                             .terraformStatePathService(terraformStatePathService)
                             .terraformOutputPathService(terraformOutputPathService)
+                            .artifactVerifier(artifactVerifier)
                             .build();
                     break;
                 case GcpTerraformStateImpl:
@@ -139,6 +142,7 @@ public class TerraformStateAutoConfiguration {
                                 .bucketName(gcpTerraformStateProperties.getBucketName())
                                 .credentials(gcpTerraformStateProperties.getCredentials())
                                 .terrakubeClient(terrakubeClient)
+                                .artifactVerifier(artifactVerifier)
                                 .build();
                     } catch (IOException e) {
                         log.error(e.getMessage());
@@ -149,12 +153,14 @@ public class TerraformStateAutoConfiguration {
                             .terrakubeClient(terrakubeClient)
                             .terraformStatePathService(terraformStatePathService)
                             .terraformOutputPathService(terraformOutputPathService)
+                            .artifactVerifier(artifactVerifier)
                             .build();
             }
         else
             terraformState = LocalTerraformStateImpl.builder()
                     .terrakubeClient(terrakubeClient)
                     .terraformStatePathService(terraformStatePathService)
+                    .artifactVerifier(artifactVerifier)
                     .build();
         return terraformState;
     }

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/gcp/GcpTerraformStateImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/gcp/GcpTerraformStateImpl.java
@@ -12,16 +12,22 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.text.TextStringBuilder;
 import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.organization.job.JobAttributes;
 import io.terrakube.client.model.organization.workspace.history.History;
 import io.terrakube.client.model.organization.workspace.history.HistoryAttributes;
 import io.terrakube.client.model.organization.workspace.history.HistoryRequest;
+import io.terrakube.executor.plugin.tfstate.ArtifactVerificationException;
 import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
 import io.terrakube.executor.plugin.tfstate.TerraformState;
 import io.terrakube.executor.plugin.tfstate.TerraformStatePathService;
+import io.terrakube.executor.service.artifact.ArtifactPackagingService;
+import io.terrakube.executor.service.artifact.ArtifactVerifier;
 import io.terrakube.executor.service.mode.TerraformJob;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -37,6 +43,10 @@ public class GcpTerraformStateImpl implements TerraformState {
     private static final String TERRAFORM_PLAN_FILE = "terraformLibrary.tfPlan";
     private static final String GCP_CREDENTIALS_FILE = "GCP_CREDENTIALS_FILE.json";
     private static final String BACKEND_FILE_NAME = "gcp_backend_override.tf";
+    // A separate top-level prefix from "tfstate/" (where the plan file and state live), so an
+    // Object Lifecycle Management rule can expire artifacts - which can be far larger than a plan
+    // file - without touching plan/state history.
+    private static final String ARTIFACTS_PREFIX = "plan-artifacts/";
 
     @NonNull
     TerraformOutputPathService terraformOutputPathService;
@@ -54,6 +64,8 @@ public class GcpTerraformStateImpl implements TerraformState {
     TerraformStatePathService terraformStatePathService;
 
     @NonNull TerrakubeClient terrakubeClient;
+
+    @NonNull ArtifactVerifier artifactVerifier;
 
     @Override
     public String getBackendStateFile(String organizationId, String workspaceId, File workingDirectory, String terraformVersion) {
@@ -143,6 +155,56 @@ public class GcpTerraformStateImpl implements TerraformState {
                     }
                 });
         return planGcExist.get();
+    }
+
+    @Override
+    public String saveArtifacts(String organizationId, String workspaceId, String jobId, String stepId, File workingDirectory) {
+        String blobKey = String.format(ARTIFACTS_PREFIX + "%s/%s/%s/%s/%s", organizationId, workspaceId, jobId, stepId, ArtifactPackagingService.ARTIFACTS_FILE_NAME);
+        log.info("terraformGcpArtifactsFile: {}", blobKey);
+
+        File artifactsTarGz = new File(FilenameUtils.concat(workingDirectory.getAbsolutePath(), ArtifactPackagingService.ARTIFACTS_FILE_NAME));
+        if (artifactsTarGz.exists()) {
+            try {
+                BlobId blobId = BlobId.of(bucketName, blobKey);
+                BlobInfo blobInfo = BlobInfo.newBuilder(blobId).build();
+                storage.create(blobInfo, FileUtils.readFileToByteArray(artifactsTarGz));
+                return String.format("https://storage.cloud.google.com/%s/%s", bucketName, blobKey);
+            } catch (IOException e) {
+                log.error(e.getMessage());
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean downloadArtifacts(String organizationId, String workspaceId, String jobId, String stepId, File workingDirectory)
+            throws ArtifactVerificationException {
+        JobAttributes attributes = terrakubeClient.getJobById(organizationId, jobId).getData().getAttributes();
+        String artifactsUrl = attributes.getTerraformPlanArtifacts();
+        if (artifactsUrl == null || artifactsUrl.isBlank()) {
+            return false;
+        }
+
+        byte[] artifactBytes;
+        try {
+            log.info("Downloading plan artifacts from {}", artifactsUrl);
+            String bucketNamePath = String.format("/%s/", bucketName);
+            BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, new URL(artifactsUrl).getPath().replace(bucketNamePath, ""))).build();
+            URL signedUrl = storage.signUrl(blobInfo, 5, TimeUnit.MINUTES);
+
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            try (InputStream in = signedUrl.openStream()) {
+                in.transferTo(buffer);
+            }
+            artifactBytes = buffer.toByteArray();
+        } catch (IOException e) {
+            throw new ArtifactVerificationException("Failed to download plan artifacts bundle from " + artifactsUrl + ": " + e.getMessage());
+        }
+
+        artifactVerifier.verifyAndExtract(artifactBytes, attributes.getTerraformPlanArtifactsChecksum(), workingDirectory);
+        return true;
     }
 
     @Override

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/local/LocalTerraformStateImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/local/LocalTerraformStateImpl.java
@@ -17,12 +17,16 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.text.TextStringBuilder;
 import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.organization.job.JobAttributes;
 import io.terrakube.client.model.organization.workspace.history.History;
 import io.terrakube.client.model.organization.workspace.history.HistoryAttributes;
 import io.terrakube.client.model.organization.workspace.history.HistoryRequest;
+import io.terrakube.executor.plugin.tfstate.ArtifactVerificationException;
 import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
 import io.terrakube.executor.plugin.tfstate.TerraformState;
 import io.terrakube.executor.plugin.tfstate.TerraformStatePathService;
+import io.terrakube.executor.service.artifact.ArtifactPackagingService;
+import io.terrakube.executor.service.artifact.ArtifactVerifier;
 import io.terrakube.executor.service.mode.TerraformJob;
 
 @Slf4j
@@ -36,6 +40,10 @@ public class LocalTerraformStateImpl implements TerraformState {
     private static final String LOCAL_BACKEND_DIRECTORY = "/.terraform-spring-boot/local/backend/%s/%s/" + TERRAFORM_STATE_FILE;
     private static final String LOCAL_PLAN_DIRECTORY = "/.terraform-spring-boot/local/state/%s/%s/%s/%s/" + TERRAFORM_PLAN_FILE;
     private static final String LOCAL_PLAN_DIRECTORY_JSON = "/.terraform-spring-boot/local/state/%s/%s/state/%s.json";
+    // A separate top-level directory from ".../local/state/" (where the plan file lives), so a
+    // simple cron/tmpwatch cleanup can expire artifacts - which can be far larger than a plan
+    // file - without touching plan/state history.
+    private static final String LOCAL_ARTIFACTS_DIRECTORY = "/.terraform-spring-boot/local/plan-artifacts/%s/%s/%s/%s/" + ArtifactPackagingService.ARTIFACTS_FILE_NAME;
     private static final String BACKEND_FILE_NAME = "terrakube_override.tf";
     private static final String LOCAL_OUTPUT_DIRECTORY = "/.terraform-spring-boot/local/output/%s/%s/%s.tfoutput";
     private static final String LOCAL_BINARY_DIRECTORY = "/.terraform-spring-boot/local/binary/%s/%s/%s";
@@ -48,6 +56,9 @@ public class LocalTerraformStateImpl implements TerraformState {
 
     @NonNull
     TerraformStatePathService terraformStatePathService;
+
+    @NonNull
+    ArtifactVerifier artifactVerifier;
 
     @Override
     public String getBackendStateFile(String organizationId, String workspaceId, File workingDirectory, String terraformVersion) {
@@ -129,6 +140,53 @@ public class LocalTerraformStateImpl implements TerraformState {
                     }
                 });
         return planExists.get();
+    }
+
+    @Override
+    public String saveArtifacts(String organizationId, String workspaceId, String jobId, String stepId,
+                                 File workingDirectory) {
+
+        String artifactsFilePath = String.format(LOCAL_ARTIFACTS_DIRECTORY, organizationId, workspaceId, jobId, stepId);
+
+        String stepArtifactsPath = FileUtils.getUserDirectoryPath().concat(
+                FilenameUtils.separatorsToSystem(
+                        artifactsFilePath));
+
+        File artifactsTarGz = new File(String.join(File.separator,
+                Stream.of(workingDirectory.getAbsolutePath(), ArtifactPackagingService.ARTIFACTS_FILE_NAME).toArray(String[]::new)));
+
+        if (artifactsTarGz.exists()) {
+            try {
+                FileUtils.copyFile(artifactsTarGz, new File(stepArtifactsPath));
+            } catch (IOException e) {
+                log.error(e.getMessage());
+                return null;
+            }
+            log.info("Local artifacts bundle saved to {}", stepArtifactsPath);
+            return stepArtifactsPath;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public boolean downloadArtifacts(String organizationId, String workspaceId, String jobId, String stepId,
+                                      File workingDirectory) throws ArtifactVerificationException {
+        JobAttributes attributes = terrakubeClient.getJobById(organizationId, jobId).getData().getAttributes();
+        String artifactsPath = attributes.getTerraformPlanArtifacts();
+        if (artifactsPath == null || artifactsPath.isBlank()) {
+            return false;
+        }
+
+        byte[] artifactBytes;
+        try {
+            artifactBytes = FileUtils.readFileToByteArray(new File(artifactsPath));
+        } catch (IOException e) {
+            throw new ArtifactVerificationException("Failed to read plan artifacts bundle from " + artifactsPath + ": " + e.getMessage());
+        }
+
+        artifactVerifier.verifyAndExtract(artifactBytes, attributes.getTerraformPlanArtifactsChecksum(), workingDirectory);
+        return true;
     }
 
     @Override

--- a/executor/src/main/java/io/terrakube/executor/service/artifact/ArtifactGlobMatcher.java
+++ b/executor/src/main/java/io/terrakube/executor/service/artifact/ArtifactGlobMatcher.java
@@ -1,0 +1,75 @@
+package io.terrakube.executor.service.artifact;
+
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+@Component
+public class ArtifactGlobMatcher {
+
+    private static final Set<String> EXCLUDED_NAMES = Set.of(
+            ".git", ".terraform", ".ssh", ".sshModule",
+            "terrakube_config_dynamic_credentials_aws.txt",
+            "terrakube_dynamic_credentials.json",
+            "terrakube_config_dynamic_credentials.json",
+            ".terrakube_temp_env", "commitHash.info");
+
+    private static final Pattern BACKEND_OVERRIDE_PATTERN = Pattern.compile(".*_override\\.tf$");
+
+    public List<File> match(File workingDirectory, List<String> resolvedPatterns) throws IOException {
+        Path root = workingDirectory.toPath().toAbsolutePath().normalize();
+        FileSystem fileSystem = FileSystems.getDefault();
+        List<PathMatcher> matchers = resolvedPatterns.stream()
+                .map(pattern -> fileSystem.getPathMatcher("glob:" + pattern))
+                .toList();
+
+        List<File> matched = new ArrayList<>();
+        try (Stream<Path> walk = Files.walk(root)) {
+            List<Path> files = walk.filter(Files::isRegularFile).toList();
+            for (Path path : files) {
+                Path relative = root.relativize(path);
+                if (isExcluded(relative)) {
+                    continue;
+                }
+                if (matchesAny(matchers, relative)) {
+                    Path resolved = path.toRealPath();
+                    if (!resolved.startsWith(root)) {
+                        throw new IOException("Artifact pattern resolved outside the working directory: " + relative);
+                    }
+                    matched.add(resolved.toFile());
+                }
+            }
+        }
+        return matched;
+    }
+
+    private boolean matchesAny(List<PathMatcher> matchers, Path relative) {
+        for (PathMatcher matcher : matchers) {
+            if (matcher.matches(relative)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isExcluded(Path relative) {
+        for (Path part : relative) {
+            String name = part.toString();
+            if (EXCLUDED_NAMES.contains(name) || BACKEND_OVERRIDE_PATTERN.matcher(name).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/executor/src/main/java/io/terrakube/executor/service/artifact/ArtifactPackagingService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/artifact/ArtifactPackagingService.java
@@ -1,0 +1,59 @@
+package io.terrakube.executor.service.artifact;
+
+import io.terrakube.executor.service.mode.TerraformJob;
+import io.terrakube.executor.service.workspace.TarGzArchiver;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.FileUtils;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+public class ArtifactPackagingService {
+
+    public static final String ARTIFACTS_FILE_NAME = "plan-artifacts.tar.gz";
+
+    private final ArtifactPatternResolver patternResolver;
+    private final ArtifactGlobMatcher globMatcher;
+    private final TarGzArchiver tarGzArchiver;
+
+    public ArtifactPackagingService(ArtifactPatternResolver patternResolver, ArtifactGlobMatcher globMatcher,
+                                     TarGzArchiver tarGzArchiver) {
+        this.patternResolver = patternResolver;
+        this.globMatcher = globMatcher;
+        this.tarGzArchiver = tarGzArchiver;
+    }
+
+    public Optional<String> packageArtifacts(TerraformJob terraformJob, File workingDirectory) throws IOException {
+        List<String> declaredPatterns = terraformJob.getArtifactPatterns();
+        if (declaredPatterns == null || declaredPatterns.isEmpty()) {
+            return Optional.empty();
+        }
+
+        List<String> resolvedPatterns = patternResolver.resolve(declaredPatterns, terraformJob.getEnvironmentVariables());
+        if (resolvedPatterns.isEmpty()) {
+            log.info("Artifact patterns declared but resolved to nothing for job {} step {}",
+                    terraformJob.getJobId(), terraformJob.getStepId());
+            return Optional.empty();
+        }
+
+        List<File> matchedFiles = globMatcher.match(workingDirectory, resolvedPatterns);
+        if (matchedFiles.isEmpty()) {
+            log.info("Artifact patterns resolved but matched no files for job {} step {}",
+                    terraformJob.getJobId(), terraformJob.getStepId());
+            return Optional.empty();
+        }
+
+        File archive = new File(workingDirectory, ARTIFACTS_FILE_NAME);
+        tarGzArchiver.create(archive, workingDirectory, matchedFiles);
+        String checksum = DigestUtils.sha256Hex(FileUtils.readFileToByteArray(archive));
+        log.info("Packaged {} artifact file(s) for job {} step {} into {} (sha256 {})",
+                matchedFiles.size(), terraformJob.getJobId(), terraformJob.getStepId(), archive.getName(), checksum);
+        return Optional.of(checksum);
+    }
+}

--- a/executor/src/main/java/io/terrakube/executor/service/artifact/ArtifactPatternResolver.java
+++ b/executor/src/main/java/io/terrakube/executor/service/artifact/ArtifactPatternResolver.java
@@ -1,0 +1,52 @@
+package io.terrakube.executor.service.artifact;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class ArtifactPatternResolver {
+
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\$\\{([^}]+)\\}");
+
+    public List<String> resolve(List<String> patterns, Map<String, String> environmentVariables) {
+        Map<String, String> env = environmentVariables == null ? Map.of() : environmentVariables;
+        List<String> resolved = new ArrayList<>();
+
+        for (String pattern : patterns) {
+            String substituted = substitute(pattern, env);
+            if (substituted == null) {
+                // A placeholder referenced a variable that isn't set - drop this whole pattern
+                // entry rather than substituting an empty string in place, which would otherwise
+                // turn e.g. "${ARTIFACT_PATH}/**" into the bogus, overly-broad pattern "/**".
+                continue;
+            }
+            for (String piece : substituted.split(",")) {
+                String trimmed = piece.trim();
+                if (!trimmed.isEmpty()) {
+                    resolved.add(trimmed);
+                }
+            }
+        }
+
+        return resolved;
+    }
+
+    private String substitute(String pattern, Map<String, String> env) {
+        Matcher matcher = PLACEHOLDER.matcher(pattern);
+        StringBuilder result = new StringBuilder();
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            if (!env.containsKey(key)) {
+                return null;
+            }
+            matcher.appendReplacement(result, Matcher.quoteReplacement(env.get(key)));
+        }
+        matcher.appendTail(result);
+        return result.toString();
+    }
+}

--- a/executor/src/main/java/io/terrakube/executor/service/artifact/ArtifactVerifier.java
+++ b/executor/src/main/java/io/terrakube/executor/service/artifact/ArtifactVerifier.java
@@ -1,0 +1,40 @@
+package io.terrakube.executor.service.artifact;
+
+import io.terrakube.executor.plugin.tfstate.ArtifactVerificationException;
+import io.terrakube.executor.service.workspace.TarGzArchiver;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class ArtifactVerifier {
+
+    private final TarGzArchiver tarGzArchiver;
+
+    public ArtifactVerifier(TarGzArchiver tarGzArchiver) {
+        this.tarGzArchiver = tarGzArchiver;
+    }
+
+    public void verifyAndExtract(byte[] artifactBytes, String expectedChecksumHex, File workingDirectory)
+            throws ArtifactVerificationException {
+        String actualChecksum = DigestUtils.sha256Hex(artifactBytes);
+        if (expectedChecksumHex != null && !expectedChecksumHex.isBlank()
+                && !actualChecksum.equalsIgnoreCase(expectedChecksumHex)) {
+            throw new ArtifactVerificationException(
+                    "Plan artifacts checksum mismatch: expected " + expectedChecksumHex
+                            + " but downloaded bundle hashed to " + actualChecksum);
+        }
+
+        try {
+            tarGzArchiver.extract(new ByteArrayInputStream(artifactBytes), workingDirectory.getCanonicalPath());
+        } catch (IOException e) {
+            log.error("Failed to extract plan artifacts bundle: {}", e.getMessage());
+            throw new ArtifactVerificationException("Failed to extract plan artifacts bundle: " + e.getMessage());
+        }
+    }
+}

--- a/executor/src/main/java/io/terrakube/executor/service/mode/TerraformJob.java
+++ b/executor/src/main/java/io/terrakube/executor/service/mode/TerraformJob.java
@@ -41,5 +41,9 @@ public class TerraformJob {
     private HashMap<String, String> variables;
     private List<Map<String, Object>> liveChanges;
     private List<Map<String, Object>> jobDiagnostics;
+    private List<String> artifactPatterns;
+    private String artifactsUrl;
+    private String artifactsChecksum;
+    private boolean multiStepJob;
 
 }

--- a/executor/src/main/java/io/terrakube/executor/service/status/UpdateJobStatusImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/status/UpdateJobStatusImpl.java
@@ -60,7 +60,7 @@ public class UpdateJobStatusImpl implements UpdateJobStatus {
         if (!executorFlagsProperties.isDisableAcknowledge()) {
             updateStepStatus(successful, terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), jobOutput, jobErrorOutput);
             if(!isJobCancelled(terraformJob))
-                updateJobStatus(successful, isPlan, exitCode, terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), jobOutput, jobErrorOutput, jobPlan, commitId);
+                updateJobStatus(successful, isPlan, exitCode, terraformJob, jobOutput, jobErrorOutput, jobPlan, commitId);
         }
     }
 
@@ -76,7 +76,10 @@ public class UpdateJobStatusImpl implements UpdateJobStatus {
         }
     }
 
-    private void updateJobStatus(boolean successful, boolean isPlan, int exitCode, String organizationId, String jobId, String stepId, String jobOutput, String jobErrorOutput, String jobPlan, String commitId) {
+    private void updateJobStatus(boolean successful, boolean isPlan, int exitCode, TerraformJob terraformJob, String jobOutput, String jobErrorOutput, String jobPlan, String commitId) {
+        String organizationId = terraformJob.getOrganizationId();
+        String jobId = terraformJob.getJobId();
+        String stepId = terraformJob.getStepId();
         Job job = terrakubeClient.getJobById(organizationId, jobId).getData();
         String status = "";
         boolean planChanges = true;
@@ -116,6 +119,8 @@ public class UpdateJobStatusImpl implements UpdateJobStatus {
                 job.getAttributes().getOutput() == null ? "" : job.getAttributes().getOutput() + " Step " + stepId + " completed\n"
         );
         job.getAttributes().setTerraformPlan(jobPlan);
+        job.getAttributes().setTerraformPlanArtifacts(terraformJob.getArtifactsUrl());
+        job.getAttributes().setTerraformPlanArtifactsChecksum(terraformJob.getArtifactsChecksum());
         job.getAttributes().setCommitId(commitId);
 
         JobRequest jobRequest = new JobRequest();

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -3,7 +3,9 @@ package io.terrakube.executor.service.terraform;
 import com.diogonunes.jcolor.AnsiFormat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.executor.plugin.tfstate.ArtifactVerificationException;
 import io.terrakube.executor.plugin.tfstate.TerraformState;
+import io.terrakube.executor.service.artifact.ArtifactPackagingService;
 import io.terrakube.executor.service.executor.ExecutorJobResult;
 import io.terrakube.executor.service.logs.LogsConsumer;
 import io.terrakube.executor.service.logs.ProcessLogs;
@@ -60,8 +62,9 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
     ApplyStructuredOutputService applyStructuredOutputService;
     TerraformOutputsService terraformOutputsService;
     ObjectMapper objectMapper;
+    ArtifactPackagingService artifactPackagingService;
 
-    public TerraformExecutorServiceImpl(TerraformClient terraformClient, TerraformState terraformState, ScriptEngineService scriptEngineService, ProcessLogs logsService, PlanStructuredOutputService planStructuredOutputService, ApplyStructuredOutputService applyStructuredOutputService, TerraformOutputsService terraformOutputsService, ObjectMapper objectMapper, @Value("${io.terrakube.terraform.flags.enableColor}") boolean enableColorOutput, RedisTemplate redisTemplate, @Value("${io.terrakube.executor.redis.timeout}") int redisTimeout) {
+    public TerraformExecutorServiceImpl(TerraformClient terraformClient, TerraformState terraformState, ScriptEngineService scriptEngineService, ProcessLogs logsService, PlanStructuredOutputService planStructuredOutputService, ApplyStructuredOutputService applyStructuredOutputService, TerraformOutputsService terraformOutputsService, ObjectMapper objectMapper, ArtifactPackagingService artifactPackagingService, @Value("${io.terrakube.terraform.flags.enableColor}") boolean enableColorOutput, RedisTemplate redisTemplate, @Value("${io.terrakube.executor.redis.timeout}") int redisTimeout) {
         this.terraformClient = terraformClient;
         this.terraformState = terraformState;
         this.scriptEngineService = scriptEngineService;
@@ -71,6 +74,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         this.applyStructuredOutputService = applyStructuredOutputService;
         this.terraformOutputsService = terraformOutputsService;
         this.objectMapper = objectMapper;
+        this.artifactPackagingService = artifactPackagingService;
         this.enableColorOutput = enableColorOutput;
         this.redisTimeout = redisTimeout;
     }
@@ -252,6 +256,17 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     : "");
             if (executionPlan) {
                 planStructuredOutputService.publishPlanSummary(terraformJob, terraformWorkingDir, terraformJob.getLiveChanges(), terraformJob.getJobDiagnostics());
+                if (!isDestroy && exitCode == 2 && terraformJob.isMultiStepJob()) {
+                    // Only exitCode 2 (changes found) on a non-destroy plan can ever be followed by
+                    // an apply step - exitCode 0 (no changes) completes the job immediately, and
+                    // destroy plans are executed by destroy() below, which never reads artifacts back.
+                    // multiStepJob (this job has more than one step, mirroring the same check
+                    // UpdateJobStatusImpl makes to decide "pending" vs "completed") rules out
+                    // single-step plan-only templates, which have no apply step to ever consume a
+                    // packaged bundle. Packaging in any of these cases would upload a bundle nothing
+                    // ever downloads.
+                    packageAndSaveArtifacts(terraformJob, terraformWorkingDir);
+                }
             }
             result.setPlan(true);
             result.setExitCode(exitCode);
@@ -260,6 +275,25 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             result.setExitCode(1);
         }
         return result;
+    }
+
+    private void packageAndSaveArtifacts(TerraformJob terraformJob, File terraformWorkingDir) {
+        try {
+            artifactPackagingService.packageArtifacts(terraformJob, terraformWorkingDir).ifPresent(checksum -> {
+                String artifactsUrl = terraformState.saveArtifacts(terraformJob.getOrganizationId(),
+                        terraformJob.getWorkspaceId(), terraformJob.getJobId(), terraformJob.getStepId(), terraformWorkingDir);
+                if (artifactsUrl == null) {
+                    log.error("Plan artifacts were packaged for job {} step {} but upload failed",
+                            terraformJob.getJobId(), terraformJob.getStepId());
+                    return;
+                }
+                terraformJob.setArtifactsUrl(artifactsUrl);
+                terraformJob.setArtifactsChecksum(checksum);
+            });
+        } catch (IOException e) {
+            log.error("Failed to package plan artifacts for job {} step {}: {}",
+                    terraformJob.getJobId(), terraformJob.getStepId(), e.getMessage());
+        }
     }
 
     @Override
@@ -271,6 +305,16 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         TextStringBuilder terraformErrorOutput = new TextStringBuilder();
         try {
             File terraformWorkingDir = getTerraformWorkingDir(terraformJob, executorTempDirectory);
+
+            try {
+                terraformState.downloadArtifacts(terraformJob.getOrganizationId(), terraformJob.getWorkspaceId(),
+                        terraformJob.getJobId(), terraformJob.getStepId(), terraformWorkingDir);
+            } catch (ArtifactVerificationException e) {
+                log.error("Plan artifacts verification failed for job {} step {}: {}",
+                        terraformJob.getJobId(), terraformJob.getStepId(), e.getMessage());
+                return generateJobResult(false, "", "Plan artifacts verification failed: " + e.getMessage());
+            }
+
             Consumer<String> applyOutput = LogsConsumer.builder()
                     .jobId(Integer.valueOf(terraformJob.getJobId()))
                     .lineNumber(new AtomicInteger(0))

--- a/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/SetupWorkspaceImpl.java
@@ -21,9 +21,6 @@ import com.azure.core.http.netty.NettyAsyncHttpClientBuilder;
 import com.azure.identity.DefaultAzureCredential;
 import com.azure.identity.DefaultAzureCredentialBuilder;
 import io.terrakube.client.TerrakubeClient;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jgit.api.CloneCommand;
@@ -70,16 +67,19 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
     TerraformExecutor terraformExecutor;
     String apiUrl;
     TerrakubeClient terrakubeClient;
+    TarGzArchiver tarGzArchiver;
 
     public SetupWorkspaceImpl(WorkspaceSecurity workspaceSecurity,
                               @Value("${io.terrakube.client.enableSecurity}") boolean enableRegistrySecurity,
                               TerraformExecutor terraformExecutor,
-                              @Value("${io.terrakube.api.url}") String apiUrl, TerrakubeClient terrakubeClient) {
+                              @Value("${io.terrakube.api.url}") String apiUrl, TerrakubeClient terrakubeClient,
+                              TarGzArchiver tarGzArchiver) {
         this.workspaceSecurity = workspaceSecurity;
         this.enableRegistrySecurity = enableRegistrySecurity;
         this.terraformExecutor = terraformExecutor;
         this.apiUrl = apiUrl;
         this.terrakubeClient = terrakubeClient;
+        this.tarGzArchiver = tarGzArchiver;
     }
 
     @Override
@@ -357,52 +357,7 @@ public class SetupWorkspaceImpl implements SetupWorkspace {
     }
 
     public void extractTarGZ(InputStream in, String destinationFilePath) throws IOException {
-        GzipCompressorInputStream gzipIn = new GzipCompressorInputStream(in);
-        try (TarArchiveInputStream tarIn = new TarArchiveInputStream(gzipIn)) {
-            TarArchiveEntry entry;
-
-            while ((entry = (TarArchiveEntry) tarIn.getNextEntry()) != null) {
-                if (entry.isDirectory()) {
-                    File f = new File(String.format("%s/%s", destinationFilePath, entry.getName()));
-                    log.debug("Creating folder: {}", f.getCanonicalPath());
-                    String canonicalDestinationPath = f.getCanonicalPath();
-
-                    if (!canonicalDestinationPath.startsWith(destinationFilePath)) {
-                        throw new IOException("Entry is outside of the target directory");
-                    }
-
-                    boolean created = f.mkdir();
-                    if (!created) {
-                        log.info("Unable to create directory '{}', during extraction of archive contents.\n",
-                                f.getAbsolutePath());
-                    }
-                } else {
-                    int count;
-                    byte data[] = new byte[2048];
-                    File f = new File(String.format("%s/%s", destinationFilePath, entry.getName()));
-                    String canonicalDestinationPath = f.getCanonicalPath();
-
-                    if (!canonicalDestinationPath.startsWith(destinationFilePath)) {
-                        throw new IOException("Entry is outside of the target directory");
-                    }
-                    if (!f.exists()) {
-                        f.getParentFile().mkdirs();
-                        if (f.createNewFile()) {
-                            log.debug("File created: {}", f.getCanonicalPath());
-                        }
-                    }
-                    FileOutputStream fos = new FileOutputStream(f.getCanonicalPath(), false);
-                    log.info("Adding file {} to workspace context", destinationFilePath + "/" + entry.getName());
-                    try (BufferedOutputStream dest = new BufferedOutputStream(fos, 2048)) {
-                        while ((count = tarIn.read(data, 0, 2048)) != -1) {
-                            dest.write(data, 0, count);
-                        }
-                    }
-                }
-            }
-
-            log.info("Untar completed successfully!");
-        }
+        tarGzArchiver.extract(in, destinationFilePath);
     }
 
     private void getCommitId(File gitCloneFolder, String commitId) throws GitAPIException, IOException {

--- a/executor/src/main/java/io/terrakube/executor/service/workspace/TarGzArchiver.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/TarGzArchiver.java
@@ -1,0 +1,101 @@
+package io.terrakube.executor.service.workspace;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.io.IOUtils;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+@Slf4j
+@Component
+public class TarGzArchiver {
+
+    public void extract(InputStream in, String destinationFilePath) throws IOException {
+        GzipCompressorInputStream gzipIn = new GzipCompressorInputStream(in);
+        try (TarArchiveInputStream tarIn = new TarArchiveInputStream(gzipIn)) {
+            TarArchiveEntry entry;
+
+            while ((entry = (TarArchiveEntry) tarIn.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    File f = new File(String.format("%s/%s", destinationFilePath, entry.getName()));
+                    log.debug("Creating folder: {}", f.getCanonicalPath());
+                    String canonicalDestinationPath = f.getCanonicalPath();
+
+                    if (!canonicalDestinationPath.startsWith(destinationFilePath)) {
+                        throw new IOException("Entry is outside of the target directory");
+                    }
+
+                    boolean created = f.mkdir();
+                    if (!created) {
+                        log.info("Unable to create directory '{}', during extraction of archive contents.\n",
+                                f.getAbsolutePath());
+                    }
+                } else {
+                    int count;
+                    byte data[] = new byte[2048];
+                    File f = new File(String.format("%s/%s", destinationFilePath, entry.getName()));
+                    String canonicalDestinationPath = f.getCanonicalPath();
+
+                    if (!canonicalDestinationPath.startsWith(destinationFilePath)) {
+                        throw new IOException("Entry is outside of the target directory");
+                    }
+                    if (!f.exists()) {
+                        f.getParentFile().mkdirs();
+                        if (f.createNewFile()) {
+                            log.debug("File created: {}", f.getCanonicalPath());
+                        }
+                    }
+                    FileOutputStream fos = new FileOutputStream(f.getCanonicalPath(), false);
+                    log.info("Adding file {} to workspace context", destinationFilePath + "/" + entry.getName());
+                    try (BufferedOutputStream dest = new BufferedOutputStream(fos, 2048)) {
+                        while ((count = tarIn.read(data, 0, 2048)) != -1) {
+                            dest.write(data, 0, count);
+                        }
+                    }
+                }
+            }
+
+            log.info("Untar completed successfully!");
+        }
+    }
+
+    public void create(File outputTarGz, File baseDirectory, List<File> filesToInclude) throws IOException {
+        String basePath = baseDirectory.getCanonicalPath();
+        try (OutputStream fos = new FileOutputStream(outputTarGz);
+             GzipCompressorOutputStream gzos = new GzipCompressorOutputStream(fos);
+             TarArchiveOutputStream tarOs = new TarArchiveOutputStream(gzos)) {
+            tarOs.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+
+            for (File file : filesToInclude) {
+                String canonicalPath = file.getCanonicalPath();
+                if (!canonicalPath.startsWith(basePath)) {
+                    throw new IOException("File to archive is outside of the base directory: " + canonicalPath);
+                }
+                String relativeName = canonicalPath.substring(basePath.length())
+                        .replace(File.separatorChar, '/')
+                        .replaceFirst("^/", "");
+
+                TarArchiveEntry entry = new TarArchiveEntry(file, relativeName);
+                tarOs.putArchiveEntry(entry);
+                try (InputStream fis = new FileInputStream(file)) {
+                    IOUtils.copy(fis, tarOs);
+                }
+                tarOs.closeArchiveEntry();
+            }
+            tarOs.finish();
+        }
+        log.info("Created archive {} with {} entries", outputTarGz.getAbsolutePath(), filesToInclude.size());
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImplTest.java
@@ -4,7 +4,10 @@ import io.terrakube.client.TerrakubeClient;
 import io.terrakube.client.model.organization.workspace.history.HistoryRequest;
 import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
 import io.terrakube.executor.plugin.tfstate.TerraformStatePathService;
+import io.terrakube.executor.service.artifact.ArtifactPackagingService;
+import io.terrakube.executor.service.artifact.ArtifactVerifier;
 import io.terrakube.executor.service.mode.TerraformJob;
+import io.terrakube.executor.service.workspace.TarGzArchiver;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,6 +28,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -56,6 +60,7 @@ class AwsTerraformStateImplTest {
                 .terrakubeClient(terrakubeClient)
                 .terraformOutputPathService(terraformOutputPathService)
                 .terraformStatePathService(terraformStatePathService)
+                .artifactVerifier(new ArtifactVerifier(new TarGzArchiver()))
                 .includeBackendKeys(false)
                 .build();
     }
@@ -253,6 +258,57 @@ class AwsTerraformStateImplTest {
         assertTrue(result);
         File downloadedPlan = new File(workingDirectory, "terraformLibrary.tfPlan");
         assertTrue(downloadedPlan.exists());
+    }
+
+    @Test
+    void testSaveArtifacts(@TempDir Path tempDir) throws MalformedURLException, IOException {
+        File workingDirectory = tempDir.toFile();
+        File archive = new File(workingDirectory, ArtifactPackagingService.ARTIFACTS_FILE_NAME);
+        FileUtils.writeStringToFile(archive, "tar-gz-bytes", Charset.defaultCharset());
+
+        S3Utilities s3Utilities = mock(S3Utilities.class);
+        when(s3Client.utilities()).thenReturn(s3Utilities);
+        when(s3Utilities.getUrl(any(GetUrlRequest.class))).thenReturn(new URL("https://s3.amazonaws.com/test-bucket/artifacts"));
+
+        String url = awsTerraformState.saveArtifacts("org1", "ws1", "job1", "step1", workingDirectory);
+
+        assertEquals("https://s3.amazonaws.com/test-bucket/artifacts", url);
+        verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+
+    @Test
+    void testDownloadArtifactsSucceedsOnMatchingChecksum(@TempDir Path targetDir) throws Exception {
+        File sourceDir = Files.createTempDirectory("artifact-source").toFile();
+        File sourceFile = new File(sourceDir, "build/output.zip");
+        FileUtils.writeStringToFile(sourceFile, "zip-bytes", Charset.defaultCharset());
+        File tarGz = new File(sourceDir, "plan-artifacts.tar.gz");
+        new TarGzArchiver().create(tarGz, sourceDir, java.util.List.of(sourceFile));
+        byte[] bundleBytes = FileUtils.readFileToByteArray(tarGz);
+        String checksum = org.apache.commons.codec.digest.DigestUtils.sha256Hex(bundleBytes);
+
+        when(terrakubeClient.getJobById("org1", "job1").getData().getAttributes().getTerraformPlanArtifacts())
+                .thenReturn("https://s3.amazonaws.com/test-bucket/plan-artifacts/org1/ws1/job1/step1/plan-artifacts.tar.gz");
+        when(terrakubeClient.getJobById("org1", "job1").getData().getAttributes().getTerraformPlanArtifactsChecksum())
+                .thenReturn(checksum);
+
+        ResponseBytes<GetObjectResponse> responseBytes = mock(ResponseBytes.class);
+        when(responseBytes.asByteArray()).thenReturn(bundleBytes);
+        when(s3Client.getObject(any(GetObjectRequest.class), any(ResponseTransformer.class))).thenReturn(responseBytes);
+
+        boolean result = awsTerraformState.downloadArtifacts("org1", "ws1", "job1", "step1", targetDir.toFile());
+
+        assertTrue(result);
+        assertTrue(new File(targetDir.toFile(), "build/output.zip").exists());
+    }
+
+    @Test
+    void testDownloadArtifactsReturnsFalseWhenNoneDeclared(@TempDir Path targetDir) {
+        when(terrakubeClient.getJobById("org1", "job1").getData().getAttributes().getTerraformPlanArtifacts())
+                .thenReturn(null);
+
+        boolean result = awsTerraformState.downloadArtifacts("org1", "ws1", "job1", "step1", targetDir.toFile());
+
+        assertFalse(result);
     }
 
     @Test

--- a/executor/src/test/java/io/terrakube/executor/plugin/tfstate/azure/AzureTerraformStateImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/plugin/tfstate/azure/AzureTerraformStateImplTest.java
@@ -9,7 +9,10 @@ import io.terrakube.client.TerrakubeClient;
 import io.terrakube.client.model.organization.workspace.history.HistoryRequest;
 import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
 import io.terrakube.executor.plugin.tfstate.TerraformStatePathService;
+import io.terrakube.executor.service.artifact.ArtifactPackagingService;
+import io.terrakube.executor.service.artifact.ArtifactVerifier;
 import io.terrakube.executor.service.mode.TerraformJob;
+import io.terrakube.executor.service.workspace.TarGzArchiver;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,6 +65,7 @@ class AzureTerraformStateImplTest {
                 .terrakubeClient(terrakubeClient)
                 .terraformOutputPathService(terraformOutputPathService)
                 .terraformStatePathService(terraformStatePathService)
+                .artifactVerifier(new ArtifactVerifier(new TarGzArchiver()))
                 .build();
     }
 
@@ -121,6 +125,69 @@ class AzureTerraformStateImplTest {
 
         verify(blobContainerClient).create();
         verify(blobClient).uploadFromFile(planFile.getAbsolutePath());
+    }
+
+    @Test
+    void testSaveArtifacts(@TempDir Path tempDir) throws IOException {
+        String organizationId = "org1";
+        String workspaceId = "ws1";
+        String jobId = "job1";
+        String stepId = "step1";
+        File workingDirectory = tempDir.toFile();
+        File archive = new File(workingDirectory, ArtifactPackagingService.ARTIFACTS_FILE_NAME);
+        FileUtils.writeStringToFile(archive, "tar-gz-bytes", Charset.defaultCharset());
+
+        when(blobContainerClient.exists()).thenReturn(true);
+        when(blobClient.getBlobUrl()).thenReturn("https://storage.azure.com/artifacts");
+
+        String result = azureTerraformState.saveArtifacts(organizationId, workspaceId, jobId, stepId, workingDirectory);
+
+        assertEquals("https://storage.azure.com/artifacts", result);
+        verify(blobClient).uploadFromFile(archive.getAbsolutePath());
+    }
+
+    @Test
+    void testDownloadArtifactsSucceedsOnMatchingChecksum(@TempDir Path tempDir) throws Exception {
+        String organizationId = "org1";
+        String workspaceId = "ws1";
+        String jobId = "job1";
+        String stepId = "step1";
+        File workingDirectory = tempDir.toFile();
+
+        File sourceDir = new File(workingDirectory, "source");
+        sourceDir.mkdirs();
+        File sourceFile = new File(sourceDir, "build/output.zip");
+        FileUtils.writeStringToFile(sourceFile, "zip-bytes", Charset.defaultCharset());
+        File tarGz = new File(sourceDir, "plan-artifacts.tar.gz");
+        new TarGzArchiver().create(tarGz, sourceDir, java.util.List.of(sourceFile));
+        byte[] bundleBytes = FileUtils.readFileToByteArray(tarGz);
+        String checksum = org.apache.commons.codec.digest.DigestUtils.sha256Hex(bundleBytes);
+        String localUrl = tarGz.toURI().toURL().toString();
+
+        String artifactsUrl = "https://storage.azure.com/plan-artifacts/org1/ws1/job1/step1/plan-artifacts.tar.gz";
+        when(terrakubeClient.getJobById(organizationId, jobId).getData().getAttributes().getTerraformPlanArtifacts())
+                .thenReturn(artifactsUrl);
+        when(terrakubeClient.getJobById(organizationId, jobId).getData().getAttributes().getTerraformPlanArtifactsChecksum())
+                .thenReturn(checksum);
+        when(blobClient.getBlobUrl()).thenReturn(localUrl.split("\\?")[0]);
+        when(blobClient.generateSas(any())).thenReturn("");
+
+        File applyWorkingDirectory = new File(workingDirectory, "apply");
+        applyWorkingDirectory.mkdirs();
+        boolean result = azureTerraformState.downloadArtifacts(organizationId, workspaceId, jobId, stepId, applyWorkingDirectory);
+
+        assertTrue(result);
+        assertTrue(new File(applyWorkingDirectory, "build/output.zip").exists());
+    }
+
+    @Test
+    void testDownloadArtifactsReturnsFalseWhenNoneDeclared(@TempDir Path tempDir) {
+        when(terrakubeClient.getJobById("org1", "job1").getData().getAttributes().getTerraformPlanArtifacts())
+                .thenReturn(null);
+
+        boolean result = azureTerraformState.downloadArtifacts("org1", "ws1", "job1", "step1", tempDir.toFile());
+
+        assertFalse(result);
     }
 
     @Test

--- a/executor/src/test/java/io/terrakube/executor/plugin/tfstate/gcp/GcpTerraformStateImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/plugin/tfstate/gcp/GcpTerraformStateImplTest.java
@@ -7,7 +7,10 @@ import io.terrakube.client.TerrakubeClient;
 import io.terrakube.client.model.organization.workspace.history.HistoryRequest;
 import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
 import io.terrakube.executor.plugin.tfstate.TerraformStatePathService;
+import io.terrakube.executor.service.artifact.ArtifactPackagingService;
+import io.terrakube.executor.service.artifact.ArtifactVerifier;
 import io.terrakube.executor.service.mode.TerraformJob;
+import io.terrakube.executor.service.workspace.TarGzArchiver;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,6 +55,7 @@ class GcpTerraformStateImplTest {
                 .terrakubeClient(terrakubeClient)
                 .terraformOutputPathService(terraformOutputPathService)
                 .terraformStatePathService(terraformStatePathService)
+                .artifactVerifier(new ArtifactVerifier(new TarGzArchiver()))
                 .build();
     }
 
@@ -129,6 +133,65 @@ class GcpTerraformStateImplTest {
         // new URL(stateUrl).getPath() = /test-bucket/tfstate/org1/ws1/job1/step1/terraformLibrary.tfPlan
         // replace("/test-bucket/", "") = tfstate/org1/ws1/job1/step1/terraformLibrary.tfPlan
         assertEquals("tfstate/org1/ws1/job1/step1/terraformLibrary.tfPlan", blobInfoCaptor.getValue().getBlobId().getName());
+    }
+
+    @Test
+    void testSaveArtifacts(@TempDir Path tempDir) throws IOException {
+        String organizationId = "org1";
+        String workspaceId = "ws1";
+        String jobId = "job1";
+        String stepId = "step1";
+        File workingDirectory = tempDir.toFile();
+        File archive = new File(workingDirectory, ArtifactPackagingService.ARTIFACTS_FILE_NAME);
+        FileUtils.writeStringToFile(archive, "tar-gz-bytes", Charset.defaultCharset());
+
+        String result = gcpTerraformState.saveArtifacts(organizationId, workspaceId, jobId, stepId, workingDirectory);
+
+        String expectedUrl = "https://storage.cloud.google.com/test-bucket/plan-artifacts/org1/ws1/job1/step1/plan-artifacts.tar.gz";
+        assertEquals(expectedUrl, result);
+        verify(storage).create(any(BlobInfo.class), eq("tar-gz-bytes".getBytes()));
+    }
+
+    @Test
+    void testDownloadArtifactsSucceedsOnMatchingChecksum(@TempDir Path tempDir) throws Exception {
+        String organizationId = "org1";
+        String workspaceId = "ws1";
+        String jobId = "job1";
+        String stepId = "step1";
+        File workingDirectory = tempDir.toFile();
+
+        File sourceDir = new File(workingDirectory, "source");
+        sourceDir.mkdirs();
+        File sourceFile = new File(sourceDir, "build/output.zip");
+        FileUtils.writeStringToFile(sourceFile, "zip-bytes", Charset.defaultCharset());
+        File tarGz = new File(sourceDir, "plan-artifacts.tar.gz");
+        new TarGzArchiver().create(tarGz, sourceDir, java.util.List.of(sourceFile));
+        byte[] bundleBytes = FileUtils.readFileToByteArray(tarGz);
+        String checksum = org.apache.commons.codec.digest.DigestUtils.sha256Hex(bundleBytes);
+
+        String artifactsUrl = "https://storage.cloud.google.com/test-bucket/plan-artifacts/org1/ws1/job1/step1/plan-artifacts.tar.gz";
+        when(terrakubeClient.getJobById(organizationId, jobId).getData().getAttributes().getTerraformPlanArtifacts())
+                .thenReturn(artifactsUrl);
+        when(terrakubeClient.getJobById(organizationId, jobId).getData().getAttributes().getTerraformPlanArtifactsChecksum())
+                .thenReturn(checksum);
+        when(storage.signUrl(any(BlobInfo.class), anyLong(), any(TimeUnit.class))).thenReturn(tarGz.toURI().toURL());
+
+        File applyWorkingDirectory = new File(workingDirectory, "apply");
+        applyWorkingDirectory.mkdirs();
+        boolean result = gcpTerraformState.downloadArtifacts(organizationId, workspaceId, jobId, stepId, applyWorkingDirectory);
+
+        assertTrue(result);
+        assertTrue(new File(applyWorkingDirectory, "build/output.zip").exists());
+    }
+
+    @Test
+    void testDownloadArtifactsReturnsFalseWhenNoneDeclared(@TempDir Path tempDir) {
+        when(terrakubeClient.getJobById("org1", "job1").getData().getAttributes().getTerraformPlanArtifacts())
+                .thenReturn(null);
+
+        boolean result = gcpTerraformState.downloadArtifacts("org1", "ws1", "job1", "step1", tempDir.toFile());
+
+        assertFalse(result);
     }
 
     @Test

--- a/executor/src/test/java/io/terrakube/executor/plugin/tfstate/local/LocalTerraformStateImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/plugin/tfstate/local/LocalTerraformStateImplTest.java
@@ -2,9 +2,13 @@ package io.terrakube.executor.plugin.tfstate.local;
 
 import io.terrakube.client.TerrakubeClient;
 import io.terrakube.client.model.organization.workspace.history.HistoryRequest;
+import io.terrakube.executor.plugin.tfstate.ArtifactVerificationException;
 import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
 import io.terrakube.executor.plugin.tfstate.TerraformStatePathService;
+import io.terrakube.executor.service.artifact.ArtifactPackagingService;
+import io.terrakube.executor.service.artifact.ArtifactVerifier;
 import io.terrakube.executor.service.mode.TerraformJob;
+import io.terrakube.executor.service.workspace.TarGzArchiver;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +42,7 @@ class LocalTerraformStateImplTest {
                 .terrakubeClient(terrakubeClient)
                 .terraformOutputPathService(terraformOutputPathService)
                 .terraformStatePathService(terraformStatePathService)
+                .artifactVerifier(new ArtifactVerifier(new TarGzArchiver()))
                 .build();
     }
 
@@ -111,6 +116,52 @@ class LocalTerraformStateImplTest {
         
         // Cleanup
         FileUtils.deleteQuietly(new File(FileUtils.getUserDirectoryPath(), ".terraform-spring-boot"));
+    }
+
+    @Test
+    void saveArtifactsCopiesTarGzAndReturnsPath(@TempDir Path tempDir) throws IOException {
+        File workingDirectory = tempDir.toFile();
+        File archive = new File(workingDirectory, ArtifactPackagingService.ARTIFACTS_FILE_NAME);
+        FileUtils.writeStringToFile(archive, "tar-gz-bytes", Charset.defaultCharset());
+
+        String result = localTerraformState.saveArtifacts("org1", "ws1", "job1", "step1", workingDirectory);
+
+        assertNotNull(result);
+        assertTrue(new File(result).exists());
+
+        // Cleanup
+        FileUtils.deleteQuietly(new File(FileUtils.getUserDirectoryPath(), ".terraform-spring-boot"));
+    }
+
+    @Test
+    void saveArtifactsReturnsNullWhenNoBundleProduced(@TempDir Path tempDir) {
+        String result = localTerraformState.saveArtifacts("org1", "ws1", "job1", "step1", tempDir.toFile());
+
+        assertNull(result);
+    }
+
+    @Test
+    void downloadArtifactsReturnsFalseWhenNoneDeclared(@TempDir Path tempDir) {
+        when(terrakubeClient.getJobById("org1", "job1").getData().getAttributes().getTerraformPlanArtifacts())
+                .thenReturn(null);
+
+        boolean result = localTerraformState.downloadArtifacts("org1", "ws1", "job1", "step1", tempDir.toFile());
+
+        assertFalse(result);
+    }
+
+    @Test
+    void downloadArtifactsThrowsOnChecksumMismatch(@TempDir Path sourceDir, @TempDir Path targetDir) throws IOException {
+        File bundle = new File(sourceDir.toFile(), "plan-artifacts.tar.gz");
+        FileUtils.writeStringToFile(bundle, "tar-gz-bytes", Charset.defaultCharset());
+
+        when(terrakubeClient.getJobById("org1", "job1").getData().getAttributes().getTerraformPlanArtifacts())
+                .thenReturn(bundle.getAbsolutePath());
+        when(terrakubeClient.getJobById("org1", "job1").getData().getAttributes().getTerraformPlanArtifactsChecksum())
+                .thenReturn("mismatched-checksum");
+
+        assertThrows(ArtifactVerificationException.class,
+                () -> localTerraformState.downloadArtifacts("org1", "ws1", "job1", "step1", targetDir.toFile()));
     }
 
     @Test

--- a/executor/src/test/java/io/terrakube/executor/service/artifact/ArtifactGlobMatcherTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/artifact/ArtifactGlobMatcherTest.java
@@ -1,0 +1,73 @@
+package io.terrakube.executor.service.artifact;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArtifactGlobMatcherTest {
+
+    private final ArtifactGlobMatcher matcher = new ArtifactGlobMatcher();
+
+    @Test
+    void matchesNestedFilesUnderGlobStarStar(@TempDir Path dir) throws IOException {
+        File workingDirectory = dir.toFile();
+        write(workingDirectory, "build/output.zip", "zip");
+        write(workingDirectory, "build/sub/nested.txt", "nested");
+        write(workingDirectory, "README.md", "readme");
+
+        List<File> matched = matcher.match(workingDirectory, List.of("build/**"));
+
+        assertEquals(2, matched.size());
+    }
+
+    @Test
+    void excludesSensitivePathsEvenWhenGlobWouldMatch(@TempDir Path dir) throws IOException {
+        File workingDirectory = dir.toFile();
+        write(workingDirectory, "build/output.zip", "zip");
+        write(workingDirectory, ".terraform/plugin.bin", "plugin");
+        write(workingDirectory, "aws_backend_override.tf", "backend");
+        write(workingDirectory, "terrakube_config_dynamic_credentials_aws.txt", "creds");
+
+        List<File> matched = matcher.match(workingDirectory, List.of("**"));
+
+        assertEquals(1, matched.size());
+        assertEquals("output.zip", matched.get(0).getName());
+    }
+
+    @Test
+    void noMatchesReturnsEmptyList(@TempDir Path dir) throws IOException {
+        List<File> matched = matcher.match(dir.toFile(), List.of("nonexistent/**"));
+
+        assertTrue(matched.isEmpty());
+    }
+
+    @Test
+    void symlinkEscapingWorkingDirectoryThrows(@TempDir Path dir, @TempDir Path outside) throws IOException {
+        File workingDirectory = dir.toFile();
+        File secret = new File(outside.toFile(), "secret.txt");
+        FileUtils.writeStringToFile(secret, "secret", Charset.defaultCharset());
+
+        File linkDir = new File(workingDirectory, "build");
+        linkDir.mkdirs();
+        Files.createSymbolicLink(new File(linkDir, "escape.txt").toPath(), secret.toPath());
+
+        IOException thrown = org.junit.jupiter.api.Assertions.assertThrows(IOException.class,
+                () -> matcher.match(workingDirectory, List.of("build/**")));
+        assertTrue(thrown.getMessage().contains("outside"));
+    }
+
+    private void write(File baseDir, String relativePath, String content) throws IOException {
+        File file = new File(baseDir, relativePath);
+        FileUtils.writeStringToFile(file, content, Charset.defaultCharset());
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/artifact/ArtifactPackagingServiceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/artifact/ArtifactPackagingServiceTest.java
@@ -1,0 +1,68 @@
+package io.terrakube.executor.service.artifact;
+
+import io.terrakube.executor.service.mode.TerraformJob;
+import io.terrakube.executor.service.workspace.TarGzArchiver;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArtifactPackagingServiceTest {
+
+    private final ArtifactPatternResolver patternResolver = new ArtifactPatternResolver();
+    private final ArtifactGlobMatcher globMatcher = new ArtifactGlobMatcher();
+    private final TarGzArchiver tarGzArchiver = new TarGzArchiver();
+    private final ArtifactPackagingService service =
+            new ArtifactPackagingService(patternResolver, globMatcher, tarGzArchiver);
+
+    @Test
+    void noPatternsDeclaredReturnsEmpty(@TempDir Path dir) throws Exception {
+        TerraformJob job = new TerraformJob();
+        job.setEnvironmentVariables(new HashMap<>());
+
+        Optional<String> result = service.packageArtifacts(job, dir.toFile());
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void patternsResolveToNoMatchesReturnsEmpty(@TempDir Path dir) throws Exception {
+        TerraformJob job = new TerraformJob();
+        job.setArtifactPatterns(List.of("build/**"));
+        job.setEnvironmentVariables(new HashMap<>());
+
+        Optional<String> result = service.packageArtifacts(job, dir.toFile());
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void matchedFilesArePackagedWithChecksum(@TempDir Path dir) throws Exception {
+        File workingDirectory = dir.toFile();
+        File output = new File(workingDirectory, "build/output.zip");
+        FileUtils.writeStringToFile(output, "zip-bytes", Charset.defaultCharset());
+
+        TerraformJob job = new TerraformJob();
+        job.setArtifactPatterns(List.of("${ARTIFACT_PATH}/**"));
+        HashMap<String, String> env = new HashMap<>();
+        env.put("ARTIFACT_PATH", "build");
+        job.setEnvironmentVariables(env);
+
+        Optional<String> result = service.packageArtifacts(job, workingDirectory);
+
+        assertTrue(result.isPresent());
+        File archive = new File(workingDirectory, ArtifactPackagingService.ARTIFACTS_FILE_NAME);
+        assertTrue(archive.exists());
+        assertEquals(DigestUtils.sha256Hex(FileUtils.readFileToByteArray(archive)), result.get());
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/artifact/ArtifactPatternResolverTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/artifact/ArtifactPatternResolverTest.java
@@ -1,0 +1,54 @@
+package io.terrakube.executor.service.artifact;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ArtifactPatternResolverTest {
+
+    private final ArtifactPatternResolver resolver = new ArtifactPatternResolver();
+
+    @Test
+    void literalPatternPassesThroughUnchanged() {
+        List<String> result = resolver.resolve(List.of("build/**"), Map.of());
+
+        assertEquals(List.of("build/**"), result);
+    }
+
+    @Test
+    void placeholderIsSubstitutedFromEnvironmentVariables() {
+        List<String> result = resolver.resolve(
+                List.of("${ARTIFACT_PATH}/**"),
+                Map.of("ARTIFACT_PATH", "build"));
+
+        assertEquals(List.of("build/**"), result);
+    }
+
+    @Test
+    void unsetPlaceholderContributesNoPatterns() {
+        List<String> result = resolver.resolve(List.of("${ARTIFACT_PATH}/**"), Map.of());
+
+        assertEquals(List.of(), result);
+    }
+
+    @Test
+    void placeholderExpandsIntoWorkspaceControlledCommaList() {
+        List<String> result = resolver.resolve(
+                List.of("${ARTIFACT_PATHS}"),
+                Map.of("ARTIFACT_PATHS", "build/**, dist/** ,lambda-out/**"));
+
+        assertEquals(List.of("build/**", "dist/**", "lambda-out/**"), result);
+    }
+
+    @Test
+    void mixOfFixedAndTemplatedPatternsBothResolve() {
+        List<String> result = resolver.resolve(
+                List.of("${LAMBDA_ZIP_PATH}", "static/**"),
+                Map.of("LAMBDA_ZIP_PATH", "build/forwarder.zip"));
+
+        assertEquals(List.of("build/forwarder.zip", "static/**"), result);
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/artifact/ArtifactVerifierTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/artifact/ArtifactVerifierTest.java
@@ -1,0 +1,63 @@
+package io.terrakube.executor.service.artifact;
+
+import io.terrakube.executor.plugin.tfstate.ArtifactVerificationException;
+import io.terrakube.executor.service.workspace.TarGzArchiver;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArtifactVerifierTest {
+
+    private final TarGzArchiver tarGzArchiver = new TarGzArchiver();
+    private final ArtifactVerifier verifier = new ArtifactVerifier(tarGzArchiver);
+
+    @Test
+    void matchingChecksumExtractsBundle(@TempDir Path sourceDir, @TempDir Path targetDir) throws Exception {
+        File sourceFile = new File(sourceDir.toFile(), "build/output.zip");
+        FileUtils.writeStringToFile(sourceFile, "zip-bytes", Charset.defaultCharset());
+        File tarGz = new File(sourceDir.toFile(), "plan-artifacts.tar.gz");
+        tarGzArchiver.create(tarGz, sourceDir.toFile(), List.of(sourceFile));
+        byte[] bundleBytes = FileUtils.readFileToByteArray(tarGz);
+        String checksum = sha256Hex(bundleBytes);
+
+        verifier.verifyAndExtract(bundleBytes, checksum, targetDir.toFile());
+
+        assertTrue(new File(targetDir.toFile(), "build/output.zip").exists());
+    }
+
+    @Test
+    void mismatchedChecksumThrowsBeforeExtracting(@TempDir Path sourceDir, @TempDir Path targetDir) throws Exception {
+        File sourceFile = new File(sourceDir.toFile(), "build/output.zip");
+        FileUtils.writeStringToFile(sourceFile, "zip-bytes", Charset.defaultCharset());
+        File tarGz = new File(sourceDir.toFile(), "plan-artifacts.tar.gz");
+        tarGzArchiver.create(tarGz, sourceDir.toFile(), List.of(sourceFile));
+        byte[] bundleBytes = FileUtils.readFileToByteArray(tarGz);
+
+        ArtifactVerificationException thrown = assertThrows(ArtifactVerificationException.class,
+                () -> verifier.verifyAndExtract(bundleBytes,
+                        "0000000000000000000000000000000000000000000000000000000000000000", targetDir.toFile()));
+
+        assertTrue(thrown.getMessage().contains("checksum mismatch"));
+        assertFalse(new File(targetDir.toFile(), "build/output.zip").exists());
+    }
+
+    private String sha256Hex(byte[] data) throws Exception {
+        byte[] digest = MessageDigest.getInstance("SHA-256").digest(data);
+        StringBuilder sb = new StringBuilder();
+        for (byte b : digest) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/status/UpdateJobStatusImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/status/UpdateJobStatusImplTest.java
@@ -103,4 +103,19 @@ class UpdateJobStatusImplTest {
         assertEquals("pending", job.getAttributes().getStatus());
         assertEquals(true, job.getAttributes().isPlanChanges());
     }
+
+    @Test
+    void completedStatusPersistsArtifactsUrlAndChecksum() {
+        Job job = jobWithSteps(2);
+        UpdateJobStatusImpl service = newService(job);
+
+        TerraformJob terraformJob = terraformJob();
+        terraformJob.setArtifactsUrl("https://example.com/plan-artifacts.tar.gz");
+        terraformJob.setArtifactsChecksum("deadbeef");
+
+        service.setCompletedStatus(true, false, 0, terraformJob, "output", "", "", "commit-1");
+
+        assertEquals("https://example.com/plan-artifacts.tar.gz", job.getAttributes().getTerraformPlanArtifacts());
+        assertEquals("deadbeef", job.getAttributes().getTerraformPlanArtifactsChecksum());
+    }
 }

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/PlanApplyArtifactHandoffIntegrationTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/PlanApplyArtifactHandoffIntegrationTest.java
@@ -1,0 +1,122 @@
+package io.terrakube.executor.service.terraform;
+
+import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.organization.job.JobAttributes;
+import io.terrakube.executor.plugin.tfstate.ArtifactVerificationException;
+import io.terrakube.executor.plugin.tfstate.TerraformOutputPathService;
+import io.terrakube.executor.plugin.tfstate.TerraformStatePathService;
+import io.terrakube.executor.plugin.tfstate.local.LocalTerraformStateImpl;
+import io.terrakube.executor.service.artifact.ArtifactGlobMatcher;
+import io.terrakube.executor.service.artifact.ArtifactPackagingService;
+import io.terrakube.executor.service.artifact.ArtifactPatternResolver;
+import io.terrakube.executor.service.artifact.ArtifactVerifier;
+import io.terrakube.executor.service.mode.TerraformJob;
+import io.terrakube.executor.service.workspace.TarGzArchiver;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PlanApplyArtifactHandoffIntegrationTest {
+
+    private final TarGzArchiver tarGzArchiver = new TarGzArchiver();
+    private final ArtifactPackagingService packagingService =
+            new ArtifactPackagingService(new ArtifactPatternResolver(), new ArtifactGlobMatcher(), tarGzArchiver);
+    private final ArtifactVerifier verifier = new ArtifactVerifier(tarGzArchiver);
+
+    @Test
+    void planStepArtifactsSurviveHandoffToFreshApplyClone(@TempDir Path planDir, @TempDir Path applyDir) throws Exception {
+        // Simulate the plan step's working directory: a before-script produced a build output.
+        File planWorkingDirectory = planDir.toFile();
+        File builtZip = new File(planWorkingDirectory, "build/forwarder.zip");
+        FileUtils.writeStringToFile(builtZip, "zip-bytes", Charset.defaultCharset());
+
+        TerraformJob terraformJob = new TerraformJob();
+        terraformJob.setOrganizationId("org1");
+        terraformJob.setWorkspaceId("ws1");
+        terraformJob.setJobId("job1");
+        terraformJob.setStepId("step1");
+        terraformJob.setArtifactPatterns(List.of("${ARTIFACT_PATH}/**"));
+        HashMap<String, String> env = new HashMap<>();
+        env.put("ARTIFACT_PATH", "build");
+        terraformJob.setEnvironmentVariables(env);
+
+        Optional<String> checksum = packagingService.packageArtifacts(terraformJob, planWorkingDirectory);
+        assertTrue(checksum.isPresent());
+
+        TerrakubeClient terrakubeClient = mock(TerrakubeClient.class, Answers.RETURNS_DEEP_STUBS);
+        TerraformOutputPathService outputPathService = mock(TerraformOutputPathService.class);
+        TerraformStatePathService statePathService = mock(TerraformStatePathService.class);
+        LocalTerraformStateImpl terraformState = LocalTerraformStateImpl.builder()
+                .terrakubeClient(terrakubeClient)
+                .terraformOutputPathService(outputPathService)
+                .terraformStatePathService(statePathService)
+                .artifactVerifier(verifier)
+                .build();
+
+        String artifactsPath = terraformState.saveArtifacts("org1", "ws1", "job1", "step1", planWorkingDirectory);
+        assertNotNull(artifactsPath);
+
+        // Simulate apply's fresh clone: a brand new, empty directory that never ran the build.
+        File applyWorkingDirectory = applyDir.toFile();
+        JobAttributes attributes = new JobAttributes();
+        attributes.setTerraformPlanArtifacts(artifactsPath);
+        attributes.setTerraformPlanArtifactsChecksum(checksum.get());
+        when(terrakubeClient.getJobById("org1", "job1").getData().getAttributes()).thenReturn(attributes);
+
+        boolean downloaded = terraformState.downloadArtifacts("org1", "ws1", "job1", "step1", applyWorkingDirectory);
+
+        assertTrue(downloaded);
+        File extractedZip = new File(applyWorkingDirectory, "build/forwarder.zip");
+        assertTrue(extractedZip.exists());
+        assertEquals("zip-bytes", FileUtils.readFileToString(extractedZip, Charset.defaultCharset()));
+    }
+
+    @Test
+    void tamperedChecksumFailsBeforeExtractingIntoApplyClone(@TempDir Path planDir, @TempDir Path applyDir) throws Exception {
+        File planWorkingDirectory = planDir.toFile();
+        File builtZip = new File(planWorkingDirectory, "build/forwarder.zip");
+        FileUtils.writeStringToFile(builtZip, "zip-bytes", Charset.defaultCharset());
+
+        TerraformJob terraformJob = new TerraformJob();
+        terraformJob.setArtifactPatterns(List.of("build/**"));
+        terraformJob.setEnvironmentVariables(new HashMap<>());
+        packagingService.packageArtifacts(terraformJob, planWorkingDirectory);
+
+        TerrakubeClient terrakubeClient = mock(TerrakubeClient.class, Answers.RETURNS_DEEP_STUBS);
+        LocalTerraformStateImpl terraformState = LocalTerraformStateImpl.builder()
+                .terrakubeClient(terrakubeClient)
+                .terraformOutputPathService(mock(TerraformOutputPathService.class))
+                .terraformStatePathService(mock(TerraformStatePathService.class))
+                .artifactVerifier(verifier)
+                .build();
+
+        String artifactsPath = terraformState.saveArtifacts("org1", "ws1", "job1", "step1", planWorkingDirectory);
+
+        File applyWorkingDirectory = applyDir.toFile();
+        JobAttributes attributes = new JobAttributes();
+        attributes.setTerraformPlanArtifacts(artifactsPath);
+        attributes.setTerraformPlanArtifactsChecksum("tampered-checksum-value");
+        when(terrakubeClient.getJobById("org1", "job1").getData().getAttributes()).thenReturn(attributes);
+
+        assertThrows(ArtifactVerificationException.class,
+                () -> terraformState.downloadArtifacts("org1", "ws1", "job1", "step1", applyWorkingDirectory));
+
+        assertFalse(new File(applyWorkingDirectory, "build/forwarder.zip").exists());
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
@@ -1,7 +1,9 @@
 package io.terrakube.executor.service.terraform;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.executor.plugin.tfstate.ArtifactVerificationException;
 import io.terrakube.executor.plugin.tfstate.TerraformState;
+import io.terrakube.executor.service.artifact.ArtifactPackagingService;
 import io.terrakube.executor.service.executor.ExecutorJobResult;
 import io.terrakube.executor.service.logs.ProcessLogs;
 import io.terrakube.executor.service.mode.TerraformJob;
@@ -19,6 +21,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
@@ -29,6 +32,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -49,11 +53,13 @@ class TerraformExecutorServiceImplTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final RedisTemplate redisTemplate = Mockito.mock(RedisTemplate.class);
     private final StreamOperations streamOperations = Mockito.mock(StreamOperations.class);
+    private final ArtifactPackagingService artifactPackagingService = Mockito.mock(ArtifactPackagingService.class);
 
-    private TerraformExecutorServiceImpl subject() {
+    private TerraformExecutorServiceImpl subject() throws Exception {
         when(redisTemplate.opsForStream()).thenReturn(streamOperations);
         when(streamOperations.size(anyString())).thenReturn(0L);
         when(terraformState.getBackendStateFile(anyString(), anyString(), any(File.class), anyString())).thenReturn("backend.tfvars");
+        when(artifactPackagingService.packageArtifacts(any(TerraformJob.class), any(File.class))).thenReturn(Optional.empty());
 
         return new TerraformExecutorServiceImpl(
                 terraformClient,
@@ -64,6 +70,7 @@ class TerraformExecutorServiceImplTest {
                 applyStructuredOutputService,
                 terraformOutputsService,
                 objectMapper,
+                artifactPackagingService,
                 false,
                 redisTemplate,
                 1);
@@ -150,7 +157,7 @@ class TerraformExecutorServiceImplTest {
     }
 
     @Test
-    void jsonApplyClientMergesErrorStream() {
+    void jsonApplyClientMergesErrorStream() throws Exception {
         TerraformClient jsonApplyClient = subject().buildJsonEnabledApplyClient();
 
         assertTrue(jsonApplyClient.isJsonOutput());
@@ -158,7 +165,7 @@ class TerraformExecutorServiceImplTest {
     }
 
     @Test
-    void jsonPlanClientMergesErrorStream() {
+    void jsonPlanClientMergesErrorStream() throws Exception {
         TerraformClient jsonPlanClient = subject().buildJsonEnabledPlanClient();
 
         assertTrue(jsonPlanClient.isJsonOutput());
@@ -212,5 +219,130 @@ class TerraformExecutorServiceImplTest {
         verify(planStructuredOutputService, Mockito.atLeastOnce()).publishPlanProgress(
                 eq("org"), eq("42"), eq("1"), any(), any());
         verify(logsService, Mockito.atLeastOnce()).sendStructuredUpdate(eq(42), eq("1"), anyString());
+    }
+
+    @Test
+    void planPackagesArtifactsWhenChangesAreFound() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+        terraformJob.setArtifactPatterns(List.of("build/**"));
+        terraformJob.setMultiStepJob(true);
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        TerraformClient jsonPlanClient = Mockito.mock(TerraformClient.class);
+        when(jsonPlanClient.planDetailExitCode(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(2));
+        doReturn(jsonPlanClient).when(subject).buildJsonEnabledPlanClient();
+
+        when(artifactPackagingService.packageArtifacts(eq(terraformJob), any(File.class)))
+                .thenReturn(Optional.of("deadbeef"));
+        when(terraformState.saveArtifacts(eq("org"), eq("workspace"), eq("42"), eq("1"), any(File.class)))
+                .thenReturn("https://example.com/plan-artifacts.tar.gz");
+
+        subject.plan(terraformJob, tempDir.toFile(), false);
+
+        verify(artifactPackagingService).packageArtifacts(eq(terraformJob), any(File.class));
+        assertEquals("https://example.com/plan-artifacts.tar.gz", terraformJob.getArtifactsUrl());
+        assertEquals("deadbeef", terraformJob.getArtifactsChecksum());
+    }
+
+    @Test
+    void planDoesNotPackageArtifactsWhenNoChangesFound() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+        terraformJob.setArtifactPatterns(List.of("build/**"));
+        terraformJob.setMultiStepJob(true);
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        TerraformClient jsonPlanClient = Mockito.mock(TerraformClient.class);
+        when(jsonPlanClient.planDetailExitCode(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(0));
+        doReturn(jsonPlanClient).when(subject).buildJsonEnabledPlanClient();
+
+        subject.plan(terraformJob, tempDir.toFile(), false);
+
+        verify(artifactPackagingService, never()).packageArtifacts(any(TerraformJob.class), any(File.class));
+    }
+
+    @Test
+    void planDoesNotPackageArtifactsForDestroyPlanEvenWithChanges() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+        terraformJob.setArtifactPatterns(List.of("build/**"));
+        terraformJob.setMultiStepJob(true);
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        TerraformClient jsonPlanDestroyClient = Mockito.mock(TerraformClient.class);
+        when(jsonPlanDestroyClient.planDestroyDetailExitCode(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(2));
+        doReturn(jsonPlanDestroyClient).when(subject).buildJsonEnabledPlanClient();
+
+        subject.plan(terraformJob, tempDir.toFile(), true);
+
+        verify(artifactPackagingService, never()).packageArtifacts(any(TerraformJob.class), any(File.class));
+    }
+
+    @Test
+    void planDoesNotPackageArtifactsForSingleStepPlanOnlyTemplate() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+        terraformJob.setArtifactPatterns(List.of("build/**"));
+        terraformJob.setMultiStepJob(false);
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        TerraformClient jsonPlanClient = Mockito.mock(TerraformClient.class);
+        when(jsonPlanClient.planDetailExitCode(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(2));
+        doReturn(jsonPlanClient).when(subject).buildJsonEnabledPlanClient();
+
+        subject.plan(terraformJob, tempDir.toFile(), false);
+
+        verify(artifactPackagingService, never()).packageArtifacts(any(TerraformJob.class), any(File.class));
+    }
+
+    @Test
+    void applyFailsBeforeInitWhenArtifactChecksumMismatches() throws Exception {
+        TerraformExecutorServiceImpl subject = subject();
+        TerraformJob terraformJob = createJob();
+
+        doThrow(new ArtifactVerificationException("checksum mismatch"))
+                .when(terraformState).downloadArtifacts(eq("org"), eq("workspace"), eq("42"), eq("1"), any(File.class));
+
+        ExecutorJobResult result = subject.apply(terraformJob, tempDir.toFile());
+
+        assertFalse(result.isSuccessfulExecution());
+        assertTrue(result.getOutputErrorLog().contains("Plan artifacts verification failed"));
+        verify(terraformClient, never()).init(any(TerraformProcessData.class), any(Consumer.class), any());
+    }
+
+    @Test
+    void applyProceedsWhenNoArtifactsDeclared() throws Exception {
+        TerraformExecutorServiceImpl subject = subject();
+        TerraformJob terraformJob = createJob();
+
+        when(terraformState.downloadArtifacts(eq("org"), eq("workspace"), eq("42"), eq("1"), any(File.class)))
+                .thenReturn(false);
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(applyStructuredOutputService.seedFromPlan("org", "42")).thenReturn(List.of());
+        when(terraformClient.apply(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.show(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+        when(terraformClient.statePull(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+
+        subject.apply(terraformJob, tempDir.toFile());
+
+        verify(terraformState).downloadArtifacts(eq("org"), eq("workspace"), eq("42"), eq("1"), any(File.class));
+        verify(terraformClient).init(any(TerraformProcessData.class), any(Consumer.class), any());
     }
 }

--- a/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
@@ -117,7 +117,7 @@ public class SetupWorkspaceTest {
     private SetupWorkspace standardSetupWorkspaceImpl(TerraformJob job) {
         String overrideSource = job != null && "remote-content".equals(job.getBranch()) ? job.getSource() : null;
         return new SetupWorkspaceImpl(new NoopWorkspaceSecurity(), false, new NoopTerraformExecutor(),
-                "https://terrakube-api.example.com", terrakubeClient(overrideSource));
+                "https://terrakube-api.example.com", terrakubeClient(overrideSource), new TarGzArchiver());
     }
 
     private static TerrakubeClient terrakubeClient(String overrideSource) {
@@ -214,7 +214,7 @@ public class SetupWorkspaceTest {
 
         UnshallowRecordingSetupWorkspace() {
             super(new NoopWorkspaceSecurity(), false, new NoopTerraformExecutor(),
-                    "https://terrakube-api.example.com", terrakubeClient(null));
+                    "https://terrakube-api.example.com", terrakubeClient(null), new TarGzArchiver());
         }
 
         @Override
@@ -230,7 +230,7 @@ public class SetupWorkspaceTest {
 
         RejectingShaFetchSetupWorkspace() {
             super(new NoopWorkspaceSecurity(), false, new NoopTerraformExecutor(),
-                    "https://terrakube-api.example.com", terrakubeClient(null));
+                    "https://terrakube-api.example.com", terrakubeClient(null), new TarGzArchiver());
         }
 
         @Override

--- a/executor/src/test/java/io/terrakube/executor/service/workspace/TarGzArchiverTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/workspace/TarGzArchiverTest.java
@@ -1,0 +1,46 @@
+package io.terrakube.executor.service.workspace;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TarGzArchiverTest {
+
+    private final TarGzArchiver archiver = new TarGzArchiver();
+
+    @Test
+    void createThenExtractRoundTrips(@TempDir Path sourceDir, @TempDir Path extractDir) throws Exception {
+        File baseDirectory = sourceDir.toFile();
+        File nested = new File(baseDirectory, "build/sub");
+        nested.mkdirs();
+        File file1 = new File(baseDirectory, "build/output.zip");
+        File file2 = new File(baseDirectory, "build/sub/nested.txt");
+        FileUtils.writeStringToFile(file1, "zip-bytes", Charset.defaultCharset());
+        FileUtils.writeStringToFile(file2, "nested-content", Charset.defaultCharset());
+
+        File tarGz = new File(baseDirectory, "artifacts.tar.gz");
+        archiver.create(tarGz, baseDirectory, List.of(file1, file2));
+
+        assertTrue(tarGz.exists());
+
+        try (FileInputStream fis = new FileInputStream(tarGz)) {
+            archiver.extract(fis, extractDir.toFile().getCanonicalPath());
+        }
+
+        File extractedFile1 = new File(extractDir.toFile(), "build/output.zip");
+        File extractedFile2 = new File(extractDir.toFile(), "build/sub/nested.txt");
+        assertTrue(extractedFile1.exists());
+        assertTrue(extractedFile2.exists());
+        assertEquals("zip-bytes", FileUtils.readFileToString(extractedFile1, Charset.defaultCharset()));
+        assertEquals("nested-content", FileUtils.readFileToString(extractedFile2, Charset.defaultCharset()));
+    }
+}


### PR DESCRIPTION
 **Status: experiment, up for discussion.** Posting this as a working spike against #852, not a finished proposal — open to a different design if there's a better way to do this.

## Why

Terrakube runs every TCL step — plan, apply — in a brand-new git clone, on a stateless pool of executor pods with no shared filesystem and no session affinity. Plan and apply aren't guaranteed to land on the same pod, or the same directory on the same pod. Terrakube also applies from a *saved* plan file (`terraform apply terraformLibrary.tfPlan`), not a live plan+apply in one process.

That combination breaks any Terraform construct where a build artifact gets produced by something outside Terraform's own apply-time execution graph, then referenced by a later resource via a bare file path:

- `data "archive_file"` — its `Read` has a side effect of writing a zip to disk, but Terraform only calls `Read` once, during plan (since its inputs are statically known), and freezes the result into the saved plan. Apply never re-invokes it. The zip plan wrote only ever existed in plan's now-discarded clone.
- A before-script step that builds some output file directly — same problem: nothing regenerates it in apply's clone.
- Even `path.module`-derived paths make this worse, not better: `path.module` resolves to plan's own temp clone directory, so a value computed via `path.module` freezes an *absolute* path into the saved plan that's meaningless once apply runs somewhere else.

Originally reported as #852: a Lambda zip built by a before-script, referenced via `local_existing_package`, plans fine, apply fails with "no such file or directory".

Affected resource types:

- `aws_lambda_function`
- `aws_lambda_layer_version`
- `aws_s3_object` / `aws_s3_bucket_object`
- `aws_elastic_beanstalk_application_version`
- `aws_glue_job`
- `aws_cloudfront_function`
- `aws_codebuild_project`
- `aws_appsync_resolver` / `aws_appsync_function`
- `google_cloudfunctions_function` / `google_cloudfunctions2_function`
- `google_storage_bucket_object`
- `google_app_engine_standard_app_version` / `google_app_engine_flexible_app_version`
- `azurerm_linux_function_app` / `azurerm_windows_function_app` / `azurerm_function_app`
- `azurerm_linux_web_app` / `azurerm_windows_web_app` / `azurerm_app_service`
- `azurerm_storage_blob`
- `azurerm_template_deployment`
- `helm_release`
- `kubernetes_manifest` / `kubectl_manifest`
- `data "archive_file"` (upstream of most of the above)

Worth noting: it's *not* needed for modules that deliberately engineer around this with a real apply-time provisioner instead of a data source — e.g. `terraform-aws-modules/lambda`'s `create_package = true` rebuilds its zip inside a `null_resource` `local-exec` provisioner with an explicit `depends_on`, which genuinely re-executes in apply's own clone. Verified live: a job using that module's `create_package` path completes successfully with zero use of this feature. But most real-world Terraform isn't engineered that way — this covers the common case.

## What

- **Opt-in via Template TCL.** Nothing happens automatically — a workspace only gets this behavior once its Template's plan step is edited to add an `artifacts:` list. Existing workspaces with no `artifacts:` declared see zero behavior change; no packaging step runs, nothing extra gets stored
  ```yaml
  flow:
    - type: "terraformPlan"
      step: 100
      name: "Plan"
      artifacts:
        - "build/**"        # packaged after a successful plan with changes
        - "${LAMBDA_DIR}/*.zip"   # ${VAR} patterns are substituted; dropped
                                  # entirely (not blank-matched) if unset
    - type: "terraformApply"
      step: 200
      name: "Apply"

Everything under build/** (and any *.zip in $LAMBDA_DIR, if set) gets tarballed after step 100 and extracted into step 200's clone before terraform apply runs. Remove the artifacts: list to go back to the old behavior for that workspace
- New `artifacts:` field on TCL plan steps — a list of glob patterns (with `${VAR}` substitution) describing which files a plan step is expected to produce
- After a successful multi-step plan with changes, the executor packages every file matching those patterns into a tarball and stores it alongside the plan file
- Before the apply step runs, the executor downloads and extracts that tarball into apply's fresh clone, before `terraform apply` starts
- Checksum-verified end to end: a declared artifact that's missing or doesn't match its stored checksum fails the apply step loudly, rather than silently proceeding without it
- Implemented across all four state backends — AWS S3, Azure Blob, GCP Cloud Storage, and local disk — each storing artifacts under their own container/prefix (`plan-artifacts/`, separate from `tfstate/`) so a storage lifecycle policy can expire build artifacts independently of plan/state history.
- New `job.terraform_plan_artifacts` / `job.terraform_plan_artifacts_checksum` columns.
- Companion PR to terrakube-io/terrakube-spring-boot-starter#87 adds the matching `JobAttributes` fields the executor needs to read/write these through the generated client.

## How

- `Flow.artifacts` (TCL model) → `ExecutorContext.artifactPatterns` (API) → `TerraformJob.artifactPatterns` (executor).
- `ArtifactPatternResolver` substitutes `${VAR}` references in each glob; a pattern referencing an unset variable is dropped entirely, rather than substituting to an empty string (which would silently widen the glob to match everything).
- `ArtifactGlobMatcher` + `ArtifactPackagingService` walk the workspace after a successful plan and package matches into `plan-artifacts.tar.gz` via `TarGzArchiver`.
- Packaging is gated on `!isDestroy && exitCode == 2 && multiStepJob` — only plans with real changes, in multi-step jobs, get packaged; plan-only jobs and no-op plans skip the work entirely.
- `ArtifactVerifier` checksums the tarball on the way up and the way down.
- Each state backend (`AwsTerraformStateImpl`, `AzureTerraformStateImpl`, `GcpTerraformStateImpl`, `LocalTerraformStateImpl`) implements `saveArtifacts`/`downloadArtifacts` against its own container/prefix.
- 631 api + 190 executor tests green (new + existing), plus live verification on a real minikube deployment against real AWS, including an A/B comparison confirming the original bug reproduces with the feature stashed out.

## Related

- Fixes #852
- Depends on terrakube-io/terrakube-spring-boot-starter#87
