### PR TITLE
fix(auth): recover from stale sessions after API/Dex restarts

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolver.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolver.java
@@ -16,6 +16,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationManagerResolver;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -26,6 +27,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Builder
 @Getter
@@ -41,6 +43,10 @@ public class DexAuthenticationManagerResolver implements AuthenticationManagerRe
     private PatRepository patRepository;
     private TeamTokenRepository teamTokenRepository;
     private FederatedRepository federatedRepository;
+
+    // Avoids re-fetching issuer metadata from Dex on every request.
+    @Builder.Default
+    private final Map<String, JwtDecoder> decoderCache = new ConcurrentHashMap<>();
 
     @Override
     public AuthenticationManager resolve(HttpServletRequest request) {
@@ -66,7 +72,7 @@ public class DexAuthenticationManagerResolver implements AuthenticationManagerRe
         }
 
         if (!federatedIssuer.isEmpty()) {
-            providerManager = new ProviderManager(new JwtAuthenticationProvider(JwtDecoders.fromIssuerLocation(federatedIssuer)));
+            providerManager = new ProviderManager(new JwtAuthenticationProvider(getIssuerDecoder(federatedIssuer)));
         } else {
             switch (issuer) {
                 case jwtTypePat:
@@ -79,17 +85,37 @@ public class DexAuthenticationManagerResolver implements AuthenticationManagerRe
                     break;
                 default:
                     log.debug("Using Dex JWT Authentication Provider");
-                    providerManager = new ProviderManager(new JwtAuthenticationProvider(JwtDecoders.fromIssuerLocation(this.dexIssuerUri)));
+                    providerManager = new ProviderManager(new JwtAuthenticationProvider(getIssuerDecoder(this.dexIssuerUri)));
                     break;
             }
         }
         return providerManager;
     }
 
+    // computeIfAbsent drops failed mappings, so a failed fetch is retried next request.
+    private JwtDecoder getIssuerDecoder(String issuerUri) {
+        return decoderCache.computeIfAbsent(issuerUri, uri -> {
+            try {
+                return JwtDecoders.fromIssuerLocation(uri);
+            } catch (RuntimeException ex) {
+                log.warn("Unable to load JWT decoder metadata from issuer {}: {}", uri, ex.getMessage());
+                // AuthenticationException -> clean 401 instead of an unhandled 500.
+                throw new AuthenticationServiceException("Unable to reach identity provider", ex);
+            }
+        });
+    }
+
     private JwtDecoder getJwtEncoder(String issuerType) {
+        String cacheKey = "secret:" + issuerType;
+        JwtDecoder cached = decoderCache.get(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
         String jwtSecret = (issuerType.equals(jwtTypePat) ? patJwtSecret : internalJwtSecret);
         SecretKey jwtSecretKey = new SecretKeySpec(Decoders.BASE64URL.decode(jwtSecret), "HMACSHA256");
-        return NimbusJwtDecoder.withSecretKey(jwtSecretKey).macAlgorithm(MacAlgorithm.HS256).build();
+        JwtDecoder decoder = NimbusJwtDecoder.withSecretKey(jwtSecretKey).macAlgorithm(MacAlgorithm.HS256).build();
+        decoderCache.putIfAbsent(cacheKey, decoder);
+        return decoderCache.get(cacheKey);
     }
 
     private String getJwtClaim(HttpServletRequest request, String claim) {

--- a/api/src/test/java/io/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolverTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolverTest.java
@@ -1,0 +1,124 @@
+package io.terrakube.api.plugin.security.authentication.dex;
+
+import io.terrakube.api.repository.FederatedRepository;
+import io.terrakube.api.repository.PatRepository;
+import io.terrakube.api.repository.TeamTokenRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+
+import java.util.Base64;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DexAuthenticationManagerResolverTest {
+
+    @Mock
+    PatRepository patRepository;
+
+    @Mock
+    TeamTokenRepository teamTokenRepository;
+
+    @Mock
+    FederatedRepository federatedRepository;
+
+    private HttpServletRequest dexTokenRequest() {
+        String jti = UUID.randomUUID().toString();
+        String payloadJson = "{\"iss\":\"https://dummy-dex-issuer\",\"aud\":\"terrakube\",\"jti\":\"" + jti + "\"}";
+        String payload = Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.getBytes());
+        String token = "header." + payload + ".signature";
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("authorization")).thenReturn("Bearer " + token);
+        return request;
+    }
+
+    private DexAuthenticationManagerResolver newResolver() {
+        return DexAuthenticationManagerResolver.builder()
+                .dexIssuerUri("https://dummy-dex-issuer")
+                .patJwtSecret(Base64.getUrlEncoder().encodeToString("pat-secret-pat-secret-pat-secret".getBytes()))
+                .internalJwtSecret(Base64.getUrlEncoder().encodeToString("internal-secret-internal-secret".getBytes()))
+                .patRepository(patRepository)
+                .teamTokenRepository(teamTokenRepository)
+                .federatedRepository(federatedRepository)
+                .build();
+    }
+
+    @Test
+    void reusesTheDecoderAcrossRequestsInsteadOfRefetchingIssuerMetadataEveryTime() {
+        when(patRepository.findById(any())).thenReturn(Optional.empty());
+        when(teamTokenRepository.findById(any())).thenReturn(Optional.empty());
+        when(federatedRepository.findByIssuerUrlAndAudience(anyString(), anyString())).thenReturn(Optional.empty());
+
+        DexAuthenticationManagerResolver resolver = newResolver();
+        JwtDecoder decoder = mock(JwtDecoder.class);
+
+        try (MockedStatic<JwtDecoders> jwtDecoders = Mockito.mockStatic(JwtDecoders.class)) {
+            jwtDecoders.when(() -> JwtDecoders.fromIssuerLocation("https://dummy-dex-issuer")).thenReturn(decoder);
+
+            AuthenticationManager first = resolver.resolve(dexTokenRequest());
+            AuthenticationManager second = resolver.resolve(dexTokenRequest());
+
+            assertThat(first).isNotNull();
+            assertThat(second).isNotNull();
+            jwtDecoders.verify(() -> JwtDecoders.fromIssuerLocation("https://dummy-dex-issuer"), Mockito.times(1));
+        }
+    }
+
+    @Test
+    void translatesAnUnreachableIssuerIntoAnAuthenticationExceptionInsteadOfALeakingRuntimeException() {
+        when(patRepository.findById(any())).thenReturn(Optional.empty());
+        when(teamTokenRepository.findById(any())).thenReturn(Optional.empty());
+        when(federatedRepository.findByIssuerUrlAndAudience(anyString(), anyString())).thenReturn(Optional.empty());
+
+        DexAuthenticationManagerResolver resolver = newResolver();
+
+        try (MockedStatic<JwtDecoders> jwtDecoders = Mockito.mockStatic(JwtDecoders.class)) {
+            jwtDecoders.when(() -> JwtDecoders.fromIssuerLocation("https://dummy-dex-issuer"))
+                    .thenThrow(new IllegalStateException("Connection refused"));
+
+            assertThatThrownBy(() -> resolver.resolve(dexTokenRequest()))
+                    .isInstanceOf(AuthenticationServiceException.class);
+        }
+    }
+
+    @Test
+    void retriesOnTheNextRequestAfterAFailedFetchInsteadOfCachingTheFailure() {
+        when(patRepository.findById(any())).thenReturn(Optional.empty());
+        when(teamTokenRepository.findById(any())).thenReturn(Optional.empty());
+        when(federatedRepository.findByIssuerUrlAndAudience(anyString(), anyString())).thenReturn(Optional.empty());
+
+        DexAuthenticationManagerResolver resolver = newResolver();
+        JwtDecoder decoder = mock(JwtDecoder.class);
+
+        try (MockedStatic<JwtDecoders> jwtDecoders = Mockito.mockStatic(JwtDecoders.class)) {
+            jwtDecoders.when(() -> JwtDecoders.fromIssuerLocation("https://dummy-dex-issuer"))
+                    .thenThrow(new IllegalStateException("Connection refused"))
+                    .thenReturn(decoder);
+
+            assertThatThrownBy(() -> resolver.resolve(dexTokenRequest()))
+                    .isInstanceOf(AuthenticationServiceException.class);
+
+            AuthenticationManager recovered = resolver.resolve(dexTokenRequest());
+
+            assertThat(recovered).isNotNull();
+            jwtDecoders.verify(() -> JwtDecoders.fromIssuerLocation("https://dummy-dex-issuer"), Mockito.times(2));
+        }
+    }
+}

--- a/ui/src/config/__tests__/axiosConfig.test.ts
+++ b/ui/src/config/__tests__/axiosConfig.test.ts
@@ -1,0 +1,50 @@
+import { mgr } from "../authConfig";
+
+jest.mock("../authConfig", () => ({
+  mgr: { removeUser: jest.fn() },
+}));
+
+jest.mock("../authUser", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ access_token: "token" })),
+}));
+
+const mockRemoveUser = mgr.removeUser as jest.Mock;
+
+describe("axiosConfig response interceptor", () => {
+  beforeEach(() => {
+    mockRemoveUser.mockClear();
+  });
+
+  it("signs the user out when a request comes back 401", async () => {
+    // Importing after mocks are registered so the interceptors below are wired
+    // against the mocked authConfig/authUser modules.
+    const { default: axiosInstance } = await import("../axiosConfig");
+
+    axiosInstance.defaults.adapter = () =>
+      Promise.reject({
+        isAxiosError: true,
+        response: { status: 401, data: {}, statusText: "Unauthorized", headers: {}, config: {} },
+        config: {},
+        toJSON: () => ({}),
+      });
+
+    await expect(axiosInstance.get("/organizations")).rejects.toBeTruthy();
+    expect(mockRemoveUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not sign the user out on other error statuses (e.g. 403)", async () => {
+    const { default: axiosInstance } = await import("../axiosConfig");
+
+    axiosInstance.defaults.adapter = () =>
+      Promise.reject({
+        isAxiosError: true,
+        response: { status: 403, data: {}, statusText: "Forbidden", headers: {}, config: {} },
+        config: {},
+        toJSON: () => ({}),
+      });
+
+    await expect(axiosInstance.get("/organizations")).rejects.toBeTruthy();
+    expect(mockRemoveUser).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/config/axiosConfig.ts
+++ b/ui/src/config/axiosConfig.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError, AxiosResponse } from "axios";
+import { mgr } from "./authConfig";
 import getUserFromStorage from "./authUser";
 
 type RuntimeEnv = Window["_env_"] & { REACT_APP_TERRAKUBE_SEND_COOKIES?: string };
@@ -49,6 +50,10 @@ function handleResponseSuccess(response: AxiosResponse) {
 }
 
 function handleResponseError(error: AxiosError) {
+  if (error.response?.status === 401) {
+    // Token rejected by the API - sign out so the user lands back on Login.
+    mgr.removeUser();
+  }
   if (error.response?.status === 403) {
     // Enrich the error with a clear permission message so callers can display it
     const enriched = error as AxiosError & { permissionError: true; permissionMessage: string };

--- a/ui/src/domain/Login/Login.tsx
+++ b/ui/src/domain/Login/Login.tsx
@@ -1,4 +1,5 @@
 import { Button, ConfigProvider, Typography, theme } from "antd";
+import { useState } from "react";
 import { mgr } from "../../config/authConfig";
 import { getUiRedirectUri } from "../../config/basePath";
 import {
@@ -26,6 +27,18 @@ const Login = () => {
 
 const LoginContent = () => {
   const { token } = theme.useToken();
+  const [signinError, setSigninError] = useState<string | null>(null);
+  const [isSigningIn, setIsSigningIn] = useState(false);
+
+  const handleSignIn = () => {
+    setSigninError(null);
+    setIsSigningIn(true);
+    // signinRedirect() can reject (e.g. identity provider unreachable) before it navigates away.
+    mgr.signinRedirect({ state: getUiRedirectUri() }).catch(() => {
+      setIsSigningIn(false);
+      setSigninError("Unable to reach the identity provider. Please try again in a moment.");
+    });
+  };
 
   return (
     <div className="login-container" style={{ backgroundColor: token.colorBgLayout }}>
@@ -33,9 +46,10 @@ const LoginContent = () => {
         <img src={logo} alt="Terrakube" className="login-logo" />
         <Title level={3}>Sign in to Terrakube</Title>
         <Text type="secondary">Click below to continue with your identity provider.</Text>
-        <Button type="primary" block size="large" onClick={() => mgr.signinRedirect({ state: getUiRedirectUri() })}>
+        <Button type="primary" block size="large" loading={isSigningIn} onClick={handleSignIn}>
           Sign in
         </Button>
+        {signinError && <Text type="danger">{signinError}</Text>}
       </div>
     </div>
   );

--- a/ui/src/domain/Login/__tests__/Login.test.tsx
+++ b/ui/src/domain/Login/__tests__/Login.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { mgr } from "@/config/authConfig";
+import Login from "../Login";
+
+jest.mock("@/config/authConfig", () => ({
+  mgr: { signinRedirect: jest.fn() },
+}));
+
+const mockSigninRedirect = mgr.signinRedirect as jest.Mock;
+
+describe("Login", () => {
+  beforeEach(() => {
+    mockSigninRedirect.mockReset();
+  });
+
+  it("shows an error instead of doing nothing when the identity provider is unreachable", async () => {
+    mockSigninRedirect.mockRejectedValue(new Error("Failed to fetch"));
+
+    render(<Login />);
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    expect(await screen.findByText(/unable to reach the identity provider/i)).toBeInTheDocument();
+  });
+
+  it("does not show an error when sign-in redirect succeeds", async () => {
+    mockSigninRedirect.mockResolvedValue(undefined);
+
+    render(<Login />);
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => expect(mockSigninRedirect).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText(/unable to reach the identity provider/i)).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -4,7 +4,7 @@ import "./styles/global.css";
 import React from "react";
 import { createRoot } from "react-dom/client";
 import { AuthProvider } from "react-oidc-context";
-import { oidcConfig } from "./config/authConfig";
+import { mgr } from "./config/authConfig";
 import { getUiRedirectUri } from "./config/basePath";
 import App from "./domain/Home/App";
 import "./index.css";
@@ -24,10 +24,10 @@ const onSigninCallback = (): void => {
   window.history.replaceState({}, document.title, base);
 };
 
-// Initial render
+// Shares the UserManager with axiosConfig/apiWrapper so removeUser() there updates this provider immediately.
 root.render(
   <React.StrictMode>
-    <AuthProvider {...oidcConfig} onSigninCallback={onSigninCallback}>
+    <AuthProvider userManager={mgr} onSigninCallback={onSigninCallback}>
       <App />
     </AuthProvider>
   </React.StrictMode>

--- a/ui/src/modules/api/__tests__/apiWrapper.test.ts
+++ b/ui/src/modules/api/__tests__/apiWrapper.test.ts
@@ -1,0 +1,52 @@
+import axios from "axios";
+import { mgr } from "@/config/authConfig";
+import { apiGet } from "../apiWrapper";
+
+jest.mock("axios", () => {
+  const mockAxios = jest.fn();
+  (mockAxios as any).isAxiosError = jest.fn(() => true);
+  return { __esModule: true, default: mockAxios };
+});
+
+jest.mock("@/config/authConfig", () => ({
+  mgr: { removeUser: jest.fn() },
+}));
+
+jest.mock("@/config/authUser", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ access_token: "token" })),
+}));
+
+const mockedAxios = axios as unknown as jest.Mock;
+const mockRemoveUser = mgr.removeUser as jest.Mock;
+
+describe("apiWrapper 401 handling", () => {
+  beforeEach(() => {
+    mockedAxios.mockReset();
+    mockRemoveUser.mockClear();
+  });
+
+  it("signs the user out and returns a friendly message when the API rejects the token with 401", async () => {
+    mockedAxios.mockRejectedValue({
+      response: { status: 401, data: {}, statusText: "Unauthorized" },
+    });
+
+    const result = await apiGet("/organizations");
+
+    expect(mockRemoveUser).toHaveBeenCalledTimes(1);
+    expect(result.isError).toBe(true);
+    expect(result.responseCode).toBe(401);
+  });
+
+  it("does not sign the user out on unrelated errors (e.g. 403)", async () => {
+    mockedAxios.mockRejectedValue({
+      response: { status: 403, data: {}, statusText: "Forbidden" },
+    });
+
+    const result = await apiGet("/organizations");
+
+    expect(mockRemoveUser).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.responseCode).toBe(403);
+  });
+});

--- a/ui/src/modules/api/apiWrapper.ts
+++ b/ui/src/modules/api/apiWrapper.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { mgr } from "../../config/authConfig";
 import getUserFromStorage from "../../config/authUser";
 import { ApiResponse, RequestOptions } from "./types";
 
@@ -43,6 +44,20 @@ async function requestWrapper<T>(
     return await requestFunc();
   } catch (error) {
     if (axios.isAxiosError(error)) {
+      if (error.response?.status === 401) {
+        // Token rejected by the API - sign out so the user lands back on Login.
+        mgr.removeUser();
+        return {
+          isError: true,
+          error: {
+            status: "Unauthorized",
+            statusCode: 401,
+            message: "Your session has expired. Please sign in again.",
+          },
+          responseCode: 401,
+        };
+      }
+
       if (error.response?.status === 404) {
         return {
           isError: true,


### PR DESCRIPTION
## Summary

Fixes two auth UX bugs reported after restarting the API/Dex container:

1. If you were already logged in, an API restart left the UI stuck showing errors instead of returning to the Login screen.
2. The "Sign in" button did nothing if Dex or the API was unreachable when clicked — the OIDC discovery fetch failed silently.

Root cause on the API side: `DexAuthenticationManagerResolver` rebuilt its JWT decoder from Dex's discovery endpoint on *every* request, so a momentary Dex hiccup surfaced as an unhandled `500` instead of a clean `401`, and the frontend had no handling for `401` at all.

## Changes

- **ui**: sign out and fall back to Login on any `401` (`axiosConfig.ts`, `apiWrapper.ts`); `index.tsx` now shares a single `UserManager` instance so the sign-out is reflected immediately instead of only after reload
   - _any 401 will end the session ... so any flakiness would trigger this behaviour_
- **ui**: `Login.tsx` shows an error message and a loading state when `signinRedirect` fails, instead of doing nothing
<img width="460" height="410" alt="terrakube-login-dex-fail" src="https://github.com/user-attachments/assets/497ec037-cb47-45ec-b9e0-83e94d3da572" />

- **api**: `DexAuthenticationManagerResolver` caches the JWT decoder per issuer and translates a Dex-fetch failure into a clean `401` (`AuthenticationServiceException`) instead of a raw `500`.

## Test plan

- [x] Unit tests added/passing: `axiosConfig.test.ts`, `apiWrapper.test.ts`, `Login.test.tsx`, `DexAuthenticationManagerResolverTest.java`
- [x] Full suites green: 348 UI tests, 633 API tests
- [x] Manually verified in a local minikube cluster: hard-restarted the API pod while logged in, scaled Dex to 0 while active in the UI (confirmed the app now recovers to the Login screen instead of getting stuck), rebuilt/redeployed the API with the decoder-caching fix and re-verified clean recovery
