### PR TITLE
fix(variable): prevent job crashes from workspace variables with no category

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -9,6 +9,7 @@ import io.terrakube.api.plugin.scheduler.job.tcl.model.FlowType;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.ScheduleTemplate;
 import io.terrakube.api.plugin.softdelete.SoftDeleteService;
 import io.terrakube.api.plugin.variable.IncompleteVariableException;
+import io.terrakube.api.plugin.variable.InvalidVariableCategoryException;
 import io.terrakube.api.plugin.variable.WorkspaceVariableValidationService;
 import io.terrakube.api.plugin.vcs.PrCommentService;
 import io.terrakube.api.plugin.vcs.WebhookService;
@@ -569,26 +570,35 @@ public class ScheduleJob implements org.quartz.Job {
         try {
             workspaceVariableValidationService.validateWorkspaceVariables(job.getWorkspace());
             return false;
+        } catch (InvalidVariableCategoryException exception) {
+            String failureMessage = workspaceVariableValidationService.buildInvalidCategoryMessage(job.getWorkspace());
+            log.warn("Failing job {} because of variables with no category", job.getId(), exception);
+            failJobWithVariableValidationError(job, failureMessage, WorkspaceVariableValidationService.INVALID_CATEGORY_STEP_NAME);
+            return true;
         } catch (IncompleteVariableException exception) {
             String failureMessage = workspaceVariableValidationService.buildIncompleteVariableMessage(job.getWorkspace());
             log.warn("Failing job {} because of incomplete variables", job.getId(), exception);
-            job.setStatus(JobStatus.failed);
-            job.setOutput(failureMessage);
-            jobRepository.save(job);
-
-            try {
-                String stepId = tclService.getCurrentStepId(job);
-                Step step = stepRepository.getReferenceById(UUID.fromString(stepId));
-                step.setName(WorkspaceVariableValidationService.INCOMPLETE_VARIABLE_STEP_NAME);
-                stepRepository.save(step);
-            } catch (Exception stepException) {
-                log.warn("Unable to update step for job {}", job.getId(), stepException);
-            }
-
-            updateJobStepsWithStatus(job.getId(), JobStatus.failed);
-            updateJobStatusOnVcs(job, JobStatus.failed);
+            failJobWithVariableValidationError(job, failureMessage, WorkspaceVariableValidationService.INCOMPLETE_VARIABLE_STEP_NAME);
             return true;
         }
+    }
+
+    private void failJobWithVariableValidationError(Job job, String failureMessage, String stepName) {
+        job.setStatus(JobStatus.failed);
+        job.setOutput(failureMessage);
+        jobRepository.save(job);
+
+        try {
+            String stepId = tclService.getCurrentStepId(job);
+            Step step = stepRepository.getReferenceById(UUID.fromString(stepId));
+            step.setName(stepName);
+            stepRepository.save(step);
+        } catch (Exception stepException) {
+            log.warn("Unable to update step for job {}", job.getId(), stepException);
+        }
+
+        updateJobStepsWithStatus(job.getId(), JobStatus.failed);
+        updateJobStatusOnVcs(job, JobStatus.failed);
     }
 
     /**

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -122,18 +122,7 @@ public class ExecutorService {
         environmentVariables.put("TF_IN_AUTOMATION", "1");
         environmentVariables.put("workspaceName", job.getWorkspace().getName());
         environmentVariables.put("organizationName", job.getOrganization().getName());
-        List<Variable> variableList = variableRepository.findByWorkspace(job.getWorkspace()).orElse(new ArrayList<>());
-        for (Variable variable : variableList) {
-            if (variable.getCategory().equals(Category.TERRAFORM)) {
-                log.info("Adding terraform");
-                terraformVariables.put(variable.getKey(), variable.getValue());
-            } else {
-                log.info("Adding environment variable");
-                environmentVariables.put(variable.getKey(), variable.getValue());
-            }
-            log.info("Variable Key: {} Value {}", variable.getKey(),
-                    variable.isSensitive() ? "sensitive" : variable.getValue());
-        }
+        splitWorkspaceVariablesByCategory(job, terraformVariables, environmentVariables);
 
         environmentVariables = loadOtherEnvironmentVariables(job, flow, environmentVariables);
         terraformVariables = loadOtherTerraformVariables(job, flow, terraformVariables);
@@ -190,6 +179,26 @@ public class ExecutorService {
             ephemeralExecutorService.send(job, executorContext);
         } else {
             persistentExecutorService.send(job, executorContext);
+        }
+    }
+
+    void splitWorkspaceVariablesByCategory(Job job, HashMap<String, String> terraformVariables,
+            HashMap<String, String> environmentVariables) throws ExecutionException {
+        List<Variable> variableList = variableRepository.findByWorkspace(job.getWorkspace()).orElse(new ArrayList<>());
+        for (Variable variable : variableList) {
+            if (variable.getCategory() == null) {
+                throw new ExecutionException(String.format(
+                        "Cannot run job %s: workspace '%s' has variable '%s' with no category (expected TERRAFORM or ENV). "
+                                + "Update the variable's category before retrying.",
+                        job.getId(), job.getWorkspace().getName(), variable.getKey()));
+            }
+            if (Category.TERRAFORM.equals(variable.getCategory())) {
+                log.info("Adding terraform variable, Key: {}", variable.getKey());
+                terraformVariables.put(variable.getKey(), variable.getValue());
+            } else {
+                log.info("Adding environment variable, Key: {}", variable.getKey());
+                environmentVariables.put(variable.getKey(), variable.getValue());
+            }
         }
     }
 

--- a/api/src/main/java/io/terrakube/api/plugin/variable/InvalidVariableCategoryException.java
+++ b/api/src/main/java/io/terrakube/api/plugin/variable/InvalidVariableCategoryException.java
@@ -1,0 +1,7 @@
+package io.terrakube.api.plugin.variable;
+
+public class InvalidVariableCategoryException extends RuntimeException {
+    public InvalidVariableCategoryException(String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/variable/WorkspaceVariableValidationService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/variable/WorkspaceVariableValidationService.java
@@ -13,6 +13,8 @@ public class WorkspaceVariableValidationService {
 
     public static final String INCOMPLETE_VARIABLE_STEP_NAME = "Incomplete sensitive variables";
     public static final String INCOMPLETE_VARIABLE_TITLE = "Run blocked because this workspace still has incomplete sensitive variables.";
+    public static final String INVALID_CATEGORY_STEP_NAME = "Invalid variable category";
+    public static final String INVALID_CATEGORY_TITLE = "Run blocked because this workspace has variables with no category (must be TERRAFORM or ENV).";
 
     private final VariableRepository variableRepository;
 
@@ -21,12 +23,15 @@ public class WorkspaceVariableValidationService {
     }
 
     public void validateWorkspaceVariables(Workspace workspace) {
-        List<Variable> incompleteVariables = getIncompleteVariables(workspace);
-        if (incompleteVariables.isEmpty()) {
-            return;
+        List<Variable> invalidCategoryVariables = getInvalidCategoryVariables(workspace);
+        if (!invalidCategoryVariables.isEmpty()) {
+            throw new InvalidVariableCategoryException(buildInvalidCategoryMessage(invalidCategoryVariables));
         }
 
-        throw new IncompleteVariableException(buildIncompleteVariableMessage(incompleteVariables));
+        List<Variable> incompleteVariables = getIncompleteVariables(workspace);
+        if (!incompleteVariables.isEmpty()) {
+            throw new IncompleteVariableException(buildIncompleteVariableMessage(incompleteVariables));
+        }
     }
 
     public List<Variable> getIncompleteVariables(Workspace workspace) {
@@ -34,6 +39,15 @@ public class WorkspaceVariableValidationService {
                 .orElse(List.of())
                 .stream()
                 .filter(Variable::isIncomplete)
+                .sorted(Comparator.comparing(Variable::getKey, Comparator.nullsLast(String::compareToIgnoreCase)))
+                .toList();
+    }
+
+    public List<Variable> getInvalidCategoryVariables(Workspace workspace) {
+        return variableRepository.findByWorkspace(workspace)
+                .orElse(List.of())
+                .stream()
+                .filter(variable -> variable.getCategory() == null)
                 .sorted(Comparator.comparing(Variable::getKey, Comparator.nullsLast(String::compareToIgnoreCase)))
                 .toList();
     }
@@ -51,6 +65,25 @@ public class WorkspaceVariableValidationService {
         for (Variable variable : incompleteVariables) {
             String category = variable.getCategory() == null ? "terraform" : variable.getCategory().name().toLowerCase();
             lines.add("- " + variable.getKey() + " (" + category + ")");
+        }
+
+        lines.add("");
+        lines.add("Open the workspace Variables page to update them.");
+        return String.join("\n", lines);
+    }
+
+    public String buildInvalidCategoryMessage(Workspace workspace) {
+        return buildInvalidCategoryMessage(getInvalidCategoryVariables(workspace));
+    }
+
+    public String buildInvalidCategoryMessage(List<Variable> invalidCategoryVariables) {
+        List<String> lines = new ArrayList<>();
+        lines.add(INVALID_CATEGORY_TITLE);
+        lines.add("");
+        lines.add("Set a category (Terraform variable or Environment variable) for these variables before retrying:");
+
+        for (Variable variable : invalidCategoryVariables) {
+            lines.add("- " + variable.getKey());
         }
 
         lines.add("");

--- a/api/src/main/java/io/terrakube/api/plugin/variable/WorkspaceVariableValidationService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/variable/WorkspaceVariableValidationService.java
@@ -25,7 +25,7 @@ public class WorkspaceVariableValidationService {
     public void validateWorkspaceVariables(Workspace workspace) {
         List<Variable> invalidCategoryVariables = getInvalidCategoryVariables(workspace);
         if (!invalidCategoryVariables.isEmpty()) {
-            throw new InvalidVariableCategoryException(buildInvalidCategoryMessage(invalidCategoryVariables));
+            throw new InvalidVariableCategoryException(buildInvalidCategoryMessage(workspace, invalidCategoryVariables));
         }
 
         List<Variable> incompleteVariables = getIncompleteVariables(workspace);
@@ -73,14 +73,14 @@ public class WorkspaceVariableValidationService {
     }
 
     public String buildInvalidCategoryMessage(Workspace workspace) {
-        return buildInvalidCategoryMessage(getInvalidCategoryVariables(workspace));
+        return buildInvalidCategoryMessage(workspace, getInvalidCategoryVariables(workspace));
     }
 
-    public String buildInvalidCategoryMessage(List<Variable> invalidCategoryVariables) {
+    public String buildInvalidCategoryMessage(Workspace workspace, List<Variable> invalidCategoryVariables) {
         List<String> lines = new ArrayList<>();
         lines.add(INVALID_CATEGORY_TITLE);
         lines.add("");
-        lines.add("Set a category (Terraform variable or Environment variable) for these variables before retrying:");
+        lines.add(String.format("Workspace \"%s\" has variables with no category. Set a category (Terraform variable or Environment variable) for these variables before retrying:", workspace.getName()));
 
         for (Variable variable : invalidCategoryVariables) {
             lines.add("- " + variable.getKey());

--- a/api/src/main/java/io/terrakube/api/rs/workspace/parameters/Variable.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/parameters/Variable.java
@@ -8,6 +8,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import io.terrakube.api.rs.IdConverter;
 import io.terrakube.api.rs.workspace.Workspace;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import java.sql.Types;
 import java.util.UUID;
 
@@ -33,8 +34,9 @@ public class Variable {
     @Column(name="variable_description")
     private String description;
 
+    @NotNull(message = "category is required and must be TERRAFORM or ENV")
     @Enumerated(EnumType.STRING)
-    @Column(name="variable_category")
+    @Column(name="variable_category", nullable = false)
     private Category category;
 
     @Column(name="sensitive")

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -115,4 +115,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-job-command-comment-id.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-job-soft-delete.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-job-status-index.xml"/>
+    <include file="/db/changelog/local/changelog-2.33.0-variable-category-not-null.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-variable-category-not-null.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-variable-category-not-null.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <!--
+      Issue #3395: variable.variable_category has allowed NULL since it was added in
+      changelog-1.3.xml, and ExecutorService dereferenced it without a null check, crashing
+      scheduled jobs. This backfills the only NULL rows we can infer unambiguously - keys that
+      are well-known cloud-provider auth env vars, which are never valid as TERRAFORM variables
+      - and leaves everything else NULL. Application code (WorkspaceVariableValidationService)
+      fails any job run against a workspace that still has NULL-category variables, reporting the
+      workspace and variable key so the remaining ambiguous rows can be remediated by hand.
+    -->
+
+    <changeSet id="2-33-0-variable-category-backfill-known-env" author="jake">
+        <update tableName="variable">
+            <column name="variable_category" value="ENV"/>
+            <where>variable_category IS NULL AND variable_key IN (
+                'AWS_ACCESS_KEY_ID','AWS_SECRET_ACCESS_KEY','AWS_SESSION_TOKEN','AWS_DEFAULT_REGION','AWS_PROFILE','AWS_REGION',
+                'ARM_CLIENT_ID','ARM_CLIENT_SECRET','ARM_SUBSCRIPTION_ID','ARM_TENANT_ID',
+                'GOOGLE_CREDENTIALS','GOOGLE_PROJECT','GOOGLE_APPLICATION_CREDENTIALS',
+                'HTTP_PROXY','HTTPS_PROXY','NO_PROXY','http_proxy','https_proxy','no_proxy'
+                )</where>
+        </update>
+    </changeSet>
+
+    <!--
+      Deferred: only applied once no NULL rows remain, so an instance with unremediated legacy
+      data keeps starting up (ExecutorService/WorkspaceVariableValidationService already guard
+      against the NULLs at runtime). Re-evaluated on every startup until it can succeed.
+    -->
+    <changeSet id="2-33-0-variable-category-not-null" author="jake">
+        <preConditions onFail="WARN" onFailMessage="Skipping NOT NULL constraint on variable.variable_category: rows with a NULL category still exist. Terrakube fails jobs run against workspaces with those rows, reporting the workspace and variable key; once every row is remediated this constraint will be applied automatically on a later startup.">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM variable WHERE variable_category IS NULL</sqlCheck>
+        </preConditions>
+        <addNotNullConstraint tableName="variable" columnName="variable_category" columnDataType="varchar(32)"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
@@ -47,6 +47,8 @@ import io.terrakube.api.plugin.scheduler.job.tcl.model.Flow;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.FlowType;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.ScheduleTemplate;
 import io.terrakube.api.plugin.softdelete.SoftDeleteService;
+import io.terrakube.api.plugin.variable.IncompleteVariableException;
+import io.terrakube.api.plugin.variable.InvalidVariableCategoryException;
 import io.terrakube.api.plugin.variable.WorkspaceVariableValidationService;
 import io.terrakube.api.plugin.vcs.PrCommentService;
 import io.terrakube.api.plugin.vcs.WebhookService;
@@ -284,6 +286,74 @@ public class ScheduleJobTest {
         verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.unknown, null);
         Assertions.assertEquals(JobStatus.failed, job.getStatus());
         Assertions.assertEquals(JobStatus.failed, job.getStep().get(0).getStatus());
+    }
+
+    @Test
+    public void pendingJobFailsClearlyWithWorkspaceAndKeyWhenVariableHasNoCategory() throws Exception {
+        Job job = job(JobStatus.pending);
+        job.setPlanChanges(true);
+
+        doReturn(false).when(tclService).isTemplatePlanOnly(any());
+        doReturn(Optional.of(Collections.emptyList()))
+                .when(jobRepository)
+                .findByWorkspaceAndStatusNotInAndIdLessThan(
+                        any(Workspace.class),
+                        anyList(),
+                        anyInt());
+        doReturn(job).when(tclService).initJobConfiguration(any(Job.class));
+        doThrow(new InvalidVariableCategoryException("LEGACY_VAR has no category"))
+                .when(workspaceVariableValidationService).validateWorkspaceVariables(any());
+        doReturn("Run blocked because this workspace has variables with no category (must be TERRAFORM or ENV).\n- LEGACY_VAR")
+                .when(workspaceVariableValidationService).buildInvalidCategoryMessage(any(Workspace.class));
+        doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
+        doReturn(job).when(jobRepository).save(any());
+        doReturn(stepId.toString()).when(tclService).getCurrentStepId(any());
+        doReturn(job.getStep().get(0)).when(stepRepository).getReferenceById(any());
+        doReturn(job.getStep()).when(stepRepository).findByJobId(anyInt());
+        doReturn(null).when(stepRepository).save(any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
+
+        // A malformed legacy variable must fail the job outright, not leave it pending/retrying.
+        Assertions.assertTrue(subject().runExecution(job));
+
+        verify(executorService, never()).execute(any(), any(), any());
+        Assertions.assertEquals(JobStatus.failed, job.getStatus());
+        Assertions.assertEquals(JobStatus.failed, job.getStep().get(0).getStatus());
+        Assertions.assertEquals(WorkspaceVariableValidationService.INVALID_CATEGORY_STEP_NAME, job.getStep().get(0).getName());
+        Assertions.assertTrue(job.getOutput().contains("LEGACY_VAR"));
+    }
+
+    @Test
+    public void pendingJobFailsWhenWorkspaceVariablesAreIncomplete() throws Exception {
+        Job job = job(JobStatus.pending);
+        job.setPlanChanges(true);
+
+        doReturn(false).when(tclService).isTemplatePlanOnly(any());
+        doReturn(Optional.of(Collections.emptyList()))
+                .when(jobRepository)
+                .findByWorkspaceAndStatusNotInAndIdLessThan(
+                        any(Workspace.class),
+                        anyList(),
+                        anyInt());
+        doReturn(job).when(tclService).initJobConfiguration(any(Job.class));
+        doThrow(new IncompleteVariableException("TF_API_TOKEN is incomplete"))
+                .when(workspaceVariableValidationService).validateWorkspaceVariables(any());
+        doReturn("Run blocked because this workspace still has incomplete sensitive variables.\n- TF_API_TOKEN")
+                .when(workspaceVariableValidationService).buildIncompleteVariableMessage(any(Workspace.class));
+        doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
+        doReturn(job).when(jobRepository).save(any());
+        doReturn(stepId.toString()).when(tclService).getCurrentStepId(any());
+        doReturn(job.getStep().get(0)).when(stepRepository).getReferenceById(any());
+        doReturn(job.getStep()).when(stepRepository).findByJobId(anyInt());
+        doReturn(null).when(stepRepository).save(any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
+
+        Assertions.assertTrue(subject().runExecution(job));
+
+        verify(executorService, never()).execute(any(), any(), any());
+        Assertions.assertEquals(JobStatus.failed, job.getStatus());
+        Assertions.assertEquals(WorkspaceVariableValidationService.INCOMPLETE_VARIABLE_STEP_NAME, job.getStep().get(0).getName());
+        Assertions.assertTrue(job.getOutput().contains("TF_API_TOKEN"));
     }
 
     @Test

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorServiceTest.java
@@ -1,0 +1,93 @@
+package io.terrakube.api.plugin.scheduler.job.tcl.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import io.terrakube.api.repository.VariableRepository;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.workspace.Workspace;
+import io.terrakube.api.rs.workspace.parameters.Category;
+import io.terrakube.api.rs.workspace.parameters.Variable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExecutorServiceTest {
+
+    @Mock
+    private VariableRepository variableRepository;
+
+    @InjectMocks
+    private ExecutorService executorService;
+
+    private Workspace workspace;
+    private Job job;
+
+    @BeforeEach
+    void setUp() {
+        workspace = new Workspace();
+        workspace.setName("my-workspace");
+
+        job = new Job();
+        job.setId(42);
+        job.setWorkspace(workspace);
+    }
+
+    @Test
+    void shouldRouteTerraformAndEnvVariablesToTheirRespectiveMaps() throws ExecutionException {
+        Variable terraformVariable = new Variable();
+        terraformVariable.setKey("instance_type");
+        terraformVariable.setValue("t3.micro");
+        terraformVariable.setCategory(Category.TERRAFORM);
+
+        Variable envVariable = new Variable();
+        envVariable.setKey("AWS_REGION");
+        envVariable.setValue("us-east-1");
+        envVariable.setCategory(Category.ENV);
+
+        when(variableRepository.findByWorkspace(workspace)).thenReturn(Optional.of(List.of(terraformVariable, envVariable)));
+
+        HashMap<String, String> terraformVariables = new HashMap<>();
+        HashMap<String, String> environmentVariables = new HashMap<>();
+        executorService.splitWorkspaceVariablesByCategory(job, terraformVariables, environmentVariables);
+
+        assertThat(terraformVariables).containsEntry("instance_type", "t3.micro");
+        assertThat(environmentVariables).containsEntry("AWS_REGION", "us-east-1");
+    }
+
+    @Test
+    void shouldFailClearlyWithWorkspaceAndKeyWhenCategoryIsNull() {
+        Variable malformedVariable = new Variable();
+        malformedVariable.setKey("LEGACY_VAR");
+        malformedVariable.setValue("super-secret");
+        malformedVariable.setCategory(null);
+
+        when(variableRepository.findByWorkspace(workspace)).thenReturn(Optional.of(List.of(malformedVariable)));
+
+        assertThatThrownBy(() -> executorService.splitWorkspaceVariablesByCategory(job, new HashMap<>(), new HashMap<>()))
+                .isInstanceOf(ExecutionException.class)
+                .hasMessageContaining("my-workspace")
+                .hasMessageContaining("LEGACY_VAR")
+                .hasMessageNotContaining("super-secret");
+    }
+
+    @Test
+    void shouldNotThrowWhenWorkspaceHasNoVariables() throws ExecutionException {
+        when(variableRepository.findByWorkspace(workspace)).thenReturn(Optional.empty());
+
+        HashMap<String, String> terraformVariables = new HashMap<>();
+        HashMap<String, String> environmentVariables = new HashMap<>();
+        executorService.splitWorkspaceVariablesByCategory(job, terraformVariables, environmentVariables);
+
+        assertThat(terraformVariables).isEmpty();
+        assertThat(environmentVariables).isEmpty();
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/variable/WorkspaceVariableValidationServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/variable/WorkspaceVariableValidationServiceTest.java
@@ -55,6 +55,7 @@ class WorkspaceVariableValidationServiceTest {
     @Test
     void shouldFailWhenWorkspaceContainsVariablesWithNoCategory() {
         Workspace workspace = new Workspace();
+        workspace.setName("acme-workspace");
 
         Variable invalidCategoryVariable = new Variable();
         invalidCategoryVariable.setKey("LEGACY_VAR");
@@ -70,6 +71,7 @@ class WorkspaceVariableValidationServiceTest {
 
         assertThatThrownBy(() -> validationService.validateWorkspaceVariables(workspace))
                 .isInstanceOf(InvalidVariableCategoryException.class)
+                .hasMessageContaining("acme-workspace")
                 .hasMessageContaining("LEGACY_VAR")
                 .hasMessageNotContaining("AWS_REGION")
                 .hasMessageContaining("Run blocked because this workspace has variables with no category (must be TERRAFORM or ENV).")

--- a/api/src/test/java/io/terrakube/api/plugin/variable/WorkspaceVariableValidationServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/variable/WorkspaceVariableValidationServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 
 import io.terrakube.api.repository.VariableRepository;
 import io.terrakube.api.rs.workspace.Workspace;
+import io.terrakube.api.rs.workspace.parameters.Category;
 import io.terrakube.api.rs.workspace.parameters.Variable;
 import java.util.List;
 import java.util.Optional;
@@ -33,10 +34,12 @@ class WorkspaceVariableValidationServiceTest {
 
         Variable incompleteVariable = new Variable();
         incompleteVariable.setKey("TF_API_TOKEN");
+        incompleteVariable.setCategory(Category.ENV);
         incompleteVariable.setIncomplete(true);
 
         Variable completeVariable = new Variable();
         completeVariable.setKey("AWS_REGION");
+        completeVariable.setCategory(Category.TERRAFORM);
         completeVariable.setIncomplete(false);
 
         when(variableRepository.findByWorkspace(workspace)).thenReturn(Optional.of(List.of(incompleteVariable, completeVariable)));
@@ -47,5 +50,64 @@ class WorkspaceVariableValidationServiceTest {
                 .hasMessageContaining("Run blocked because this workspace still has incomplete sensitive variables.")
                 .hasMessageContaining("Complete or delete these variables before retrying:")
                 .hasMessageContaining("Open the workspace Variables page to update them.");
+    }
+
+    @Test
+    void shouldFailWhenWorkspaceContainsVariablesWithNoCategory() {
+        Workspace workspace = new Workspace();
+
+        Variable invalidCategoryVariable = new Variable();
+        invalidCategoryVariable.setKey("LEGACY_VAR");
+        invalidCategoryVariable.setCategory(null);
+        invalidCategoryVariable.setIncomplete(false);
+
+        Variable validVariable = new Variable();
+        validVariable.setKey("AWS_REGION");
+        validVariable.setCategory(Category.TERRAFORM);
+        validVariable.setIncomplete(false);
+
+        when(variableRepository.findByWorkspace(workspace)).thenReturn(Optional.of(List.of(invalidCategoryVariable, validVariable)));
+
+        assertThatThrownBy(() -> validationService.validateWorkspaceVariables(workspace))
+                .isInstanceOf(InvalidVariableCategoryException.class)
+                .hasMessageContaining("LEGACY_VAR")
+                .hasMessageNotContaining("AWS_REGION")
+                .hasMessageContaining("Run blocked because this workspace has variables with no category (must be TERRAFORM or ENV).")
+                .hasMessageContaining("Open the workspace Variables page to update them.");
+    }
+
+    @Test
+    void shouldPreferInvalidCategoryOverIncompleteWhenBothPresent() {
+        Workspace workspace = new Workspace();
+
+        Variable invalidCategoryVariable = new Variable();
+        invalidCategoryVariable.setKey("LEGACY_VAR");
+        invalidCategoryVariable.setCategory(null);
+        invalidCategoryVariable.setIncomplete(false);
+
+        Variable incompleteVariable = new Variable();
+        incompleteVariable.setKey("TF_API_TOKEN");
+        incompleteVariable.setCategory(Category.ENV);
+        incompleteVariable.setIncomplete(true);
+
+        when(variableRepository.findByWorkspace(workspace))
+                .thenReturn(Optional.of(List.of(invalidCategoryVariable, incompleteVariable)));
+
+        assertThatThrownBy(() -> validationService.validateWorkspaceVariables(workspace))
+                .isInstanceOf(InvalidVariableCategoryException.class);
+    }
+
+    @Test
+    void shouldPassWhenAllVariablesAreCompleteAndHaveAValidCategory() {
+        Workspace workspace = new Workspace();
+
+        Variable validVariable = new Variable();
+        validVariable.setKey("AWS_REGION");
+        validVariable.setCategory(Category.ENV);
+        validVariable.setIncomplete(false);
+
+        when(variableRepository.findByWorkspace(workspace)).thenReturn(Optional.of(List.of(validVariable)));
+
+        validationService.validateWorkspaceVariables(workspace);
     }
 }

--- a/ui/src/domain/Workspaces/Variables.tsx
+++ b/ui/src/domain/Workspaces/Variables.tsx
@@ -20,7 +20,7 @@ import {
 import { useState } from "react";
 import { ORGANIZATION_ARCHIVE, WORKSPACE_ARCHIVE } from "../../config/actionTypes";
 import axiosInstance, { getErrorMessage } from "../../config/axiosConfig";
-import { CreateVariableForm, FlatVariable } from "../types";
+import { CreateVariableForm, FlatVariable, VariableCategory } from "../types";
 import SettingsSection from "@/modules/layout/SettingsSection/SettingsSection";
 
 const VARIABLES_COLUMS = (
@@ -157,9 +157,9 @@ const COLLECTION_VARIABLES_COLUMNS = () => [
     dataIndex: "category",
     width: "15%",
     key: "category",
-    sorter: (a: any, b: any) => a.category.localeCompare(b.category),
+    sorter: (a: any, b: any) => (a.category ?? "").localeCompare(b.category ?? ""),
     render: (_: string, record: any) => {
-      return record.category === "TERRAFORM" ? "terraform" : "env";
+      return record.category === "TERRAFORM" ? "terraform" : record.category === "ENV" ? "env" : "unset";
     },
   },
   {
@@ -225,9 +225,9 @@ const GLOBAL_VARIABLES_COLUMNS = () => [
     dataIndex: "category",
     width: "20%",
     key: "category",
-    sorter: (a: FlatVariable, b: FlatVariable) => a.category.localeCompare(b.category),
+    sorter: (a: FlatVariable, b: FlatVariable) => (a.category ?? "").localeCompare(b.category ?? ""),
     render: (_: string, record: FlatVariable) => {
-      return record.category === "TERRAFORM" ? "terraform" : "env";
+      return record.category === "TERRAFORM" ? "terraform" : record.category === "ENV" ? "env" : "unset";
     },
   },
 ];
@@ -262,7 +262,7 @@ export const Variables = ({
   const [form] = Form.useForm<CreateVariableForm>();
   const [visible, setVisible] = useState(false);
   const [variableName, setVariableName] = useState("");
-  const [category, setCategory] = useState("TERRAFORM");
+  const [category, setCategory] = useState<VariableCategory | null>("TERRAFORM");
   const [mode, setMode] = useState("create");
   const [variableId, setVariableId] = useState("");
   const onCancel = () => {
@@ -278,7 +278,7 @@ export const Variables = ({
       sensitive: variable.sensitive,
       hcl: variable.hcl,
       description: variable.description,
-      category: variable.category,
+      category: variable.category ?? undefined,
     });
     setVisible(true);
     setCategory(variable.category);
@@ -498,7 +498,7 @@ export const Variables = ({
               Select variable category
             </Typography.Title>
 
-            <Form.Item name="category">
+            <Form.Item name="category" rules={[{ required: true, message: "Please select a variable category" }]}>
               <Radio.Group value={category} onChange={(e) => setCategory(e.target.value)}>
                 <div style={{ display: "flex", flexDirection: "column", gap: "15px" }}>
                   <Radio value="TERRAFORM" style={{ display: "flex", alignItems: "flex-start" }}>

--- a/ui/src/domain/types.ts
+++ b/ui/src/domain/types.ts
@@ -308,6 +308,8 @@ export type TeamToken = {
 
 // Variables
 
+export type VariableCategory = "TERRAFORM" | "ENV";
+
 export type Variable = {
   id: string;
   attributes: VariableAttributes;
@@ -316,7 +318,8 @@ export type VariableAttributes = {
   key: string;
   value: string;
   hcl: boolean;
-  category: string;
+  // Legacy rows may still have no category until remediated; see issue #3395.
+  category: VariableCategory | null;
   description: string;
   sensitive: boolean;
   incomplete: boolean;
@@ -334,7 +337,7 @@ export type UpdateVariableForm = {
   key: string;
   value: string;
   hcl: boolean;
-  category: string;
+  category: VariableCategory;
   description: string;
 };
 


### PR DESCRIPTION
## What
Fixes #3395: workspace variables with a `NULL` category crashed scheduled jobs with an unhandled `NullPointerException`, leaving them stuck retrying forever instead of failing cleanly.

- `ExecutorService` now uses a null-safe category comparison and, if it ever sees a null-category variable, fails the job with a message naming the workspace and variable key (never the value).
- `ScheduleJob` now rejects a job up front, before it reaches the executor, if the workspace has any variable with no category — via a new `InvalidVariableCategoryException` path in `WorkspaceVariableValidationService`, mirroring the existing incomplete-variable check.
- The `Variable` entity now requires `category` (`@NotNull` + `NOT NULL` column), so API create/update requests without a valid category are rejected.
- The UI now requires a category to be selected when creating or editing a variable.
- A new Liquibase migration backfills the only legacy `NULL` rows that can be inferred unambiguously (well-known cloud-provider/proxy env var names) and defers the `NOT NULL` constraint until no ambiguous rows remain anywhere in the table.

## How
- `ExecutorService`: null-safe category comparison; throws a clear error (workspace + variable key, never the value) instead of NPE-ing.
- `ScheduleJob` / `WorkspaceVariableValidationService`: new pre-flight check fails the job outright, before it reaches the executor, if any variable has no category.
- `Variable` entity: `category` is now `@NotNull` / `NOT NULL`, so the API rejects invalid create/update requests.
- UI: category is now a required field when creating/editing a variable.
- New Liquibase migration: backfills unambiguous legacy `NULL` rows (known cloud-provider/proxy env var names), defers the `NOT NULL` constraint until no ambiguous rows remain (safe for instances upgrading with dirty data).
- Tests added/updated across all of the above.

## Why
`ExecutorService` dereferenced `variable.getCategory()` without a null check, so any workspace with a legacy or malformed variable (category was nullable at the DB level since it was added) would crash job execution with an unhandled NPE. Because that exception wasn't caught anywhere, the job never got marked `failed` and Quartz kept re-triggering it every 30s indefinitely — a silent, self-perpetuating failure with no clear signal to the user about what was wrong or which variable caused it.

The fix closes this at every layer it can occur: prevent it going forward (required at both the API and UI), catch it early for jobs (clear failure instead of a crash loop), stay safe even if that early check is somehow bypassed (null-safe comparison in the executor), and clean up existing bad data without breaking upgrades for instances that still have some (deferred, non-blocking constraint).

## Test plan
- [x] `mvn test` passes for the full backend suite
- [x] New/updated unit tests cover: valid TERRAFORM/ENV routing, null-category job failure (message names workspace + key), empty-workspace edge case, and the incomplete-vs-invalid-category precedence in the pre-flight check
- [x] `tsc --noEmit` clean on the changed UI files (no new type errors)
- [x] `eslint` clean on the changed UI files
- [x] tested creating variable on workspace with no category now shows error by spinning up fresh instance
