### PR TITLE
feat(notification): add Slack/Teams/webhook notifications for job status changes

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/notification/ClaimedOutbox.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/ClaimedOutbox.java
@@ -1,0 +1,8 @@
+package io.terrakube.api.plugin.notification;
+
+import java.util.Date;
+
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+
+record ClaimedOutbox(NotificationConfiguration configuration, String payload, int attemptCount, Date lastAttemptAt) {
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/JobNotificationTrigger.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/JobNotificationTrigger.java
@@ -1,0 +1,128 @@
+package io.terrakube.api.plugin.notification;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import io.terrakube.api.plugin.notification.payload.NotificationContext;
+import io.terrakube.api.plugin.notification.payload.NotificationPayloadRenderer;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.notification.NotificationOutbox;
+import io.terrakube.api.rs.notification.NotificationOutboxStatus;
+import io.terrakube.api.repository.NotificationOutboxRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+// Shared by two very different callers:
+//  - JobNotificationHook (an Elide LifeCycleHook) uses enqueue() only, deferring dispatch to its
+//    own POSTCOMMIT phase so a notification is never sent for a Job update that later rolls back.
+//  - ScheduleJob/ScheduleJobTrigger use notifyStatusChanged() directly: real job status
+//    transitions during a run (queue -> pending -> running -> completed/failed/...) happen via a
+//    plain jobRepository.save() on a Quartz-invoked bean, never through an Elide JSON:API/GraphQL
+//    request - so JobNotificationHook, which only fires on operations Elide itself observes, never
+//    sees them. Calling this directly, immediately after the save that changed the status, is the
+//    only way these transitions ever get noticed.
+//
+// notifyStatusChanged() is safe to call from either a non-transactional caller (ScheduleJob,
+// RemoteTfeService - a plain save() is its own auto-committing transaction, already committed by
+// the time control returns here) or a transactional one (ScheduleJobTrigger wraps its whole
+// execute() in @Transactional): when a transaction is active, the outbox row insert isn't visible
+// to the async dispatch thread's own connection until it commits, so dispatch is deferred to run
+// after that commit instead of racing it.
+@Slf4j
+@Service
+public class JobNotificationTrigger {
+
+    private final NotificationConfigResolver notificationConfigResolver;
+    private final NotificationPayloadRenderer notificationPayloadRenderer;
+    private final NotificationOutboxRepository notificationOutboxRepository;
+    private final NotificationDispatchService notificationDispatchService;
+
+    @Value("${io.terrakube.ui.url:}")
+    private String uiUrl;
+
+    public JobNotificationTrigger(NotificationConfigResolver notificationConfigResolver,
+            NotificationPayloadRenderer notificationPayloadRenderer,
+            NotificationOutboxRepository notificationOutboxRepository,
+            NotificationDispatchService notificationDispatchService) {
+        this.notificationConfigResolver = notificationConfigResolver;
+        this.notificationPayloadRenderer = notificationPayloadRenderer;
+        this.notificationOutboxRepository = notificationOutboxRepository;
+        this.notificationDispatchService = notificationDispatchService;
+    }
+
+    public List<UUID> enqueue(Job job) {
+        if (job.getWorkspace() == null) {
+            return List.of();
+        }
+        List<UUID> insertedIds = new ArrayList<>();
+        try {
+            List<NotificationConfiguration> configs = notificationConfigResolver.resolve(job.getWorkspace());
+            for (NotificationConfiguration configuration : configs) {
+                boolean matches = configuration.getTriggers() != null && configuration.getTriggers().stream()
+                        .anyMatch(trigger -> trigger.getJobStatus() == job.getStatus());
+                if (!matches) {
+                    continue;
+                }
+                String payload = notificationPayloadRenderer.render(configuration.getChannelType(), buildContext(job));
+
+                NotificationOutbox outbox = new NotificationOutbox();
+                outbox.setId(UUID.randomUUID());
+                outbox.setJob(job);
+                outbox.setConfiguration(configuration);
+                outbox.setPayload(payload);
+                outbox.setStatus(NotificationOutboxStatus.PENDING);
+                notificationOutboxRepository.save(outbox);
+                insertedIds.add(outbox.getId());
+            }
+        } catch (Exception e) {
+            // Never let a resolution/render failure fail the job status update itself.
+            log.error("Failed to resolve/enqueue notifications for job {}", job.getId(), e);
+        }
+        return insertedIds;
+    }
+
+    public void notifyStatusChanged(Job job) {
+        List<UUID> outboxIds = enqueue(job);
+        if (outboxIds.isEmpty()) {
+            return;
+        }
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    outboxIds.forEach(notificationDispatchService::dispatchAsync);
+                }
+            });
+        } else {
+            outboxIds.forEach(notificationDispatchService::dispatchAsync);
+        }
+    }
+
+    NotificationContext buildContext(Job job) {
+        String runUrl = String.format("%s/organizations/%s/workspaces/%s/runs/%s", uiUrl,
+                job.getOrganization().getId(), job.getWorkspace().getId(), job.getId());
+        // job.output is the raw Terraform/OpenTofu run output; there is no dedicated
+        // failure-reason field on Job, so this trims the tail of that log as a
+        // best-effort summary rather than shipping the whole (possibly huge) output.
+        String failureReason = null;
+        if (job.getOutput() != null && !job.getOutput().isBlank()) {
+            String output = job.getOutput();
+            failureReason = output.length() > 500 ? output.substring(output.length() - 500) : output;
+        }
+        return new NotificationContext(
+                job.getOrganization().getName(),
+                job.getWorkspace().getName(),
+                job.getId(),
+                job.getStatus(),
+                runUrl,
+                job.getCommitId(),
+                failureReason);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/JobNotificationTrigger.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/JobNotificationTrigger.java
@@ -15,6 +15,7 @@ import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.notification.NotificationConfiguration;
 import io.terrakube.api.rs.notification.NotificationOutbox;
 import io.terrakube.api.rs.notification.NotificationOutboxStatus;
+import io.terrakube.api.rs.template.Template;
 import io.terrakube.api.repository.NotificationOutboxRepository;
 
 import lombok.extern.slf4j.Slf4j;
@@ -65,12 +66,13 @@ public class JobNotificationTrigger {
         try {
             List<NotificationConfiguration> configs = notificationConfigResolver.resolve(job.getWorkspace());
             for (NotificationConfiguration configuration : configs) {
-                boolean matches = configuration.getTriggers() != null && configuration.getTriggers().stream()
+                boolean statusMatches = configuration.getTriggers() != null && configuration.getTriggers().stream()
                         .anyMatch(trigger -> trigger.getJobStatus() == job.getStatus());
-                if (!matches) {
+                if (!statusMatches || !templateMatches(configuration, job)) {
                     continue;
                 }
-                String payload = notificationPayloadRenderer.render(configuration.getChannelType(), buildContext(job));
+                String payload = notificationPayloadRenderer.render(configuration.getChannelType(),
+                        buildContext(job, configuration));
 
                 NotificationOutbox outbox = new NotificationOutbox();
                 outbox.setId(UUID.randomUUID());
@@ -86,6 +88,17 @@ public class JobNotificationTrigger {
             log.error("Failed to resolve/enqueue notifications for job {}", job.getId(), e);
         }
         return insertedIds;
+    }
+
+    // Empty/null templates means "applies to every template" - this only ever narrows which
+    // templates a configuration fires for, never widens it, so existing configurations (no
+    // templates selected) keep matching every job exactly as before this filter existed.
+    private boolean templateMatches(NotificationConfiguration configuration, Job job) {
+        List<Template> templates = configuration.getTemplates();
+        if (templates == null || templates.isEmpty()) {
+            return true;
+        }
+        return templates.stream().anyMatch(template -> template.getId().toString().equals(job.getTemplateReference()));
     }
 
     public void notifyStatusChanged(Job job) {
@@ -105,9 +118,10 @@ public class JobNotificationTrigger {
         }
     }
 
-    NotificationContext buildContext(Job job) {
-        String runUrl = String.format("%s/organizations/%s/workspaces/%s/runs/%s", uiUrl,
-                job.getOrganization().getId(), job.getWorkspace().getId(), job.getId());
+    NotificationContext buildContext(Job job, NotificationConfiguration configuration) {
+        String workspaceUrl = String.format("%s/organizations/%s/workspaces/%s", uiUrl,
+                job.getOrganization().getId(), job.getWorkspace().getId());
+        String runUrl = workspaceUrl + "/runs/" + job.getId();
         // job.output is the raw Terraform/OpenTofu run output; there is no dedicated
         // failure-reason field on Job, so this trims the tail of that log as a
         // best-effort summary rather than shipping the whole (possibly huge) output.
@@ -123,6 +137,9 @@ public class JobNotificationTrigger {
                 job.getStatus(),
                 runUrl,
                 job.getCommitId(),
-                failureReason);
+                failureReason,
+                configuration.getName(),
+                workspaceUrl,
+                configuration.getMessageStyle());
     }
 }

--- a/api/src/main/java/io/terrakube/api/plugin/notification/NotificationConfigResolver.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/NotificationConfigResolver.java
@@ -1,0 +1,31 @@
+package io.terrakube.api.plugin.notification;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.springframework.stereotype.Service;
+
+import io.terrakube.api.repository.NotificationConfigurationRepository;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.workspace.Workspace;
+
+@Service
+public class NotificationConfigResolver {
+
+    private final NotificationConfigurationRepository notificationConfigurationRepository;
+
+    public NotificationConfigResolver(NotificationConfigurationRepository notificationConfigurationRepository) {
+        this.notificationConfigurationRepository = notificationConfigurationRepository;
+    }
+
+    // Purely additive: a workspace gets every active org-wide config plus every active config
+    // scoped directly to it. No per-channel-type override/suppression - keeping the two scopes
+    // simple and independent is the whole point.
+    public List<NotificationConfiguration> resolve(Workspace workspace) {
+        List<NotificationConfiguration> workspaceConfigs = notificationConfigurationRepository
+                .findByWorkspaceIdAndActiveTrue(workspace.getId());
+        List<NotificationConfiguration> orgConfigs = notificationConfigurationRepository
+                .findByOrganizationIdAndWorkspaceIsNullAndActiveTrue(workspace.getOrganization().getId());
+        return Stream.concat(workspaceConfigs.stream(), orgConfigs.stream()).toList();
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/NotificationConfigurationAccessService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/NotificationConfigurationAccessService.java
@@ -1,0 +1,145 @@
+package io.terrakube.api.plugin.notification;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.repository.NotificationConfigurationRepository;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.repository.TeamRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+import io.terrakube.api.rs.team.Team;
+import io.terrakube.api.rs.workspace.Workspace;
+import io.terrakube.api.rs.workspace.access.Access;
+
+/**
+ * Mirrors Workspace's own three-tier manage permission (org-wide team access,
+ * OR a workspace-level Access grant, OR a project-level ProjectAccess grant)
+ * for workspace-scoped notification operations, so anyone who can otherwise
+ * manage a workspace can also manage/view its notifications - not just teams
+ * with blanket org-wide "manage workspace" rights. Org-scoped configurations
+ * only have the org-wide tier to check against (no specific workspace).
+ */
+@Service
+public class NotificationConfigurationAccessService {
+
+    private final TeamRepository teamRepository;
+    private final NotificationConfigurationRepository notificationConfigurationRepository;
+    private final OrganizationRepository organizationRepository;
+    private final WorkspaceRepository workspaceRepository;
+    private final RbacService rbacService;
+
+    public NotificationConfigurationAccessService(TeamRepository teamRepository,
+            NotificationConfigurationRepository notificationConfigurationRepository,
+            OrganizationRepository organizationRepository, WorkspaceRepository workspaceRepository,
+            RbacService rbacService) {
+        this.teamRepository = teamRepository;
+        this.notificationConfigurationRepository = notificationConfigurationRepository;
+        this.organizationRepository = organizationRepository;
+        this.workspaceRepository = workspaceRepository;
+        this.rbacService = rbacService;
+    }
+
+    @Transactional
+    public boolean hasManagePermission(Authentication authentication, String configurationId) {
+        if (isInternalIssuer(authentication)) {
+            return true;
+        }
+        NotificationConfiguration configuration = notificationConfigurationRepository
+                .findById(UUID.fromString(configurationId)).orElse(null);
+        if (configuration == null) {
+            return false;
+        }
+        if (configuration.getWorkspace() != null) {
+            return hasManagePermissionForWorkspace(authentication, configuration.getWorkspace());
+        }
+        return hasManagePermissionForOrganization(authentication, configuration.getOrganization());
+    }
+
+    @Transactional
+    public boolean hasManagePermissionForOrganization(Authentication authentication, String organizationId) {
+        if (isInternalIssuer(authentication)) {
+            return true;
+        }
+        Organization organization = organizationRepository.findById(UUID.fromString(organizationId)).orElse(null);
+        if (organization == null) {
+            return false;
+        }
+        return hasManagePermissionForOrganization(authentication, organization);
+    }
+
+    @Transactional
+    public boolean hasManagePermissionForWorkspace(Authentication authentication, String workspaceId) {
+        if (isInternalIssuer(authentication)) {
+            return true;
+        }
+        Workspace workspace = workspaceRepository.findById(UUID.fromString(workspaceId)).orElse(null);
+        if (workspace == null) {
+            return false;
+        }
+        return hasManagePermissionForWorkspace(authentication, workspace);
+    }
+
+    private boolean isInternalIssuer(Authentication authentication) {
+        return ((JwtAuthenticationToken) authentication).getTokenAttributes().get("iss").equals("TerrakubeInternal");
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> groupNames(Authentication authentication) {
+        Object groupNames = ((JwtAuthenticationToken) authentication).getTokenAttributes().get("groups");
+        return groupNames == null ? List.of() : (List<String>) groupNames;
+    }
+
+    private boolean hasManagePermissionForOrganization(Authentication authentication, Organization organization) {
+        List<String> groupNames = groupNames(authentication);
+        if (groupNames.isEmpty()) {
+            return false;
+        }
+        List<Team> teams = teamRepository.findAllByOrganizationIdAndNameIn(organization.getId(), groupNames);
+        for (Team team : teams) {
+            if (rbacService.canManageWorkspace(team)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasManagePermissionForWorkspace(Authentication authentication, Workspace workspace) {
+        if (hasManagePermissionForOrganization(authentication, workspace.getOrganization())) {
+            return true;
+        }
+
+        List<String> groupNames = groupNames(authentication);
+        if (groupNames.isEmpty()) {
+            return false;
+        }
+
+        List<Access> accessList = workspace.getAccess();
+        if (accessList != null) {
+            for (Access access : accessList) {
+                if (groupNames.contains(access.getName()) && rbacService.canManageWorkspace(access)) {
+                    return true;
+                }
+            }
+        }
+
+        Project project = workspace.getProject();
+        if (project != null && project.getProjectAccess() != null) {
+            for (ProjectAccess access : project.getProjectAccess()) {
+                if (groupNames.contains(access.getName()) && rbacService.canManageWorkspace(access)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/NotificationDispatchExecutorConfig.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/NotificationDispatchExecutorConfig.java
@@ -1,0 +1,31 @@
+package io.terrakube.api.plugin.notification;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class NotificationDispatchExecutorConfig {
+
+    // Bounded, dedicated pool for the immediate-dispatch path (JobNotificationHook's
+    // POSTCOMMIT calling NotificationDispatchService.dispatchAsync). Without a named executor
+    // here, Spring's @Async falls back to the unbounded SimpleAsyncTaskExecutor (a new thread
+    // per call, no queue, no cap) - a burst of job status changes could spawn unbounded
+    // concurrent deliveries all competing for the same DB connection pool. A full queue rejects
+    // rather than blocks the caller (JobNotificationHook's POSTCOMMIT): the row stays PENDING
+    // and the outbox poller picks it up on its next tick, so a rejection is safe, not lossy.
+    @Bean("notificationDispatchExecutor")
+    public ThreadPoolTaskExecutor notificationDispatchExecutor(
+            @Value("${io.terrakube.notification.dispatch.executor.corePoolSize:10}") int corePoolSize,
+            @Value("${io.terrakube.notification.dispatch.executor.maxPoolSize:20}") int maxPoolSize,
+            @Value("${io.terrakube.notification.dispatch.executor.queueCapacity:200}") int queueCapacity) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(queueCapacity);
+        executor.setThreadNamePrefix("notification-dispatch-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/NotificationDispatchService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/NotificationDispatchService.java
@@ -1,0 +1,104 @@
+package io.terrakube.api.plugin.notification;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.UUID;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import io.terrakube.api.plugin.notification.sender.NotificationDeliveryException;
+import io.terrakube.api.plugin.notification.sender.NotificationDeliveryService;
+import io.terrakube.api.rs.notification.NotificationOutboxStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class NotificationDispatchService {
+
+    static final int MAX_ATTEMPTS = 3;
+    private static final long ONE_MINUTE_MILLIS = 60_000L;
+    private static final long FIVE_MINUTES_MILLIS = 5 * ONE_MINUTE_MILLIS;
+
+    private final NotificationOutboxTransactions notificationOutboxTransactions;
+    private final NotificationDeliveryService notificationDeliveryService;
+
+    public NotificationDispatchService(NotificationOutboxTransactions notificationOutboxTransactions,
+            NotificationDeliveryService notificationDeliveryService) {
+        this.notificationOutboxTransactions = notificationOutboxTransactions;
+        this.notificationDeliveryService = notificationDeliveryService;
+    }
+
+    @Async("notificationDispatchExecutor")
+    public void dispatchAsync(UUID outboxId) {
+        attemptDelivery(outboxId);
+    }
+
+    // claim() and recordResult() each open their own short transaction on a separate bean
+    // (NotificationOutboxTransactions) - the HTTP delivery call in between runs with no
+    // transaction (and therefore no DB connection or row lock) held for its duration.
+    // Previously the pessimistic lock and the outbound call to Slack/Teams/webhook shared one
+    // transaction, so a slow or hanging destination could hold a pooled DB connection for up to
+    // the sender's full timeout (10s connect + 30s read).
+    public void attemptDelivery(UUID outboxId) {
+        ClaimedOutbox claimed = notificationOutboxTransactions.claim(outboxId);
+        if (claimed == null) {
+            return;
+        }
+        DeliveryOutcome outcome = deliver(claimed);
+
+        NotificationOutboxStatus newStatus;
+        Date nextAttemptAt = null;
+        String lastError = null;
+        if (outcome.delivered()) {
+            newStatus = NotificationOutboxStatus.SENT;
+        } else {
+            lastError = outcome.errorMessage();
+            if (!outcome.retryable()) {
+                newStatus = NotificationOutboxStatus.FAILED;
+                log.warn("Notification outbox {} permanently failed (non-retryable failure): {}", outboxId, lastError);
+            } else if (claimed.attemptCount() >= MAX_ATTEMPTS) {
+                newStatus = NotificationOutboxStatus.FAILED;
+                log.warn("Notification outbox {} permanently failed after {} attempts: {}", outboxId,
+                        claimed.attemptCount(), lastError);
+            } else {
+                newStatus = NotificationOutboxStatus.PENDING;
+                // A server-supplied Retry-After overrides the fixed attemptCount-based backoff -
+                // e.g. Slack's 429 tells us exactly how long its rate limit window is, which may
+                // be longer (or shorter) than our default schedule.
+                long delayMillis = outcome.retryAfter() != null ? outcome.retryAfter().toMillis()
+                        : backoffMillis(claimed.attemptCount());
+                nextAttemptAt = new Date(System.currentTimeMillis() + delayMillis);
+                log.info("Notification outbox {} attempt {} failed, will retry: {}", outboxId, claimed.attemptCount(),
+                        lastError);
+            }
+        }
+
+        notificationOutboxTransactions.recordResult(outboxId, claimed.lastAttemptAt(), newStatus, lastError,
+                nextAttemptAt);
+    }
+
+    private DeliveryOutcome deliver(ClaimedOutbox claimed) {
+        try {
+            notificationDeliveryService.deliver(claimed.configuration(), claimed.payload());
+            return DeliveryOutcome.success();
+        } catch (NotificationDeliveryException e) {
+            return DeliveryOutcome.failure(e);
+        }
+    }
+
+    private long backoffMillis(int attemptCount) {
+        return attemptCount <= 1 ? ONE_MINUTE_MILLIS : FIVE_MINUTES_MILLIS;
+    }
+
+    private record DeliveryOutcome(boolean delivered, String errorMessage, boolean retryable, Duration retryAfter) {
+        static DeliveryOutcome success() {
+            return new DeliveryOutcome(true, null, true, null);
+        }
+
+        static DeliveryOutcome failure(NotificationDeliveryException e) {
+            return new DeliveryOutcome(false, e.getMessage(), e.isRetryable(), e.getRetryAfter());
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/NotificationOutboxTransactions.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/NotificationOutboxTransactions.java
@@ -1,0 +1,118 @@
+package io.terrakube.api.plugin.notification;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.Hibernate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.terrakube.api.repository.NotificationOutboxRepository;
+import io.terrakube.api.rs.notification.NotificationOutbox;
+import io.terrakube.api.rs.notification.NotificationOutboxStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+// A separate bean (not just extra methods on NotificationDispatchService/NotificationOutboxPollerJob)
+// so every DB-mutating call here goes through THIS bean's own Spring transactional proxy:
+// - NotificationDispatchService.attemptDelivery calling claim()/recordResult() "this."-style
+//   would be a self-invocation, and @Transactional (like @Async) is proxy-based AOP with no
+//   effect on a method invoked that way from within the same class.
+// - NotificationOutboxPollerJob is a Quartz Job: Spring's SchedulerFactoryBean instantiates and
+//   field-autowires Job instances directly (SpringBeanJobFactory) rather than looking them up
+//   from the ApplicationContext, so a Job class never gets an AOP proxy of its own at all -
+//   @Transactional on a method declared directly on the Job class would silently never apply.
+@Slf4j
+@Service
+public class NotificationOutboxTransactions {
+
+    private final NotificationOutboxRepository notificationOutboxRepository;
+
+    NotificationOutboxTransactions(NotificationOutboxRepository notificationOutboxRepository) {
+        this.notificationOutboxRepository = notificationOutboxRepository;
+    }
+
+    @Transactional
+    ClaimedOutbox claim(UUID outboxId) {
+        Date now = new Date();
+        // Atomic conditional UPDATE, not a pessimistic-lock read: only one concurrent caller's
+        // UPDATE can match "id = :outboxId AND status = PENDING", so only one ever sees rows == 1
+        // and proceeds past this method. The other sees 0 and returns immediately - no blocking,
+        // no lock held while the winner goes on to make the HTTP call outside any transaction.
+        int rows = notificationOutboxRepository.claimForDelivery(outboxId, NotificationOutboxStatus.PENDING,
+                NotificationOutboxStatus.SENDING, now);
+        if (rows == 0) {
+            return null;
+        }
+        NotificationOutbox outbox = notificationOutboxRepository.findById(outboxId).orElse(null);
+        if (outbox == null) {
+            return null;
+        }
+        // The delivery call happens after this transaction (and its Hibernate session) has
+        // closed, so a still-lazy configuration proxy would blow up with a
+        // LazyInitializationException the moment the sender reads a field off it. Force it to
+        // load now, while the session is still open.
+        Hibernate.initialize(outbox.getConfiguration());
+        return new ClaimedOutbox(outbox.getConfiguration(), outbox.getPayload(), outbox.getAttemptCount(),
+                outbox.getLastAttemptAt());
+    }
+
+    @Transactional
+    void recordResult(UUID outboxId, Date expectedLastAttemptAt, NotificationOutboxStatus newStatus, String lastError,
+            Date nextAttemptAt) {
+        // Keyed on the exact lastAttemptAt observed at claim time, not just id+SENDING: if this
+        // row was reclaimed by the stuck-row sweep (this attempt outlived the sweep's threshold)
+        // and re-delivered by someone else in the meantime, lastAttemptAt will have moved on and
+        // this update becomes a no-op instead of clobbering the newer attempt's result.
+        int updated = notificationOutboxRepository.recordDeliveryResult(outboxId, NotificationOutboxStatus.SENDING,
+                expectedLastAttemptAt, newStatus, lastError, nextAttemptAt, new Date());
+        if (updated == 0) {
+            log.warn("Discarding stale delivery result for outbox {} - the row was reclaimed (stuck-row sweep) "
+                    + "before this attempt finished; a duplicate delivery attempt may have reached the destination",
+                    outboxId);
+        }
+    }
+
+    // Manual "Retry" from the delivery-history UI. Public (unlike claim/recordResult) because its
+    // caller, NotificationDeliveryController, lives in a different package - same reasoning as
+    // sweepStuckSendingRows below.
+    @Transactional
+    public boolean rearmForRetry(UUID outboxId) {
+        int rows = notificationOutboxRepository.rearmFailedForRetry(outboxId, NotificationOutboxStatus.FAILED,
+                NotificationOutboxStatus.PENDING, new Date());
+        return rows > 0;
+    }
+
+    // A row can only be stuck in SENDING if whatever claimed it (this poller's own dispatch, the
+    // immediate-dispatch path, another pod) died mid-HTTP-call without ever reaching
+    // recordResult - normal completion always transitions it to SENT/PENDING/FAILED. Called by
+    // NotificationOutboxPollerJob every tick so a crashed pod never permanently strands a
+    // notification.
+    @Transactional
+    public void sweepStuckSendingRows(Date cutoff, int maxAttempts) {
+        int reclaimed = notificationOutboxRepository.reclaimStuckSendingRows(NotificationOutboxStatus.SENDING,
+                NotificationOutboxStatus.PENDING, cutoff, maxAttempts, new Date());
+        int failed = notificationOutboxRepository.failStuckSendingRowsAtMaxAttempts(NotificationOutboxStatus.SENDING,
+                NotificationOutboxStatus.FAILED, cutoff, maxAttempts,
+                "Delivery attempt did not complete within the stuck-row threshold; the claiming instance likely crashed",
+                new Date());
+        if (reclaimed > 0 || failed > 0) {
+            log.warn("Notification outbox sweep reclaimed {} stuck SENDING row(s) for retry and permanently "
+                    + "failed {} that had already exhausted their attempts", reclaimed, failed);
+        }
+    }
+
+    // Housekeeping: without this, notification_outbox grows forever - every SENT/FAILED row from
+    // every job status change with a matching trigger sits around indefinitely. Public for the
+    // same cross-package reason as sweepStuckSendingRows.
+    @Transactional
+    public int pruneTerminalRowsOlderThan(Date cutoff) {
+        int deleted = notificationOutboxRepository.deleteTerminalRowsCreatedBefore(
+                List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED), cutoff);
+        if (deleted > 0) {
+            log.info("Notification outbox retention sweep deleted {} row(s) older than {}", deleted, cutoff);
+        }
+        return deleted;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/NotificationTestService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/NotificationTestService.java
@@ -1,0 +1,39 @@
+package io.terrakube.api.plugin.notification;
+
+import org.springframework.stereotype.Service;
+
+import io.terrakube.api.plugin.notification.payload.NotificationContext;
+import io.terrakube.api.plugin.notification.payload.NotificationPayloadRenderer;
+import io.terrakube.api.plugin.notification.sender.NotificationDeliveryService;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+
+@Service
+public class NotificationTestService {
+
+    private final NotificationPayloadRenderer notificationPayloadRenderer;
+    private final NotificationDeliveryService notificationDeliveryService;
+
+    public NotificationTestService(NotificationPayloadRenderer notificationPayloadRenderer,
+            NotificationDeliveryService notificationDeliveryService) {
+        this.notificationPayloadRenderer = notificationPayloadRenderer;
+        this.notificationDeliveryService = notificationDeliveryService;
+    }
+
+    public void sendTest(NotificationConfiguration configuration) {
+        String workspaceName = configuration.getWorkspace() != null
+                ? configuration.getWorkspace().getName()
+                : "(test notification)";
+        NotificationContext context = new NotificationContext(
+                configuration.getOrganization().getName(),
+                workspaceName,
+                0,
+                JobStatus.completed,
+                "#",
+                null,
+                null);
+
+        String payload = notificationPayloadRenderer.render(configuration.getChannelType(), context);
+        notificationDeliveryService.deliver(configuration, payload);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/NotificationTestService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/NotificationTestService.java
@@ -7,6 +7,7 @@ import io.terrakube.api.plugin.notification.payload.NotificationPayloadRenderer;
 import io.terrakube.api.plugin.notification.sender.NotificationDeliveryService;
 import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.notification.NotificationMessageStyle;
 
 @Service
 public class NotificationTestService {
@@ -24,14 +25,22 @@ public class NotificationTestService {
         String workspaceName = configuration.getWorkspace() != null
                 ? configuration.getWorkspace().getName()
                 : "(test notification)";
+        String configurationName = configuration.getName() != null ? configuration.getName() : "Test Notification";
+        NotificationMessageStyle messageStyle = configuration.getMessageStyle() != null
+                ? configuration.getMessageStyle() : NotificationMessageStyle.DETAILED;
+        // null, not a placeholder like "#" - there's no real run to link to for a test send, and
+        // Slack's Block Kit rejects a button whose url isn't a valid absolute URL (invalid_payload).
         NotificationContext context = new NotificationContext(
                 configuration.getOrganization().getName(),
                 workspaceName,
                 0,
                 JobStatus.completed,
-                "#",
                 null,
-                null);
+                null,
+                null,
+                configurationName,
+                null,
+                messageStyle);
 
         String payload = notificationPayloadRenderer.render(configuration.getChannelType(), context);
         notificationDeliveryService.deliver(configuration, payload);

--- a/api/src/main/java/io/terrakube/api/plugin/notification/controller/NotificationAdHocTestRequest.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/controller/NotificationAdHocTestRequest.java
@@ -1,0 +1,7 @@
+package io.terrakube.api.plugin.notification.controller;
+
+import io.terrakube.api.rs.notification.NotificationChannelType;
+
+public record NotificationAdHocTestRequest(NotificationChannelType channelType, String destinationUrl,
+        String signingSecret) {
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/controller/NotificationDeliveryController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/controller/NotificationDeliveryController.java
@@ -1,0 +1,83 @@
+package io.terrakube.api.plugin.notification.controller;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.RejectedExecutionException;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.terrakube.api.plugin.notification.NotificationDispatchService;
+import io.terrakube.api.plugin.notification.NotificationOutboxTransactions;
+import io.terrakube.api.repository.NotificationOutboxRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/notification/v1")
+public class NotificationDeliveryController {
+
+    private final NotificationOutboxRepository notificationOutboxRepository;
+    private final NotificationOutboxTransactions notificationOutboxTransactions;
+    private final NotificationDispatchService notificationDispatchService;
+
+    public NotificationDeliveryController(NotificationOutboxRepository notificationOutboxRepository,
+            NotificationOutboxTransactions notificationOutboxTransactions,
+            NotificationDispatchService notificationDispatchService) {
+        this.notificationOutboxRepository = notificationOutboxRepository;
+        this.notificationOutboxTransactions = notificationOutboxTransactions;
+        this.notificationDispatchService = notificationDispatchService;
+    }
+
+    // Read-only transaction kept open through the mapping below: NotificationDeliveryView.from()
+    // reads the lazy job/configuration proxies on each row, which otherwise throw
+    // LazyInitializationException the moment the repository call (and its session) has returned.
+    @Transactional(readOnly = true)
+    @GetMapping("/workspace/{workspaceId}/deliveries")
+    @PreAuthorize("@notificationConfigurationAccessService.hasManagePermissionForWorkspace(authentication, #workspaceId)")
+    public ResponseEntity<List<NotificationDeliveryView>> recentDeliveries(@PathVariable String workspaceId,
+            @RequestParam(defaultValue = "10") int limit) {
+        List<NotificationDeliveryView> deliveries = notificationOutboxRepository
+                .findByJob_Workspace_IdOrderByCreatedDateDesc(UUID.fromString(workspaceId), PageRequest.of(0, limit))
+                .stream()
+                .map(NotificationDeliveryView::from)
+                .toList();
+        return ResponseEntity.ok(deliveries);
+    }
+
+    // Re-arms a permanently FAILED delivery (a terminal SSRF-blocked/4xx failure, or one that
+    // exhausted MAX_ATTEMPTS) and dispatches it immediately instead of waiting for the next
+    // poller tick, so a "Retry" click in the UI gets a near-instant result.
+    @PostMapping("/workspace/{workspaceId}/deliveries/{deliveryId}/retry")
+    @PreAuthorize("@notificationConfigurationAccessService.hasManagePermissionForWorkspace(authentication, #workspaceId)")
+    public ResponseEntity<Void> retryDelivery(@PathVariable String workspaceId, @PathVariable String deliveryId) {
+        UUID workspaceUuid = UUID.fromString(workspaceId);
+        UUID outboxId = UUID.fromString(deliveryId);
+        if (!notificationOutboxRepository.existsByIdAndJob_Workspace_Id(outboxId, workspaceUuid)) {
+            return ResponseEntity.notFound().build();
+        }
+        if (!notificationOutboxTransactions.rearmForRetry(outboxId)) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+        try {
+            notificationDispatchService.dispatchAsync(outboxId);
+        } catch (RejectedExecutionException e) {
+            // The dispatch executor's queue is full - the row is already re-armed to PENDING
+            // (this submission never claimed it), so the outbox poller will pick it up on its
+            // next tick. The retry itself still succeeded; don't surface this as an error.
+            log.warn("Notification dispatch executor rejected retry of outbox {}, will be picked up by the poller",
+                    outboxId);
+        }
+        return ResponseEntity.ok().build();
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/controller/NotificationDeliveryView.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/controller/NotificationDeliveryView.java
@@ -1,0 +1,32 @@
+package io.terrakube.api.plugin.notification.controller;
+
+import java.util.Date;
+
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationOutbox;
+import io.terrakube.api.rs.notification.NotificationOutboxStatus;
+
+public record NotificationDeliveryView(
+        String id,
+        int jobId,
+        String configurationName,
+        NotificationChannelType channelType,
+        NotificationOutboxStatus status,
+        int attemptCount,
+        Date lastAttemptAt,
+        String lastError,
+        Date createdDate) {
+
+    public static NotificationDeliveryView from(NotificationOutbox outbox) {
+        return new NotificationDeliveryView(
+                outbox.getId().toString(),
+                outbox.getJob().getId(),
+                outbox.getConfiguration().getName(),
+                outbox.getConfiguration().getChannelType(),
+                outbox.getStatus(),
+                outbox.getAttemptCount(),
+                outbox.getLastAttemptAt(),
+                outbox.getLastError(),
+                outbox.getCreatedDate());
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/controller/NotificationTestController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/controller/NotificationTestController.java
@@ -1,0 +1,97 @@
+package io.terrakube.api.plugin.notification.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.terrakube.api.plugin.notification.NotificationTestService;
+import io.terrakube.api.plugin.notification.sender.NotificationDeliveryException;
+import io.terrakube.api.repository.NotificationConfigurationRepository;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/notification/v1")
+public class NotificationTestController {
+
+    private final NotificationConfigurationRepository notificationConfigurationRepository;
+    private final OrganizationRepository organizationRepository;
+    private final NotificationTestService notificationTestService;
+    private final TransactionTemplate readOnlyTransactionTemplate;
+
+    public NotificationTestController(NotificationConfigurationRepository notificationConfigurationRepository,
+            OrganizationRepository organizationRepository, NotificationTestService notificationTestService,
+            PlatformTransactionManager transactionManager) {
+        this.notificationConfigurationRepository = notificationConfigurationRepository;
+        this.organizationRepository = organizationRepository;
+        this.notificationTestService = notificationTestService;
+        this.readOnlyTransactionTemplate = new TransactionTemplate(transactionManager);
+        this.readOnlyTransactionTemplate.setReadOnly(true);
+    }
+
+    @PostMapping("/configuration/{configId}/test")
+    @PreAuthorize("@notificationConfigurationAccessService.hasManagePermission(authentication, #configId)")
+    public ResponseEntity<Void> sendTest(@PathVariable String configId) {
+        // Fetch and force-initialize the lazy organization proxy inside a short, dedicated
+        // transaction that closes before the outbound HTTP call below - keeping a transaction
+        // (and its pooled DB connection) open across a real network call to an external
+        // destination is exactly the anti-pattern the outbox's claim/deliver/record-result split
+        // was built to avoid for real deliveries; a burst of concurrent "Send Test" clicks against
+        // a slow/hanging destination shouldn't be able to exhaust the connection pool.
+        NotificationConfiguration configuration = readOnlyTransactionTemplate.execute(status -> {
+            NotificationConfiguration found = notificationConfigurationRepository
+                    .findById(UUID.fromString(configId)).orElse(null);
+            if (found != null) {
+                found.getOrganization().getName();
+            }
+            return found;
+        });
+        if (configuration == null) {
+            return ResponseEntity.notFound().build();
+        }
+        try {
+            notificationTestService.sendTest(configuration);
+            return ResponseEntity.ok().build();
+        } catch (NotificationDeliveryException e) {
+            log.warn("Test notification failed for configuration {}: {}", configId, e.getMessage());
+            return ResponseEntity.status(502).build();
+        }
+    }
+
+    // Lets the create form verify a destination before the configuration has ever
+    // been saved: same rendering/delivery path as the saved-config test above, just
+    // against a NotificationConfiguration that's built in memory and never persisted.
+    @PostMapping("/organization/{orgId}/configuration/test")
+    @PreAuthorize("@notificationConfigurationAccessService.hasManagePermissionForOrganization(authentication, #orgId)")
+    public ResponseEntity<Void> sendAdHocTest(@PathVariable String orgId,
+            @RequestBody NotificationAdHocTestRequest request) {
+        Organization organization = organizationRepository.findById(UUID.fromString(orgId)).orElse(null);
+        if (organization == null) {
+            return ResponseEntity.notFound().build();
+        }
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setOrganization(organization);
+        configuration.setChannelType(request.channelType());
+        configuration.setDestinationUrl(request.destinationUrl());
+        configuration.setSigningSecret(request.signingSecret());
+        try {
+            notificationTestService.sendTest(configuration);
+            return ResponseEntity.ok().build();
+        } catch (NotificationDeliveryException e) {
+            log.warn("Ad-hoc test notification failed for organization {}: {}", orgId, e.getMessage());
+            return ResponseEntity.status(502).build();
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/payload/HmacSigner.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/payload/HmacSigner.java
@@ -1,0 +1,26 @@
+package io.terrakube.api.plugin.notification.payload;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+public final class HmacSigner {
+
+    private static final String ALGORITHM = "HmacSHA256";
+
+    private HmacSigner() {
+    }
+
+    public static String sign(String secret, String payload) {
+        try {
+            Mac mac = Mac.getInstance(ALGORITHM);
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), ALGORITHM));
+            byte[] signature = mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(signature);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to compute HMAC signature", e);
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/payload/NotificationContext.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/payload/NotificationContext.java
@@ -1,6 +1,7 @@
 package io.terrakube.api.plugin.notification.payload;
 
 import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.notification.NotificationMessageStyle;
 
 public record NotificationContext(
         String organizationName,
@@ -9,5 +10,8 @@ public record NotificationContext(
         JobStatus jobStatus,
         String runUrl,
         String commitId,
-        String failureReason) {
+        String failureReason,
+        String configurationName,
+        String workspaceUrl,
+        NotificationMessageStyle messageStyle) {
 }

--- a/api/src/main/java/io/terrakube/api/plugin/notification/payload/NotificationContext.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/payload/NotificationContext.java
@@ -1,0 +1,13 @@
+package io.terrakube.api.plugin.notification.payload;
+
+import io.terrakube.api.rs.job.JobStatus;
+
+public record NotificationContext(
+        String organizationName,
+        String workspaceName,
+        int jobId,
+        JobStatus jobStatus,
+        String runUrl,
+        String commitId,
+        String failureReason) {
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/payload/NotificationPayloadBuilder.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/payload/NotificationPayloadBuilder.java
@@ -1,0 +1,9 @@
+package io.terrakube.api.plugin.notification.payload;
+
+import io.terrakube.api.rs.notification.NotificationChannelType;
+
+public interface NotificationPayloadBuilder {
+    NotificationChannelType supports();
+
+    String build(NotificationContext context);
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/payload/NotificationPayloadRenderer.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/payload/NotificationPayloadRenderer.java
@@ -1,0 +1,29 @@
+package io.terrakube.api.plugin.notification.payload;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import io.terrakube.api.rs.notification.NotificationChannelType;
+
+@Service
+public class NotificationPayloadRenderer {
+
+    private final Map<NotificationChannelType, NotificationPayloadBuilder> buildersByType;
+
+    public NotificationPayloadRenderer(List<NotificationPayloadBuilder> builders) {
+        this.buildersByType = builders.stream()
+                .collect(Collectors.toMap(NotificationPayloadBuilder::supports, Function.identity()));
+    }
+
+    public String render(NotificationChannelType channelType, NotificationContext context) {
+        NotificationPayloadBuilder builder = buildersByType.get(channelType);
+        if (builder == null) {
+            throw new IllegalStateException("No payload builder registered for channel type " + channelType);
+        }
+        return builder.build(context);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/payload/SlackPayloadBuilder.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/payload/SlackPayloadBuilder.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationMessageStyle;
 
 @Component
 public class SlackPayloadBuilder implements NotificationPayloadBuilder {
@@ -29,7 +30,12 @@ public class SlackPayloadBuilder implements NotificationPayloadBuilder {
     public String build(NotificationContext context) {
         String statusLabel = statusLabel(context.jobStatus());
 
+        if (context.messageStyle() == NotificationMessageStyle.SIMPLE) {
+            return buildCompactPayload(context, statusLabel);
+        }
+
         List<Map<String, Object>> blocks = new ArrayList<>();
+
         blocks.add(Map.of(
                 "type", "header",
                 "text", Map.of("type", "plain_text",
@@ -52,12 +58,25 @@ public class SlackPayloadBuilder implements NotificationPayloadBuilder {
                     "text", Map.of("type", "mrkdwn", "text", "*Failure reason:* " + context.failureReason())));
         }
 
-        blocks.add(Map.of(
-                "type", "actions",
-                "elements", List.of(Map.of(
-                        "type", "button",
-                        "text", Map.of("type", "plain_text", "text", "View Run"),
-                        "url", context.runUrl()))));
+        if (context.runUrl() != null && !context.runUrl().isBlank()) {
+            blocks.add(Map.of(
+                    "type", "actions",
+                    "elements", List.of(Map.of(
+                            "type", "button",
+                            "text", Map.of("type", "plain_text", "text", "View Run"),
+                            "url", context.runUrl()))));
+        }
+
+        // A workspace's org-wide and workspace-scoped configurations both fire independently (by
+        // design - see NotificationConfigResolver), so the same job can post more than one Slack
+        // message. Naming which configuration sent each one is what makes that additive behavior
+        // legible instead of looking like an accidental duplicate.
+        if (context.configurationName() != null && !context.configurationName().isBlank()) {
+            blocks.add(Map.of(
+                    "type", "context",
+                    "elements", List.of(Map.of("type", "mrkdwn",
+                            "text", "Sent by notification: *" + context.configurationName() + "*"))));
+        }
 
         // Slack only colors an attachment's left border when blocks are nested inside the
         // legacy "attachments" wrapper - a bare top-level "blocks" array (what chat.postMessage
@@ -66,8 +85,39 @@ public class SlackPayloadBuilder implements NotificationPayloadBuilder {
         attachment.put("color", statusColor(context.jobStatus()));
         attachment.put("blocks", blocks);
 
+        Map<String, Object> payload = new java.util.LinkedHashMap<>();
+        // Incoming Webhooks reject a payload with no top-level "text" (error "no_text"). Once
+        // blocks live inside "attachments" (needed for the color bar), Slack always renders this
+        // as a separate line above the card rather than hiding it - so instead of repeating the
+        // header (a pure duplicate), it carries the "Run notification for org/workspace" link.
+        // That also makes it the text shown in OS/push notification previews and whenever link
+        // previews are collapsed, so a user can still get to the workspace from just that line.
+        payload.put("text", context.workspaceUrl() != null && !context.workspaceUrl().isBlank()
+                ? "Run notification for <" + context.workspaceUrl() + "|" + context.organizationName() + "/"
+                        + context.workspaceName() + ">"
+                : context.workspaceName() + " - " + statusLabel);
+        // Overrides the webhook's default bot name/avatar so messages from different workspaces
+        // posting into the same channel are visually distinguishable at a glance.
+        payload.put("username", context.workspaceName());
+        payload.put("attachments", List.of(attachment));
+
         try {
-            return objectMapper.writeValueAsString(Map.of("attachments", List.of(attachment)));
+            return objectMapper.writeValueAsString(payload);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to render Slack payload", e);
+        }
+    }
+
+    // SIMPLE-style configurations get a single-line ping for every status instead of the full
+    // card - this is a plain top-level "text" message (no blocks/attachments): Slack only shows
+    // the visible-duplicate-line behavior when blocks are present, so the simplest way to avoid
+    // it here is to not use blocks at all, since there's nothing more to say than the one line.
+    private String buildCompactPayload(NotificationContext context, String statusLabel) {
+        Map<String, Object> payload = new java.util.LinkedHashMap<>();
+        payload.put("text", context.workspaceName() + " - " + statusLabel);
+        payload.put("username", context.workspaceName());
+        try {
+            return objectMapper.writeValueAsString(payload);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to render Slack payload", e);
         }

--- a/api/src/main/java/io/terrakube/api/plugin/notification/payload/SlackPayloadBuilder.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/payload/SlackPayloadBuilder.java
@@ -1,0 +1,97 @@
+package io.terrakube.api.plugin.notification.payload;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+
+@Component
+public class SlackPayloadBuilder implements NotificationPayloadBuilder {
+
+    private final ObjectMapper objectMapper;
+
+    public SlackPayloadBuilder(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public NotificationChannelType supports() {
+        return NotificationChannelType.SLACK;
+    }
+
+    @Override
+    public String build(NotificationContext context) {
+        String statusLabel = statusLabel(context.jobStatus());
+
+        List<Map<String, Object>> blocks = new ArrayList<>();
+        blocks.add(Map.of(
+                "type", "header",
+                "text", Map.of("type", "plain_text",
+                        "text", context.workspaceName() + " - " + statusLabel)));
+
+        StringBuilder contextText = new StringBuilder()
+                .append("Organization: ").append(context.organizationName())
+                .append(" | Job: #").append(context.jobId());
+        if (context.commitId() != null && !context.commitId().isBlank()) {
+            contextText.append(" | Commit: ").append(context.commitId());
+        }
+        blocks.add(Map.of(
+                "type", "context",
+                "elements", List.of(Map.of("type", "mrkdwn", "text", contextText.toString()))));
+
+        if (context.jobStatus() == JobStatus.failed && context.failureReason() != null
+                && !context.failureReason().isBlank()) {
+            blocks.add(Map.of(
+                    "type", "section",
+                    "text", Map.of("type", "mrkdwn", "text", "*Failure reason:* " + context.failureReason())));
+        }
+
+        blocks.add(Map.of(
+                "type", "actions",
+                "elements", List.of(Map.of(
+                        "type", "button",
+                        "text", Map.of("type", "plain_text", "text", "View Run"),
+                        "url", context.runUrl()))));
+
+        // Slack only colors an attachment's left border when blocks are nested inside the
+        // legacy "attachments" wrapper - a bare top-level "blocks" array (what chat.postMessage
+        // renders edge-to-edge) has no color affordance at all.
+        Map<String, Object> attachment = new java.util.LinkedHashMap<>();
+        attachment.put("color", statusColor(context.jobStatus()));
+        attachment.put("blocks", blocks);
+
+        try {
+            return objectMapper.writeValueAsString(Map.of("attachments", List.of(attachment)));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to render Slack payload", e);
+        }
+    }
+
+    private String statusLabel(JobStatus status) {
+        return switch (status) {
+            case completed, noChanges -> "✅ Completed";
+            case waitingApproval -> "⚠️ Needs Approval";
+            case failed, rejected, cancelled -> "❌ " + capitalize(status.name());
+            default -> capitalize(status.name());
+        };
+    }
+
+    private String statusColor(JobStatus status) {
+        return switch (status) {
+            case completed, noChanges -> "#2eb67d";
+            case waitingApproval -> "#ecb22e";
+            case failed, rejected, cancelled -> "#e01e5a";
+            default -> "#868686";
+        };
+    }
+
+    private String capitalize(String value) {
+        return value.isEmpty() ? value : Character.toUpperCase(value.charAt(0)) + value.substring(1);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/payload/TeamsPayloadBuilder.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/payload/TeamsPayloadBuilder.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationMessageStyle;
 
 @Component
 public class TeamsPayloadBuilder implements NotificationPayloadBuilder {
@@ -27,14 +28,25 @@ public class TeamsPayloadBuilder implements NotificationPayloadBuilder {
 
     @Override
     public String build(NotificationContext context) {
+        if (context.messageStyle() == NotificationMessageStyle.SIMPLE) {
+            return buildCompactPayload(context);
+        }
+
         List<Map<String, Object>> facts = new ArrayList<>();
         facts.add(Map.of("title", "Organization", "value", context.organizationName()));
         facts.add(Map.of("title", "Job", "value", "#" + context.jobId()));
         if (context.commitId() != null && !context.commitId().isBlank()) {
             facts.add(Map.of("title", "Commit", "value", context.commitId()));
         }
+        if (context.configurationName() != null && !context.configurationName().isBlank()) {
+            facts.add(Map.of("title", "Notification", "value", context.configurationName()));
+        }
 
         List<Map<String, Object>> body = new ArrayList<>();
+        if (context.workspaceUrl() != null && !context.workspaceUrl().isBlank()) {
+            body.add(Map.of("type", "TextBlock", "isSubtle", true, "text", "Run notification for ["
+                    + context.organizationName() + "/" + context.workspaceName() + "](" + context.workspaceUrl() + ")"));
+        }
         body.add(Map.of("type", "TextBlock", "size", "Large", "weight", "Bolder",
                 "text", context.workspaceName() + " - " + context.jobStatus().name()));
         body.add(Map.of("type", "FactSet", "facts", facts));
@@ -44,15 +56,42 @@ public class TeamsPayloadBuilder implements NotificationPayloadBuilder {
                     "text", "Failure reason: " + context.failureReason()));
         }
 
+        Map<String, Object> card = new java.util.LinkedHashMap<>();
+        card.put("$schema", "http://adaptivecards.io/schemas/adaptive-card.json");
+        card.put("type", "AdaptiveCard");
+        card.put("version", "1.4");
+        card.put("body", body);
+        if (context.runUrl() != null && !context.runUrl().isBlank()) {
+            card.put("actions", List.of(Map.of(
+                    "type", "Action.OpenUrl",
+                    "title", "View Run",
+                    "url", context.runUrl())));
+        }
+
+        Map<String, Object> attachment = Map.of(
+                "contentType", "application/vnd.microsoft.card.adaptive",
+                "content", card);
+
+        try {
+            return objectMapper.writeValueAsString(Map.of("type", "message", "attachments", List.of(attachment)));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to render Teams payload", e);
+        }
+    }
+
+    // SIMPLE-style configurations get a single-line card instead of the full one - no facts, no
+    // failure reason, no View Run button. Unlike Slack, Teams' incoming-webhook envelope has no
+    // documented plain-text-only message form, so this still has to be a valid (if minimal)
+    // Adaptive Card rather than a bare "text" field.
+    private String buildCompactPayload(NotificationContext context) {
+        Map<String, Object> body = Map.of("type", "TextBlock", "wrap", true,
+                "text", context.workspaceName() + " - " + context.jobStatus().name());
+
         Map<String, Object> card = Map.of(
                 "$schema", "http://adaptivecards.io/schemas/adaptive-card.json",
                 "type", "AdaptiveCard",
                 "version", "1.4",
-                "body", body,
-                "actions", List.of(Map.of(
-                        "type", "Action.OpenUrl",
-                        "title", "View Run",
-                        "url", context.runUrl())));
+                "body", List.of(body));
 
         Map<String, Object> attachment = Map.of(
                 "contentType", "application/vnd.microsoft.card.adaptive",

--- a/api/src/main/java/io/terrakube/api/plugin/notification/payload/TeamsPayloadBuilder.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/payload/TeamsPayloadBuilder.java
@@ -1,0 +1,67 @@
+package io.terrakube.api.plugin.notification.payload;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+
+@Component
+public class TeamsPayloadBuilder implements NotificationPayloadBuilder {
+
+    private final ObjectMapper objectMapper;
+
+    public TeamsPayloadBuilder(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public NotificationChannelType supports() {
+        return NotificationChannelType.TEAMS;
+    }
+
+    @Override
+    public String build(NotificationContext context) {
+        List<Map<String, Object>> facts = new ArrayList<>();
+        facts.add(Map.of("title", "Organization", "value", context.organizationName()));
+        facts.add(Map.of("title", "Job", "value", "#" + context.jobId()));
+        if (context.commitId() != null && !context.commitId().isBlank()) {
+            facts.add(Map.of("title", "Commit", "value", context.commitId()));
+        }
+
+        List<Map<String, Object>> body = new ArrayList<>();
+        body.add(Map.of("type", "TextBlock", "size", "Large", "weight", "Bolder",
+                "text", context.workspaceName() + " - " + context.jobStatus().name()));
+        body.add(Map.of("type", "FactSet", "facts", facts));
+        if (context.jobStatus() == JobStatus.failed && context.failureReason() != null
+                && !context.failureReason().isBlank()) {
+            body.add(Map.of("type", "TextBlock", "wrap", true,
+                    "text", "Failure reason: " + context.failureReason()));
+        }
+
+        Map<String, Object> card = Map.of(
+                "$schema", "http://adaptivecards.io/schemas/adaptive-card.json",
+                "type", "AdaptiveCard",
+                "version", "1.4",
+                "body", body,
+                "actions", List.of(Map.of(
+                        "type", "Action.OpenUrl",
+                        "title", "View Run",
+                        "url", context.runUrl())));
+
+        Map<String, Object> attachment = Map.of(
+                "contentType", "application/vnd.microsoft.card.adaptive",
+                "content", card);
+
+        try {
+            return objectMapper.writeValueAsString(Map.of("type", "message", "attachments", List.of(attachment)));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to render Teams payload", e);
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/payload/WebhookPayloadBuilder.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/payload/WebhookPayloadBuilder.java
@@ -1,0 +1,42 @@
+package io.terrakube.api.plugin.notification.payload;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.terrakube.api.rs.notification.NotificationChannelType;
+
+@Component
+public class WebhookPayloadBuilder implements NotificationPayloadBuilder {
+
+    private final ObjectMapper objectMapper;
+
+    public WebhookPayloadBuilder(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public NotificationChannelType supports() {
+        return NotificationChannelType.WEBHOOK;
+    }
+
+    @Override
+    public String build(NotificationContext context) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("organization", context.organizationName());
+        body.put("workspace", context.workspaceName());
+        body.put("jobId", context.jobId());
+        body.put("status", context.jobStatus().name());
+        body.put("runUrl", context.runUrl());
+        body.put("commitId", context.commitId());
+        body.put("failureReason", context.failureReason());
+        try {
+            return objectMapper.writeValueAsString(body);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to render webhook payload", e);
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/payload/WebhookPayloadBuilder.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/payload/WebhookPayloadBuilder.java
@@ -31,8 +31,10 @@ public class WebhookPayloadBuilder implements NotificationPayloadBuilder {
         body.put("jobId", context.jobId());
         body.put("status", context.jobStatus().name());
         body.put("runUrl", context.runUrl());
+        body.put("workspaceUrl", context.workspaceUrl());
         body.put("commitId", context.commitId());
         body.put("failureReason", context.failureReason());
+        body.put("configurationName", context.configurationName());
         try {
             return objectMapper.writeValueAsString(body);
         } catch (Exception e) {

--- a/api/src/main/java/io/terrakube/api/plugin/notification/sender/DestinationUrlValidator.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/sender/DestinationUrlValidator.java
@@ -1,0 +1,100 @@
+package io.terrakube.api.plugin.notification.sender;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+// Blocks the notification senders from being used as an SSRF pivot: destinationUrl is set by an
+// authenticated workspace/org admin, but a careless or compromised admin account could still point
+// it at internal infrastructure (a cloud metadata endpoint, an internal admin API, another pod in
+// the cluster) and have the API server make an authenticated-context request to it on their
+// behalf - and the ad-hoc pre-save test endpoint turns that into a free port-scanning oracle
+// (its 200-vs-502 response leaks whether something is listening) unless this runs there too.
+// Resolves the hostname and rejects anything that lands in a private/reserved/loopback/link-local
+// range. Re-checked on every send (not just at config save time) so a DNS record that pointed
+// somewhere public when the config was created can't quietly start resolving internally later -
+// this narrows, but (being a resolve-then-connect check rather than a pinned-IP request) does not
+// fully close, a same-millisecond DNS-rebinding race, which is an accepted tradeoff given the
+// destination is set by an already-authenticated, RBAC-gated admin rather than an arbitrary caller.
+//
+// Blocking is opt-out (io.terrakube.notification.ssrf.blockPrivateNetworks=false)
+// rather than hardcoded, because plenty of self-hosted Terrakube installs legitimately want to
+// notify something on their own private network (an internal ChatOps relay, a webhook aggregator
+// inside the same cluster) - default is blocked (secure by default), matching the multi-tenant
+// SaaS-style trust model this feature is otherwise built around.
+@Component
+public class DestinationUrlValidator {
+
+    private final boolean blockPrivateDestinations;
+
+    public DestinationUrlValidator(
+            @Value("${io.terrakube.notification.ssrf.blockPrivateNetworks:true}") boolean blockPrivateDestinations) {
+        this.blockPrivateDestinations = blockPrivateDestinations;
+    }
+
+    void validate(String channelLabel, String rawUrl) {
+        URI uri;
+        try {
+            uri = new URI(rawUrl);
+        } catch (URISyntaxException | NullPointerException e) {
+            throw blocked(channelLabel, "destination URL is not a valid URI");
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null || !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https"))) {
+            throw blocked(channelLabel, "destination URL must use http or https");
+        }
+        String host = uri.getHost();
+        if (host == null || host.isBlank()) {
+            throw blocked(channelLabel, "destination URL has no host");
+        }
+        if (!blockPrivateDestinations) {
+            return;
+        }
+
+        InetAddress[] addresses;
+        try {
+            addresses = InetAddress.getAllByName(host);
+        } catch (UnknownHostException e) {
+            throw blocked(channelLabel, "destination host could not be resolved");
+        }
+        for (InetAddress address : addresses) {
+            if (isDisallowed(address)) {
+                throw blocked(channelLabel, "destination resolves to a private/reserved address");
+            }
+        }
+    }
+
+    private static boolean isDisallowed(InetAddress address) {
+        if (address.isLoopbackAddress() || address.isLinkLocalAddress() || address.isSiteLocalAddress()
+                || address.isAnyLocalAddress() || address.isMulticastAddress()) {
+            return true;
+        }
+        byte[] bytes = address.getAddress();
+        if (address instanceof Inet4Address && bytes.length == 4) {
+            // 100.64.0.0/10 - carrier-grade NAT shared address space; not covered by any of the
+            // isXxx() helpers above but still not a legitimate public destination.
+            int first = bytes[0] & 0xFF;
+            int second = bytes[1] & 0xFF;
+            if (first == 100 && second >= 64 && second <= 127) {
+                return true;
+            }
+        } else if (bytes.length == 16) {
+            // fc00::/7 - IPv6 unique local addresses. isSiteLocalAddress() only recognizes the
+            // older, deprecated fec0::/10 range, not this one.
+            int first = bytes[0] & 0xFF;
+            if ((first & 0xFE) == 0xFC) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static NotificationDeliveryException blocked(String channelLabel, String reason) {
+        return new NotificationDeliveryException(channelLabel + " delivery blocked: " + reason, null, false);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/sender/HttpDeliveryErrors.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/sender/HttpDeliveryErrors.java
@@ -1,0 +1,61 @@
+package io.terrakube.api.plugin.notification.sender;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
+
+// Shared HTTP failure classification for the Slack/Teams/webhook senders: a 429 or 5xx is the
+// destination (or an intermediary) saying "try again later", so it's retryable and may carry a
+// Retry-After hint; any other 4xx (bad payload, bad/expired webhook URL, auth rejected, etc.) is
+// the destination permanently rejecting this request, so retrying it would just fail the same way
+// forever. Network-level failures (timeout, connection refused, DNS) carry no status code at all
+// and are treated as retryable, since they're usually transient.
+final class HttpDeliveryErrors {
+
+    private HttpDeliveryErrors() {
+    }
+
+    static NotificationDeliveryException fromStatus(String channelLabel, HttpStatusCodeException e) {
+        HttpStatusCode status = e.getStatusCode();
+        boolean retryable = status.value() == 429 || status.is5xxServerError();
+        String message = channelLabel + " endpoint returned status " + status.value();
+        if (!retryable) {
+            return new NotificationDeliveryException(message, e, false);
+        }
+        return new NotificationDeliveryException(message, e, true, parseRetryAfter(e.getResponseHeaders()));
+    }
+
+    static NotificationDeliveryException fromNetworkError(String channelLabel, RestClientException e) {
+        return new NotificationDeliveryException("Failed to deliver " + channelLabel + " notification: " + e.getMessage(),
+                e, true);
+    }
+
+    private static Duration parseRetryAfter(HttpHeaders headers) {
+        if (headers == null) {
+            return null;
+        }
+        String value = headers.getFirst(HttpHeaders.RETRY_AFTER);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        value = value.trim();
+        try {
+            long seconds = Long.parseLong(value);
+            return seconds >= 0 ? Duration.ofSeconds(seconds) : null;
+        } catch (NumberFormatException notDeltaSeconds) {
+            try {
+                ZonedDateTime target = ZonedDateTime.parse(value, DateTimeFormatter.RFC_1123_DATE_TIME);
+                Duration delay = Duration.between(ZonedDateTime.now(target.getZone()), target);
+                return delay.isNegative() ? Duration.ZERO : delay;
+            } catch (DateTimeParseException notHttpDate) {
+                return null;
+            }
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/sender/NotificationDeliveryException.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/sender/NotificationDeliveryException.java
@@ -1,0 +1,37 @@
+package io.terrakube.api.plugin.notification.sender;
+
+import java.time.Duration;
+
+public class NotificationDeliveryException extends RuntimeException {
+
+    private final boolean retryable;
+    private final Duration retryAfter;
+
+    public NotificationDeliveryException(String message) {
+        this(message, null, true, null);
+    }
+
+    public NotificationDeliveryException(String message, Throwable cause) {
+        this(message, cause, true, null);
+    }
+
+    public NotificationDeliveryException(String message, Throwable cause, boolean retryable) {
+        this(message, cause, retryable, null);
+    }
+
+    public NotificationDeliveryException(String message, Throwable cause, boolean retryable, Duration retryAfter) {
+        super(message, cause);
+        this.retryable = retryable;
+        this.retryAfter = retryAfter;
+    }
+
+    public boolean isRetryable() {
+        return retryable;
+    }
+
+    // Non-null only when the destination told us explicitly how long to wait (e.g. a 429/503's
+    // Retry-After header). Null means "use the standard attemptCount-based backoff".
+    public Duration getRetryAfter() {
+        return retryAfter;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/sender/NotificationDeliveryService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/sender/NotificationDeliveryService.java
@@ -1,0 +1,30 @@
+package io.terrakube.api.plugin.notification.sender;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+
+@Service
+public class NotificationDeliveryService {
+
+    private final Map<NotificationChannelType, NotificationSender> sendersByType;
+
+    public NotificationDeliveryService(List<NotificationSender> senders) {
+        this.sendersByType = senders.stream()
+                .collect(Collectors.toMap(NotificationSender::supports, Function.identity()));
+    }
+
+    public void deliver(NotificationConfiguration configuration, String payload) {
+        NotificationSender sender = sendersByType.get(configuration.getChannelType());
+        if (sender == null) {
+            throw new NotificationDeliveryException("No sender registered for channel type " + configuration.getChannelType());
+        }
+        sender.send(configuration, payload);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/sender/NotificationSender.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/sender/NotificationSender.java
@@ -1,0 +1,10 @@
+package io.terrakube.api.plugin.notification.sender;
+
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+
+public interface NotificationSender {
+    NotificationChannelType supports();
+
+    void send(NotificationConfiguration configuration, String payload);
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/sender/SlackSender.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/sender/SlackSender.java
@@ -3,6 +3,7 @@ package io.terrakube.api.plugin.notification.sender;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -41,11 +42,19 @@ public class SlackSender implements NotificationSender {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         try {
-            HttpStatusCode status = restTemplate
-                    .postForEntity(configuration.getDestinationUrl(), new HttpEntity<>(payload, headers), String.class)
-                    .getStatusCode();
+            ResponseEntity<String> response = restTemplate
+                    .postForEntity(configuration.getDestinationUrl(), new HttpEntity<>(payload, headers), String.class);
+            HttpStatusCode status = response.getStatusCode();
             if (!status.is2xxSuccessful()) {
                 throw new NotificationDeliveryException("Slack endpoint returned status " + status.value());
+            }
+            // Incoming Webhooks report payload/config errors (invalid_payload, no_text,
+            // channel_not_found, no_service, ...) as HTTP 200 with a plain-text error body, not a
+            // non-2xx status - the status check above alone would silently record these as
+            // delivered. A genuinely successful call's body is the literal string "ok".
+            String body = response.getBody() == null ? "" : response.getBody().trim();
+            if (!"ok".equals(body)) {
+                throw new NotificationDeliveryException("Slack endpoint rejected the payload: " + body, null, false);
             }
         } catch (HttpStatusCodeException e) {
             throw HttpDeliveryErrors.fromStatus("Slack", e);

--- a/api/src/main/java/io/terrakube/api/plugin/notification/sender/SlackSender.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/sender/SlackSender.java
@@ -1,0 +1,56 @@
+package io.terrakube.api.plugin.notification.sender;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import io.terrakube.api.plugin.proxy.RestTemplateFactory;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+
+@Component
+public class SlackSender implements NotificationSender {
+
+    private final RestTemplate restTemplate;
+    private final DestinationUrlValidator destinationUrlValidator;
+
+    @Autowired
+    public SlackSender(DestinationUrlValidator destinationUrlValidator) {
+        this(RestTemplateFactory.build(), destinationUrlValidator);
+    }
+
+    SlackSender(RestTemplate restTemplate, DestinationUrlValidator destinationUrlValidator) {
+        this.restTemplate = restTemplate;
+        this.destinationUrlValidator = destinationUrlValidator;
+    }
+
+    @Override
+    public NotificationChannelType supports() {
+        return NotificationChannelType.SLACK;
+    }
+
+    @Override
+    public void send(NotificationConfiguration configuration, String payload) {
+        destinationUrlValidator.validate("Slack", configuration.getDestinationUrl());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        try {
+            HttpStatusCode status = restTemplate
+                    .postForEntity(configuration.getDestinationUrl(), new HttpEntity<>(payload, headers), String.class)
+                    .getStatusCode();
+            if (!status.is2xxSuccessful()) {
+                throw new NotificationDeliveryException("Slack endpoint returned status " + status.value());
+            }
+        } catch (HttpStatusCodeException e) {
+            throw HttpDeliveryErrors.fromStatus("Slack", e);
+        } catch (RestClientException e) {
+            throw HttpDeliveryErrors.fromNetworkError("Slack", e);
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/sender/TeamsSender.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/sender/TeamsSender.java
@@ -1,0 +1,56 @@
+package io.terrakube.api.plugin.notification.sender;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import io.terrakube.api.plugin.proxy.RestTemplateFactory;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+
+@Component
+public class TeamsSender implements NotificationSender {
+
+    private final RestTemplate restTemplate;
+    private final DestinationUrlValidator destinationUrlValidator;
+
+    @Autowired
+    public TeamsSender(DestinationUrlValidator destinationUrlValidator) {
+        this(RestTemplateFactory.build(), destinationUrlValidator);
+    }
+
+    TeamsSender(RestTemplate restTemplate, DestinationUrlValidator destinationUrlValidator) {
+        this.restTemplate = restTemplate;
+        this.destinationUrlValidator = destinationUrlValidator;
+    }
+
+    @Override
+    public NotificationChannelType supports() {
+        return NotificationChannelType.TEAMS;
+    }
+
+    @Override
+    public void send(NotificationConfiguration configuration, String payload) {
+        destinationUrlValidator.validate("Teams", configuration.getDestinationUrl());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        try {
+            HttpStatusCode status = restTemplate
+                    .postForEntity(configuration.getDestinationUrl(), new HttpEntity<>(payload, headers), String.class)
+                    .getStatusCode();
+            if (!status.is2xxSuccessful()) {
+                throw new NotificationDeliveryException("Teams endpoint returned status " + status.value());
+            }
+        } catch (HttpStatusCodeException e) {
+            throw HttpDeliveryErrors.fromStatus("Teams", e);
+        } catch (RestClientException e) {
+            throw HttpDeliveryErrors.fromNetworkError("Teams", e);
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/sender/WebhookSender.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/sender/WebhookSender.java
@@ -1,0 +1,62 @@
+package io.terrakube.api.plugin.notification.sender;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import io.terrakube.api.plugin.notification.payload.HmacSigner;
+import io.terrakube.api.plugin.proxy.RestTemplateFactory;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+
+@Component
+public class WebhookSender implements NotificationSender {
+
+    private final RestTemplate restTemplate;
+    private final DestinationUrlValidator destinationUrlValidator;
+
+    @Autowired
+    public WebhookSender(DestinationUrlValidator destinationUrlValidator) {
+        this(RestTemplateFactory.build(), destinationUrlValidator);
+    }
+
+    WebhookSender(RestTemplate restTemplate, DestinationUrlValidator destinationUrlValidator) {
+        this.restTemplate = restTemplate;
+        this.destinationUrlValidator = destinationUrlValidator;
+    }
+
+    @Override
+    public NotificationChannelType supports() {
+        return NotificationChannelType.WEBHOOK;
+    }
+
+    @Override
+    public void send(NotificationConfiguration configuration, String payload) {
+        destinationUrlValidator.validate("Webhook", configuration.getDestinationUrl());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String secret = configuration.getSigningSecret();
+        if (secret != null && !secret.isBlank()) {
+            headers.set("X-Terrakube-Signature", HmacSigner.sign(secret, payload));
+        }
+
+        try {
+            HttpStatusCode status = restTemplate
+                    .postForEntity(configuration.getDestinationUrl(), new HttpEntity<>(payload, headers), String.class)
+                    .getStatusCode();
+            if (!status.is2xxSuccessful()) {
+                throw new NotificationDeliveryException("Webhook endpoint returned status " + status.value());
+            }
+        } catch (HttpStatusCodeException e) {
+            throw HttpDeliveryErrors.fromStatus("Webhook", e);
+        } catch (RestClientException e) {
+            throw HttpDeliveryErrors.fromNetworkError("Webhook", e);
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/proxy/ProxyService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/proxy/ProxyService.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +17,6 @@ import io.terrakube.api.rs.workspace.parameters.Variable;
 import io.terrakube.api.rs.globalvar.Globalvar;
 
 import java.net.URLDecoder;
-import java.time.Duration;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -28,20 +26,13 @@ import java.util.regex.Pattern;
 @Service
 public class ProxyService {
 
-    private final RestTemplate restTemplate = buildRestTemplate();
+    private final RestTemplate restTemplate = RestTemplateFactory.build();
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final WorkspaceRepository workspaceRepository;
     private final VariableRepository variableRepository;
     private final GlobalVarRepository globalVarRepository;
 
     public static final Map<String, String> VARS = new HashMap<>();
-
-    private static RestTemplate buildRestTemplate() {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(Duration.ofSeconds(10));
-        factory.setReadTimeout(Duration.ofSeconds(30));
-        return new RestTemplate(factory);
-    }
 
     public ProxyService(WorkspaceRepository workspaceRepository, VariableRepository variableRepository, GlobalVarRepository globalVarRepository) {
         this.workspaceRepository = workspaceRepository;

--- a/api/src/main/java/io/terrakube/api/plugin/proxy/RestTemplateFactory.java
+++ b/api/src/main/java/io/terrakube/api/plugin/proxy/RestTemplateFactory.java
@@ -1,0 +1,38 @@
+package io.terrakube.api.plugin.proxy;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.time.Duration;
+
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+public final class RestTemplateFactory {
+
+    private RestTemplateFactory() {
+    }
+
+    public static RestTemplate build(Duration connectTimeout, Duration readTimeout) {
+        // Destination URLs are validated against private/loopback/link-local/reserved ranges
+        // before every send (see DestinationUrlValidator), but that check only ever looks at the
+        // configured URL's host - a 3xx response from an allowed public host would otherwise be
+        // followed transparently (HttpURLConnection's instance-follow-redirects defaults to true),
+        // letting an attacker-controlled or compromised destination redirect the request to an
+        // internal address after validation has already passed. Disabling redirects here closes
+        // that bypass; a webhook destination has no legitimate reason to redirect.
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory() {
+            @Override
+            protected void prepareConnection(HttpURLConnection connection, String httpMethod) throws IOException {
+                super.prepareConnection(connection, httpMethod);
+                connection.setInstanceFollowRedirects(false);
+            }
+        };
+        factory.setConnectTimeout(connectTimeout);
+        factory.setReadTimeout(readTimeout);
+        return new RestTemplate(factory);
+    }
+
+    public static RestTemplate build() {
+        return build(Duration.ofSeconds(10), Duration.ofSeconds(30));
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -7,6 +7,7 @@ import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorUnavailableExc
 import io.terrakube.api.plugin.scheduler.job.tcl.model.Flow;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.FlowType;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.ScheduleTemplate;
+import io.terrakube.api.plugin.notification.JobNotificationTrigger;
 import io.terrakube.api.plugin.softdelete.SoftDeleteService;
 import io.terrakube.api.plugin.variable.IncompleteVariableException;
 import io.terrakube.api.plugin.variable.InvalidVariableCategoryException;
@@ -105,6 +106,12 @@ public class ScheduleJob implements org.quartz.Job {
     VariableRepository variableRepository;
     WorkspaceVariableValidationService workspaceVariableValidationService;
     PlatformTransactionManager transactionManager;
+    // Real job status transitions happen here via plain jobRepository.save(), never through an
+    // Elide JSON:API/GraphQL request - JobNotificationHook (an Elide LifeCycleHook) never sees
+    // them. Every save below that follows a job.setStatus(...) call is followed by a call to
+    // this so status-change notifications actually fire for real runs, not just for a job
+    // updated via a direct API PATCH.
+    JobNotificationTrigger jobNotificationTrigger;
 
     @Override
     public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
@@ -156,6 +163,7 @@ public class ScheduleJob implements org.quartz.Job {
             try {
                 job.setStatus(JobStatus.failed);
                 jobRepository.save(job);
+                jobNotificationTrigger.notifyStatusChanged(job);
                 log.warn("Deleting Job Context {} from Quartz", PREFIX_JOB_CONTEXT + job.getId());
                 updateJobStepsWithStatus(job.getId(), JobStatus.failed);
                 updateJobStatusOnVcs(job, JobStatus.unknown);
@@ -332,6 +340,7 @@ public class ScheduleJob implements org.quartz.Job {
                         executorService.execute(job, stepId, flow.get());
                         job.setStatus(JobStatus.queue);
                         jobRepository.save(job);
+                        jobNotificationTrigger.notifyStatusChanged(job);
                         wakeNextDispatchableJob();
                     } catch (ExecutorUnavailableException e) {
                         log.warn("No executor available for Job {} Step {}, will retry: {}", job.getId(), stepId, e.getMessage());
@@ -345,6 +354,7 @@ public class ScheduleJob implements org.quartz.Job {
                         job.setStatus(JobStatus.waitingApproval);
                         job.setApprovalTeam(flow.get().getTeam());
                         jobRepository.save(job);
+                        jobNotificationTrigger.notifyStatusChanged(job);
                         log.info("Waiting Approval for Job {} Step Id {}", job.getId(), stepId);
                     } else {
                         log.info("Auto Approving is enabled for Job {} Step Id {}", job.getId(), stepId);
@@ -355,6 +365,7 @@ public class ScheduleJob implements org.quartz.Job {
                     log.warn("Disable workspace {} updating status to COMPLETED", job.getId());
                     job.setStatus(JobStatus.completed);
                     jobRepository.save(job);
+                    jobNotificationTrigger.notifyStatusChanged(job);
                     log.warn("Disable workspace scheduler for {} {}", job.getWorkspace().getId(), job.getWorkspace().getName());
                     softDeleteService.disableWorkspaceSchedules(job.getWorkspace());
                     log.warn("Update workspace deleted to true");
@@ -376,15 +387,18 @@ public class ScheduleJob implements org.quartz.Job {
                         log.info("Updating Job {} to pending to continue execution", stepId);
                         job.setStatus(JobStatus.pending);
                         jobRepository.save(job);
+                        jobNotificationTrigger.notifyStatusChanged(job);
                     } else {
                         job.setStatus(JobStatus.failed);
                         jobRepository.save(job);
+                        jobNotificationTrigger.notifyStatusChanged(job);
                     }
                     break;
                 case yamlError:
                     log.error("Terrakube Template error, please verify the template definition");
                     job.setStatus(JobStatus.failed);
                     jobRepository.save(job);
+                    jobNotificationTrigger.notifyStatusChanged(job);
                     updateJobStepsWithStatus(job.getId(), JobStatus.failed);
                     updateJobStatusOnVcs(job, JobStatus.unknown);
                     break;
@@ -436,6 +450,7 @@ public class ScheduleJob implements org.quartz.Job {
     private void completeJob(Job job) {
         job.setStatus(JobStatus.completed);
         jobRepository.save(job);
+        jobNotificationTrigger.notifyStatusChanged(job);
         updateJobStatusOnVcs(job, JobStatus.completed);
         postPrCommentIfNeeded(job);
         updateWorkspaceStatus(job);
@@ -502,6 +517,7 @@ public class ScheduleJob implements org.quartz.Job {
         log.error(logMessage, e);
         job.setStatus(JobStatus.failed);
         jobRepository.save(job);
+        jobNotificationTrigger.notifyStatusChanged(job);
         Step step = stepRepository.getReferenceById(UUID.fromString(stepId));
         String message = String.format("Error sending to executor: %s", e.getMessage())
                 .substring(0, Math.min(e.getMessage().length(), 127));
@@ -545,6 +561,7 @@ public class ScheduleJob implements org.quartz.Job {
                 executorService.execute(job, stepId, flow.get());
                 job.setStatus(JobStatus.queue);
                 jobRepository.save(job);
+                jobNotificationTrigger.notifyStatusChanged(job);
                 wakeNextDispatchableJob();
             } catch (ExecutorUnavailableException e) {
                 log.warn("No executor available for Job {} Step {}, will retry: {}", job.getId(), stepId, e.getMessage());
@@ -587,6 +604,7 @@ public class ScheduleJob implements org.quartz.Job {
         job.setStatus(JobStatus.failed);
         job.setOutput(failureMessage);
         jobRepository.save(job);
+        jobNotificationTrigger.notifyStatusChanged(job);
 
         try {
             String stepId = tclService.getCurrentStepId(job);

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJobTrigger.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJobTrigger.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import io.terrakube.api.plugin.notification.JobNotificationTrigger;
 import io.terrakube.api.repository.JobRepository;
 import io.terrakube.api.repository.ScheduleRepository;
 import io.terrakube.api.repository.TemplateRepository;
@@ -36,6 +37,9 @@ public class ScheduleJobTrigger implements org.quartz.Job {
     JobRepository jobRepository;
     TemplateRepository templateRepository;
     ScheduleJobService scheduleJobService;
+    // See ScheduleJob's field of the same name/type: this job's status-setting save() also
+    // bypasses Elide, so JobNotificationHook never fires for it either.
+    JobNotificationTrigger jobNotificationTrigger;
 
     @Transactional
     @Override
@@ -66,6 +70,7 @@ public class ScheduleJobTrigger implements org.quartz.Job {
             job.setUpdatedDate(triggerDate);
 
             job = jobRepository.save(job);
+            jobNotificationTrigger.notifyStatusChanged(job);
             log.info("New jobId: {}", job.getId());
             try {
                 log.info("Creating Job Context: {}", job.getId());

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/notification/NotificationOutboxPollerJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/notification/NotificationOutboxPollerJob.java
@@ -1,0 +1,81 @@
+package io.terrakube.api.plugin.scheduler.notification;
+
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+import io.terrakube.api.plugin.notification.NotificationDispatchService;
+import io.terrakube.api.plugin.notification.NotificationOutboxTransactions;
+import io.terrakube.api.repository.NotificationOutboxRepository;
+import io.terrakube.api.rs.notification.NotificationOutbox;
+import io.terrakube.api.rs.notification.NotificationOutboxStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@DisallowConcurrentExecution
+public class NotificationOutboxPollerJob implements Job {
+
+    private static final int MAX_ATTEMPTS = 3;
+
+    private final NotificationOutboxRepository notificationOutboxRepository;
+    private final NotificationDispatchService notificationDispatchService;
+    private final NotificationOutboxTransactions notificationOutboxTransactions;
+    private final int batchSize;
+    private final long stuckSendingThresholdMillis;
+
+    public NotificationOutboxPollerJob(NotificationOutboxRepository notificationOutboxRepository,
+            NotificationDispatchService notificationDispatchService,
+            NotificationOutboxTransactions notificationOutboxTransactions,
+            @Value("${io.terrakube.notification.poller.batchSize:200}") int batchSize,
+            @Value("${io.terrakube.notification.poller.stuckSendingThresholdMinutes:5}") long stuckSendingThresholdMinutes) {
+        this.notificationOutboxRepository = notificationOutboxRepository;
+        this.notificationDispatchService = notificationDispatchService;
+        this.notificationOutboxTransactions = notificationOutboxTransactions;
+        this.batchSize = batchSize;
+        this.stuckSendingThresholdMillis = stuckSendingThresholdMinutes * 60_000L;
+    }
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        // Quartz's SchedulerFactoryBean instantiates and field-autowires Job instances directly
+        // rather than looking them up from the ApplicationContext, so this class never gets an
+        // AOP proxy of its own - any @Transactional declared directly here would silently never
+        // apply. Both DB-mutating steps below are therefore delegated to
+        // NotificationOutboxTransactions, a real Spring-managed bean whose own proxy the calls
+        // below go through.
+        notificationOutboxTransactions.sweepStuckSendingRows(
+                new Date(System.currentTimeMillis() - stuckSendingThresholdMillis), MAX_ATTEMPTS);
+        dispatchDueRows();
+    }
+
+    private void dispatchDueRows() {
+        List<NotificationOutbox> due = notificationOutboxRepository.findDueForDispatch(NotificationOutboxStatus.PENDING,
+                new Date(), PageRequest.of(0, batchSize));
+
+        int dispatched = 0;
+        for (NotificationOutbox outbox : due) {
+            try {
+                notificationDispatchService.dispatchAsync(outbox.getId());
+                dispatched++;
+            } catch (RejectedExecutionException e) {
+                // The dispatch executor's queue is full - this row is still PENDING (this
+                // submission never claimed it) and will be picked up again on the next tick.
+                log.warn("Notification dispatch executor rejected outbox {}, will retry next poll cycle",
+                        outbox.getId());
+            }
+        }
+        if (dispatched > 0) {
+            log.info("Notification outbox poller dispatched {} pending row(s)", dispatched);
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/notification/NotificationOutboxPollerScheduler.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/notification/NotificationOutboxPollerScheduler.java
@@ -1,0 +1,56 @@
+package io.terrakube.api.plugin.scheduler.notification;
+
+import jakarta.annotation.PostConstruct;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.*;
+import org.springframework.stereotype.Service;
+
+import java.text.ParseException;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+public class NotificationOutboxPollerScheduler {
+
+    private static final String PREFIX_NOTIFICATION_OUTBOX_POLLER = "TerrakubeV2_NotificationOutboxPoller";
+
+    private Scheduler scheduler;
+
+    @PostConstruct
+    public void initNotificationOutboxPoller() {
+        try {
+            log.info("Setup notification outbox poller");
+            JobDetail jobDetail = scheduler.getJobDetail(new JobKey(PREFIX_NOTIFICATION_OUTBOX_POLLER));
+            if (jobDetail != null) {
+                scheduler.deleteJob(new JobKey(PREFIX_NOTIFICATION_OUTBOX_POLLER));
+            }
+            setupNotificationOutboxPoller("0 * * ? * *");
+        } catch (Exception ex) {
+            log.error(ex.getMessage());
+        }
+    }
+
+    public void setupNotificationOutboxPoller(String quartzSchedule) throws ParseException, SchedulerException {
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put("NotificationOutboxPoller", "NotificationOutboxPollerV1");
+
+        JobDetail jobDetail = JobBuilder.newJob().ofType(NotificationOutboxPollerJob.class)
+                .storeDurably()
+                .setJobData(jobDataMap)
+                .withIdentity(PREFIX_NOTIFICATION_OUTBOX_POLLER)
+                .withDescription("NotificationOutboxPollerV1")
+                .build();
+
+        Trigger trigger = TriggerBuilder.newTrigger()
+                .startNow()
+                .forJob(jobDetail)
+                .withIdentity(PREFIX_NOTIFICATION_OUTBOX_POLLER)
+                .withDescription("NotificationOutboxPollerV1")
+                .withSchedule(CronScheduleBuilder.cronSchedule(new CronExpression(quartzSchedule)))
+                .build();
+
+        log.info("Create schedule job trigger for notification outbox poller {}", jobDetail.getKey());
+        scheduler.scheduleJob(jobDetail, trigger);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/notification/NotificationOutboxRetentionJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/notification/NotificationOutboxRetentionJob.java
@@ -1,0 +1,39 @@
+package io.terrakube.api.plugin.scheduler.notification;
+
+import java.util.Date;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.terrakube.api.plugin.notification.NotificationOutboxTransactions;
+
+import lombok.extern.slf4j.Slf4j;
+
+// Runs far less often than NotificationOutboxPollerJob (daily, not every minute) - this is
+// housekeeping, not delivery, so there's no reason to pay a DELETE's cost on the hot dispatch
+// cadence. Same reasoning as NotificationOutboxPollerJob for why the actual DB work is delegated
+// to NotificationOutboxTransactions rather than done directly here: Quartz Jobs never get an AOP
+// proxy of their own, so a @Transactional method declared directly on this class would be a no-op.
+@Slf4j
+@Component
+@DisallowConcurrentExecution
+public class NotificationOutboxRetentionJob implements Job {
+
+    private final NotificationOutboxTransactions notificationOutboxTransactions;
+    private final long retentionMillis;
+
+    public NotificationOutboxRetentionJob(NotificationOutboxTransactions notificationOutboxTransactions,
+            @Value("${io.terrakube.notification.outbox.retentionDays:90}") long retentionDays) {
+        this.notificationOutboxTransactions = notificationOutboxTransactions;
+        this.retentionMillis = retentionDays * 24 * 60 * 60 * 1000L;
+    }
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        notificationOutboxTransactions.pruneTerminalRowsOlderThan(new Date(System.currentTimeMillis() - retentionMillis));
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/notification/NotificationOutboxRetentionScheduler.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/notification/NotificationOutboxRetentionScheduler.java
@@ -1,0 +1,58 @@
+package io.terrakube.api.plugin.scheduler.notification;
+
+import jakarta.annotation.PostConstruct;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.*;
+import org.springframework.stereotype.Service;
+
+import java.text.ParseException;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+public class NotificationOutboxRetentionScheduler {
+
+    private static final String PREFIX_NOTIFICATION_OUTBOX_RETENTION = "TerrakubeV2_NotificationOutboxRetention";
+
+    private Scheduler scheduler;
+
+    @PostConstruct
+    public void initNotificationOutboxRetention() {
+        try {
+            log.info("Setup notification outbox retention sweep");
+            JobDetail jobDetail = scheduler.getJobDetail(new JobKey(PREFIX_NOTIFICATION_OUTBOX_RETENTION));
+            if (jobDetail != null) {
+                scheduler.deleteJob(new JobKey(PREFIX_NOTIFICATION_OUTBOX_RETENTION));
+            }
+            // Once a day at 03:00 - a DELETE sweep has no reason to run on the poller's
+            // once-a-minute cadence.
+            setupNotificationOutboxRetention("0 0 3 * * ?");
+        } catch (Exception ex) {
+            log.error(ex.getMessage());
+        }
+    }
+
+    public void setupNotificationOutboxRetention(String quartzSchedule) throws ParseException, SchedulerException {
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put("NotificationOutboxRetention", "NotificationOutboxRetentionV1");
+
+        JobDetail jobDetail = JobBuilder.newJob().ofType(NotificationOutboxRetentionJob.class)
+                .storeDurably()
+                .setJobData(jobDataMap)
+                .withIdentity(PREFIX_NOTIFICATION_OUTBOX_RETENTION)
+                .withDescription("NotificationOutboxRetentionV1")
+                .build();
+
+        Trigger trigger = TriggerBuilder.newTrigger()
+                .startNow()
+                .forJob(jobDetail)
+                .withIdentity(PREFIX_NOTIFICATION_OUTBOX_RETENTION)
+                .withDescription("NotificationOutboxRetentionV1")
+                .withSchedule(CronScheduleBuilder.cronSchedule(new CronExpression(quartzSchedule)))
+                .build();
+
+        log.info("Create schedule job trigger for notification outbox retention {}", jobDetail.getKey());
+        scheduler.scheduleJob(jobDetail, trigger);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
@@ -58,6 +58,7 @@ import io.terrakube.api.rs.workspace.history.archive.ArchiveType;
 import io.terrakube.api.rs.workspace.parameters.Category;
 import io.terrakube.api.rs.workspace.parameters.Variable;
 import io.terrakube.api.rs.workspace.tag.WorkspaceTag;
+import io.terrakube.api.plugin.notification.JobNotificationTrigger;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.TextStringBuilder;
 import org.quartz.SchedulerException;
@@ -113,6 +114,12 @@ public class RemoteTfeService {
 
     private RbacService rbacService;
 
+    // Real job status transitions happen here via plain jobRepository.save(), never through an
+    // Elide JSON:API/GraphQL request - JobNotificationHook (an Elide LifeCycleHook) never sees
+    // them, so every status-changing save below calls this directly, same as ScheduleJob/
+    // ScheduleJobTrigger.
+    private JobNotificationTrigger jobNotificationTrigger;
+
     public RemoteTfeService(JobRepository jobRepository,
                             ContentRepository contentRepository,
                             OrganizationRepository organizationRepository,
@@ -130,7 +137,7 @@ public class RemoteTfeService {
                             TeamTokenService teamTokenService,
                             ArchiveRepository archiveRepository,
                             AccessRepository accessRepository,
-                            EncryptionService encryptionService, AddressRepository addressRepository, ProjectRepository projectRepository, VariableRepository variableRepository, GlobalVarRepository globalVarRepository, RbacService rbacService) {
+                            EncryptionService encryptionService, AddressRepository addressRepository, ProjectRepository projectRepository, VariableRepository variableRepository, GlobalVarRepository globalVarRepository, RbacService rbacService, JobNotificationTrigger jobNotificationTrigger) {
         this.jobRepository = jobRepository;
         this.contentRepository = contentRepository;
         this.organizationRepository = organizationRepository;
@@ -154,6 +161,7 @@ public class RemoteTfeService {
         this.variableRepository = variableRepository;
         this.globalVarRepository = globalVarRepository;
         this.rbacService = rbacService;
+        this.jobNotificationTrigger = jobNotificationTrigger;
     }
 
     private boolean validateTerrakubeUser(JwtAuthenticationToken currentUser) {
@@ -808,6 +816,7 @@ public class RemoteTfeService {
         job.setPlanChanges(true);
         job.setRefreshOnly(false);
         job = jobRepository.save(job);
+        jobNotificationTrigger.notifyStatusChanged(job);
 
         // dummy step
         Step step = new Step();
@@ -1198,6 +1207,7 @@ public class RemoteTfeService {
         }
 
         job = jobRepository.save(job);
+        jobNotificationTrigger.notifyStatusChanged(job);
         log.info("Job Created");
 
         if(runsData.getData().getAttributes().get("target-addrs") != null) {
@@ -1439,6 +1449,7 @@ public class RemoteTfeService {
                 job.setTcl(cliTemplate.getTcl());
                 job.setStatus(JobStatus.pending);
                 job = jobRepository.save(job);
+                jobNotificationTrigger.notifyStatusChanged(job);
                 log.warn("Update job {} to status PENDING to continue execution", job.getId());
             }
 
@@ -1449,7 +1460,8 @@ public class RemoteTfeService {
                             job.getOrganization().getId().toString(), job.getId(), step.getId()));
                     stepRepository.save(step);
                     job.setStatus(JobStatus.pending);
-                    jobRepository.save(job);
+                    job = jobRepository.save(job);
+                    jobNotificationTrigger.notifyStatusChanged(job);
                     try {
                         scheduleJobService.createJobContextNow(job);
                     } catch (SchedulerException e) {
@@ -1474,7 +1486,8 @@ public class RemoteTfeService {
                         "User does not have permission to discard runs in this workspace");
             }
             job.setStatus(JobStatus.cancelled);
-            jobRepository.save(job);
+            job = jobRepository.save(job);
+            jobNotificationTrigger.notifyStatusChanged(job);
             scheduleJobService.deleteJobContext(job.getId());
         } catch (ParseException | SchedulerException e) {
             log.error(e.getMessage());

--- a/api/src/main/java/io/terrakube/api/repository/NotificationConfigurationRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/NotificationConfigurationRepository.java
@@ -1,0 +1,15 @@
+package io.terrakube.api.repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+
+public interface NotificationConfigurationRepository extends JpaRepository<NotificationConfiguration, UUID> {
+
+    List<NotificationConfiguration> findByWorkspaceIdAndActiveTrue(UUID workspaceId);
+
+    List<NotificationConfiguration> findByOrganizationIdAndWorkspaceIsNullAndActiveTrue(UUID organizationId);
+}

--- a/api/src/main/java/io/terrakube/api/repository/NotificationOutboxRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/NotificationOutboxRepository.java
@@ -1,0 +1,98 @@
+package io.terrakube.api.repository;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import io.terrakube.api.rs.notification.NotificationOutbox;
+import io.terrakube.api.rs.notification.NotificationOutboxStatus;
+
+// Every bulk UPDATE below uses @Modifying(clearAutomatically = true): a bulk UPDATE bypasses
+// Hibernate's first-level cache, so without clearing, an entity already loaded in the caller's
+// persistence context would keep showing its pre-update values on a subsequent find/query.
+public interface NotificationOutboxRepository extends JpaRepository<NotificationOutbox, UUID> {
+
+    List<NotificationOutbox> findByJob_Workspace_IdOrderByCreatedDateDesc(UUID workspaceId, Pageable pageable);
+
+    List<NotificationOutbox> findByJob_Workspace_IdAndJob_IdInOrderByCreatedDateDesc(UUID workspaceId,
+            List<Integer> jobIds);
+
+    // Ownership check for the manual-retry endpoint: confirms the delivery actually belongs to
+    // the workspace in the request path before rearming it, so a caller who can manage
+    // notifications for their own workspace can't retry (or probe the existence of) a delivery
+    // belonging to a workspace they have no access to just by guessing its UUID.
+    boolean existsByIdAndJob_Workspace_Id(UUID id, UUID workspaceId);
+
+    // Atomic claim: flips PENDING -> SENDING and bumps bookkeeping in one statement, so two
+    // concurrent callers on the same row (an overlapping poller cycle, another pod, the
+    // immediate-dispatch path racing the poller) can't both pass a check-then-act race - only
+    // one UPDATE can match the WHERE status = :expectedStatus predicate, so only one caller
+    // ever sees rows == 1 and proceeds to actually deliver. The HTTP call itself happens with
+    // no transaction/lock held once this returns.
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE notification_outbox o SET o.status = :newStatus, o.attemptCount = o.attemptCount + 1, "
+            + "o.lastAttemptAt = :now, o.updatedDate = :now "
+            + "WHERE o.id = :id AND o.status = :expectedStatus")
+    int claimForDelivery(@Param("id") UUID id, @Param("expectedStatus") NotificationOutboxStatus expectedStatus,
+            @Param("newStatus") NotificationOutboxStatus newStatus, @Param("now") Date now);
+
+    // Keyed on the exact lastAttemptAt observed at claim time (not just id+SENDING) so a result
+    // from a delivery attempt that outlived the stuck-row sweep's reclaim window is discarded
+    // instead of clobbering whatever a later claimant already recorded for this row.
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE notification_outbox o SET o.status = :newStatus, o.lastError = :lastError, "
+            + "o.nextAttemptAt = :nextAttemptAt, o.updatedDate = :now "
+            + "WHERE o.id = :id AND o.status = :expectedStatus AND o.lastAttemptAt = :expectedLastAttemptAt")
+    int recordDeliveryResult(@Param("id") UUID id, @Param("expectedStatus") NotificationOutboxStatus expectedStatus,
+            @Param("expectedLastAttemptAt") Date expectedLastAttemptAt, @Param("newStatus") NotificationOutboxStatus newStatus,
+            @Param("lastError") String lastError, @Param("nextAttemptAt") Date nextAttemptAt, @Param("now") Date now);
+
+    // Bounded, fairness-ordered (oldest first) replacement for the old pair of unbounded,
+    // unordered finders. nextAttemptAt is null for a row that has never failed with a
+    // server-supplied delay (e.g. Retry-After); such a row is due as soon as it's PENDING.
+    @Query("SELECT o FROM notification_outbox o WHERE o.status = :status "
+            + "AND (o.nextAttemptAt IS NULL OR o.nextAttemptAt <= :now) ORDER BY o.createdDate ASC")
+    List<NotificationOutbox> findDueForDispatch(@Param("status") NotificationOutboxStatus status,
+            @Param("now") Date now, Pageable pageable);
+
+    // Crash recovery: a pod that claimed a row (PENDING -> SENDING) and died mid-HTTP-call
+    // leaves it stuck in SENDING forever without this. attemptCount is NOT bumped again here -
+    // the attempt was already counted at claim time.
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE notification_outbox o SET o.status = :pending, o.updatedDate = :cutoffQueriedAt "
+            + "WHERE o.status = :sending AND o.lastAttemptAt < :cutoff AND o.attemptCount < :maxAttempts")
+    int reclaimStuckSendingRows(@Param("sending") NotificationOutboxStatus sending,
+            @Param("pending") NotificationOutboxStatus pending, @Param("cutoff") Date cutoff,
+            @Param("maxAttempts") int maxAttempts, @Param("cutoffQueriedAt") Date cutoffQueriedAt);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE notification_outbox o SET o.status = :failed, o.lastError = :note, o.updatedDate = :cutoffQueriedAt "
+            + "WHERE o.status = :sending AND o.lastAttemptAt < :cutoff AND o.attemptCount >= :maxAttempts")
+    int failStuckSendingRowsAtMaxAttempts(@Param("sending") NotificationOutboxStatus sending,
+            @Param("failed") NotificationOutboxStatus failed, @Param("cutoff") Date cutoff,
+            @Param("maxAttempts") int maxAttempts, @Param("note") String note,
+            @Param("cutoffQueriedAt") Date cutoffQueriedAt);
+
+    // Manual retry: only re-arms a row that is actually FAILED, via the same conditional-update
+    // discipline as the claim/record steps above rather than read-then-write.
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE notification_outbox o SET o.status = :pending, o.attemptCount = 0, o.lastError = null, "
+            + "o.nextAttemptAt = null, o.updatedDate = :now "
+            + "WHERE o.id = :id AND o.status = :failed")
+    int rearmFailedForRetry(@Param("id") UUID id, @Param("failed") NotificationOutboxStatus failed,
+            @Param("pending") NotificationOutboxStatus pending, @Param("now") Date now);
+
+    // Retention sweep: only ever targets rows in a terminal state (SENT/FAILED) older than the
+    // cutoff - a row still PENDING/SENDING is mid-flight regardless of age and must never be
+    // deleted out from under the dispatch pipeline.
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM notification_outbox o WHERE o.status IN :terminalStatuses AND o.createdDate < :cutoff")
+    int deleteTerminalRowsCreatedBefore(@Param("terminalStatuses") List<NotificationOutboxStatus> terminalStatuses,
+            @Param("cutoff") Date cutoff);
+}

--- a/api/src/main/java/io/terrakube/api/repository/NotificationTriggerRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/NotificationTriggerRepository.java
@@ -1,0 +1,10 @@
+package io.terrakube.api.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import io.terrakube.api.rs.notification.NotificationTrigger;
+
+public interface NotificationTriggerRepository extends JpaRepository<NotificationTrigger, UUID> {
+}

--- a/api/src/main/java/io/terrakube/api/rs/Organization.java
+++ b/api/src/main/java/io/terrakube/api/rs/Organization.java
@@ -7,6 +7,7 @@ import io.terrakube.api.rs.globalvar.Globalvar;
 import io.terrakube.api.rs.hooks.organization.OrganizationManageHook;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.module.Module;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
 import io.terrakube.api.rs.project.Project;
 import io.terrakube.api.rs.provider.Provider;
 import io.terrakube.api.rs.ssh.Ssh;
@@ -109,4 +110,8 @@ public class Organization {
 
     @Column(name = "icon")
     private String icon;
+
+    @UpdatePermission(expression = "user belongs organization")
+    @OneToMany(mappedBy = "organization")
+    private List<NotificationConfiguration> notificationConfiguration;
 }

--- a/api/src/main/java/io/terrakube/api/rs/checks/notification/NotificationConfigurationAccessSupport.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/notification/NotificationConfigurationAccessSupport.java
@@ -1,0 +1,84 @@
+package io.terrakube.api.rs.checks.notification;
+
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import io.terrakube.api.plugin.security.groups.GroupService;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.team.Team;
+import io.terrakube.api.rs.workspace.Workspace;
+import io.terrakube.api.rs.workspace.access.Access;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+// Shared team/access-tier lookups behind both TeamManageNotificationConfiguration (write access,
+// and read access to workspace-scoped rows) and TeamReadNotificationConfiguration (read access to
+// org-wide default rows for anyone who manages at least one workspace they apply to).
+abstract class NotificationConfigurationAccessSupport extends OperationCheck<NotificationConfiguration> {
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    GroupService groupService;
+
+    @Autowired
+    RbacService rbacService;
+
+    @Autowired
+    MembershipService membershipService;
+
+    protected boolean hasOrgWideAccess(Organization organization, RequestScope requestScope) {
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
+        List<Team> teamList = organization.getTeam();
+        for (Team team : teamList) {
+            boolean isMember = isServiceAccount
+                    ? groupService.isServiceMember(requestScope.getUser(), team.getName())
+                    : groupService.isMember(requestScope.getUser(), team.getName());
+            if (isMember && rbacService.canManageWorkspace(team)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected boolean hasWorkspaceLevelAccess(Workspace workspace, RequestScope requestScope) {
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
+        List<Access> accessList = workspace.getAccess();
+        if (accessList == null) {
+            return false;
+        }
+        for (Access access : accessList) {
+            boolean isMember = isServiceAccount
+                    ? groupService.isServiceMember(requestScope.getUser(), access.getName())
+                    : groupService.isMember(requestScope.getUser(), access.getName());
+            if (isMember && rbacService.canManageWorkspace(access)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected boolean hasProjectLevelAccess(Workspace workspace, RequestScope requestScope) {
+        Project project = workspace.getProject();
+        if (project == null || project.getProjectAccess() == null || project.getProjectAccess().isEmpty()) {
+            return false;
+        }
+        return membershipService.checkProjectMembership(
+                requestScope.getUser(), project.getProjectAccess(), rbacService::canManageWorkspace);
+    }
+
+    protected boolean canManageAtLeastOneWorkspaceIn(Organization organization, RequestScope requestScope) {
+        List<Workspace> workspaces = organization.getWorkspace();
+        if (workspaces == null) {
+            return false;
+        }
+        return workspaces.stream()
+                .anyMatch(ws -> hasWorkspaceLevelAccess(ws, requestScope) || hasProjectLevelAccess(ws, requestScope));
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/notification/ReadNotificationSigningSecret.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/notification/ReadNotificationSigningSecret.java
@@ -1,0 +1,22 @@
+package io.terrakube.api.rs.checks.notification;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import lombok.extern.slf4j.Slf4j;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(ReadNotificationSigningSecret.RULE)
+public class ReadNotificationSigningSecret extends OperationCheck<NotificationConfiguration> {
+    public static final String RULE = "read notification signing secret";
+
+    @Override
+    public boolean ok(NotificationConfiguration configuration, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("user view notification signing secret {}", configuration.getId());
+        return false;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/notification/TeamManageNotificationConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/notification/TeamManageNotificationConfiguration.java
@@ -1,0 +1,42 @@
+package io.terrakube.api.rs.checks.notification;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import lombok.extern.slf4j.Slf4j;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.workspace.Workspace;
+
+import java.util.Optional;
+
+/**
+ * Mirrors Workspace's own three-tier update permission ("team manage workspace
+ * OR team project limited manage workspace OR team limited manage workspace")
+ * for workspace-scoped configurations, so anyone who can otherwise manage a
+ * workspace - whether via blanket org-wide team access, a project-level grant,
+ * or a workspace-level grant - can also manage its notifications. Org-scoped
+ * configurations (no workspace) only have the org-wide tier to check against;
+ * see TeamReadNotificationConfiguration for the more permissive rule that
+ * governs read access to those org-wide rows.
+ */
+@Slf4j
+@SecurityCheck(TeamManageNotificationConfiguration.RULE)
+public class TeamManageNotificationConfiguration extends NotificationConfigurationAccessSupport {
+    public static final String RULE = "team manage notification configuration";
+
+    @Override
+    public boolean ok(NotificationConfiguration configuration, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team manage notification configuration {}", configuration.getId());
+        Workspace workspace = configuration.getWorkspace();
+        Organization organization = workspace != null ? workspace.getOrganization() : configuration.getOrganization();
+
+        if (hasOrgWideAccess(organization, requestScope)) {
+            return true;
+        }
+        if (workspace == null) {
+            return false;
+        }
+        return hasWorkspaceLevelAccess(workspace, requestScope) || hasProjectLevelAccess(workspace, requestScope);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/notification/TeamReadNotificationConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/notification/TeamReadNotificationConfiguration.java
@@ -1,0 +1,41 @@
+package io.terrakube.api.rs.checks.notification;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import lombok.extern.slf4j.Slf4j;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.workspace.Workspace;
+
+import java.util.Optional;
+
+/**
+ * Read access to NotificationConfiguration rows. Workspace-scoped rows use the same tiers as
+ * TeamManageNotificationConfiguration. Org-wide default rows (no workspace) are additionally
+ * readable by anyone who manages at least one workspace in that organization - not just org-wide
+ * managers - because NotificationConfigResolver applies no permission filter of its own: an
+ * org-wide default notification fires for every workspace in the org regardless of who can see
+ * it here, so a workspace/project-level manager who can't see it would otherwise be misled into
+ * thinking no organization-wide defaults apply to a workspace they manage.
+ */
+@Slf4j
+@SecurityCheck(TeamReadNotificationConfiguration.RULE)
+public class TeamReadNotificationConfiguration extends NotificationConfigurationAccessSupport {
+    public static final String RULE = "team read notification configuration";
+
+    @Override
+    public boolean ok(NotificationConfiguration configuration, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        log.debug("team read notification configuration {}", configuration.getId());
+        Workspace workspace = configuration.getWorkspace();
+        Organization organization = workspace != null ? workspace.getOrganization() : configuration.getOrganization();
+
+        if (hasOrgWideAccess(organization, requestScope)) {
+            return true;
+        }
+        if (workspace != null) {
+            return hasWorkspaceLevelAccess(workspace, requestScope) || hasProjectLevelAccess(workspace, requestScope);
+        }
+        return canManageAtLeastOneWorkspaceIn(organization, requestScope);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/hooks/notification/JobNotificationHook.java
+++ b/api/src/main/java/io/terrakube/api/rs/hooks/notification/JobNotificationHook.java
@@ -1,0 +1,94 @@
+package io.terrakube.api.rs.hooks.notification;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.RejectedExecutionException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding.Operation;
+import com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase;
+import com.yahoo.elide.core.lifecycle.LifeCycleHook;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+
+import io.terrakube.api.plugin.notification.JobNotificationTrigger;
+import io.terrakube.api.plugin.notification.NotificationDispatchService;
+import io.terrakube.api.rs.job.Job;
+
+import lombok.extern.slf4j.Slf4j;
+
+// Covers job status changes that happen as an actual Elide JSON:API/GraphQL UPDATE (e.g. a
+// direct API PATCH). Most real run status transitions (queue -> pending -> running -> ...) never
+// go through Elide at all - see JobNotificationTrigger's javadoc - so ScheduleJob/ScheduleJobTrigger
+// call JobNotificationTrigger.notifyStatusChanged() directly instead of relying on this hook.
+@Slf4j
+@Component
+public class JobNotificationHook implements LifeCycleHook<Job> {
+
+    @Autowired
+    JobNotificationTrigger jobNotificationTrigger;
+
+    @Autowired
+    NotificationDispatchService notificationDispatchService;
+
+    // Keyed by job id (not a flat list) because a single Elide transaction can update more than
+    // one Job entity's status on the same thread - Elide fires PRECOMMIT/POSTCOMMIT once per
+    // updated entity, so a flat, reset-on-every-PRECOMMIT list would have a second job's
+    // PRECOMMIT overwrite the first job's still-undispatched outbox IDs before its POSTCOMMIT
+    // ever ran.
+    private static final ThreadLocal<Map<Integer, List<UUID>>> PENDING_OUTBOX_IDS_BY_JOB = ThreadLocal
+            .withInitial(HashMap::new);
+
+    @Override
+    public void execute(Operation operation, TransactionPhase phase, Job job, RequestScope requestScope,
+            Optional<ChangeSpec> changes) {
+        if (operation != Operation.UPDATE || job.getWorkspace() == null) {
+            return;
+        }
+        switch (phase) {
+            case PRECOMMIT -> handlePrecommit(job);
+            case POSTCOMMIT -> handlePostcommit(job);
+            default -> {
+            }
+        }
+    }
+
+    private void handlePrecommit(Job job) {
+        // Entry per job id (not a reset of a single shared slot) so a prior PRECOMMIT for a
+        // DIFFERENT job on this thread whose POSTCOMMIT hasn't run yet keeps its own pending
+        // outbox IDs. A prior PRECOMMIT for the SAME job id whose POSTCOMMIT never ran (e.g. the
+        // transaction rolled back) is still safely overwritten here, since it can't have any
+        // rows worth dispatching left over.
+        PENDING_OUTBOX_IDS_BY_JOB.get().put(job.getId(), jobNotificationTrigger.enqueue(job));
+    }
+
+    private void handlePostcommit(Job job) {
+        Map<Integer, List<UUID>> pending = PENDING_OUTBOX_IDS_BY_JOB.get();
+        List<UUID> outboxIds = pending.remove(job.getId());
+        try {
+            if (outboxIds == null) {
+                return;
+            }
+            for (UUID outboxId : outboxIds) {
+                try {
+                    notificationDispatchService.dispatchAsync(outboxId);
+                } catch (RejectedExecutionException e) {
+                    // The dispatch executor's queue is full - the row is still PENDING (this
+                    // submission never claimed it), so the outbox poller will pick it up on its
+                    // next tick. Never let this escape into the Elide POSTCOMMIT lifecycle.
+                    log.warn("Notification dispatch executor rejected outbox {}, will be picked up by the poller",
+                            outboxId);
+                }
+            }
+        } finally {
+            if (pending.isEmpty()) {
+                PENDING_OUTBOX_IDS_BY_JOB.remove();
+            }
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/Job.java
@@ -5,6 +5,7 @@ import java.util.List;
 import io.terrakube.api.plugin.security.audit.GenericAuditFields;
 import io.terrakube.api.rs.Organization;
 import io.terrakube.api.rs.hooks.job.JobManageHook;
+import io.terrakube.api.rs.hooks.notification.JobNotificationHook;
 import io.terrakube.api.rs.job.address.Address;
 import io.terrakube.api.rs.job.step.Step;
 import io.terrakube.api.rs.workspace.Workspace;
@@ -51,6 +52,8 @@ public class Job extends GenericAuditFields {
     private String comments;
 
     @UpdatePermission(expression = "team approve job OR team approve job rbac OR team limited approve job OR team project limited approve job OR user is a super service")
+    @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE, phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT, hook = JobNotificationHook.class)
+    @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = JobNotificationHook.class)
     @Enumerated(EnumType.STRING)
     private JobStatus status = JobStatus.pending;
 

--- a/api/src/main/java/io/terrakube/api/rs/notification/NotificationChannelType.java
+++ b/api/src/main/java/io/terrakube/api/rs/notification/NotificationChannelType.java
@@ -1,0 +1,7 @@
+package io.terrakube.api.rs.notification;
+
+public enum NotificationChannelType {
+    SLACK,
+    TEAMS,
+    WEBHOOK
+}

--- a/api/src/main/java/io/terrakube/api/rs/notification/NotificationConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/rs/notification/NotificationConfiguration.java
@@ -8,6 +8,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import io.terrakube.api.plugin.security.audit.GenericAuditFields;
 import io.terrakube.api.rs.IdConverter;
 import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.template.Template;
 import io.terrakube.api.rs.workspace.Workspace;
 
 import com.yahoo.elide.annotation.CreatePermission;
@@ -26,6 +27,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
@@ -82,8 +86,24 @@ public class NotificationConfiguration extends GenericAuditFields {
 
     private boolean active = true;
 
+    // DETAILED renders the full card (org/job/commit, View Run button, sent-by footer) for every
+    // status; SIMPLE renders a single-line ping instead. Defaults to DETAILED - not tied to job
+    // status, so the same choice applies uniformly across the run's lifecycle rather than this
+    // code silently deciding which statuses deserve detail.
+    @Column(name = "message_style")
+    @Enumerated(EnumType.STRING)
+    private NotificationMessageStyle messageStyle = NotificationMessageStyle.DETAILED;
+
     @OneToMany(mappedBy = "configuration", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<NotificationTrigger> triggers;
+
+    // Empty/null means "applies to every template" - this only ever narrows which templates a
+    // configuration fires for (see JobNotificationTrigger), it never widens it.
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "notification_configuration_template",
+            joinColumns = @JoinColumn(name = "configuration_id"),
+            inverseJoinColumns = @JoinColumn(name = "template_id"))
+    private List<Template> templates;
 
     // Elide's nested-URL relationship inference only populates the immediate parent
     // (workspace, for organization/{orgId}/workspace/{wsId}/notificationConfiguration)

--- a/api/src/main/java/io/terrakube/api/rs/notification/NotificationConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/rs/notification/NotificationConfiguration.java
@@ -81,6 +81,7 @@ public class NotificationConfiguration extends GenericAuditFields {
     @Column(name = "destination_url")
     private String destinationUrl;
 
+    @ReadPermission(expression = "read notification signing secret")
     @Column(name = "signing_secret")
     private String signingSecret;
 

--- a/api/src/main/java/io/terrakube/api/rs/notification/NotificationConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/rs/notification/NotificationConfiguration.java
@@ -1,0 +1,101 @@
+package io.terrakube.api.rs.notification;
+
+import java.sql.Types;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import io.terrakube.api.plugin.security.audit.GenericAuditFields;
+import io.terrakube.api.rs.IdConverter;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.workspace.Workspace;
+
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.DeletePermission;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.UpdatePermission;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.Getter;
+import lombok.Setter;
+
+@Include
+@Getter
+@Setter
+@ReadPermission(expression = "team read notification configuration")
+@CreatePermission(expression = "team manage notification configuration")
+@UpdatePermission(expression = "team manage notification configuration")
+@DeletePermission(expression = "team manage notification configuration")
+@Entity(name = "notification_configuration")
+public class NotificationConfiguration extends GenericAuditFields {
+
+    @Id
+    @JdbcTypeCode(Types.VARCHAR)
+    @Convert(converter = IdConverter.class)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private String name;
+
+    // Plain @Column (not @Lob) mapped to a "text" column - see NotificationOutbox for why @Lob
+    // is avoided here: it maps to PostgreSQL's oid-backed Large Object storage, which requires
+    // every read to happen inside a real (non-autocommit) transaction.
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Organization organization;
+
+    // EAGER, not LAZY: reading configuration.getWorkspace().getId() through a plain Java getter
+    // (e.g. from TeamManageNotificationConfiguration's permission check) returns the correct id
+    // off an uninitialized Hibernate proxy just fine, but Elide's GraphQL serialization of the
+    // nested "workspace { edges { node { id } } }" relationship does not go through that getter -
+    // it reads the proxy's own backing id field directly, which is unset until the proxy is
+    // triggered, and renders as the literal string "null" instead of the real UUID or JSON null.
+    // Eager fetch means there's a fully-populated Workspace object by serialization time, not a
+    // lazy proxy, so there's no uninitialized field for that path to read.
+    @ManyToOne(fetch = FetchType.EAGER)
+    private Workspace workspace;
+
+    @Column(name = "channel_type")
+    @Enumerated(EnumType.STRING)
+    private NotificationChannelType channelType;
+
+    @Column(name = "destination_url")
+    private String destinationUrl;
+
+    @Column(name = "signing_secret")
+    private String signingSecret;
+
+    private boolean active = true;
+
+    @OneToMany(mappedBy = "configuration", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    private List<NotificationTrigger> triggers;
+
+    // Elide's nested-URL relationship inference only populates the immediate parent
+    // (workspace, for organization/{orgId}/workspace/{wsId}/notificationConfiguration)
+    // - it doesn't also walk up to set organization, even though the column is
+    // NOT NULL. Derive it from the workspace whenever the client didn't set it
+    // directly (the org-scoped create path, organization/{orgId}/notificationConfiguration,
+    // already sets it from its own immediate parent).
+    @PrePersist
+    @PreUpdate
+    private void syncOrganizationFromWorkspace() {
+        if (organization == null && workspace != null) {
+            organization = workspace.getOrganization();
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/notification/NotificationMessageStyle.java
+++ b/api/src/main/java/io/terrakube/api/rs/notification/NotificationMessageStyle.java
@@ -1,0 +1,6 @@
+package io.terrakube.api.rs.notification;
+
+public enum NotificationMessageStyle {
+    DETAILED,
+    SIMPLE
+}

--- a/api/src/main/java/io/terrakube/api/rs/notification/NotificationOutbox.java
+++ b/api/src/main/java/io/terrakube/api/rs/notification/NotificationOutbox.java
@@ -1,0 +1,70 @@
+package io.terrakube.api.rs.notification;
+
+import java.sql.Types;
+import java.util.Date;
+import java.util.UUID;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import io.terrakube.api.plugin.security.audit.GenericAuditFields;
+import io.terrakube.api.rs.IdConverter;
+import io.terrakube.api.rs.job.Job;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity(name = "notification_outbox")
+public class NotificationOutbox extends GenericAuditFields {
+
+    @Id
+    @JdbcTypeCode(Types.VARCHAR)
+    @Convert(converter = IdConverter.class)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Job job;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private NotificationConfiguration configuration;
+
+    // Plain @Column, not @Lob: @Lob maps a String to PostgreSQL's true oid-backed Large Object
+    // storage here, which requires every read to happen inside a real (non-autocommit)
+    // transaction - the outbox poller's findDueForDispatch() runs with no surrounding
+    // transaction (a plain repository query call from a Quartz job), so every poll tick threw
+    // "Large Objects may not be used in auto-commit mode." A plain text column has no such
+    // requirement and, unlike a Java in-memory Lob illusion, is PostgreSQL's native
+    // unbounded-length string type anyway - see changelog-2.33.0-notification.xml.
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationOutboxStatus status = NotificationOutboxStatus.PENDING;
+
+    @Column(name = "attempt_count")
+    private int attemptCount = 0;
+
+    @Column(name = "last_attempt_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date lastAttemptAt;
+
+    // Null means "due as soon as picked up" (first attempt, or a retryable failure whose
+    // backoff is purely a function of attemptCount). Set explicitly when a failure carries
+    // a server-supplied delay (e.g. Slack's Retry-After on 429) that must not be undercut
+    // by the fixed attemptCount-based backoff.
+    @Column(name = "next_attempt_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date nextAttemptAt;
+
+    @Column(name = "last_error")
+    private String lastError;
+}

--- a/api/src/main/java/io/terrakube/api/rs/notification/NotificationOutboxStatus.java
+++ b/api/src/main/java/io/terrakube/api/rs/notification/NotificationOutboxStatus.java
@@ -1,0 +1,8 @@
+package io.terrakube.api.rs.notification;
+
+public enum NotificationOutboxStatus {
+    PENDING,
+    SENDING,
+    SENT,
+    FAILED
+}

--- a/api/src/main/java/io/terrakube/api/rs/notification/NotificationTrigger.java
+++ b/api/src/main/java/io/terrakube/api/rs/notification/NotificationTrigger.java
@@ -1,0 +1,43 @@
+package io.terrakube.api.rs.notification;
+
+import java.sql.Types;
+import java.util.UUID;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import io.terrakube.api.plugin.security.audit.GenericAuditFields;
+import io.terrakube.api.rs.IdConverter;
+import io.terrakube.api.rs.job.JobStatus;
+
+import com.yahoo.elide.annotation.Include;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Include
+@Entity(name = "notification_trigger")
+public class NotificationTrigger extends GenericAuditFields {
+    @Id
+    @JdbcTypeCode(Types.VARCHAR)
+    @Convert(converter = IdConverter.class)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "job_status")
+    @Enumerated(EnumType.STRING)
+    private JobStatus jobStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private NotificationConfiguration configuration;
+}

--- a/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
@@ -10,6 +10,7 @@ import io.terrakube.api.rs.collection.Reference;
 import io.terrakube.api.rs.hooks.workspace.WorkspaceManageHook;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
 import io.terrakube.api.rs.project.Project;
 import io.terrakube.api.rs.ssh.Ssh;
 import io.terrakube.api.rs.vcs.Vcs;
@@ -144,6 +145,9 @@ public class Workspace extends GenericAuditFields {
     
     @OneToOne(mappedBy = "workspace", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private Webhook webhook;
+
+    @OneToMany(mappedBy = "workspace", fetch = FetchType.LAZY)
+    private List<NotificationConfiguration> notificationConfiguration;
 
     @OneToMany(mappedBy = "workspace", fetch = FetchType.LAZY)
     private List<Reference> reference;

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -95,6 +95,11 @@ io.terrakube.ui.url=${TerrakubeUiURL}
 spring.quartz.job-store-type=jdbc
 spring.quartz.jdbc.initialize-schema=never
 
+####################
+#NOTIFICATION SETUP#
+####################
+io.terrakube.notification.ssrf.blockPrivateNetworks=true
+
 ##############
 #EXECUTOR URL#
 ##############

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -94,6 +94,28 @@ io.terrakube.ui.url=${TerrakubeUiURL}
 ##############
 spring.quartz.job-store-type=jdbc
 spring.quartz.jdbc.initialize-schema=never
+# Without isClustered=true, a JDBC job store alone does NOT coordinate across API
+# replicas: each pod runs its own independent scheduler and would separately fire
+# every job on its own schedule (e.g. the notification outbox poller, the repo
+# webhook sync sweep), duplicating work. instanceId=AUTO lets Quartz derive a unique
+# ID per JVM so the cluster can tell pods apart.
+spring.quartz.properties.org.quartz.jobStore.isClustered=true
+spring.quartz.properties.org.quartz.scheduler.instanceId=AUTO
+spring.quartz.properties.org.quartz.jobStore.clusterCheckinInterval=20000
+
+####################
+#NOTIFICATION SETUP#
+####################
+# Dispatch pool is bounded so a burst of deliveries can't spawn unbounded threads competing for
+# the app's DB connection pool. SSRF protection blocks private/loopback/link-local destinations by
+# default; self-hosted deployments that intentionally target an internal receiver can opt out.
+io.terrakube.notification.dispatch.executor.corePoolSize=10
+io.terrakube.notification.dispatch.executor.maxPoolSize=20
+io.terrakube.notification.dispatch.executor.queueCapacity=200
+io.terrakube.notification.poller.batchSize=200
+io.terrakube.notification.poller.stuckSendingThresholdMinutes=5
+io.terrakube.notification.ssrf.blockPrivateNetworks=true
+io.terrakube.notification.outbox.retentionDays=90
 
 ##############
 #EXECUTOR URL#

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -116,4 +116,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-job-soft-delete.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-job-status-index.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-variable-category-not-null.xml"/>
+    <include file="/db/changelog/local/changelog-2.33.0-notification.xml" />
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-notification.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-notification.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-33-0-notification-configuration" author="jake">
+        <createTable tableName="notification_configuration">
+            <column name="id" type="varchar(36)">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="name" type="varchar(255)">
+                <constraints nullable="false" />
+            </column>
+            <column name="description" type="text" />
+            <column name="organization_id" type="varchar(36)">
+                <constraints nullable="false" />
+            </column>
+            <column name="workspace_id" type="varchar(36)" />
+            <column name="channel_type" type="varchar(20)">
+                <constraints nullable="false" />
+            </column>
+            <column name="destination_url" type="varchar(2048)">
+                <constraints nullable="false" />
+            </column>
+            <column name="signing_secret" type="varchar(255)" />
+            <column name="active" type="boolean" defaultValueBoolean="true">
+                <constraints nullable="false" />
+            </column>
+            <column name="created_date" type="datetime" />
+            <column name="updated_date" type="datetime" />
+            <column name="created_by" type="varchar(128)" />
+            <column name="updated_by" type="varchar(128)" />
+        </createTable>
+        <addForeignKeyConstraint baseTableName="notification_configuration" baseColumnNames="organization_id"
+            constraintName="fk_notification_configuration_organization_id" referencedTableName="organization"
+            referencedColumnNames="id" />
+        <addForeignKeyConstraint baseTableName="notification_configuration" baseColumnNames="workspace_id"
+            constraintName="fk_notification_configuration_workspace_id" referencedTableName="workspace"
+            referencedColumnNames="id" />
+        <createIndex tableName="notification_configuration" indexName="idx_notification_configuration_workspace_id">
+            <column name="workspace_id" />
+        </createIndex>
+        <createIndex tableName="notification_configuration" indexName="idx_notification_configuration_org_workspace_null">
+            <column name="organization_id" />
+            <column name="workspace_id" />
+        </createIndex>
+    </changeSet>
+    <changeSet id="2-33-0-notification-trigger" author="jake">
+        <createTable tableName="notification_trigger">
+            <column name="id" type="varchar(36)">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="job_status" type="varchar(20)">
+                <constraints nullable="false" />
+            </column>
+            <column name="configuration_id" type="varchar(36)">
+                <constraints nullable="false" />
+            </column>
+            <column name="created_date" type="datetime" />
+            <column name="updated_date" type="datetime" />
+            <column name="created_by" type="varchar(128)" />
+            <column name="updated_by" type="varchar(128)" />
+        </createTable>
+        <addForeignKeyConstraint baseTableName="notification_trigger" baseColumnNames="configuration_id"
+            constraintName="fk_notification_trigger_configuration_id" referencedTableName="notification_configuration"
+            referencedColumnNames="id" />
+        <createIndex tableName="notification_trigger" indexName="idx_notification_trigger_configuration_id">
+            <column name="configuration_id" />
+        </createIndex>
+    </changeSet>
+    <changeSet id="2-33-0-notification-outbox" author="jake">
+        <!-- payload/last_error are "text", not "clob": clob maps to PostgreSQL's oid-backed
+             Large Object storage, which requires every read to happen inside a real
+             (non-autocommit) transaction - the outbox poller's findDueForDispatch() query runs
+             on a plain repository call from a Quartz job with no surrounding transaction, so a
+             clob column here crashes every poll tick with "Large Objects may not be used in
+             auto-commit mode." -->
+        <createTable tableName="notification_outbox">
+            <column name="id" type="varchar(36)">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="job_id" type="int">
+                <constraints nullable="false" />
+            </column>
+            <column name="configuration_id" type="varchar(36)">
+                <constraints nullable="false" />
+            </column>
+            <column name="payload" type="text" />
+            <column name="status" type="varchar(20)" defaultValue="PENDING">
+                <constraints nullable="false" />
+            </column>
+            <column name="attempt_count" type="int" defaultValueNumeric="0">
+                <constraints nullable="false" />
+            </column>
+            <column name="last_attempt_at" type="datetime" />
+            <!-- Null means "due as soon as picked up". Set explicitly when a failure carries a
+                 server-supplied delay (e.g. Slack's Retry-After on 429). -->
+            <column name="next_attempt_at" type="datetime" />
+            <column name="last_error" type="text" />
+            <column name="created_date" type="datetime" />
+            <column name="updated_date" type="datetime" />
+            <column name="created_by" type="varchar(128)" />
+            <column name="updated_by" type="varchar(128)" />
+        </createTable>
+        <addForeignKeyConstraint baseTableName="notification_outbox" baseColumnNames="job_id"
+            constraintName="fk_notification_outbox_job_id" referencedTableName="job"
+            referencedColumnNames="id" />
+        <addForeignKeyConstraint baseTableName="notification_outbox" baseColumnNames="configuration_id"
+            constraintName="fk_notification_outbox_configuration_id" referencedTableName="notification_configuration"
+            referencedColumnNames="id" onDelete="CASCADE" />
+        <createIndex tableName="notification_outbox" indexName="idx_notification_outbox_status_last_attempt">
+            <column name="status" />
+            <column name="last_attempt_at" />
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-notification.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-notification.xml
@@ -113,4 +113,32 @@
             <column name="last_attempt_at" />
         </createIndex>
     </changeSet>
+    <changeSet id="2-33-0-notification-configuration-message-style" author="jake">
+        <addColumn tableName="notification_configuration">
+            <column name="message_style" type="varchar(20)" defaultValue="DETAILED">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="2-33-0-notification-configuration-template" author="jake">
+        <!-- No rows here means "applies to every template" - this table only ever narrows which
+             templates a configuration fires for, it never widens it, so an empty set for a
+             configuration is exactly today's (pre-filter) behavior. -->
+        <createTable tableName="notification_configuration_template">
+            <column name="configuration_id" type="varchar(36)">
+                <constraints nullable="false" />
+            </column>
+            <column name="template_id" type="varchar(36)">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+        <addPrimaryKey tableName="notification_configuration_template"
+            columnNames="configuration_id, template_id" constraintName="pk_notification_configuration_template" />
+        <addForeignKeyConstraint baseTableName="notification_configuration_template" baseColumnNames="configuration_id"
+            constraintName="fk_notification_configuration_template_configuration_id"
+            referencedTableName="notification_configuration" referencedColumnNames="id" onDelete="CASCADE" />
+        <addForeignKeyConstraint baseTableName="notification_configuration_template" baseColumnNames="template_id"
+            constraintName="fk_notification_configuration_template_template_id"
+            referencedTableName="template" referencedColumnNames="id" onDelete="CASCADE" />
+    </changeSet>
 </databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/NotificationConfigurationGraphQlTest.java
+++ b/api/src/test/java/io/terrakube/api/NotificationConfigurationGraphQlTest.java
@@ -1,0 +1,75 @@
+package io.terrakube.api;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import io.terrakube.api.repository.NotificationConfigurationRepository;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.workspace.Workspace;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.Mockito.when;
+
+class NotificationConfigurationGraphQlTest extends ServerApplicationTests {
+
+    private static final String ORGANIZATION_ID = "d9b58bd3-f3fc-4056-a026-1163297e80a8";
+    private static final String WORKSPACE_ID = "5ed411ca-7ab8-4d2f-b591-02d0d5788afc";
+
+    @Autowired
+    NotificationConfigurationRepository notificationConfigurationRepository;
+    @Autowired
+    OrganizationRepository organizationRepository;
+    @Autowired
+    WorkspaceRepository workspaceRepository;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    // Regression test: NotificationConfiguration.workspace was LAZY, and reading its id through
+    // Elide's GraphQL relationship traversal (workspace { edges { node { id } } }) - as opposed
+    // to a plain Java getter call, e.g. from a permission check - serialized the literal string
+    // "null" instead of the real UUID. That silently broke every UI query that scopes
+    // notification configs by workspace, since "null" never equals a real workspace id.
+    @Test
+    void graphQlServesTheRealWorkspaceIdNotTheLiteralStringNull() {
+        Organization organization = organizationRepository.findById(UUID.fromString(ORGANIZATION_ID)).orElseThrow();
+        Workspace workspace = workspaceRepository.findById(UUID.fromString(WORKSPACE_ID)).orElseThrow();
+
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setName("GraphQL Workspace Id Regression");
+        configuration.setOrganization(organization);
+        configuration.setWorkspace(workspace);
+        configuration.setChannelType(NotificationChannelType.WEBHOOK);
+        configuration.setDestinationUrl("https://example.com/hook");
+        configuration.setActive(true);
+        configuration = notificationConfigurationRepository.saveAndFlush(configuration);
+
+        String query = "{ \"query\": \"{ organization(ids: [\\\"" + ORGANIZATION_ID + "\\\"]) { edges { node { "
+                + "notificationConfiguration { edges { node { id workspace { edges { node { id } } } } } } } } } }\" }";
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type",
+                        "application/json")
+                .body(query)
+                .when()
+                .post("/graphql/api/v1")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body(
+                        "data.organization.edges[0].node.notificationConfiguration.edges.find { it.node.id == '"
+                                + configuration.getId() + "' }.node.workspace.edges[0].node.id",
+                        org.hamcrest.Matchers.equalTo(WORKSPACE_ID));
+    }
+}

--- a/api/src/test/java/io/terrakube/api/NotificationConfigurationRepositoryTest.java
+++ b/api/src/test/java/io/terrakube/api/NotificationConfigurationRepositoryTest.java
@@ -1,0 +1,78 @@
+package io.terrakube.api;
+
+import io.terrakube.api.repository.NotificationConfigurationRepository;
+import io.terrakube.api.repository.NotificationTriggerRepository;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.notification.NotificationTrigger;
+import io.terrakube.api.rs.workspace.Workspace;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotificationConfigurationRepositoryTest extends ServerApplicationTests {
+
+    @Autowired
+    NotificationConfigurationRepository notificationConfigurationRepository;
+
+    @Autowired
+    NotificationTriggerRepository notificationTriggerRepository;
+
+    @Autowired
+    OrganizationRepository organizationRepository;
+
+    @Autowired
+    WorkspaceRepository workspaceRepository;
+
+    @Test
+    void savesWorkspaceScopedConfiguration_organizationIsDerivedFromWorkspace() {
+        Workspace workspace = workspaceRepository
+                .findById(UUID.fromString("5ed411ca-7ab8-4d2f-b591-02d0d5788afc")).orElseThrow();
+
+        // Mirrors what Elide's nested-URL relationship inference does when creating via
+        // organization/{orgId}/workspace/{wsId}/notificationConfiguration: only the
+        // immediate parent (workspace) gets set, organization is left null.
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setName("Workspace Webhook");
+        configuration.setWorkspace(workspace);
+        configuration.setChannelType(NotificationChannelType.WEBHOOK);
+        configuration.setDestinationUrl("https://example.com/hook");
+        configuration.setActive(true);
+
+        configuration = notificationConfigurationRepository.saveAndFlush(configuration);
+
+        assertThat(configuration.getOrganization()).isEqualTo(workspace.getOrganization());
+    }
+
+    @Test
+    void savesOrgScopedConfigurationWithTriggers() {
+        Organization organization = organizationRepository
+                .findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).orElseThrow();
+
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setName("Org Slack Alerts");
+        configuration.setOrganization(organization);
+        configuration.setChannelType(NotificationChannelType.SLACK);
+        configuration.setDestinationUrl("https://hooks.slack.com/services/X/Y/Z");
+        configuration.setActive(true);
+        configuration = notificationConfigurationRepository.saveAndFlush(configuration);
+
+        NotificationTrigger trigger = new NotificationTrigger();
+        trigger.setConfiguration(configuration);
+        trigger.setJobStatus(JobStatus.failed);
+        notificationTriggerRepository.saveAndFlush(trigger);
+
+        List<NotificationConfiguration> found = notificationConfigurationRepository
+                .findByOrganizationIdAndWorkspaceIsNullAndActiveTrue(organization.getId());
+
+        assertThat(found).extracting(NotificationConfiguration::getId).contains(configuration.getId());
+    }
+}

--- a/api/src/test/java/io/terrakube/api/NotificationDeliveryControllerTest.java
+++ b/api/src/test/java/io/terrakube/api/NotificationDeliveryControllerTest.java
@@ -1,0 +1,158 @@
+package io.terrakube.api;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.repository.NotificationConfigurationRepository;
+import io.terrakube.api.repository.NotificationOutboxRepository;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.notification.NotificationOutbox;
+import io.terrakube.api.rs.notification.NotificationOutboxStatus;
+import io.terrakube.api.rs.workspace.Workspace;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.restassured.RestAssured.given;
+import static org.mockito.Mockito.when;
+
+class NotificationDeliveryControllerTest extends ServerApplicationTests {
+
+    private static final String ORGANIZATION_ID = "d9b58bd3-f3fc-4056-a026-1163297e80a8";
+    private static final String WORKSPACE_ID = "5ed411ca-7ab8-4d2f-b591-02d0d5788afc";
+
+    @Autowired
+    NotificationOutboxRepository notificationOutboxRepository;
+    @Autowired
+    NotificationConfigurationRepository notificationConfigurationRepository;
+    @Autowired
+    JobRepository jobRepository;
+    @Autowired
+    OrganizationRepository organizationRepository;
+    @Autowired
+    WorkspaceRepository workspaceRepository;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        wireMockServer.resetAll();
+    }
+
+    private NotificationOutbox failedDelivery() {
+        Organization organization = organizationRepository.findById(UUID.fromString(ORGANIZATION_ID)).orElseThrow();
+        Workspace workspace = workspaceRepository.findById(UUID.fromString(WORKSPACE_ID)).orElseThrow();
+
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setName("Retry Test Config");
+        configuration.setOrganization(organization);
+        configuration.setChannelType(NotificationChannelType.WEBHOOK);
+        configuration.setDestinationUrl("http://localhost:" + wireMockServer.port() + "/hook");
+        configuration.setActive(true);
+        configuration = notificationConfigurationRepository.saveAndFlush(configuration);
+
+        Job job = new Job();
+        job.setStatus(JobStatus.failed);
+        job.setOrganization(organization);
+        job.setWorkspace(workspace);
+        jobRepository.saveAndFlush(job);
+
+        NotificationOutbox outbox = new NotificationOutbox();
+        outbox.setId(UUID.randomUUID());
+        outbox.setJob(job);
+        outbox.setConfiguration(configuration);
+        outbox.setPayload("{}");
+        outbox.setStatus(NotificationOutboxStatus.FAILED);
+        outbox.setAttemptCount(3);
+        outbox.setLastError("boom");
+        return notificationOutboxRepository.saveAndFlush(outbox);
+    }
+
+    @Test
+    void retryingAFailedDeliveryRearmsItAndDispatchesImmediately() throws InterruptedException {
+        wireMockServer.stubFor(post(urlPathEqualTo("/hook")).willReturn(aResponse().withStatus(200)));
+        NotificationOutbox outbox = failedDelivery();
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS")).when()
+                .post("/notification/v1/workspace/" + WORKSPACE_ID + "/deliveries/" + outbox.getId() + "/retry")
+                .then()
+                .statusCode(HttpStatus.OK.value());
+
+        NotificationOutbox persisted = awaitDeliveryOutcome(outbox.getId());
+        org.assertj.core.api.Assertions.assertThat(persisted.getStatus()).isEqualTo(NotificationOutboxStatus.SENT);
+        wireMockServer.verify(1, postRequestedFor(urlPathEqualTo("/hook")));
+    }
+
+    // Async dispatch (@Async("notificationDispatchExecutor")) runs on a separate thread pool, so
+    // the HTTP response for the retry request returns before delivery actually completes.
+    private NotificationOutbox awaitDeliveryOutcome(UUID outboxId) throws InterruptedException {
+        for (int i = 0; i < 20; i++) {
+            NotificationOutbox current = notificationOutboxRepository.findById(outboxId).orElseThrow();
+            if (current.getStatus() != NotificationOutboxStatus.PENDING
+                    && current.getStatus() != NotificationOutboxStatus.SENDING) {
+                return current;
+            }
+            Thread.sleep(250);
+        }
+        throw new AssertionError("delivery " + outboxId + " did not complete within the wait window");
+    }
+
+    @Test
+    void retryingANonFailedDeliveryReturnsConflict() {
+        NotificationOutbox outbox = failedDelivery();
+        outbox.setStatus(NotificationOutboxStatus.SENT);
+        notificationOutboxRepository.saveAndFlush(outbox);
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS")).when()
+                .post("/notification/v1/workspace/" + WORKSPACE_ID + "/deliveries/" + outbox.getId() + "/retry")
+                .then()
+                .statusCode(HttpStatus.CONFLICT.value());
+    }
+
+    @Test
+    void retryingAnUnknownDeliveryReturnsNotFound() {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS")).when()
+                .post("/notification/v1/workspace/" + WORKSPACE_ID + "/deliveries/" + UUID.randomUUID() + "/retry")
+                .then()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    void retryingWithoutWorkspaceAccessIsForbidden() {
+        NotificationOutbox outbox = failedDelivery();
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("FAKE_DEVELOPERS")).when()
+                .post("/notification/v1/workspace/" + WORKSPACE_ID + "/deliveries/" + outbox.getId() + "/retry")
+                .then()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+    }
+
+    @Test
+    void recentDeliveriesListsDeliveriesForTheWorkspace() {
+        NotificationOutbox outbox = failedDelivery();
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS")).when()
+                .get("/notification/v1/workspace/" + WORKSPACE_ID + "/deliveries")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("id", org.hamcrest.Matchers.hasItem(outbox.getId().toString()));
+    }
+}

--- a/api/src/test/java/io/terrakube/api/NotificationDispatchConcurrencyTest.java
+++ b/api/src/test/java/io/terrakube/api/NotificationDispatchConcurrencyTest.java
@@ -1,0 +1,136 @@
+package io.terrakube.api;
+
+import io.terrakube.api.plugin.notification.NotificationDispatchService;
+import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.repository.NotificationConfigurationRepository;
+import io.terrakube.api.repository.NotificationOutboxRepository;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.notification.NotificationOutbox;
+import io.terrakube.api.rs.notification.NotificationOutboxStatus;
+import io.terrakube.api.rs.workspace.Workspace;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.mockito.Mockito.when;
+
+class NotificationDispatchConcurrencyTest extends ServerApplicationTests {
+
+    @Autowired
+    NotificationDispatchService notificationDispatchService;
+
+    @Autowired
+    NotificationOutboxRepository notificationOutboxRepository;
+
+    @Autowired
+    NotificationConfigurationRepository notificationConfigurationRepository;
+
+    @Autowired
+    JobRepository jobRepository;
+
+    @Autowired
+    OrganizationRepository organizationRepository;
+
+    @Autowired
+    WorkspaceRepository workspaceRepository;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        wireMockServer.resetAll();
+    }
+
+    @Test
+    void twoConcurrentAttemptsOnTheSameOutboxRowOnlyDeliverOnce() throws Exception {
+        wireMockServer.stubFor(post(urlPathEqualTo("/hook"))
+                .willReturn(aResponse().withStatus(200).withFixedDelay(200)));
+
+        Organization organization = organizationRepository
+                .findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).orElseThrow();
+        Workspace workspace = workspaceRepository
+                .findById(UUID.fromString("5ed411ca-7ab8-4d2f-b591-02d0d5788afc")).orElseThrow();
+
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setName("Concurrency Test Config");
+        configuration.setOrganization(organization);
+        configuration.setChannelType(NotificationChannelType.WEBHOOK);
+        configuration.setDestinationUrl("http://localhost:" + wireMockServer.port() + "/hook");
+        configuration.setActive(true);
+        configuration = notificationConfigurationRepository.saveAndFlush(configuration);
+
+        Job job = new Job();
+        job.setStatus(JobStatus.failed);
+        job.setOrganization(organization);
+        job.setWorkspace(workspace);
+        jobRepository.saveAndFlush(job);
+
+        NotificationOutbox outbox = new NotificationOutbox();
+        outbox.setId(UUID.randomUUID());
+        outbox.setJob(job);
+        outbox.setConfiguration(configuration);
+        outbox.setPayload("{}");
+        outbox.setStatus(NotificationOutboxStatus.PENDING);
+        notificationOutboxRepository.saveAndFlush(outbox);
+
+        // Simulates the real-world race this fix targets: an overlapping poller cycle
+        // (or a second pod's poller) attempting the same row while the immediate
+        // async dispatch is still in flight.
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        CountDownLatch bothReady = new CountDownLatch(2);
+        CountDownLatch go = new CountDownLatch(1);
+
+        Future<?> first = pool.submit(() -> {
+            bothReady.countDown();
+            await(go);
+            notificationDispatchService.attemptDelivery(outbox.getId());
+        });
+        Future<?> second = pool.submit(() -> {
+            bothReady.countDown();
+            await(go);
+            notificationDispatchService.attemptDelivery(outbox.getId());
+        });
+
+        bothReady.await(5, TimeUnit.SECONDS);
+        go.countDown();
+        first.get(10, TimeUnit.SECONDS);
+        second.get(10, TimeUnit.SECONDS);
+        pool.shutdown();
+
+        wireMockServer.verify(1, postRequestedFor(urlPathEqualTo("/hook")));
+
+        NotificationOutbox persisted = notificationOutboxRepository.findById(outbox.getId()).orElseThrow();
+        assertEqualsSent(persisted);
+    }
+
+    private void await(CountDownLatch latch) {
+        try {
+            latch.await(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void assertEqualsSent(NotificationOutbox outbox) {
+        org.assertj.core.api.Assertions.assertThat(outbox.getStatus()).isEqualTo(NotificationOutboxStatus.SENT);
+        org.assertj.core.api.Assertions.assertThat(outbox.getAttemptCount()).isEqualTo(1);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/NotificationOutboxRepositoryTest.java
+++ b/api/src/test/java/io/terrakube/api/NotificationOutboxRepositoryTest.java
@@ -1,0 +1,373 @@
+package io.terrakube.api;
+
+import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.repository.NotificationConfigurationRepository;
+import io.terrakube.api.repository.NotificationOutboxRepository;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.notification.NotificationOutbox;
+import io.terrakube.api.rs.notification.NotificationOutboxStatus;
+import io.terrakube.api.rs.workspace.Workspace;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// @Modifying bulk-update queries (claimForDelivery, recordDeliveryResult, the stuck-row sweep,
+// rearmFailedForRetry) require an active transaction to execute at all - unlike save()/findById(),
+// they don't get one implicitly from the repository proxy. This also gives each test method
+// rollback-based isolation.
+@Transactional
+class NotificationOutboxRepositoryTest extends ServerApplicationTests {
+
+    @Autowired
+    NotificationOutboxRepository notificationOutboxRepository;
+
+    @Autowired
+    NotificationConfigurationRepository notificationConfigurationRepository;
+
+    @Autowired
+    JobRepository jobRepository;
+
+    @Autowired
+    OrganizationRepository organizationRepository;
+
+    @Autowired
+    WorkspaceRepository workspaceRepository;
+
+    @PersistenceContext
+    EntityManager entityManager;
+
+    // GenericAuditFields.createdDate is @CreationTimestamp (Hibernate sets it on insert,
+    // overriding any value passed to setCreatedDate) and updatable = false (a later entity-level
+    // save never touches the column either) - a raw UPDATE is the only way to backdate a row for
+    // a retention-cutoff test.
+    private void backdate(UUID id, Date date) {
+        entityManager.createNativeQuery("UPDATE notification_outbox SET created_date = ?1 WHERE id = ?2")
+                .setParameter(1, date)
+                .setParameter(2, id.toString())
+                .executeUpdate();
+        entityManager.clear();
+    }
+
+    private NotificationConfiguration savedConfiguration(Organization organization, String name) {
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setName(name);
+        configuration.setOrganization(organization);
+        configuration.setChannelType(NotificationChannelType.WEBHOOK);
+        configuration.setDestinationUrl("https://example.com/hook");
+        configuration.setActive(true);
+        return notificationConfigurationRepository.saveAndFlush(configuration);
+    }
+
+    private Job savedJob(Organization organization, Workspace workspace) {
+        Job job = new Job();
+        job.setStatus(JobStatus.failed);
+        job.setOrganization(organization);
+        job.setWorkspace(workspace);
+        jobRepository.saveAndFlush(job);
+        return job;
+    }
+
+    @Test
+    void findDueForDispatchReturnsPendingRowsWhoseNextAttemptHasArrivedOrIsUnset() {
+        Organization organization = organizationRepository
+                .findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).orElseThrow();
+        Workspace workspace = workspaceRepository
+                .findById(UUID.fromString("5ed411ca-7ab8-4d2f-b591-02d0d5788afc")).orElseThrow();
+        NotificationConfiguration configuration = savedConfiguration(organization, "Outbox Test Config");
+
+        NotificationOutbox due = new NotificationOutbox();
+        due.setId(UUID.randomUUID());
+        due.setJob(savedJob(organization, workspace));
+        due.setConfiguration(configuration);
+        due.setPayload("{}");
+        due.setStatus(NotificationOutboxStatus.PENDING);
+        due.setAttemptCount(1);
+        due.setLastAttemptAt(new Date(System.currentTimeMillis() - 120_000));
+        due.setNextAttemptAt(new Date(System.currentTimeMillis() - 60_000));
+        notificationOutboxRepository.saveAndFlush(due);
+
+        NotificationOutbox notYetDue = new NotificationOutbox();
+        notYetDue.setId(UUID.randomUUID());
+        notYetDue.setJob(savedJob(organization, workspace));
+        notYetDue.setConfiguration(configuration);
+        notYetDue.setPayload("{}");
+        notYetDue.setStatus(NotificationOutboxStatus.PENDING);
+        notYetDue.setAttemptCount(1);
+        notYetDue.setNextAttemptAt(new Date(System.currentTimeMillis() + 300_000));
+        notificationOutboxRepository.saveAndFlush(notYetDue);
+
+        List<NotificationOutbox> result = notificationOutboxRepository
+                .findDueForDispatch(NotificationOutboxStatus.PENDING, new Date(), PageRequest.of(0, 200));
+
+        assertThat(result).extracting(NotificationOutbox::getId).contains(due.getId())
+                .doesNotContain(notYetDue.getId());
+    }
+
+    @Test
+    void claimForDeliveryOnlySucceedsOnceForTheSameRow() {
+        Organization organization = organizationRepository
+                .findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).orElseThrow();
+        Workspace workspace = workspaceRepository
+                .findById(UUID.fromString("5ed411ca-7ab8-4d2f-b591-02d0d5788afc")).orElseThrow();
+        NotificationConfiguration configuration = savedConfiguration(organization, "Claim Test Config");
+
+        NotificationOutbox outbox = new NotificationOutbox();
+        outbox.setId(UUID.randomUUID());
+        outbox.setJob(savedJob(organization, workspace));
+        outbox.setConfiguration(configuration);
+        outbox.setPayload("{}");
+        outbox.setStatus(NotificationOutboxStatus.PENDING);
+        notificationOutboxRepository.saveAndFlush(outbox);
+
+        Date now = new Date();
+        int firstClaim = notificationOutboxRepository.claimForDelivery(outbox.getId(), NotificationOutboxStatus.PENDING,
+                NotificationOutboxStatus.SENDING, now);
+        int secondClaim = notificationOutboxRepository.claimForDelivery(outbox.getId(), NotificationOutboxStatus.PENDING,
+                NotificationOutboxStatus.SENDING, now);
+
+        assertThat(firstClaim).isEqualTo(1);
+        assertThat(secondClaim).isEqualTo(0);
+
+        NotificationOutbox reloaded = notificationOutboxRepository.findById(outbox.getId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(NotificationOutboxStatus.SENDING);
+        assertThat(reloaded.getAttemptCount()).isEqualTo(1);
+    }
+
+    @Test
+    void recordDeliveryResultIsANoOpWhenTheRowWasReclaimedInTheMeantime() {
+        Organization organization = organizationRepository
+                .findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).orElseThrow();
+        Workspace workspace = workspaceRepository
+                .findById(UUID.fromString("5ed411ca-7ab8-4d2f-b591-02d0d5788afc")).orElseThrow();
+        NotificationConfiguration configuration = savedConfiguration(organization, "Record Result Test Config");
+
+        NotificationOutbox outbox = new NotificationOutbox();
+        outbox.setId(UUID.randomUUID());
+        outbox.setJob(savedJob(organization, workspace));
+        outbox.setConfiguration(configuration);
+        outbox.setPayload("{}");
+        outbox.setStatus(NotificationOutboxStatus.PENDING);
+        notificationOutboxRepository.saveAndFlush(outbox);
+
+        Date firstClaimAt = new Date();
+        notificationOutboxRepository.claimForDelivery(outbox.getId(), NotificationOutboxStatus.PENDING,
+                NotificationOutboxStatus.SENDING, firstClaimAt);
+
+        // Simulate the stuck-row sweep reclaiming and a second caller re-claiming with a newer
+        // lastAttemptAt while the first caller's delivery is still "in flight" from its point of
+        // view.
+        notificationOutboxRepository.reclaimStuckSendingRows(NotificationOutboxStatus.SENDING,
+                NotificationOutboxStatus.PENDING, new Date(System.currentTimeMillis() + 1), 3, new Date());
+        Date secondClaimAt = new Date(firstClaimAt.getTime() + 1000);
+        notificationOutboxRepository.claimForDelivery(outbox.getId(), NotificationOutboxStatus.PENDING,
+                NotificationOutboxStatus.SENDING, secondClaimAt);
+
+        // The first (stale) caller's result, keyed on its original lastAttemptAt, must not apply.
+        int updated = notificationOutboxRepository.recordDeliveryResult(outbox.getId(), NotificationOutboxStatus.SENDING,
+                firstClaimAt, NotificationOutboxStatus.SENT, null, null, new Date());
+
+        assertThat(updated).isZero();
+        NotificationOutbox reloaded = notificationOutboxRepository.findById(outbox.getId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(NotificationOutboxStatus.SENDING);
+    }
+
+    @Test
+    void stuckRowSweepReclaimsBelowMaxAttemptsAndFailsAtMaxAttempts() {
+        Organization organization = organizationRepository
+                .findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).orElseThrow();
+        Workspace workspace = workspaceRepository
+                .findById(UUID.fromString("5ed411ca-7ab8-4d2f-b591-02d0d5788afc")).orElseThrow();
+        NotificationConfiguration configuration = savedConfiguration(organization, "Sweep Test Config");
+        Date staleAttemptAt = new Date(System.currentTimeMillis() - 600_000);
+
+        NotificationOutbox belowMax = new NotificationOutbox();
+        belowMax.setId(UUID.randomUUID());
+        belowMax.setJob(savedJob(organization, workspace));
+        belowMax.setConfiguration(configuration);
+        belowMax.setPayload("{}");
+        belowMax.setStatus(NotificationOutboxStatus.SENDING);
+        belowMax.setAttemptCount(1);
+        belowMax.setLastAttemptAt(staleAttemptAt);
+        notificationOutboxRepository.saveAndFlush(belowMax);
+
+        NotificationOutbox atMax = new NotificationOutbox();
+        atMax.setId(UUID.randomUUID());
+        atMax.setJob(savedJob(organization, workspace));
+        atMax.setConfiguration(configuration);
+        atMax.setPayload("{}");
+        atMax.setStatus(NotificationOutboxStatus.SENDING);
+        atMax.setAttemptCount(3);
+        atMax.setLastAttemptAt(staleAttemptAt);
+        notificationOutboxRepository.saveAndFlush(atMax);
+
+        Date cutoff = new Date(System.currentTimeMillis() - 300_000);
+        notificationOutboxRepository.reclaimStuckSendingRows(NotificationOutboxStatus.SENDING,
+                NotificationOutboxStatus.PENDING, cutoff, 3, new Date());
+        notificationOutboxRepository.failStuckSendingRowsAtMaxAttempts(NotificationOutboxStatus.SENDING,
+                NotificationOutboxStatus.FAILED, cutoff, 3, "stuck", new Date());
+
+        assertThat(notificationOutboxRepository.findById(belowMax.getId()).orElseThrow().getStatus())
+                .isEqualTo(NotificationOutboxStatus.PENDING);
+        assertThat(notificationOutboxRepository.findById(atMax.getId()).orElseThrow().getStatus())
+                .isEqualTo(NotificationOutboxStatus.FAILED);
+    }
+
+    @Test
+    void rearmFailedForRetryOnlyAffectsFailedRows() {
+        Organization organization = organizationRepository
+                .findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).orElseThrow();
+        Workspace workspace = workspaceRepository
+                .findById(UUID.fromString("5ed411ca-7ab8-4d2f-b591-02d0d5788afc")).orElseThrow();
+        NotificationConfiguration configuration = savedConfiguration(organization, "Rearm Test Config");
+
+        NotificationOutbox failed = new NotificationOutbox();
+        failed.setId(UUID.randomUUID());
+        failed.setJob(savedJob(organization, workspace));
+        failed.setConfiguration(configuration);
+        failed.setPayload("{}");
+        failed.setStatus(NotificationOutboxStatus.FAILED);
+        failed.setAttemptCount(3);
+        failed.setLastError("boom");
+        notificationOutboxRepository.saveAndFlush(failed);
+
+        NotificationOutbox sent = new NotificationOutbox();
+        sent.setId(UUID.randomUUID());
+        sent.setJob(savedJob(organization, workspace));
+        sent.setConfiguration(configuration);
+        sent.setPayload("{}");
+        sent.setStatus(NotificationOutboxStatus.SENT);
+        notificationOutboxRepository.saveAndFlush(sent);
+
+        int failedRowsUpdated = notificationOutboxRepository.rearmFailedForRetry(failed.getId(),
+                NotificationOutboxStatus.FAILED, NotificationOutboxStatus.PENDING, new Date());
+        int sentRowsUpdated = notificationOutboxRepository.rearmFailedForRetry(sent.getId(),
+                NotificationOutboxStatus.FAILED, NotificationOutboxStatus.PENDING, new Date());
+
+        assertThat(failedRowsUpdated).isEqualTo(1);
+        assertThat(sentRowsUpdated).isZero();
+        NotificationOutbox reloaded = notificationOutboxRepository.findById(failed.getId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(NotificationOutboxStatus.PENDING);
+        assertThat(reloaded.getAttemptCount()).isZero();
+        assertThat(reloaded.getLastError()).isNull();
+    }
+
+    @Test
+    void deleteTerminalRowsCreatedBeforeOnlyRemovesOldTerminalRows() {
+        Organization organization = organizationRepository
+                .findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).orElseThrow();
+        Workspace workspace = workspaceRepository
+                .findById(UUID.fromString("5ed411ca-7ab8-4d2f-b591-02d0d5788afc")).orElseThrow();
+        NotificationConfiguration configuration = savedConfiguration(organization, "Retention Test Config");
+        Date cutoff = new Date();
+        Date old = new Date(cutoff.getTime() - 1000);
+        Date recent = new Date(cutoff.getTime() + 1000);
+
+        NotificationOutbox oldSent = new NotificationOutbox();
+        oldSent.setId(UUID.randomUUID());
+        oldSent.setJob(savedJob(organization, workspace));
+        oldSent.setConfiguration(configuration);
+        oldSent.setPayload("{}");
+        oldSent.setStatus(NotificationOutboxStatus.SENT);
+        notificationOutboxRepository.saveAndFlush(oldSent);
+        backdate(oldSent.getId(), old);
+
+        NotificationOutbox recentSent = new NotificationOutbox();
+        recentSent.setId(UUID.randomUUID());
+        recentSent.setJob(savedJob(organization, workspace));
+        recentSent.setConfiguration(configuration);
+        recentSent.setPayload("{}");
+        recentSent.setStatus(NotificationOutboxStatus.SENT);
+        notificationOutboxRepository.saveAndFlush(recentSent);
+        backdate(recentSent.getId(), recent);
+
+        NotificationOutbox oldPending = new NotificationOutbox();
+        oldPending.setId(UUID.randomUUID());
+        oldPending.setJob(savedJob(organization, workspace));
+        oldPending.setConfiguration(configuration);
+        oldPending.setPayload("{}");
+        oldPending.setStatus(NotificationOutboxStatus.PENDING);
+        notificationOutboxRepository.saveAndFlush(oldPending);
+        backdate(oldPending.getId(), old);
+
+        // Not asserting the exact deleted count: this suite shares a real Postgres testcontainer
+        // across test classes, and sibling tests that don't roll back (e.g.
+        // NotificationDispatchConcurrencyTest) can leave their own old terminal rows behind -
+        // what matters here is the filter logic, checked precisely against these three rows by id.
+        notificationOutboxRepository.deleteTerminalRowsCreatedBefore(
+                List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED), cutoff);
+
+        assertThat(notificationOutboxRepository.findById(oldSent.getId())).isEmpty();
+        assertThat(notificationOutboxRepository.findById(recentSent.getId())).isPresent();
+        assertThat(notificationOutboxRepository.findById(oldPending.getId())).isPresent();
+    }
+
+    @Test
+    void findsRecentDeliveriesForAWorkspaceNewestFirst() {
+        Organization organization = organizationRepository
+                .findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).orElseThrow();
+        Workspace workspace = workspaceRepository
+                .findById(UUID.fromString("5ed411ca-7ab8-4d2f-b591-02d0d5788afc")).orElseThrow();
+
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setName("Delivery Visibility Config");
+        configuration.setOrganization(organization);
+        configuration.setChannelType(NotificationChannelType.SLACK);
+        configuration.setDestinationUrl("https://hooks.slack.com/services/X");
+        configuration.setActive(true);
+        configuration = notificationConfigurationRepository.saveAndFlush(configuration);
+
+        Job olderJob = new Job();
+        olderJob.setStatus(JobStatus.completed);
+        olderJob.setOrganization(organization);
+        olderJob.setWorkspace(workspace);
+        jobRepository.saveAndFlush(olderJob);
+
+        Job newerJob = new Job();
+        newerJob.setStatus(JobStatus.failed);
+        newerJob.setOrganization(organization);
+        newerJob.setWorkspace(workspace);
+        jobRepository.saveAndFlush(newerJob);
+
+        NotificationOutbox older = new NotificationOutbox();
+        older.setId(UUID.randomUUID());
+        older.setJob(olderJob);
+        older.setConfiguration(configuration);
+        older.setPayload("{}");
+        older.setStatus(NotificationOutboxStatus.SENT);
+        notificationOutboxRepository.saveAndFlush(older);
+        // Relying on real-time separation between the two saveAndFlush calls to order these two
+        // rows is flaky under load (fast execution + timestamp resolution can tie or invert them);
+        // backdating "older" explicitly makes the ordering deterministic.
+        backdate(older.getId(), new Date(System.currentTimeMillis() - 60_000));
+
+        NotificationOutbox newer = new NotificationOutbox();
+        newer.setId(UUID.randomUUID());
+        newer.setJob(newerJob);
+        newer.setConfiguration(configuration);
+        newer.setPayload("{}");
+        newer.setStatus(NotificationOutboxStatus.FAILED);
+        newer.setLastError("connection refused");
+        notificationOutboxRepository.saveAndFlush(newer);
+
+        List<NotificationOutbox> deliveries = notificationOutboxRepository
+                .findByJob_Workspace_IdOrderByCreatedDateDesc(workspace.getId(), PageRequest.of(0, 10));
+
+        assertThat(deliveries).extracting(NotificationOutbox::getId)
+                .containsSubsequence(newer.getId(), older.getId());
+    }
+}

--- a/api/src/test/java/io/terrakube/api/NotificationTestControllerTest.java
+++ b/api/src/test/java/io/terrakube/api/NotificationTestControllerTest.java
@@ -1,0 +1,108 @@
+package io.terrakube.api;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import io.terrakube.api.repository.NotificationConfigurationRepository;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.restassured.RestAssured.given;
+import static org.mockito.Mockito.when;
+
+class NotificationTestControllerTest extends ServerApplicationTests {
+
+    private static final String ORGANIZATION_ID = "d9b58bd3-f3fc-4056-a026-1163297e80a8";
+
+    @Autowired
+    NotificationConfigurationRepository notificationConfigurationRepository;
+    @Autowired
+    OrganizationRepository organizationRepository;
+
+    @BeforeEach
+    void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        wireMockServer.resetAll();
+    }
+
+    private NotificationConfiguration savedWebhookConfig() {
+        Organization organization = organizationRepository.findById(UUID.fromString(ORGANIZATION_ID)).orElseThrow();
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setName("Send Test Config");
+        configuration.setOrganization(organization);
+        configuration.setChannelType(NotificationChannelType.WEBHOOK);
+        configuration.setDestinationUrl("http://localhost:" + wireMockServer.port() + "/hook");
+        configuration.setActive(true);
+        return notificationConfigurationRepository.saveAndFlush(configuration);
+    }
+
+    @Test
+    void sendTestAgainstASavedConfigurationSucceeds() {
+        // Regression test: configuration.getOrganization() is a lazy proxy once re-fetched by
+        // sendTest's own repository lookup (a fresh request, no longer the same persistence
+        // context savedWebhookConfig() used to create it) - without a transaction open around
+        // that fetch, this threw LazyInitializationException instead of ever reaching the
+        // destination. The transaction closes before the outbound HTTP call, unlike the
+        // configuration's own repository lookup.
+        wireMockServer.stubFor(post(urlPathEqualTo("/hook")).willReturn(aResponse().withStatus(200)));
+        NotificationConfiguration configuration = savedWebhookConfig();
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS")).when()
+                .post("/notification/v1/configuration/" + configuration.getId() + "/test")
+                .then()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void sendTestReturnsBadGatewayWhenDestinationRejectsTheRequest() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/hook")).willReturn(aResponse().withStatus(500)));
+        NotificationConfiguration configuration = savedWebhookConfig();
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS")).when()
+                .post("/notification/v1/configuration/" + configuration.getId() + "/test")
+                .then()
+                .statusCode(HttpStatus.BAD_GATEWAY.value());
+    }
+
+    @Test
+    void sendTestForAnUnknownConfigurationIsForbidden() {
+        // @PreAuthorize's hasManagePermission resolves the config to check permission before the
+        // controller body ever runs; it fails closed (403) for anything it can't resolve, missing
+        // or not, so the controller's own "if configuration == null" 404 branch is unreachable
+        // from this endpoint - this asserts the actual (and reasonable, avoids leaking which IDs
+        // exist) behavior rather than the never-hit branch.
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS")).when()
+                .post("/notification/v1/configuration/" + UUID.randomUUID() + "/test")
+                .then()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+    }
+
+    @Test
+    void sendAdHocTestSucceedsAgainstAnUnsavedConfiguration() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/hook")).willReturn(aResponse().withStatus(200)));
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type",
+                        "application/json")
+                .body("{\"channelType\":\"WEBHOOK\",\"destinationUrl\":\"http://localhost:" + wireMockServer.port()
+                        + "/hook\"}")
+                .when()
+                .post("/notification/v1/organization/" + ORGANIZATION_ID + "/configuration/test")
+                .then()
+                .statusCode(HttpStatus.OK.value());
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/JobNotificationTriggerTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/JobNotificationTriggerTest.java
@@ -9,6 +9,7 @@ import io.terrakube.api.rs.notification.NotificationChannelType;
 import io.terrakube.api.rs.notification.NotificationConfiguration;
 import io.terrakube.api.rs.notification.NotificationOutbox;
 import io.terrakube.api.rs.notification.NotificationTrigger;
+import io.terrakube.api.rs.template.Template;
 import io.terrakube.api.rs.workspace.Workspace;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -157,6 +158,55 @@ class JobNotificationTriggerTest {
         TransactionSynchronizationManager.getSynchronizations().forEach(sync -> sync.afterCommit());
 
         verify(notificationDispatchService, times(1)).dispatchAsync(any());
+    }
+
+    @Test
+    void enqueue_configScopedToADifferentTemplateIsSkipped() {
+        Job job = jobWithStatus(JobStatus.failed);
+        job.setTemplateReference(UUID.randomUUID().toString());
+        NotificationConfiguration configuration = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        Template otherTemplate = new Template();
+        otherTemplate.setId(UUID.randomUUID());
+        configuration.setTemplates(List.of(otherTemplate));
+        when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(configuration));
+
+        List<UUID> ids = subject.enqueue(job);
+
+        verify(notificationOutboxRepository, never()).save(any());
+        assertThat(ids).isEmpty();
+    }
+
+    @Test
+    void enqueue_configScopedToTheJobsTemplateMatches() {
+        Job job = jobWithStatus(JobStatus.failed);
+        UUID templateId = UUID.randomUUID();
+        job.setTemplateReference(templateId.toString());
+        NotificationConfiguration configuration = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        Template matchingTemplate = new Template();
+        matchingTemplate.setId(templateId);
+        configuration.setTemplates(List.of(matchingTemplate));
+        when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(configuration));
+        when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");
+
+        List<UUID> ids = subject.enqueue(job);
+
+        verify(notificationOutboxRepository, times(1)).save(any());
+        assertThat(ids).hasSize(1);
+    }
+
+    @Test
+    void enqueue_configWithNoTemplatesSelectedMatchesEveryTemplate() {
+        Job job = jobWithStatus(JobStatus.failed);
+        job.setTemplateReference(UUID.randomUUID().toString());
+        NotificationConfiguration configuration = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        // templates left null/unset - see NotificationConfiguration.templates javadoc.
+        when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(configuration));
+        when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");
+
+        List<UUID> ids = subject.enqueue(job);
+
+        verify(notificationOutboxRepository, times(1)).save(any());
+        assertThat(ids).hasSize(1);
     }
 
     @Test

--- a/api/src/test/java/io/terrakube/api/plugin/notification/JobNotificationTriggerTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/JobNotificationTriggerTest.java
@@ -1,0 +1,171 @@
+package io.terrakube.api.plugin.notification;
+
+import io.terrakube.api.plugin.notification.payload.NotificationPayloadRenderer;
+import io.terrakube.api.repository.NotificationOutboxRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.notification.NotificationOutbox;
+import io.terrakube.api.rs.notification.NotificationTrigger;
+import io.terrakube.api.rs.workspace.Workspace;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JobNotificationTriggerTest {
+
+    @Mock
+    NotificationConfigResolver notificationConfigResolver;
+    @Mock
+    NotificationPayloadRenderer notificationPayloadRenderer;
+    @Mock
+    NotificationOutboxRepository notificationOutboxRepository;
+    @Mock
+    NotificationDispatchService notificationDispatchService;
+
+    @InjectMocks
+    JobNotificationTrigger subject;
+
+    @AfterEach
+    void clearTransactionSynchronization() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    private NotificationConfiguration configWithTrigger(NotificationChannelType type, JobStatus status) {
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setId(UUID.randomUUID());
+        configuration.setChannelType(type);
+        NotificationTrigger trigger = new NotificationTrigger();
+        trigger.setJobStatus(status);
+        configuration.setTriggers(List.of(trigger));
+        return configuration;
+    }
+
+    private Job jobWithStatus(JobStatus status) {
+        Job job = new Job();
+        job.setId(42);
+        job.setStatus(status);
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+        organization.setName("acme");
+        Workspace workspace = new Workspace();
+        workspace.setId(UUID.randomUUID());
+        workspace.setName("networking");
+        workspace.setOrganization(organization);
+        job.setOrganization(organization);
+        job.setWorkspace(workspace);
+        return job;
+    }
+
+    @Test
+    void enqueue_matchingConfigInsertsExactlyOneOutboxRow() {
+        Job job = jobWithStatus(JobStatus.failed);
+        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        NotificationConfiguration nonMatching = configWithTrigger(NotificationChannelType.WEBHOOK, JobStatus.completed);
+        when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(matching, nonMatching));
+        when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");
+
+        List<UUID> ids = subject.enqueue(job);
+
+        ArgumentCaptor<NotificationOutbox> captor = ArgumentCaptor.forClass(NotificationOutbox.class);
+        verify(notificationOutboxRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getConfiguration()).isEqualTo(matching);
+        assertThat(captor.getValue().getJob()).isEqualTo(job);
+        assertThat(ids).containsExactly(captor.getValue().getId());
+    }
+
+    @Test
+    void enqueue_noMatchingConfigInsertsNothing() {
+        Job job = jobWithStatus(JobStatus.running);
+        when(notificationConfigResolver.resolve(job.getWorkspace()))
+                .thenReturn(List.of(configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed)));
+
+        List<UUID> ids = subject.enqueue(job);
+
+        verify(notificationOutboxRepository, never()).save(any());
+        assertThat(ids).isEmpty();
+    }
+
+    @Test
+    void enqueue_jobWithNoWorkspaceIsSkippedWithoutResolving() {
+        Job job = new Job();
+        job.setId(99);
+
+        List<UUID> ids = subject.enqueue(job);
+
+        verifyNoInteractions(notificationConfigResolver);
+        assertThat(ids).isEmpty();
+    }
+
+    @Test
+    void enqueue_aFailureResolvingConfigsNeverThrows() {
+        Job job = jobWithStatus(JobStatus.failed);
+        when(notificationConfigResolver.resolve(job.getWorkspace())).thenThrow(new RuntimeException("db down"));
+
+        List<UUID> ids = subject.enqueue(job);
+
+        verify(notificationOutboxRepository, never()).save(any());
+        assertThat(ids).isEmpty();
+    }
+
+    @Test
+    void notifyStatusChanged_dispatchesEveryEnqueuedOutboxRowImmediately() {
+        Job job = jobWithStatus(JobStatus.failed);
+        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(matching));
+        when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");
+
+        subject.notifyStatusChanged(job);
+
+        ArgumentCaptor<UUID> outboxIdCaptor = ArgumentCaptor.forClass(UUID.class);
+        verify(notificationDispatchService, times(1)).dispatchAsync(outboxIdCaptor.capture());
+        assertThat(outboxIdCaptor.getValue()).isNotNull();
+    }
+
+    @Test
+    void notifyStatusChanged_defersDispatchUntilAfterCommitWhenATransactionIsActive() {
+        Job job = jobWithStatus(JobStatus.failed);
+        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(matching));
+        when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");
+
+        TransactionSynchronizationManager.initSynchronization();
+        subject.notifyStatusChanged(job);
+
+        // The outbox row was enqueued, but dispatch must not race an async thread's connection
+        // against this still-open transaction's own uncommitted insert.
+        verifyNoInteractions(notificationDispatchService);
+
+        TransactionSynchronizationManager.getSynchronizations().forEach(sync -> sync.afterCommit());
+
+        verify(notificationDispatchService, times(1)).dispatchAsync(any());
+    }
+
+    @Test
+    void notifyStatusChanged_noMatchingConfigDispatchesNothing() {
+        Job job = jobWithStatus(JobStatus.running);
+        when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of());
+
+        subject.notifyStatusChanged(job);
+
+        verifyNoInteractions(notificationDispatchService);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/NotificationConfigResolverTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/NotificationConfigResolverTest.java
@@ -1,0 +1,83 @@
+package io.terrakube.api.plugin.notification;
+
+import io.terrakube.api.repository.NotificationConfigurationRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.workspace.Workspace;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationConfigResolverTest {
+
+    @Mock
+    NotificationConfigurationRepository notificationConfigurationRepository;
+
+    @InjectMocks
+    NotificationConfigResolver resolver;
+
+    private NotificationConfiguration config(NotificationChannelType type, String name) {
+        NotificationConfiguration c = new NotificationConfiguration();
+        c.setId(UUID.randomUUID());
+        c.setChannelType(type);
+        c.setName(name);
+        c.setActive(true);
+        return c;
+    }
+
+    @Test
+    void workspaceAndOrgConfigsOfTheSameChannelTypeBothApply() {
+        UUID orgId = UUID.randomUUID();
+        UUID workspaceId = UUID.randomUUID();
+        Workspace workspace = new Workspace();
+        workspace.setId(workspaceId);
+        Organization organization = new Organization();
+        organization.setId(orgId);
+        workspace.setOrganization(organization);
+
+        NotificationConfiguration workspaceSlack = config(NotificationChannelType.SLACK, "workspace-slack");
+        NotificationConfiguration orgSlack = config(NotificationChannelType.SLACK, "org-slack");
+        NotificationConfiguration orgTeams = config(NotificationChannelType.TEAMS, "org-teams");
+
+        when(notificationConfigurationRepository.findByWorkspaceIdAndActiveTrue(workspaceId))
+                .thenReturn(List.of(workspaceSlack));
+        when(notificationConfigurationRepository.findByOrganizationIdAndWorkspaceIsNullAndActiveTrue(orgId))
+                .thenReturn(List.of(orgSlack, orgTeams));
+
+        List<NotificationConfiguration> effective = resolver.resolve(workspace);
+
+        // No suppression by channel type: the workspace's own Slack config and the org's Slack
+        // default both apply, alongside the org's Teams default.
+        assertThat(effective).containsExactlyInAnyOrder(workspaceSlack, orgSlack, orgTeams);
+    }
+
+    @Test
+    void noWorkspaceConfigs_allOrgConfigsApply() {
+        UUID orgId = UUID.randomUUID();
+        UUID workspaceId = UUID.randomUUID();
+        Workspace workspace = new Workspace();
+        workspace.setId(workspaceId);
+        Organization organization = new Organization();
+        organization.setId(orgId);
+        workspace.setOrganization(organization);
+
+        NotificationConfiguration orgSlack = config(NotificationChannelType.SLACK, "org-slack");
+
+        when(notificationConfigurationRepository.findByWorkspaceIdAndActiveTrue(workspaceId))
+                .thenReturn(List.of());
+        when(notificationConfigurationRepository.findByOrganizationIdAndWorkspaceIsNullAndActiveTrue(orgId))
+                .thenReturn(List.of(orgSlack));
+
+        assertThat(resolver.resolve(workspace)).containsExactly(orgSlack);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/NotificationConfigurationAccessServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/NotificationConfigurationAccessServiceTest.java
@@ -1,0 +1,226 @@
+package io.terrakube.api.plugin.notification;
+
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.repository.NotificationConfigurationRepository;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.repository.TeamRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+import io.terrakube.api.rs.team.Team;
+import io.terrakube.api.rs.workspace.Workspace;
+import io.terrakube.api.rs.workspace.access.Access;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NotificationConfigurationAccessServiceTest {
+
+    TeamRepository teamRepository;
+    NotificationConfigurationRepository notificationConfigurationRepository;
+    OrganizationRepository organizationRepository;
+    WorkspaceRepository workspaceRepository;
+    RbacService rbacService;
+    NotificationConfigurationAccessService subject;
+
+    final UUID orgId = UUID.randomUUID();
+    final UUID workspaceId = UUID.randomUUID();
+    final UUID configId = UUID.randomUUID();
+
+    @BeforeEach
+    void setup() {
+        teamRepository = mock(TeamRepository.class);
+        notificationConfigurationRepository = mock(NotificationConfigurationRepository.class);
+        organizationRepository = mock(OrganizationRepository.class);
+        workspaceRepository = mock(WorkspaceRepository.class);
+        rbacService = mock(RbacService.class);
+
+        subject = new NotificationConfigurationAccessService(teamRepository, notificationConfigurationRepository,
+                organizationRepository, workspaceRepository, rbacService);
+    }
+
+    private JwtAuthenticationToken authWithClaims(Map<String, Object> claims) {
+        JwtAuthenticationToken token = mock(JwtAuthenticationToken.class);
+        when(token.getTokenAttributes()).thenReturn(claims);
+        return token;
+    }
+
+    private Organization org() {
+        Organization organization = new Organization();
+        organization.setId(orgId);
+        return organization;
+    }
+
+    private Workspace workspace() {
+        Workspace workspace = new Workspace();
+        workspace.setId(workspaceId);
+        workspace.setOrganization(org());
+        return workspace;
+    }
+
+    private NotificationConfiguration orgScopedConfig() {
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setId(configId);
+        configuration.setOrganization(org());
+        return configuration;
+    }
+
+    private NotificationConfiguration workspaceScopedConfig(Workspace workspace) {
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setId(configId);
+        configuration.setWorkspace(workspace);
+        return configuration;
+    }
+
+    @Test
+    void hasManagePermission_internalIssuerBypassesAllChecks() {
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "TerrakubeInternal"));
+
+        assertThat(subject.hasManagePermission(token, configId.toString())).isTrue();
+    }
+
+    @Test
+    void hasManagePermission_returnsFalseWhenConfigurationNotFound() {
+        when(notificationConfigurationRepository.findById(configId)).thenReturn(Optional.empty());
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube", "groups", List.of("team-a")));
+
+        assertThat(subject.hasManagePermission(token, configId.toString())).isFalse();
+    }
+
+    @Test
+    void hasManagePermission_orgScoped_returnsTrueWhenTeamCanManageWorkspace() {
+        when(notificationConfigurationRepository.findById(configId)).thenReturn(Optional.of(orgScopedConfig()));
+        Team writeTeam = new Team();
+        writeTeam.setRole("write");
+        when(teamRepository.findAllByOrganizationIdAndNameIn(eq(orgId), any())).thenReturn(List.of(writeTeam));
+        when(rbacService.canManageWorkspace(writeTeam)).thenReturn(true);
+
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube", "groups", List.of("team-a")));
+
+        assertThat(subject.hasManagePermission(token, configId.toString())).isTrue();
+    }
+
+    @Test
+    void hasManagePermission_workspaceScoped_returnsTrueViaWorkspaceLevelAccessGrant_whenNoOrgWideAccess() {
+        Workspace workspace = workspace();
+        Access limitedAccess = new Access();
+        limitedAccess.setName("scoped-team");
+        workspace.setAccess(List.of(limitedAccess));
+        when(notificationConfigurationRepository.findById(configId))
+                .thenReturn(Optional.of(workspaceScopedConfig(workspace)));
+        when(teamRepository.findAllByOrganizationIdAndNameIn(eq(orgId), any())).thenReturn(List.of());
+        when(rbacService.canManageWorkspace(limitedAccess)).thenReturn(true);
+
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube", "groups", List.of("scoped-team")));
+
+        assertThat(subject.hasManagePermission(token, configId.toString())).isTrue();
+    }
+
+    @Test
+    void hasManagePermission_workspaceScoped_returnsTrueViaProjectLevelAccessGrant_whenNoOrgOrWorkspaceAccess() {
+        Workspace workspace = workspace();
+        workspace.setAccess(List.of());
+        Project project = new Project();
+        ProjectAccess projectAccess = new ProjectAccess();
+        projectAccess.setName("project-team");
+        project.setProjectAccess(List.of(projectAccess));
+        workspace.setProject(project);
+        when(notificationConfigurationRepository.findById(configId))
+                .thenReturn(Optional.of(workspaceScopedConfig(workspace)));
+        when(teamRepository.findAllByOrganizationIdAndNameIn(eq(orgId), any())).thenReturn(List.of());
+        when(rbacService.canManageWorkspace(projectAccess)).thenReturn(true);
+
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube", "groups", List.of("project-team")));
+
+        assertThat(subject.hasManagePermission(token, configId.toString())).isTrue();
+    }
+
+    @Test
+    void hasManagePermission_workspaceScoped_returnsFalseWhenNoTierGrantsAccess() {
+        Workspace workspace = workspace();
+        workspace.setAccess(List.of());
+        when(notificationConfigurationRepository.findById(configId))
+                .thenReturn(Optional.of(workspaceScopedConfig(workspace)));
+        when(teamRepository.findAllByOrganizationIdAndNameIn(eq(orgId), any())).thenReturn(List.of());
+
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube", "groups", List.of("unrelated-team")));
+
+        assertThat(subject.hasManagePermission(token, configId.toString())).isFalse();
+    }
+
+    @Test
+    void hasManagePermissionForOrganization_returnsFalseWhenOrganizationNotFound() {
+        when(organizationRepository.findById(orgId)).thenReturn(Optional.empty());
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube", "groups", List.of("team-a")));
+
+        assertThat(subject.hasManagePermissionForOrganization(token, orgId.toString())).isFalse();
+    }
+
+    @Test
+    void hasManagePermissionForOrganization_returnsTrueWhenTeamCanManageWorkspace() {
+        when(organizationRepository.findById(orgId)).thenReturn(Optional.of(org()));
+        Team writeTeam = new Team();
+        writeTeam.setRole("write");
+        when(teamRepository.findAllByOrganizationIdAndNameIn(eq(orgId), any())).thenReturn(List.of(writeTeam));
+        when(rbacService.canManageWorkspace(writeTeam)).thenReturn(true);
+
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube", "groups", List.of("team-a")));
+
+        assertThat(subject.hasManagePermissionForOrganization(token, orgId.toString())).isTrue();
+    }
+
+    @Test
+    void hasManagePermissionForOrganization_returnsFalseWhenNoTeamGrantsAccess() {
+        when(organizationRepository.findById(orgId)).thenReturn(Optional.of(org()));
+        Team readOnlyTeam = new Team();
+        readOnlyTeam.setRole("read");
+        when(teamRepository.findAllByOrganizationIdAndNameIn(eq(orgId), any())).thenReturn(List.of(readOnlyTeam));
+        when(rbacService.canManageWorkspace(readOnlyTeam)).thenReturn(false);
+
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube", "groups", List.of("team-a")));
+
+        assertThat(subject.hasManagePermissionForOrganization(token, orgId.toString())).isFalse();
+    }
+
+    @Test
+    void hasManagePermissionForWorkspace_internalIssuerBypassesAllChecks() {
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "TerrakubeInternal"));
+
+        assertThat(subject.hasManagePermissionForWorkspace(token, workspaceId.toString())).isTrue();
+    }
+
+    @Test
+    void hasManagePermissionForWorkspace_returnsFalseWhenWorkspaceNotFound() {
+        when(workspaceRepository.findById(workspaceId)).thenReturn(Optional.empty());
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube", "groups", List.of("team-a")));
+
+        assertThat(subject.hasManagePermissionForWorkspace(token, workspaceId.toString())).isFalse();
+    }
+
+    @Test
+    void hasManagePermissionForWorkspace_returnsTrueViaOrgWideAccess() {
+        Workspace workspace = workspace();
+        when(workspaceRepository.findById(workspaceId)).thenReturn(Optional.of(workspace));
+        Team writeTeam = new Team();
+        writeTeam.setRole("write");
+        when(teamRepository.findAllByOrganizationIdAndNameIn(eq(orgId), any())).thenReturn(List.of(writeTeam));
+        when(rbacService.canManageWorkspace(writeTeam)).thenReturn(true);
+
+        JwtAuthenticationToken token = authWithClaims(Map.of("iss", "Terrakube", "groups", List.of("team-a")));
+
+        assertThat(subject.hasManagePermissionForWorkspace(token, workspaceId.toString())).isTrue();
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/NotificationDispatchServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/NotificationDispatchServiceTest.java
@@ -1,0 +1,121 @@
+package io.terrakube.api.plugin.notification;
+
+import io.terrakube.api.plugin.notification.sender.NotificationDeliveryException;
+import io.terrakube.api.plugin.notification.sender.NotificationDeliveryService;
+import io.terrakube.api.rs.notification.NotificationOutboxStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationDispatchServiceTest {
+
+    @Mock
+    NotificationOutboxTransactions notificationOutboxTransactions;
+    @Mock
+    NotificationDeliveryService notificationDeliveryService;
+
+    @InjectMocks
+    NotificationDispatchService subject;
+
+    private ClaimedOutbox claimed(int attemptCount, Date lastAttemptAt) {
+        return new ClaimedOutbox(null, "{}", attemptCount, lastAttemptAt);
+    }
+
+    @Test
+    void successMarksRowSentAndClearsLastError() {
+        UUID id = UUID.randomUUID();
+        Date lastAttemptAt = new Date();
+        when(notificationOutboxTransactions.claim(id)).thenReturn(claimed(1, lastAttemptAt));
+        doNothing().when(notificationDeliveryService).deliver(any(), any());
+
+        subject.attemptDelivery(id);
+
+        verify(notificationOutboxTransactions).recordResult(eq(id), eq(lastAttemptAt),
+                eq(NotificationOutboxStatus.SENT), isNull(), isNull());
+    }
+
+    @Test
+    void failureBelowThreeAttemptsStaysPendingWithBackoff() {
+        UUID id = UUID.randomUUID();
+        Date lastAttemptAt = new Date();
+        when(notificationOutboxTransactions.claim(id)).thenReturn(claimed(1, lastAttemptAt));
+        doThrow(new NotificationDeliveryException("boom")).when(notificationDeliveryService).deliver(any(), any());
+
+        subject.attemptDelivery(id);
+
+        ArgumentCaptor<Date> nextAttemptAtCaptor = ArgumentCaptor.forClass(Date.class);
+        verify(notificationOutboxTransactions).recordResult(eq(id), eq(lastAttemptAt),
+                eq(NotificationOutboxStatus.PENDING), eq("boom"), nextAttemptAtCaptor.capture());
+        assertThat(nextAttemptAtCaptor.getValue()).isAfter(new Date());
+    }
+
+    @Test
+    void thirdFailedAttemptMarksRowPermanentlyFailed() {
+        UUID id = UUID.randomUUID();
+        Date lastAttemptAt = new Date();
+        when(notificationOutboxTransactions.claim(id)).thenReturn(claimed(3, lastAttemptAt));
+        doThrow(new NotificationDeliveryException("still broken")).when(notificationDeliveryService).deliver(any(),
+                any());
+
+        subject.attemptDelivery(id);
+
+        verify(notificationOutboxTransactions).recordResult(eq(id), eq(lastAttemptAt),
+                eq(NotificationOutboxStatus.FAILED), eq("still broken"), isNull());
+    }
+
+    @Test
+    void nonRetryableFailureIsMarkedFailedImmediatelyEvenOnFirstAttempt() {
+        UUID id = UUID.randomUUID();
+        Date lastAttemptAt = new Date();
+        when(notificationOutboxTransactions.claim(id)).thenReturn(claimed(1, lastAttemptAt));
+        doThrow(new NotificationDeliveryException("Webhook endpoint returned status 404", null, false))
+                .when(notificationDeliveryService).deliver(any(), any());
+
+        subject.attemptDelivery(id);
+
+        verify(notificationOutboxTransactions).recordResult(eq(id), eq(lastAttemptAt),
+                eq(NotificationOutboxStatus.FAILED), eq("Webhook endpoint returned status 404"), isNull());
+    }
+
+    @Test
+    void retryAfterHintOverridesTheDefaultBackoff() {
+        UUID id = UUID.randomUUID();
+        Date lastAttemptAt = new Date();
+        when(notificationOutboxTransactions.claim(id)).thenReturn(claimed(1, lastAttemptAt));
+        doThrow(new NotificationDeliveryException("rate limited", null, true, Duration.ofMinutes(10)))
+                .when(notificationDeliveryService).deliver(any(), any());
+
+        subject.attemptDelivery(id);
+
+        ArgumentCaptor<Date> nextAttemptAtCaptor = ArgumentCaptor.forClass(Date.class);
+        verify(notificationOutboxTransactions).recordResult(eq(id), eq(lastAttemptAt),
+                eq(NotificationOutboxStatus.PENDING), eq("rate limited"), nextAttemptAtCaptor.capture());
+        long delayMillis = nextAttemptAtCaptor.getValue().getTime() - System.currentTimeMillis();
+        assertThat(delayMillis).isGreaterThan(Duration.ofMinutes(9).toMillis());
+    }
+
+    @Test
+    void unclaimedRowIsSkippedWithoutAttemptingDelivery() {
+        UUID id = UUID.randomUUID();
+        when(notificationOutboxTransactions.claim(id)).thenReturn(null);
+
+        subject.attemptDelivery(id);
+
+        verifyNoInteractions(notificationDeliveryService);
+        verify(notificationOutboxTransactions, never()).recordResult(any(), any(), any(), any(), any());
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/NotificationOutboxTransactionsTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/NotificationOutboxTransactionsTest.java
@@ -1,0 +1,101 @@
+package io.terrakube.api.plugin.notification;
+
+import io.terrakube.api.repository.NotificationOutboxRepository;
+import io.terrakube.api.rs.notification.NotificationOutbox;
+import io.terrakube.api.rs.notification.NotificationOutboxStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationOutboxTransactionsTest {
+
+    @Mock
+    NotificationOutboxRepository notificationOutboxRepository;
+
+    @InjectMocks
+    NotificationOutboxTransactions subject;
+
+    @Test
+    void claimReturnsNullWhenTheRowWasNotClaimable() {
+        UUID id = UUID.randomUUID();
+        when(notificationOutboxRepository.claimForDelivery(eq(id), eq(NotificationOutboxStatus.PENDING),
+                eq(NotificationOutboxStatus.SENDING), any())).thenReturn(0);
+
+        assertThat(subject.claim(id)).isNull();
+        verify(notificationOutboxRepository, never()).findById(any());
+    }
+
+    @Test
+    void claimReturnsTheClaimedRowsDataWhenSuccessful() {
+        UUID id = UUID.randomUUID();
+        Date lastAttemptAt = new Date();
+        NotificationOutbox row = new NotificationOutbox();
+        row.setId(id);
+        row.setPayload("{}");
+        row.setAttemptCount(1);
+        row.setLastAttemptAt(lastAttemptAt);
+        when(notificationOutboxRepository.claimForDelivery(eq(id), eq(NotificationOutboxStatus.PENDING),
+                eq(NotificationOutboxStatus.SENDING), any())).thenReturn(1);
+        when(notificationOutboxRepository.findById(id)).thenReturn(Optional.of(row));
+
+        ClaimedOutbox claimed = subject.claim(id);
+
+        assertThat(claimed).isNotNull();
+        assertThat(claimed.attemptCount()).isEqualTo(1);
+        assertThat(claimed.lastAttemptAt()).isEqualTo(lastAttemptAt);
+        assertThat(claimed.payload()).isEqualTo("{}");
+    }
+
+    @Test
+    void recordResultDelegatesToTheConditionalUpdate() {
+        UUID id = UUID.randomUUID();
+        Date lastAttemptAt = new Date();
+        Date nextAttemptAt = new Date(lastAttemptAt.getTime() + 60_000);
+        when(notificationOutboxRepository.recordDeliveryResult(eq(id), eq(NotificationOutboxStatus.SENDING),
+                eq(lastAttemptAt), eq(NotificationOutboxStatus.PENDING), eq("boom"), eq(nextAttemptAt), any()))
+                .thenReturn(1);
+
+        subject.recordResult(id, lastAttemptAt, NotificationOutboxStatus.PENDING, "boom", nextAttemptAt);
+
+        verify(notificationOutboxRepository).recordDeliveryResult(eq(id), eq(NotificationOutboxStatus.SENDING),
+                eq(lastAttemptAt), eq(NotificationOutboxStatus.PENDING), eq("boom"), eq(nextAttemptAt), any());
+    }
+
+    @Test
+    void sweepStuckSendingRowsReclaimsAndFailsInOneTransaction() {
+        Date cutoff = new Date();
+
+        subject.sweepStuckSendingRows(cutoff, 3);
+
+        verify(notificationOutboxRepository).reclaimStuckSendingRows(eq(NotificationOutboxStatus.SENDING),
+                eq(NotificationOutboxStatus.PENDING), eq(cutoff), eq(3), any());
+        verify(notificationOutboxRepository).failStuckSendingRowsAtMaxAttempts(eq(NotificationOutboxStatus.SENDING),
+                eq(NotificationOutboxStatus.FAILED), eq(cutoff), eq(3), any(), any());
+    }
+
+    @Test
+    void pruneTerminalRowsOlderThanDelegatesToTheDeleteQuery() {
+        Date cutoff = new Date();
+        when(notificationOutboxRepository.deleteTerminalRowsCreatedBefore(
+                eq(java.util.List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED)), eq(cutoff)))
+                .thenReturn(5);
+
+        int deleted = subject.pruneTerminalRowsOlderThan(cutoff);
+
+        assertThat(deleted).isEqualTo(5);
+        verify(notificationOutboxRepository).deleteTerminalRowsCreatedBefore(
+                eq(java.util.List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED)), eq(cutoff));
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/NotificationTestServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/NotificationTestServiceTest.java
@@ -1,0 +1,73 @@
+package io.terrakube.api.plugin.notification;
+
+import io.terrakube.api.plugin.notification.payload.NotificationContext;
+import io.terrakube.api.plugin.notification.payload.NotificationPayloadRenderer;
+import io.terrakube.api.plugin.notification.sender.NotificationDeliveryService;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import io.terrakube.api.rs.workspace.Workspace;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationTestServiceTest {
+
+    @Mock
+    NotificationPayloadRenderer notificationPayloadRenderer;
+    @Mock
+    NotificationDeliveryService notificationDeliveryService;
+
+    @InjectMocks
+    NotificationTestService subject;
+
+    @Test
+    void rendersAndDeliversASyntheticPayloadForOrgScopedConfig() {
+        Organization organization = new Organization();
+        organization.setName("acme");
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setChannelType(NotificationChannelType.SLACK);
+        configuration.setOrganization(organization);
+
+        when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{\"blocks\":[]}");
+
+        subject.sendTest(configuration);
+
+        ArgumentCaptor<NotificationContext> captor = ArgumentCaptor.forClass(NotificationContext.class);
+        verify(notificationPayloadRenderer).render(eq(NotificationChannelType.SLACK), captor.capture());
+        assertThat(captor.getValue().organizationName()).isEqualTo("acme");
+        assertThat(captor.getValue().workspaceName()).isEqualTo("(test notification)");
+        verify(notificationDeliveryService).deliver(configuration, "{\"blocks\":[]}");
+    }
+
+    @Test
+    void usesWorkspaceNameWhenConfigurationIsWorkspaceScoped() {
+        Organization organization = new Organization();
+        organization.setName("acme");
+        Workspace workspace = new Workspace();
+        workspace.setName("networking");
+        workspace.setOrganization(organization);
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setChannelType(NotificationChannelType.WEBHOOK);
+        configuration.setOrganization(organization);
+        configuration.setWorkspace(workspace);
+
+        when(notificationPayloadRenderer.render(eq(NotificationChannelType.WEBHOOK), any())).thenReturn("{}");
+
+        subject.sendTest(configuration);
+
+        ArgumentCaptor<NotificationContext> captor = ArgumentCaptor.forClass(NotificationContext.class);
+        verify(notificationPayloadRenderer).render(eq(NotificationChannelType.WEBHOOK), captor.capture());
+        assertThat(captor.getValue().workspaceName()).isEqualTo("networking");
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/payload/HmacSignerTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/payload/HmacSignerTest.java
@@ -1,0 +1,25 @@
+package io.terrakube.api.plugin.notification.payload;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HmacSignerTest {
+
+    @Test
+    void producesStableHexEncodedSignatureForSameInput() {
+        String signature1 = HmacSigner.sign("my-secret", "{\"a\":1}");
+        String signature2 = HmacSigner.sign("my-secret", "{\"a\":1}");
+
+        assertThat(signature1).isEqualTo(signature2);
+        assertThat(signature1).matches("^[0-9a-f]{64}$");
+    }
+
+    @Test
+    void differentSecretsProduceDifferentSignatures() {
+        String signature1 = HmacSigner.sign("secret-one", "payload");
+        String signature2 = HmacSigner.sign("secret-two", "payload");
+
+        assertThat(signature1).isNotEqualTo(signature2);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/payload/SlackPayloadBuilderTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/payload/SlackPayloadBuilderTest.java
@@ -3,6 +3,7 @@ package io.terrakube.api.plugin.notification.payload;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.notification.NotificationMessageStyle;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,32 +12,89 @@ class SlackPayloadBuilderTest {
 
     private final SlackPayloadBuilder builder = new SlackPayloadBuilder(new ObjectMapper());
 
+    private static final String WORKSPACE_URL = "https://terrakube.acme.com/organizations/acme/workspaces/networking";
+
     @Test
     void buildsBlockKitWithHeaderContextAndActionBlocks() throws Exception {
         NotificationContext context = new NotificationContext(
                 "acme", "networking", 42, JobStatus.completed,
-                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/42",
-                "abc123", null);
+                WORKSPACE_URL + "/runs/42",
+                "abc123", null, "Prod Alerts", WORKSPACE_URL, NotificationMessageStyle.DETAILED);
 
         String payload = builder.build(context);
         JsonNode root = new ObjectMapper().readTree(payload);
         JsonNode attachment = root.get("attachments").get(0);
         JsonNode blocks = attachment.get("blocks");
 
+        // The top-level "text" carries the "Run notification for org/workspace" link, not a
+        // repeat of the header - Slack always shows this as a separate line once blocks live
+        // inside "attachments", so it doubles as the preview/push-notification text and must not
+        // just duplicate what's already in the card.
+        assertThat(root.get("text").asText())
+                .contains("Run notification for").contains(WORKSPACE_URL).contains("acme/networking");
+        assertThat(root.get("username").asText()).isEqualTo("networking");
         assertThat(attachment.get("color").asText()).isEqualTo("#2eb67d");
         assertThat(blocks.get(0).get("type").asText()).isEqualTo("header");
         assertThat(blocks.get(0).get("text").get("text").asText()).contains("networking").contains("Completed");
-        assertThat(root.toString()).contains("acme").contains("42").contains(context.runUrl());
+        assertThat(root.toString()).contains("acme").contains("42").contains(context.runUrl()).contains("Prod Alerts");
     }
 
     @Test
     void includesFailureReasonWhenPresent() throws Exception {
         NotificationContext context = new NotificationContext(
                 "acme", "networking", 43, JobStatus.failed,
-                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/43",
-                null, "apply exited with code 1");
+                WORKSPACE_URL + "/runs/43",
+                null, "apply exited with code 1", "Prod Alerts", WORKSPACE_URL, NotificationMessageStyle.DETAILED);
 
         String payload = builder.build(context);
         assertThat(payload).contains("apply exited with code 1");
+    }
+
+    @Test
+    void omitsTheViewRunButtonAndWorkspaceLinkWhenNeitherUrlIsPresent() throws Exception {
+        // Test sends (NotificationTestService) have no real run/workspace page to link to -
+        // Slack's Block Kit rejects a button whose url isn't a valid absolute URL, so a
+        // placeholder like "#" would fail delivery entirely rather than just render a dead link.
+        NotificationContext context = new NotificationContext(
+                "acme", "(test notification)", 0, JobStatus.completed, null, null, null, "Test Notification", null,
+                NotificationMessageStyle.DETAILED);
+
+        String payload = builder.build(context);
+        JsonNode root = new ObjectMapper().readTree(payload);
+        JsonNode blocks = root.get("attachments").get(0).get("blocks");
+
+        assertThat(blocks).noneMatch(block -> "actions".equals(block.get("type").asText()));
+        assertThat(payload).doesNotContain("Run notification for");
+    }
+
+    @Test
+    void simpleStyleGetsACompactSingleLinePayloadRegardlessOfStatus() throws Exception {
+        NotificationContext context = new NotificationContext(
+                "acme", "networking", 42, JobStatus.running,
+                WORKSPACE_URL + "/runs/42", "abc123", null, "Prod Alerts", WORKSPACE_URL,
+                NotificationMessageStyle.SIMPLE);
+
+        String payload = builder.build(context);
+        JsonNode root = new ObjectMapper().readTree(payload);
+
+        assertThat(root.get("text").asText()).contains("networking").contains("Running");
+        assertThat(root.get("username").asText()).isEqualTo("networking");
+        assertThat(root.has("attachments")).isFalse();
+    }
+
+    @Test
+    void detailedStyleGetsTheFullCardRegardlessOfStatus() throws Exception {
+        for (JobStatus status : new JobStatus[] { JobStatus.queue, JobStatus.running, JobStatus.completed,
+                JobStatus.failed }) {
+            NotificationContext context = new NotificationContext(
+                    "acme", "networking", 42, status,
+                    WORKSPACE_URL + "/runs/42", "abc123", null, "Prod Alerts", WORKSPACE_URL,
+                    NotificationMessageStyle.DETAILED);
+
+            String payload = builder.build(context);
+            JsonNode root = new ObjectMapper().readTree(payload);
+
+            assertThat(root.has("attachments")).as("status %s should get the full card", status).isTrue();
+        }
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/notification/payload/SlackPayloadBuilderTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/payload/SlackPayloadBuilderTest.java
@@ -1,0 +1,42 @@
+package io.terrakube.api.plugin.notification.payload;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.api.rs.job.JobStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SlackPayloadBuilderTest {
+
+    private final SlackPayloadBuilder builder = new SlackPayloadBuilder(new ObjectMapper());
+
+    @Test
+    void buildsBlockKitWithHeaderContextAndActionBlocks() throws Exception {
+        NotificationContext context = new NotificationContext(
+                "acme", "networking", 42, JobStatus.completed,
+                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/42",
+                "abc123", null);
+
+        String payload = builder.build(context);
+        JsonNode root = new ObjectMapper().readTree(payload);
+        JsonNode attachment = root.get("attachments").get(0);
+        JsonNode blocks = attachment.get("blocks");
+
+        assertThat(attachment.get("color").asText()).isEqualTo("#2eb67d");
+        assertThat(blocks.get(0).get("type").asText()).isEqualTo("header");
+        assertThat(blocks.get(0).get("text").get("text").asText()).contains("networking").contains("Completed");
+        assertThat(root.toString()).contains("acme").contains("42").contains(context.runUrl());
+    }
+
+    @Test
+    void includesFailureReasonWhenPresent() throws Exception {
+        NotificationContext context = new NotificationContext(
+                "acme", "networking", 43, JobStatus.failed,
+                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/43",
+                null, "apply exited with code 1");
+
+        String payload = builder.build(context);
+        assertThat(payload).contains("apply exited with code 1");
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/payload/TeamsPayloadBuilderTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/payload/TeamsPayloadBuilderTest.java
@@ -3,6 +3,7 @@ package io.terrakube.api.plugin.notification.payload;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.notification.NotificationMessageStyle;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,12 +12,14 @@ class TeamsPayloadBuilderTest {
 
     private final TeamsPayloadBuilder builder = new TeamsPayloadBuilder(new ObjectMapper());
 
+    private static final String WORKSPACE_URL = "https://terrakube.acme.com/organizations/acme/workspaces/networking";
+
     @Test
     void buildsAnAdaptiveCardWithTitleFactSetAndActionButton() throws Exception {
         NotificationContext context = new NotificationContext(
                 "acme", "networking", 42, JobStatus.completed,
-                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/42",
-                "abc123", null);
+                WORKSPACE_URL + "/runs/42",
+                "abc123", null, "Prod Alerts", WORKSPACE_URL, NotificationMessageStyle.DETAILED);
 
         String payload = builder.build(context);
         JsonNode root = new ObjectMapper().readTree(payload);
@@ -24,16 +27,17 @@ class TeamsPayloadBuilderTest {
         JsonNode body = card.get("body");
 
         assertThat(card.get("type").asText()).isEqualTo("AdaptiveCard");
-        assertThat(body.get(0).get("text").asText()).contains("networking").contains("completed");
-        assertThat(root.toString()).contains("acme").contains("42").contains(context.runUrl());
+        assertThat(body.get(0).get("text").asText()).contains("Run notification for").contains(WORKSPACE_URL);
+        assertThat(body.get(1).get("text").asText()).contains("networking").contains("completed");
+        assertThat(root.toString()).contains("acme").contains("42").contains(context.runUrl()).contains("Prod Alerts");
     }
 
     @Test
     void includesCommitIdInTheFactSetWhenPresent() throws Exception {
         NotificationContext context = new NotificationContext(
                 "acme", "networking", 42, JobStatus.completed,
-                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/42",
-                "abc123", null);
+                WORKSPACE_URL + "/runs/42",
+                "abc123", null, "Prod Alerts", WORKSPACE_URL, NotificationMessageStyle.DETAILED);
 
         String payload = builder.build(context);
 
@@ -44,8 +48,8 @@ class TeamsPayloadBuilderTest {
     void omitsCommitFactWhenCommitIdIsAbsent() throws Exception {
         NotificationContext context = new NotificationContext(
                 "acme", "networking", 42, JobStatus.completed,
-                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/42",
-                null, null);
+                WORKSPACE_URL + "/runs/42",
+                null, null, "Prod Alerts", WORKSPACE_URL, NotificationMessageStyle.DETAILED);
 
         String payload = builder.build(context);
 
@@ -56,8 +60,8 @@ class TeamsPayloadBuilderTest {
     void includesFailureReasonWhenTheJobFailed() throws Exception {
         NotificationContext context = new NotificationContext(
                 "acme", "networking", 43, JobStatus.failed,
-                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/43",
-                null, "apply exited with code 1");
+                WORKSPACE_URL + "/runs/43",
+                null, "apply exited with code 1", "Prod Alerts", WORKSPACE_URL, NotificationMessageStyle.DETAILED);
 
         String payload = builder.build(context);
 
@@ -68,14 +72,47 @@ class TeamsPayloadBuilderTest {
     void omitsFailureReasonTextBlockWhenNotFailed() throws Exception {
         NotificationContext context = new NotificationContext(
                 "acme", "networking", 42, JobStatus.completed,
-                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/42",
-                null, null);
+                WORKSPACE_URL + "/runs/42",
+                null, null, "Prod Alerts", WORKSPACE_URL, NotificationMessageStyle.DETAILED);
 
         String payload = builder.build(context);
         JsonNode root = new ObjectMapper().readTree(payload);
         JsonNode body = root.get("attachments").get(0).get("content").get("body");
 
-        // Just the title TextBlock and the FactSet - no third, failure-reason element.
-        assertThat(body).hasSize(2);
+        // The workspace-link TextBlock, the title TextBlock, and the FactSet - no fourth,
+        // failure-reason element.
+        assertThat(body).hasSize(3);
+    }
+
+    @Test
+    void omitsTheActionsListAndWorkspaceLinkWhenNeitherUrlIsPresent() throws Exception {
+        NotificationContext context = new NotificationContext(
+                "acme", "(test notification)", 0, JobStatus.completed, null, null, null, "Test Notification", null,
+                NotificationMessageStyle.DETAILED);
+
+        String payload = builder.build(context);
+        JsonNode root = new ObjectMapper().readTree(payload);
+        JsonNode card = root.get("attachments").get(0).get("content");
+
+        assertThat(card.has("actions")).isFalse();
+        assertThat(payload).doesNotContain("Run notification for");
+    }
+
+    @Test
+    void simpleStyleGetsAMinimalOneBlockCardRegardlessOfStatus() throws Exception {
+        NotificationContext context = new NotificationContext(
+                "acme", "networking", 42, JobStatus.running,
+                WORKSPACE_URL + "/runs/42", "abc123", null, "Prod Alerts", WORKSPACE_URL,
+                NotificationMessageStyle.SIMPLE);
+
+        String payload = builder.build(context);
+        JsonNode root = new ObjectMapper().readTree(payload);
+        JsonNode card = root.get("attachments").get(0).get("content");
+        JsonNode body = card.get("body");
+
+        assertThat(body).hasSize(1);
+        assertThat(body.get(0).get("text").asText()).contains("networking").contains("running");
+        assertThat(card.has("actions")).isFalse();
+        assertThat(payload).doesNotContain("FactSet").doesNotContain("Run notification for");
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/notification/payload/TeamsPayloadBuilderTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/payload/TeamsPayloadBuilderTest.java
@@ -1,0 +1,81 @@
+package io.terrakube.api.plugin.notification.payload;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.api.rs.job.JobStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TeamsPayloadBuilderTest {
+
+    private final TeamsPayloadBuilder builder = new TeamsPayloadBuilder(new ObjectMapper());
+
+    @Test
+    void buildsAnAdaptiveCardWithTitleFactSetAndActionButton() throws Exception {
+        NotificationContext context = new NotificationContext(
+                "acme", "networking", 42, JobStatus.completed,
+                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/42",
+                "abc123", null);
+
+        String payload = builder.build(context);
+        JsonNode root = new ObjectMapper().readTree(payload);
+        JsonNode card = root.get("attachments").get(0).get("content");
+        JsonNode body = card.get("body");
+
+        assertThat(card.get("type").asText()).isEqualTo("AdaptiveCard");
+        assertThat(body.get(0).get("text").asText()).contains("networking").contains("completed");
+        assertThat(root.toString()).contains("acme").contains("42").contains(context.runUrl());
+    }
+
+    @Test
+    void includesCommitIdInTheFactSetWhenPresent() throws Exception {
+        NotificationContext context = new NotificationContext(
+                "acme", "networking", 42, JobStatus.completed,
+                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/42",
+                "abc123", null);
+
+        String payload = builder.build(context);
+
+        assertThat(payload).contains("Commit").contains("abc123");
+    }
+
+    @Test
+    void omitsCommitFactWhenCommitIdIsAbsent() throws Exception {
+        NotificationContext context = new NotificationContext(
+                "acme", "networking", 42, JobStatus.completed,
+                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/42",
+                null, null);
+
+        String payload = builder.build(context);
+
+        assertThat(payload).doesNotContain("Commit");
+    }
+
+    @Test
+    void includesFailureReasonWhenTheJobFailed() throws Exception {
+        NotificationContext context = new NotificationContext(
+                "acme", "networking", 43, JobStatus.failed,
+                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/43",
+                null, "apply exited with code 1");
+
+        String payload = builder.build(context);
+
+        assertThat(payload).contains("apply exited with code 1");
+    }
+
+    @Test
+    void omitsFailureReasonTextBlockWhenNotFailed() throws Exception {
+        NotificationContext context = new NotificationContext(
+                "acme", "networking", 42, JobStatus.completed,
+                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/42",
+                null, null);
+
+        String payload = builder.build(context);
+        JsonNode root = new ObjectMapper().readTree(payload);
+        JsonNode body = root.get("attachments").get(0).get("content").get("body");
+
+        // Just the title TextBlock and the FactSet - no third, failure-reason element.
+        assertThat(body).hasSize(2);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/payload/WebhookPayloadBuilderTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/payload/WebhookPayloadBuilderTest.java
@@ -1,0 +1,31 @@
+package io.terrakube.api.plugin.notification.payload;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.api.rs.job.JobStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebhookPayloadBuilderTest {
+
+    private final WebhookPayloadBuilder builder = new WebhookPayloadBuilder(new ObjectMapper());
+
+    @Test
+    void buildsFlatJsonWithAllContextFields() throws Exception {
+        NotificationContext context = new NotificationContext(
+                "acme", "networking", 42, JobStatus.failed,
+                "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/42",
+                "abc123", "apply exited with code 1");
+
+        String payload = builder.build(context);
+        var root = new ObjectMapper().readTree(payload);
+
+        assertThat(root.get("organization").asText()).isEqualTo("acme");
+        assertThat(root.get("workspace").asText()).isEqualTo("networking");
+        assertThat(root.get("jobId").asInt()).isEqualTo(42);
+        assertThat(root.get("status").asText()).isEqualTo("failed");
+        assertThat(root.get("runUrl").asText()).isEqualTo(context.runUrl());
+        assertThat(root.get("commitId").asText()).isEqualTo("abc123");
+        assertThat(root.get("failureReason").asText()).isEqualTo("apply exited with code 1");
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/payload/WebhookPayloadBuilderTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/payload/WebhookPayloadBuilderTest.java
@@ -2,6 +2,7 @@ package io.terrakube.api.plugin.notification.payload;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.notification.NotificationMessageStyle;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,7 +16,8 @@ class WebhookPayloadBuilderTest {
         NotificationContext context = new NotificationContext(
                 "acme", "networking", 42, JobStatus.failed,
                 "https://terrakube.acme.com/organizations/acme/workspaces/networking/runs/42",
-                "abc123", "apply exited with code 1");
+                "abc123", "apply exited with code 1", "Prod Alerts",
+                "https://terrakube.acme.com/organizations/acme/workspaces/networking", NotificationMessageStyle.DETAILED);
 
         String payload = builder.build(context);
         var root = new ObjectMapper().readTree(payload);
@@ -27,5 +29,7 @@ class WebhookPayloadBuilderTest {
         assertThat(root.get("runUrl").asText()).isEqualTo(context.runUrl());
         assertThat(root.get("commitId").asText()).isEqualTo("abc123");
         assertThat(root.get("failureReason").asText()).isEqualTo("apply exited with code 1");
+        assertThat(root.get("configurationName").asText()).isEqualTo("Prod Alerts");
+        assertThat(root.get("workspaceUrl").asText()).isEqualTo(context.workspaceUrl());
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/notification/sender/DestinationUrlValidatorTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/sender/DestinationUrlValidatorTest.java
@@ -1,0 +1,65 @@
+package io.terrakube.api.plugin.notification.sender;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DestinationUrlValidatorTest {
+
+    private final DestinationUrlValidator blocking = new DestinationUrlValidator(true);
+    private final DestinationUrlValidator permissive = new DestinationUrlValidator(false);
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://127.0.0.1/hook",
+            "http://localhost/hook",
+            "http://10.0.0.5/hook",
+            "http://172.16.4.4/hook",
+            "http://192.168.1.1/hook",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://100.64.0.1/hook",
+            "http://0.0.0.0/hook",
+    })
+    void blocksPrivateAndReservedDestinationsByDefault(String url) {
+        NotificationDeliveryException e = catchDeliveryException(url);
+
+        assertThat(e.isRetryable()).isFalse();
+    }
+
+    private NotificationDeliveryException catchDeliveryException(String url) {
+        try {
+            blocking.validate("Webhook", url);
+        } catch (NotificationDeliveryException e) {
+            return e;
+        }
+        throw new AssertionError("expected NotificationDeliveryException to be thrown for " + url);
+    }
+
+    @Test
+    void allowsAPublicHostnameByDefault() {
+        assertThatCode(() -> blocking.validate("Webhook", "https://hooks.slack.com/services/X/Y/Z"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsNonHttpSchemesEvenWhenPermissive() {
+        assertThatThrownBy(() -> permissive.validate("Webhook", "file:///etc/passwd"))
+                .isInstanceOf(NotificationDeliveryException.class);
+    }
+
+    @Test
+    void rejectsMalformedUrlsEvenWhenPermissive() {
+        assertThatThrownBy(() -> permissive.validate("Webhook", "not a url"))
+                .isInstanceOf(NotificationDeliveryException.class);
+    }
+
+    @Test
+    void permissiveModeAllowsLoopbackForLocalTesting() {
+        assertThatCode(() -> permissive.validate("Webhook", "http://127.0.0.1:8080/hook"))
+                .doesNotThrowAnyException();
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/sender/HttpDeliveryErrorsTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/sender/HttpDeliveryErrorsTest.java
@@ -1,0 +1,102 @@
+package io.terrakube.api.plugin.notification.sender;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpDeliveryErrorsTest {
+
+    @Test
+    void tooManyRequestsIsRetryable() {
+        HttpClientErrorException e = HttpClientErrorException.create(HttpStatus.TOO_MANY_REQUESTS, "Too Many Requests",
+                new HttpHeaders(), new byte[0], StandardCharsets.UTF_8);
+
+        NotificationDeliveryException result = HttpDeliveryErrors.fromStatus("Slack", e);
+
+        assertThat(result.isRetryable()).isTrue();
+        assertThat(result.getRetryAfter()).isNull();
+    }
+
+    @Test
+    void serverErrorIsRetryable() {
+        HttpServerErrorException e = HttpServerErrorException.create(HttpStatus.SERVICE_UNAVAILABLE,
+                "Service Unavailable", new HttpHeaders(), new byte[0], StandardCharsets.UTF_8);
+
+        NotificationDeliveryException result = HttpDeliveryErrors.fromStatus("Teams", e);
+
+        assertThat(result.isRetryable()).isTrue();
+    }
+
+    @Test
+    void otherClientErrorsAreNotRetryable() {
+        for (HttpStatus status : new HttpStatus[] { HttpStatus.BAD_REQUEST, HttpStatus.UNAUTHORIZED,
+                HttpStatus.FORBIDDEN, HttpStatus.NOT_FOUND, HttpStatus.GONE }) {
+            HttpClientErrorException e = HttpClientErrorException.create(status, status.getReasonPhrase(), new HttpHeaders(),
+                    new byte[0], StandardCharsets.UTF_8);
+
+            NotificationDeliveryException result = HttpDeliveryErrors.fromStatus("Webhook", e);
+
+            assertThat(result.isRetryable()).as("status %s should be terminal", status).isFalse();
+            assertThat(result.getRetryAfter()).isNull();
+        }
+    }
+
+    @Test
+    void parsesDeltaSecondsRetryAfterHeader() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.RETRY_AFTER, "30");
+        HttpClientErrorException e = HttpClientErrorException.create(HttpStatus.TOO_MANY_REQUESTS, "Too Many Requests",
+                headers, new byte[0], StandardCharsets.UTF_8);
+
+        NotificationDeliveryException result = HttpDeliveryErrors.fromStatus("Slack", e);
+
+        assertThat(result.getRetryAfter()).isEqualTo(Duration.ofSeconds(30));
+    }
+
+    @Test
+    void parsesHttpDateRetryAfterHeader() {
+        ZonedDateTime target = ZonedDateTime.now(java.time.ZoneOffset.UTC).plusMinutes(2).withNano(0);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.RETRY_AFTER, target.format(DateTimeFormatter.RFC_1123_DATE_TIME));
+        HttpServerErrorException e = HttpServerErrorException.create(HttpStatus.SERVICE_UNAVAILABLE,
+                "Service Unavailable", headers, new byte[0], StandardCharsets.UTF_8);
+
+        NotificationDeliveryException result = HttpDeliveryErrors.fromStatus("Teams", e);
+
+        assertThat(result.getRetryAfter()).isNotNull();
+        assertThat(result.getRetryAfter().toSeconds()).isBetween(100L, 125L);
+    }
+
+    @Test
+    void malformedRetryAfterHeaderIsIgnored() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.RETRY_AFTER, "not-a-valid-value");
+        HttpClientErrorException e = HttpClientErrorException.create(HttpStatus.TOO_MANY_REQUESTS, "Too Many Requests",
+                headers, new byte[0], StandardCharsets.UTF_8);
+
+        NotificationDeliveryException result = HttpDeliveryErrors.fromStatus("Slack", e);
+
+        assertThat(result.isRetryable()).isTrue();
+        assertThat(result.getRetryAfter()).isNull();
+    }
+
+    @Test
+    void networkErrorsAreRetryable() {
+        ResourceAccessException e = new ResourceAccessException("connect timed out");
+
+        NotificationDeliveryException result = HttpDeliveryErrors.fromNetworkError("Webhook", e);
+
+        assertThat(result.isRetryable()).isTrue();
+        assertThat(result.getRetryAfter()).isNull();
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/sender/SlackSenderTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/sender/SlackSenderTest.java
@@ -1,0 +1,87 @@
+package io.terrakube.api.plugin.notification.sender;
+
+import java.time.Duration;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.terrakube.api.plugin.proxy.RestTemplateFactory;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SlackSenderTest {
+
+    private WireMockServer wireMockServer;
+    // block-private-destinations off: WireMock runs on localhost, which is a loopback address.
+    private final SlackSender sender = new SlackSender(RestTemplateFactory.build(), new DestinationUrlValidator(false));
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(options().dynamicPort());
+        wireMockServer.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+    }
+
+    private NotificationConfiguration configuration() {
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setChannelType(NotificationChannelType.SLACK);
+        configuration.setDestinationUrl("http://localhost:" + wireMockServer.port() + "/services/X/Y/Z");
+        return configuration;
+    }
+
+    @Test
+    void postsBlockKitPayloadToIncomingWebhookUrl() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/services/X/Y/Z")).willReturn(aResponse().withStatus(200)));
+
+        sender.send(configuration(), "{\"blocks\":[]}");
+
+        wireMockServer.verify(postRequestedFor(urlPathEqualTo("/services/X/Y/Z")));
+    }
+
+    @Test
+    void throwsNotificationDeliveryExceptionOnNon2xxResponse() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/services/X/Y/Z")).willReturn(aResponse().withStatus(404)));
+
+        assertThatThrownBy(() -> sender.send(configuration(), "{}"))
+                .isInstanceOf(NotificationDeliveryException.class);
+    }
+
+    @Test
+    void aNotFoundIsClassifiedAsTerminal() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/services/X/Y/Z")).willReturn(aResponse().withStatus(404)));
+
+        NotificationDeliveryException e = catchDeliveryException();
+
+        assertThat(e.isRetryable()).isFalse();
+    }
+
+    @Test
+    void rateLimitedIsClassifiedAsRetryableWithRetryAfter() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/services/X/Y/Z"))
+                .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "5")));
+
+        NotificationDeliveryException e = catchDeliveryException();
+
+        assertThat(e.isRetryable()).isTrue();
+        assertThat(e.getRetryAfter()).isEqualTo(Duration.ofSeconds(5));
+    }
+
+    private NotificationDeliveryException catchDeliveryException() {
+        try {
+            sender.send(configuration(), "{}");
+        } catch (NotificationDeliveryException e) {
+            return e;
+        }
+        throw new AssertionError("expected NotificationDeliveryException to be thrown");
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/sender/SlackSenderTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/sender/SlackSenderTest.java
@@ -41,11 +41,24 @@ class SlackSenderTest {
 
     @Test
     void postsBlockKitPayloadToIncomingWebhookUrl() {
-        wireMockServer.stubFor(post(urlPathEqualTo("/services/X/Y/Z")).willReturn(aResponse().withStatus(200)));
+        wireMockServer.stubFor(post(urlPathEqualTo("/services/X/Y/Z")).willReturn(aResponse().withStatus(200).withBody("ok")));
 
-        sender.send(configuration(), "{\"blocks\":[]}");
+        sender.send(configuration(), "{\"text\":\"fallback\",\"attachments\":[{\"blocks\":[]}]}");
 
         wireMockServer.verify(postRequestedFor(urlPathEqualTo("/services/X/Y/Z")));
+    }
+
+    @Test
+    void aPlainTextErrorBodyOnA200ResponseIsTreatedAsAFailure() {
+        // Incoming Webhooks report payload/config problems (e.g. a payload missing the required
+        // top-level "text" field) as HTTP 200 with a plain-text error body, not a 4xx - a status
+        // code check alone would silently record this as delivered.
+        wireMockServer.stubFor(post(urlPathEqualTo("/services/X/Y/Z")).willReturn(aResponse().withStatus(200).withBody("no_text")));
+
+        NotificationDeliveryException e = catchDeliveryException();
+
+        assertThat(e.getMessage()).contains("no_text");
+        assertThat(e.isRetryable()).isFalse();
     }
 
     @Test

--- a/api/src/test/java/io/terrakube/api/plugin/notification/sender/TeamsSenderTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/sender/TeamsSenderTest.java
@@ -1,0 +1,74 @@
+package io.terrakube.api.plugin.notification.sender;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.terrakube.api.plugin.proxy.RestTemplateFactory;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TeamsSenderTest {
+
+    private WireMockServer wireMockServer;
+    // block-private-destinations off: WireMock runs on localhost, which is a loopback address.
+    private final TeamsSender sender = new TeamsSender(RestTemplateFactory.build(), new DestinationUrlValidator(false));
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(options().dynamicPort());
+        wireMockServer.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+    }
+
+    private NotificationConfiguration configuration() {
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setChannelType(NotificationChannelType.TEAMS);
+        configuration.setDestinationUrl("http://localhost:" + wireMockServer.port() + "/webhookb2/X");
+        return configuration;
+    }
+
+    @Test
+    void postsAdaptiveCardPayloadToIncomingWebhookUrl() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/webhookb2/X")).willReturn(aResponse().withStatus(200)));
+
+        sender.send(configuration(), "{\"type\":\"AdaptiveCard\"}");
+
+        wireMockServer.verify(postRequestedFor(urlPathEqualTo("/webhookb2/X")));
+    }
+
+    @Test
+    void notFoundIsClassifiedAsTerminal() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/webhookb2/X")).willReturn(aResponse().withStatus(404)));
+
+        NotificationDeliveryException e = catchDeliveryException();
+
+        assertThat(e.isRetryable()).isFalse();
+    }
+
+    @Test
+    void serverErrorIsClassifiedAsRetryable() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/webhookb2/X")).willReturn(aResponse().withStatus(502)));
+
+        NotificationDeliveryException e = catchDeliveryException();
+
+        assertThat(e.isRetryable()).isTrue();
+    }
+
+    private NotificationDeliveryException catchDeliveryException() {
+        try {
+            sender.send(configuration(), "{}");
+        } catch (NotificationDeliveryException e) {
+            return e;
+        }
+        throw new AssertionError("expected NotificationDeliveryException to be thrown");
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/sender/WebhookSenderTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/sender/WebhookSenderTest.java
@@ -1,0 +1,120 @@
+package io.terrakube.api.plugin.notification.sender;
+
+import java.time.Duration;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.terrakube.api.plugin.notification.payload.HmacSigner;
+import io.terrakube.api.plugin.proxy.RestTemplateFactory;
+import io.terrakube.api.rs.notification.NotificationChannelType;
+import io.terrakube.api.rs.notification.NotificationConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WebhookSenderTest {
+
+    private WireMockServer wireMockServer;
+    // block-private-destinations off: WireMock runs on localhost, which is a loopback address.
+    private final WebhookSender sender = new WebhookSender(RestTemplateFactory.build(), new DestinationUrlValidator(false));
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(options().dynamicPort());
+        wireMockServer.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+    }
+
+    private NotificationConfiguration configuration(String path, String secret) {
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setChannelType(NotificationChannelType.WEBHOOK);
+        configuration.setDestinationUrl("http://localhost:" + wireMockServer.port() + path);
+        configuration.setSigningSecret(secret);
+        return configuration;
+    }
+
+    @Test
+    void sendsUnsignedPayloadWhenNoSecretConfigured() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/hook"))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .willReturn(aResponse().withStatus(200)));
+
+        sender.send(configuration("/hook", null), "{\"a\":1}");
+
+        wireMockServer.verify(postRequestedFor(urlPathEqualTo("/hook"))
+                .withoutHeader("X-Terrakube-Signature"));
+    }
+
+    @Test
+    void signsPayloadWhenSecretConfigured() {
+        String payload = "{\"a\":1}";
+        String expectedSignature = HmacSigner.sign("my-secret", payload);
+        wireMockServer.stubFor(post(urlPathEqualTo("/hook"))
+                .withHeader("X-Terrakube-Signature", equalTo(expectedSignature))
+                .willReturn(aResponse().withStatus(200)));
+
+        sender.send(configuration("/hook", "my-secret"), payload);
+
+        wireMockServer.verify(postRequestedFor(urlPathEqualTo("/hook")));
+    }
+
+    @Test
+    void throwsNotificationDeliveryExceptionOnNon2xxResponse() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/hook")).willReturn(aResponse().withStatus(500)));
+
+        assertThatThrownBy(() -> sender.send(configuration("/hook", null), "{}"))
+                .isInstanceOf(NotificationDeliveryException.class);
+    }
+
+    @Test
+    void serverErrorIsClassifiedAsRetryable() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/hook")).willReturn(aResponse().withStatus(503)));
+
+        NotificationDeliveryException e = catchDeliveryException();
+
+        assertThat(e.isRetryable()).isTrue();
+    }
+
+    @Test
+    void badRequestIsClassifiedAsTerminal() {
+        wireMockServer.stubFor(post(urlPathEqualTo("/hook")).willReturn(aResponse().withStatus(400)));
+
+        NotificationDeliveryException e = catchDeliveryException();
+
+        assertThat(e.isRetryable()).isFalse();
+        assertThat(e.getRetryAfter()).isNull();
+    }
+
+    @Test
+    void rateLimitedParsesHttpDateRetryAfterHeader() {
+        ZonedDateTime target = ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(90).withNano(0);
+        wireMockServer.stubFor(post(urlPathEqualTo("/hook")).willReturn(aResponse().withStatus(429)
+                .withHeader("Retry-After", target.format(DateTimeFormatter.RFC_1123_DATE_TIME))));
+
+        NotificationDeliveryException e = catchDeliveryException();
+
+        assertThat(e.isRetryable()).isTrue();
+        assertThat(e.getRetryAfter()).isNotNull();
+        assertThat(e.getRetryAfter().toSeconds()).isBetween(60L, 90L);
+    }
+
+    private NotificationDeliveryException catchDeliveryException() {
+        try {
+            sender.send(configuration("/hook", null), "{}");
+        } catch (NotificationDeliveryException e) {
+            return e;
+        }
+        throw new AssertionError("expected NotificationDeliveryException to be thrown");
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
@@ -38,6 +38,7 @@ import org.springframework.transaction.TransactionStatus;
 
 import graphql.Assert;
 import io.terrakube.api.helpers.FailUnkownMethod;
+import io.terrakube.api.plugin.notification.JobNotificationTrigger;
 import io.terrakube.api.plugin.scheduler.job.tcl.TclService;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutionException;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ExecutorService;
@@ -99,6 +100,7 @@ public class ScheduleJobTest {
     RedisTemplate<String, Object> redisTemplate;
     ValueOperations<String, Object> valueOperations;
     PlatformTransactionManager transactionManager;
+    JobNotificationTrigger jobNotificationTrigger;
 
     UUID stepId = UUID.randomUUID();
 
@@ -131,6 +133,9 @@ public class ScheduleJobTest {
         // reference in ScheduleJob), which has no persistence context to commit, so it's never called.
         transactionManager = mock(PlatformTransactionManager.class,
                 new FailUnkownMethod<PlatformTransactionManager>());
+        // Plain mock (not FailUnkownMethod): almost every status-transition path under test now
+        // calls notifyStatusChanged(), and its outcome is irrelevant to what these tests assert.
+        jobNotificationTrigger = mock(JobNotificationTrigger.class);
         lenient().doReturn(valueOperations).when(redisTemplate).opsForValue();
         lenient().doReturn(true).when(valueOperations).setIfAbsent(any(), any(), any(Duration.class));
         lenient().doReturn(true).when(redisTemplate).delete(anyString());
@@ -160,7 +165,8 @@ public class ScheduleJobTest {
                 globalVarRepository,
                 variableRepository,
                 workspaceVariableValidationService,
-                transactionManager);
+                transactionManager,
+                jobNotificationTrigger);
     }
 
     private Job job(JobStatus status) {
@@ -250,6 +256,10 @@ public class ScheduleJobTest {
         verify(valueOperations, times(1)).setIfAbsent(any(), any(), any(Duration.class));
         verify(redisTemplate, times(1)).delete(anyString());
         Assertions.assertEquals(JobStatus.queue, job.getStatus());
+        // Regression check: the scheduler updates job.status via a plain jobRepository.save(),
+        // never through Elide, so JobNotificationHook (an Elide LifeCycleHook) never sees this
+        // transition - notifyStatusChanged() must be called explicitly at every such call site.
+        verify(jobNotificationTrigger, times(1)).notifyStatusChanged(job);
     }
 
     @Test
@@ -718,6 +728,7 @@ public class ScheduleJobTest {
         verify(workspaceRepository, times(2)).save(job.getWorkspace());
         verify(gitLabWebhookService, times(1)).sendCommitStatus(job, JobStatus.completed, null);
         Assertions.assertEquals(JobStatus.completed, job.getStatus());
+        verify(jobNotificationTrigger, times(1)).notifyStatusChanged(job);
     }
 
     @Test

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/notification/NotificationOutboxPollerJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/notification/NotificationOutboxPollerJobTest.java
@@ -1,0 +1,91 @@
+package io.terrakube.api.plugin.scheduler.notification;
+
+import io.terrakube.api.plugin.notification.NotificationDispatchService;
+import io.terrakube.api.plugin.notification.NotificationOutboxTransactions;
+import io.terrakube.api.repository.NotificationOutboxRepository;
+import io.terrakube.api.rs.notification.NotificationOutbox;
+import io.terrakube.api.rs.notification.NotificationOutboxStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobExecutionContext;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.RejectedExecutionException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationOutboxPollerJobTest {
+
+    @Mock
+    NotificationOutboxRepository notificationOutboxRepository;
+    @Mock
+    NotificationDispatchService notificationDispatchService;
+    @Mock
+    NotificationOutboxTransactions notificationOutboxTransactions;
+    @Mock
+    JobExecutionContext jobExecutionContext;
+
+    NotificationOutboxPollerJob subject;
+
+    @BeforeEach
+    void setUp() {
+        // Constructed directly rather than via @InjectMocks: the constructor now takes plain
+        // int/long tuning values (batchSize, stuckSendingThresholdMinutes) that @Value only
+        // resolves in a real Spring context - @InjectMocks would silently default them to 0,
+        // which breaks PageRequest.of(0, 0).
+        subject = new NotificationOutboxPollerJob(notificationOutboxRepository, notificationDispatchService,
+                notificationOutboxTransactions, 200, 5);
+    }
+
+    private NotificationOutbox row() {
+        NotificationOutbox outbox = new NotificationOutbox();
+        outbox.setId(UUID.randomUUID());
+        outbox.setStatus(NotificationOutboxStatus.PENDING);
+        return outbox;
+    }
+
+    @Test
+    void dispatchesEveryRowReturnedAsDue() throws Exception {
+        NotificationOutbox first = row();
+        NotificationOutbox second = row();
+        when(notificationOutboxRepository.findDueForDispatch(eq(NotificationOutboxStatus.PENDING), any(),
+                any(Pageable.class))).thenReturn(List.of(first, second));
+
+        subject.execute(jobExecutionContext);
+
+        verify(notificationDispatchService).dispatchAsync(first.getId());
+        verify(notificationDispatchService).dispatchAsync(second.getId());
+    }
+
+    @Test
+    void sweepsStuckSendingRowsEveryTickViaTheTransactionalBean() throws Exception {
+        when(notificationOutboxRepository.findDueForDispatch(any(), any(), any(Pageable.class))).thenReturn(List.of());
+
+        subject.execute(jobExecutionContext);
+
+        verify(notificationOutboxTransactions).sweepStuckSendingRows(any(), eq(3));
+    }
+
+    @Test
+    void aRejectedDispatchDoesNotStopTheRestOfTheBatch() throws Exception {
+        NotificationOutbox first = row();
+        NotificationOutbox second = row();
+        when(notificationOutboxRepository.findDueForDispatch(any(), any(), any(Pageable.class)))
+                .thenReturn(List.of(first, second));
+        doThrow(new RejectedExecutionException("pool full")).when(notificationDispatchService)
+                .dispatchAsync(first.getId());
+
+        subject.execute(jobExecutionContext);
+
+        verify(notificationDispatchService).dispatchAsync(second.getId());
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/notification/NotificationOutboxRetentionJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/notification/NotificationOutboxRetentionJobTest.java
@@ -1,0 +1,46 @@
+package io.terrakube.api.plugin.scheduler.notification;
+
+import io.terrakube.api.plugin.notification.NotificationOutboxTransactions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobExecutionContext;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationOutboxRetentionJobTest {
+
+    @Mock
+    NotificationOutboxTransactions notificationOutboxTransactions;
+    @Mock
+    JobExecutionContext jobExecutionContext;
+
+    NotificationOutboxRetentionJob subject;
+
+    @BeforeEach
+    void setUp() {
+        // Constructed directly rather than via @InjectMocks: retentionDays only resolves via
+        // @Value in a real Spring context - see NotificationOutboxPollerJobTest for the same
+        // reasoning.
+        subject = new NotificationOutboxRetentionJob(notificationOutboxTransactions, 90);
+    }
+
+    @Test
+    void prunesRowsOlderThanTheConfiguredRetentionWindow() throws Exception {
+        subject.execute(jobExecutionContext);
+
+        ArgumentCaptor<Date> cutoffCaptor = ArgumentCaptor.forClass(Date.class);
+        verify(notificationOutboxTransactions).pruneTerminalRowsOlderThan(cutoffCaptor.capture());
+
+        long expectedCutoffMillis = System.currentTimeMillis() - 90L * 24 * 60 * 60 * 1000;
+        assertThat(cutoffCaptor.getValue().getTime()).isCloseTo(expectedCutoffMillis, within(5000L));
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/state/RemoteTfeServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/state/RemoteTfeServiceTest.java
@@ -1,5 +1,6 @@
 package io.terrakube.api.plugin.state;
 
+import io.terrakube.api.plugin.notification.JobNotificationTrigger;
 import io.terrakube.api.plugin.scheduler.ScheduleJobService;
 import io.terrakube.api.plugin.security.encryption.EncryptionService;
 import io.terrakube.api.plugin.security.rbac.RbacService;
@@ -75,6 +76,7 @@ class RemoteTfeServiceTest {
     private final VariableRepository variableRepository = Mockito.mock(VariableRepository.class);
     private final GlobalVarRepository globalVarRepository = Mockito.mock(GlobalVarRepository.class);
     private final RbacService rbacService = Mockito.mock(RbacService.class);
+    private final JobNotificationTrigger jobNotificationTrigger = Mockito.mock(JobNotificationTrigger.class);
 
     @Test
     void listWorkspaceWithSearchNameUsesLoadedWorkspaceEntities() {
@@ -165,7 +167,7 @@ class RemoteTfeServiceTest {
                 historyRepository, templateRepository, scheduleJobService, "localhost", storageTypeService,
                 stepRepository, redisTemplate, 1, tagRepository, workspaceTagRepository, teamTokenService,
                 archiveRepository, accessRepository, encryptionService, addressRepository, projectRepository,
-                variableRepository, globalVarRepository, rbacService);
+                variableRepository, globalVarRepository, rbacService, jobNotificationTrigger);
     }
 
     private JwtAuthenticationToken currentUser() {

--- a/api/src/test/java/io/terrakube/api/rs/hooks/notification/JobNotificationHookTest.java
+++ b/api/src/test/java/io/terrakube/api/rs/hooks/notification/JobNotificationHookTest.java
@@ -1,0 +1,117 @@
+package io.terrakube.api.rs.hooks.notification;
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding.Operation;
+import com.yahoo.elide.annotation.LifeCycleHookBinding.TransactionPhase;
+import com.yahoo.elide.core.security.RequestScope;
+import io.terrakube.api.plugin.notification.JobNotificationTrigger;
+import io.terrakube.api.plugin.notification.NotificationDispatchService;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.workspace.Workspace;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JobNotificationHookTest {
+
+    @Mock
+    JobNotificationTrigger jobNotificationTrigger;
+    @Mock
+    NotificationDispatchService notificationDispatchService;
+    @Mock
+    RequestScope requestScope;
+
+    @InjectMocks
+    JobNotificationHook subject;
+
+    private Job jobWithStatus(JobStatus status) {
+        Job job = new Job();
+        job.setId(42);
+        job.setStatus(status);
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+        organization.setName("acme");
+        Workspace workspace = new Workspace();
+        workspace.setId(UUID.randomUUID());
+        workspace.setName("networking");
+        workspace.setOrganization(organization);
+        job.setOrganization(organization);
+        job.setWorkspace(workspace);
+        return job;
+    }
+
+    @Test
+    void precommit_delegatesEnqueueingToJobNotificationTrigger() {
+        Job job = jobWithStatus(JobStatus.failed);
+        when(jobNotificationTrigger.enqueue(job)).thenReturn(List.of(UUID.randomUUID()));
+
+        subject.execute(Operation.UPDATE, TransactionPhase.PRECOMMIT, job, requestScope, Optional.empty());
+
+        verify(jobNotificationTrigger).enqueue(job);
+        verifyNoInteractions(notificationDispatchService);
+    }
+
+    @Test
+    void precommit_ignoredForNonUpdateOperations() {
+        Job job = jobWithStatus(JobStatus.failed);
+
+        subject.execute(Operation.CREATE, TransactionPhase.PRECOMMIT, job, requestScope, Optional.empty());
+
+        verifyNoInteractions(jobNotificationTrigger);
+    }
+
+    @Test
+    void postcommit_dispatchesEveryOutboxIdEnqueuedInThePrecedingPrecommitOnTheSameThread() {
+        Job job = jobWithStatus(JobStatus.failed);
+        UUID outboxId = UUID.randomUUID();
+        when(jobNotificationTrigger.enqueue(job)).thenReturn(List.of(outboxId));
+
+        subject.execute(Operation.UPDATE, TransactionPhase.PRECOMMIT, job, requestScope, Optional.empty());
+        subject.execute(Operation.UPDATE, TransactionPhase.POSTCOMMIT, job, requestScope, Optional.empty());
+
+        verify(notificationDispatchService, times(1)).dispatchAsync(outboxId);
+    }
+
+    @Test
+    void postcommit_dispatchesTheCorrectJobsOutboxIdsWhenTwoJobsUpdateOnTheSameThread() {
+        Job jobA = jobWithStatus(JobStatus.failed);
+        Job jobB = jobWithStatus(JobStatus.completed);
+        jobB.setId(43);
+        UUID outboxIdA = UUID.randomUUID();
+        UUID outboxIdB = UUID.randomUUID();
+        when(jobNotificationTrigger.enqueue(jobA)).thenReturn(List.of(outboxIdA));
+        when(jobNotificationTrigger.enqueue(jobB)).thenReturn(List.of(outboxIdB));
+
+        // A single Elide transaction updating two Job entities fires PRECOMMIT for both before
+        // either POSTCOMMIT runs - jobB's PRECOMMIT must not clobber jobA's still-pending outbox
+        // ids.
+        subject.execute(Operation.UPDATE, TransactionPhase.PRECOMMIT, jobA, requestScope, Optional.empty());
+        subject.execute(Operation.UPDATE, TransactionPhase.PRECOMMIT, jobB, requestScope, Optional.empty());
+        subject.execute(Operation.UPDATE, TransactionPhase.POSTCOMMIT, jobA, requestScope, Optional.empty());
+        subject.execute(Operation.UPDATE, TransactionPhase.POSTCOMMIT, jobB, requestScope, Optional.empty());
+
+        verify(notificationDispatchService, times(1)).dispatchAsync(outboxIdA);
+        verify(notificationDispatchService, times(1)).dispatchAsync(outboxIdB);
+    }
+
+    @Test
+    void postcommit_dispatchesNothingWhenPrecommitEnqueuedNothing() {
+        Job job = jobWithStatus(JobStatus.running);
+        when(jobNotificationTrigger.enqueue(job)).thenReturn(List.of());
+
+        subject.execute(Operation.UPDATE, TransactionPhase.PRECOMMIT, job, requestScope, Optional.empty());
+        subject.execute(Operation.UPDATE, TransactionPhase.POSTCOMMIT, job, requestScope, Optional.empty());
+
+        verifyNoInteractions(notificationDispatchService);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/rs/job/JobNotificationHookBindingTest.java
+++ b/api/src/test/java/io/terrakube/api/rs/job/JobNotificationHookBindingTest.java
@@ -1,0 +1,42 @@
+package io.terrakube.api.rs.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
+
+import io.terrakube.api.rs.hooks.notification.JobNotificationHook;
+
+class JobNotificationHookBindingTest {
+
+    private record Binding(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase phase) {
+    }
+
+    @Test
+    void registersJobNotificationHookOnTheStatusFieldForUpdatePrecommitAndPostcommit() throws NoSuchFieldException {
+        LifeCycleHookBinding[] bindings = Job.class.getDeclaredField("status")
+                .getAnnotationsByType(LifeCycleHookBinding.class);
+
+        Set<Binding> registered = java.util.Arrays.stream(bindings)
+                .filter(b -> b.hook() == JobNotificationHook.class)
+                .map(b -> new Binding(b.operation(), b.phase()))
+                .collect(Collectors.toSet());
+
+        assertThat(registered).containsExactlyInAnyOrder(
+                new Binding(LifeCycleHookBinding.Operation.UPDATE, LifeCycleHookBinding.TransactionPhase.PRECOMMIT),
+                new Binding(LifeCycleHookBinding.Operation.UPDATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT));
+    }
+
+    @Test
+    void doesNotRegisterJobNotificationHookAtTheClassLevel() {
+        LifeCycleHookBinding[] bindings = Job.class.getAnnotationsByType(LifeCycleHookBinding.class);
+
+        boolean anyOnClass = java.util.Arrays.stream(bindings).anyMatch(b -> b.hook() == JobNotificationHook.class);
+
+        assertThat(anyOnClass).isFalse();
+    }
+}

--- a/api/src/test/resources/application-test.properties
+++ b/api/src/test/resources/application-test.properties
@@ -99,3 +99,9 @@ io.terrakube.api.redis.port=6379
 io.terrakube.api.redis.username=default
 io.terrakube.api.redis.password=123456
 io.terrakube.api.redis.ssl=false
+
+#####################################################
+#NOTIFICATIONS: allow loopback destinations in tests#
+#integration tests deliver to a local WireMock server#
+#####################################################
+io.terrakube.notification.ssrf.blockPrivateNetworks=false

--- a/ui/src/domain/Home/App.tsx
+++ b/ui/src/domain/Home/App.tsx
@@ -381,6 +381,14 @@ const App = () => {
             element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="webhook" />,
           },
           {
+            path: "/workspaces/:id/settings/notifications",
+            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="notifications" />,
+          },
+          {
+            path: "/organizations/:orgid/workspaces/:id/settings/notifications",
+            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="notifications" />,
+          },
+          {
             path: "/workspaces/:id/settings/state-shared",
             element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="state-shared" />,
           },
@@ -479,6 +487,10 @@ const App = () => {
           {
             path: "/organizations/:orgid/settings/actions",
             element: <OrganizationSettings selectedTab="10" />,
+          },
+          {
+            path: "/organizations/:orgid/settings/notifications",
+            element: <OrganizationSettings selectedTab="12" />,
           },
           {
             path: "/organizations/:orgid/settings/collection",

--- a/ui/src/domain/Notifications/ChannelPicker.tsx
+++ b/ui/src/domain/Notifications/ChannelPicker.tsx
@@ -1,0 +1,60 @@
+import { CheckCircleFilled } from "@ant-design/icons";
+import { theme } from "antd";
+import { NotificationChannelType } from "../types";
+import { CHANNEL_META, CHANNEL_ORDER } from "./channelMeta";
+
+type Props = {
+  value?: NotificationChannelType;
+  onChange?: (value: NotificationChannelType) => void;
+};
+
+// A Form.Item-compatible control: antd clones its single child with value/onChange
+// props, same contract as a native input, so this drops straight into <Form.Item
+// name="channelType"> in place of a <Select> without any extra wiring.
+export const ChannelPicker = ({ value, onChange }: Props) => {
+  const { token } = theme.useToken();
+
+  return (
+    <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+      {CHANNEL_ORDER.map((channelType) => {
+        const meta = CHANNEL_META[channelType];
+        const Icon = meta.icon;
+        const selected = value === channelType;
+        return (
+          <div
+            key={channelType}
+            role="radio"
+            aria-checked={selected}
+            tabIndex={0}
+            onClick={() => onChange?.(channelType)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onChange?.(channelType);
+              }
+            }}
+            style={{
+              position: "relative",
+              width: 168,
+              cursor: "pointer",
+              padding: "14px 12px",
+              borderRadius: token.borderRadius,
+              border: `2px solid ${selected ? meta.color : token.colorBorderSecondary}`,
+              background: selected ? `${meta.color}0d` : token.colorBgContainer,
+              transition: "border-color 0.15s, background 0.15s",
+            }}
+          >
+            {selected && (
+              <CheckCircleFilled
+                style={{ position: "absolute", top: 8, right: 8, color: meta.color, fontSize: 16 }}
+              />
+            )}
+            <Icon style={{ fontSize: 26, color: meta.color, display: "block", marginBottom: 8 }} />
+            <div style={{ fontWeight: 600 }}>{meta.label}</div>
+            <div style={{ fontSize: 12, color: token.colorTextSecondary, marginTop: 2 }}>{meta.description}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/ui/src/domain/Notifications/EditNotificationConfiguration.tsx
+++ b/ui/src/domain/Notifications/EditNotificationConfiguration.tsx
@@ -1,0 +1,397 @@
+import { CheckCircleOutlined, CloseCircleOutlined, LinkOutlined, SendOutlined } from "@ant-design/icons";
+import { Alert, Button, Checkbox, Form, Input, Space, Spin, Switch, Tag, Typography, message, theme } from "antd";
+import { useEffect, useState } from "react";
+import axiosInstance, { getErrorMessage } from "@/config/axiosConfig";
+import { apiPost } from "@/modules/api/apiWrapper";
+import { JobStatus, NotificationChannelType } from "../types";
+import { ChannelPicker } from "./ChannelPicker";
+import { CHANNEL_META } from "./channelMeta";
+import { JOB_STATUS_GROUPS } from "./jobStatusGroups";
+import SettingsSection from "@/modules/layout/SettingsSection/SettingsSection";
+
+type Props = {
+  orgId: string;
+  workspaceId?: string;
+  mode: "create" | "edit";
+  configId?: string;
+  onDone: () => void;
+};
+
+type ConfigurationForm = {
+  name: string;
+  description?: string;
+  channelType: NotificationChannelType;
+  destinationUrl: string;
+  signingSecret?: string;
+  active: boolean;
+};
+
+const JSONAPI_HEADERS = { "Content-Type": "application/vnd.api+json" };
+
+const TOTAL_STATUS_COUNT = JOB_STATUS_GROUPS.reduce((total, group) => total + group.statuses.length, 0);
+
+export const EditNotificationConfiguration = ({ orgId, workspaceId, mode, configId, onDone }: Props) => {
+  const [loading, setLoading] = useState(mode === "edit");
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<"success" | "error" | null>(null);
+  const [form] = Form.useForm<ConfigurationForm>();
+  const [triggerIds, setTriggerIds] = useState<Record<string, string>>({});
+  const [selectedStatuses, setSelectedStatuses] = useState<JobStatus[]>([]);
+  // Undefined while an edit-mode fetch is still in flight - the scope banner stays hidden
+  // rather than briefly showing the wrong scope. For create mode this is known immediately
+  // from whether a workspaceId was passed in at all.
+  const [configWorkspaceId, setConfigWorkspaceId] = useState<string | null | undefined>(
+    mode === "create" ? workspaceId ?? null : undefined
+  );
+  const channelType = Form.useWatch("channelType", form);
+  const destinationUrl = Form.useWatch("destinationUrl", form);
+  const { token } = theme.useToken();
+
+  const basePath = workspaceId
+    ? `organization/${orgId}/workspace/${workspaceId}/notificationConfiguration`
+    : `organization/${orgId}/notificationConfiguration`;
+
+  useEffect(() => {
+    if (mode === "edit" && configId) {
+      setLoading(true);
+      const body = {
+        // Root-level GraphQL queries (unlike a nested relationship traversal
+        // through organization/workspace) use the entity's @Entity(name=...)
+        // directly - snake_case, same rule as the REST root collection name.
+        query: `{
+          notification_configuration(ids: ["${configId}"]) {
+            edges { node {
+              name description channelType destinationUrl active
+              workspace { edges { node { id } } }
+              triggers { edges { node { id jobStatus } } }
+            } }
+          }
+        }`,
+      };
+      apiPost<unknown, any>("/graphql/api/v1", body, { dataWrapped: true, contentType: "application/json" })
+        .then((response: any) => {
+          const node = response?.data?.notification_configuration?.edges?.[0]?.node;
+          if (!node) return;
+          form.setFieldsValue({
+            name: node.name,
+            description: node.description,
+            channelType: node.channelType,
+            destinationUrl: node.destinationUrl,
+            active: node.active,
+          });
+          const triggerEdges = node.triggers?.edges || [];
+          const statuses: JobStatus[] = triggerEdges.map((e: any) => e.node.jobStatus);
+          const idsByStatus: Record<string, string> = {};
+          triggerEdges.forEach((e: any) => {
+            idsByStatus[e.node.jobStatus] = e.node.id;
+          });
+          setSelectedStatuses(statuses);
+          setTriggerIds(idsByStatus);
+          // The config's actual scope, straight from the record being edited - not the
+          // workspaceId prop, which just reflects whatever list view this was opened from and
+          // is wrong whenever that's a workspace's merged view showing an org-wide default.
+          setConfigWorkspaceId(node.workspace?.edges?.[0]?.node?.id ?? null);
+        })
+        .catch((err) => message.error(getErrorMessage(err) || "Failed to load notification configuration"))
+        .finally(() => setLoading(false));
+    } else {
+      form.setFieldsValue({ active: true });
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, configId]);
+
+  useEffect(() => {
+    setTestResult(null);
+  }, [channelType, destinationUrl]);
+
+  const saveTriggers = async (savedConfigId: string) => {
+    const existingStatuses = Object.keys(triggerIds);
+    const toCreate = selectedStatuses.filter((s) => !existingStatuses.includes(s));
+    const toDelete = existingStatuses.filter((s) => !selectedStatuses.includes(s as JobStatus));
+
+    // Sub-resource operations by ID (unlike the org/workspace-nested create path
+    // above) go through the root collection name, which Elide derives from the
+    // entity's @Entity(name=...) - snake_case, not the camelCase relationship
+    // field name used for nested creation.
+    await Promise.all(
+      toCreate.map((status) =>
+        axiosInstance.post(
+          `notification_configuration/${savedConfigId}/triggers`,
+          { data: { type: "notification_trigger", attributes: { jobStatus: status } } },
+          { headers: JSONAPI_HEADERS }
+        )
+      )
+    );
+    await Promise.all(
+      toDelete.map((status) =>
+        axiosInstance.delete(`notification_configuration/${savedConfigId}/triggers/${triggerIds[status]}`, {
+          headers: { "Content-Type": undefined },
+        })
+      )
+    );
+  };
+
+  const onFinish = async (values: ConfigurationForm) => {
+    if (selectedStatuses.length === 0) {
+      message.error("Select at least one trigger status");
+      return;
+    }
+    const body = {
+      data: {
+        type: "notification_configuration",
+        attributes: {
+          name: values.name,
+          description: values.description,
+          channelType: values.channelType,
+          destinationUrl: values.destinationUrl,
+          signingSecret: values.channelType === "WEBHOOK" ? values.signingSecret : undefined,
+          active: values.active,
+        },
+      },
+    };
+    try {
+      let savedId = configId;
+      if (mode === "create") {
+        const res = await axiosInstance.post(basePath, body, { headers: JSONAPI_HEADERS });
+        savedId = res.data.data.id;
+        message.success("Notification configuration created successfully");
+      } else {
+        await axiosInstance.patch(
+          `notification_configuration/${configId}`,
+          { data: { id: configId, ...body.data } },
+          { headers: JSONAPI_HEADERS }
+        );
+        message.success("Notification configuration updated successfully");
+      }
+      await saveTriggers(savedId!);
+      onDone();
+    } catch (err: any) {
+      message.error(getErrorMessage(err) || "Failed to save notification configuration");
+    }
+  };
+
+  const sendTest = async () => {
+    let values: Pick<ConfigurationForm, "channelType" | "destinationUrl" | "signingSecret">;
+    try {
+      values = await form.validateFields(["channelType", "destinationUrl", "signingSecret"]);
+    } catch {
+      message.error("Fill in Channel and Destination URL before testing");
+      return;
+    }
+
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const origin = new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin;
+      if (configId) {
+        // Saved config: test through the real config so it exercises exactly what
+        // production dispatch will use (including whatever's already persisted).
+        await axiosInstance.post(`${origin}/notification/v1/configuration/${configId}/test`);
+      } else {
+        // Not saved yet: verify the destination works before committing to it.
+        await axiosInstance.post(`${origin}/notification/v1/organization/${orgId}/configuration/test`, {
+          channelType: values.channelType,
+          destinationUrl: values.destinationUrl,
+          signingSecret: values.channelType === "WEBHOOK" ? values.signingSecret : undefined,
+        });
+      }
+      setTestResult("success");
+      message.success("Test notification sent");
+    } catch (err: any) {
+      setTestResult("error");
+      message.error(getErrorMessage(err) || "Failed to send test notification");
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const toggleGroup = (statuses: JobStatus[], checked: boolean) => {
+    setSelectedStatuses((current) =>
+      checked ? Array.from(new Set([...current, ...statuses])) : current.filter((s) => !statuses.includes(s))
+    );
+  };
+
+  return (
+    <Spin spinning={loading}>
+      <Typography.Title level={3}>
+        {mode === "create" ? "Add Notification" : "Edit Notification"}
+      </Typography.Title>
+      {configWorkspaceId !== undefined &&
+        (configWorkspaceId === null ? (
+          <Alert
+            type="warning"
+            showIcon
+            style={{ marginBottom: 16 }}
+            message="Organization-wide default"
+            description="Applies to every workspace in this organization, alongside whatever each workspace configures for itself. Changes here affect all of them."
+          />
+        ) : (
+          <Alert
+            type="info"
+            showIcon
+            style={{ marginBottom: 16 }}
+            message="This workspace only"
+            description="Only affects this workspace, in addition to any organization-wide defaults."
+          />
+        ))}
+      <SettingsSection>
+        <Form form={form} layout="vertical" onFinish={onFinish}>
+          <Typography.Title level={5} style={{ marginBottom: 12 }}>
+            1. Channel
+          </Typography.Title>
+          <Form.Item name="channelType" rules={[{ required: true, message: "Choose a channel" }]}>
+            <ChannelPicker />
+          </Form.Item>
+
+          <Typography.Title level={5} style={{ marginTop: 8, marginBottom: 12 }}>
+            2. Details
+          </Typography.Title>
+          <Form.Item name="name" label="Name" rules={[{ required: true, message: "Please enter a name" }]}>
+            <Input placeholder="e.g. Prod Alerts" />
+          </Form.Item>
+          <Form.Item name="description" label="Description (optional)">
+            <Input.TextArea
+              placeholder="What this is for, e.g. 'Pages on-call for prod workspace failures'"
+              autoSize={{ minRows: 1, maxRows: 4 }}
+            />
+          </Form.Item>
+          <Form.Item
+            name="destinationUrl"
+            label="Destination URL"
+            rules={[{ required: true, message: "Please enter the destination URL" }]}
+            help={
+              channelType && (
+                <Space direction="vertical" size={0} style={{ marginTop: 2 }}>
+                  <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                    {CHANNEL_META[channelType].urlHelp}
+                  </Typography.Text>
+                  {CHANNEL_META[channelType].docsUrl && (
+                    <Typography.Link
+                      href={CHANNEL_META[channelType].docsUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      style={{ fontSize: 12 }}
+                    >
+                      <LinkOutlined /> {CHANNEL_META[channelType].docsLabel}
+                    </Typography.Link>
+                  )}
+                </Space>
+              )
+            }
+          >
+            <Input placeholder={channelType ? CHANNEL_META[channelType].urlPlaceholder : "https://..."} />
+          </Form.Item>
+          {channelType === "WEBHOOK" && (
+            <Form.Item
+              name="signingSecret"
+              label="Signing Secret (optional)"
+              help={
+                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                  If set, requests are signed with an <code>X-Terrakube-Signature</code> header (HMAC-SHA256) so
+                  your endpoint can verify they came from Terrakube.
+                </Typography.Text>
+              }
+            >
+              <Input.Password placeholder="Optional" />
+            </Form.Item>
+          )}
+          <Form.Item name="active" label="Active" valuePropName="checked">
+            <Switch />
+          </Form.Item>
+
+          <Typography.Title level={5} style={{ marginTop: 8, marginBottom: 0 }}>
+            3. Trigger on
+          </Typography.Title>
+          <Typography.Text type="secondary" style={{ display: "block", marginBottom: 12 }}>
+            Choose which run outcomes send this notification. {selectedStatuses.length} of {TOTAL_STATUS_COUNT}{" "}
+            selected.
+          </Typography.Text>
+
+          {JOB_STATUS_GROUPS.map((group) => {
+            const groupValues = group.statuses.map((s) => s.value);
+            const selectedInGroup = groupValues.filter((v) => selectedStatuses.includes(v));
+            const allSelected = selectedInGroup.length === groupValues.length;
+            const GroupIcon = group.icon;
+
+            return (
+              <div
+                key={group.key}
+                data-testid={`trigger-group-${group.key}`}
+                style={{
+                  border: `1px solid ${token.colorBorderSecondary}`,
+                  borderRadius: token.borderRadius,
+                  padding: "10px 14px",
+                  marginBottom: 10,
+                }}
+              >
+                <Space align="center" style={{ marginBottom: 6 }}>
+                  <Tag color={group.color === "default" ? undefined : group.color} icon={<GroupIcon />}>
+                    {group.label}
+                  </Tag>
+                  <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                    {selectedInGroup.length}/{groupValues.length}
+                  </Typography.Text>
+                  <Button
+                    type="link"
+                    size="small"
+                    style={{ padding: 0, fontSize: 12 }}
+                    onClick={() => toggleGroup(groupValues, !allSelected)}
+                  >
+                    {allSelected ? "Clear" : "Select all"}
+                  </Button>
+                </Space>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: "4px 20px" }}>
+                  {group.statuses.map((status) => (
+                    <Checkbox
+                      key={status.value}
+                      checked={selectedStatuses.includes(status.value)}
+                      onChange={(e) => {
+                        setSelectedStatuses((current) =>
+                          e.target.checked
+                            ? [...current, status.value]
+                            : current.filter((s) => s !== status.value)
+                        );
+                      }}
+                    >
+                      {status.label}
+                    </Checkbox>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+
+          <Form.Item style={{ marginTop: 16 }}>
+            <Space direction="vertical" size="small" style={{ width: "100%" }}>
+              {testResult && (
+                <Alert
+                  type={testResult === "success" ? "success" : "error"}
+                  showIcon
+                  icon={testResult === "success" ? <CheckCircleOutlined /> : <CloseCircleOutlined />}
+                  message={testResult === "success" ? "Test notification delivered successfully" : "Test notification failed to deliver"}
+                  closable
+                  onClose={() => setTestResult(null)}
+                />
+              )}
+              <Space>
+                <Button type="primary" htmlType="submit">
+                  {mode === "create" ? "Create" : "Update"}
+                </Button>
+                <Button
+                  icon={<SendOutlined />}
+                  onClick={sendTest}
+                  loading={testing}
+                  disabled={!channelType || !destinationUrl}
+                >
+                  Send test notification
+                </Button>
+                <Button onClick={onDone}>Cancel</Button>
+              </Space>
+            </Space>
+          </Form.Item>
+        </Form>
+      </SettingsSection>
+    </Spin>
+  );
+};

--- a/ui/src/domain/Notifications/EditNotificationConfiguration.tsx
+++ b/ui/src/domain/Notifications/EditNotificationConfiguration.tsx
@@ -1,9 +1,24 @@
 import { CheckCircleOutlined, CloseCircleOutlined, LinkOutlined, SendOutlined } from "@ant-design/icons";
-import { Alert, Button, Checkbox, Form, Input, Space, Spin, Switch, Tag, Typography, message, theme } from "antd";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Form,
+  Input,
+  Radio,
+  Select,
+  Space,
+  Spin,
+  Switch,
+  Tag,
+  Typography,
+  message,
+  theme,
+} from "antd";
 import { useEffect, useState } from "react";
 import axiosInstance, { getErrorMessage } from "@/config/axiosConfig";
 import { apiPost } from "@/modules/api/apiWrapper";
-import { JobStatus, NotificationChannelType } from "../types";
+import { JobStatus, NotificationChannelType, NotificationMessageStyle, Template } from "../types";
 import { ChannelPicker } from "./ChannelPicker";
 import { CHANNEL_META } from "./channelMeta";
 import { JOB_STATUS_GROUPS } from "./jobStatusGroups";
@@ -24,6 +39,7 @@ type ConfigurationForm = {
   destinationUrl: string;
   signingSecret?: string;
   active: boolean;
+  messageStyle: NotificationMessageStyle;
 };
 
 const JSONAPI_HEADERS = { "Content-Type": "application/vnd.api+json" };
@@ -37,6 +53,10 @@ export const EditNotificationConfiguration = ({ orgId, workspaceId, mode, config
   const [form] = Form.useForm<ConfigurationForm>();
   const [triggerIds, setTriggerIds] = useState<Record<string, string>>({});
   const [selectedStatuses, setSelectedStatuses] = useState<JobStatus[]>([]);
+  const [availableTemplates, setAvailableTemplates] = useState<Template[]>([]);
+  // Empty means "applies to every template" - this only ever narrows which templates a
+  // configuration fires for, so an empty selection is the same as no filter at all.
+  const [selectedTemplateIds, setSelectedTemplateIds] = useState<string[]>([]);
   // Undefined while an edit-mode fetch is still in flight - the scope banner stays hidden
   // rather than briefly showing the wrong scope. For create mode this is known immediately
   // from whether a workspaceId was passed in at all.
@@ -52,6 +72,19 @@ export const EditNotificationConfiguration = ({ orgId, workspaceId, mode, config
     : `organization/${orgId}/notificationConfiguration`;
 
   useEffect(() => {
+    axiosInstance
+      .get(`organization/${orgId}/template`)
+      .then((response) => {
+        const templatesList = (response.data.data as Template[]).filter(
+          (t) => t.attributes.name !== "Terraform-Plan/Apply-Cli" && t.attributes.name !== "Terraform-Plan/Destroy-Cli"
+        );
+        setAvailableTemplates(templatesList);
+      })
+      .catch((err) => message.error(getErrorMessage(err) || "Failed to load templates"));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId]);
+
+  useEffect(() => {
     if (mode === "edit" && configId) {
       setLoading(true);
       const body = {
@@ -61,9 +94,10 @@ export const EditNotificationConfiguration = ({ orgId, workspaceId, mode, config
         query: `{
           notification_configuration(ids: ["${configId}"]) {
             edges { node {
-              name description channelType destinationUrl active
+              name description channelType destinationUrl active messageStyle
               workspace { edges { node { id } } }
               triggers { edges { node { id jobStatus } } }
+              templates { edges { node { id } } }
             } }
           }
         }`,
@@ -78,6 +112,7 @@ export const EditNotificationConfiguration = ({ orgId, workspaceId, mode, config
             channelType: node.channelType,
             destinationUrl: node.destinationUrl,
             active: node.active,
+            messageStyle: node.messageStyle || "DETAILED",
           });
           const triggerEdges = node.triggers?.edges || [];
           const statuses: JobStatus[] = triggerEdges.map((e: any) => e.node.jobStatus);
@@ -87,6 +122,7 @@ export const EditNotificationConfiguration = ({ orgId, workspaceId, mode, config
           });
           setSelectedStatuses(statuses);
           setTriggerIds(idsByStatus);
+          setSelectedTemplateIds((node.templates?.edges || []).map((e: any) => e.node.id));
           // The config's actual scope, straight from the record being edited - not the
           // workspaceId prop, which just reflects whatever list view this was opened from and
           // is wrong whenever that's a workspace's merged view showing an org-wide default.
@@ -95,7 +131,7 @@ export const EditNotificationConfiguration = ({ orgId, workspaceId, mode, config
         .catch((err) => message.error(getErrorMessage(err) || "Failed to load notification configuration"))
         .finally(() => setLoading(false));
     } else {
-      form.setFieldsValue({ active: true });
+      form.setFieldsValue({ active: true, messageStyle: "DETAILED" });
       setLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -132,6 +168,17 @@ export const EditNotificationConfiguration = ({ orgId, workspaceId, mode, config
     );
   };
 
+  // Replaces the entire "applies to these templates" set in one call - simpler and safer than
+  // diffing against what was previously selected, and Elide supports replacing a to-many
+  // relationship wholesale via PATCH .../relationships/{name}.
+  const saveTemplates = async (savedConfigId: string) => {
+    await axiosInstance.patch(
+      `notification_configuration/${savedConfigId}/relationships/templates`,
+      { data: selectedTemplateIds.map((id) => ({ type: "template", id })) },
+      { headers: JSONAPI_HEADERS }
+    );
+  };
+
   const onFinish = async (values: ConfigurationForm) => {
     if (selectedStatuses.length === 0) {
       message.error("Select at least one trigger status");
@@ -147,6 +194,7 @@ export const EditNotificationConfiguration = ({ orgId, workspaceId, mode, config
           destinationUrl: values.destinationUrl,
           signingSecret: values.channelType === "WEBHOOK" ? values.signingSecret : undefined,
           active: values.active,
+          messageStyle: values.messageStyle,
         },
       },
     };
@@ -165,6 +213,7 @@ export const EditNotificationConfiguration = ({ orgId, workspaceId, mode, config
         message.success("Notification configuration updated successfully");
       }
       await saveTriggers(savedId!);
+      await saveTemplates(savedId!);
       onDone();
     } catch (err: any) {
       message.error(getErrorMessage(err) || "Failed to save notification configuration");
@@ -299,9 +348,41 @@ export const EditNotificationConfiguration = ({ orgId, workspaceId, mode, config
           <Form.Item name="active" label="Active" valuePropName="checked">
             <Switch />
           </Form.Item>
+          <Form.Item
+            name="messageStyle"
+            label="Message style"
+            help={
+              <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                Detailed sends the full card (run link, commit, buttons) for every status. Simple sends a single
+                compact line instead - useful for high-frequency channels.
+              </Typography.Text>
+            }
+          >
+            <Radio.Group>
+              <Radio.Button value="DETAILED">Detailed</Radio.Button>
+              <Radio.Button value="SIMPLE">Simple</Radio.Button>
+            </Radio.Group>
+          </Form.Item>
 
           <Typography.Title level={5} style={{ marginTop: 8, marginBottom: 0 }}>
-            3. Trigger on
+            3. Templates
+          </Typography.Title>
+          <Typography.Text type="secondary" style={{ display: "block", marginBottom: 12 }}>
+            Leave empty to apply to every template. Select specific templates to only notify for runs using them.
+          </Typography.Text>
+          <Form.Item>
+            <Select
+              mode="multiple"
+              allowClear
+              placeholder="All templates"
+              value={selectedTemplateIds}
+              onChange={setSelectedTemplateIds}
+              options={availableTemplates.map((t) => ({ value: t.id, label: t.attributes.name }))}
+            />
+          </Form.Item>
+
+          <Typography.Title level={5} style={{ marginTop: 8, marginBottom: 0 }}>
+            4. Trigger on
           </Typography.Title>
           <Typography.Text type="secondary" style={{ display: "block", marginBottom: 12 }}>
             Choose which run outcomes send this notification. {selectedStatuses.length} of {TOTAL_STATUS_COUNT}{" "}

--- a/ui/src/domain/Notifications/NotificationConfigurationList.tsx
+++ b/ui/src/domain/Notifications/NotificationConfigurationList.tsx
@@ -1,0 +1,277 @@
+import { DeleteOutlined, EditOutlined, PlusOutlined } from "@ant-design/icons";
+import { Alert, Avatar, Button, List, message, Popconfirm, Spin, Tag, Typography } from "antd";
+import { useEffect, useState } from "react";
+import axiosInstance, { getErrorMessage, isPermissionError } from "@/config/axiosConfig";
+import { apiPost } from "@/modules/api/apiWrapper";
+import { NotificationConfiguration } from "../types";
+import { CHANNEL_META } from "./channelMeta";
+import { EditNotificationConfiguration } from "./EditNotificationConfiguration";
+import SettingsSection from "@/modules/layout/SettingsSection/SettingsSection";
+
+type Props = {
+  orgId: string;
+  workspaceId?: string;
+  managePermission?: boolean;
+};
+
+export const NotificationConfigurationList = ({ orgId, workspaceId, managePermission = true }: Props) => {
+  const [configurations, setConfigurations] = useState<NotificationConfiguration[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [mode, setMode] = useState<"list" | "create" | "edit">("list");
+  const [editingId, setEditingId] = useState<string>();
+
+  const load = () => {
+    setLoading(true);
+    const body = {
+      // workspace (and every other relationship in this schema) is exposed as a
+      // Relay-style Connection in GraphQL, even for a to-one field - "workspace { id }"
+      // is invalid and fails the whole query; it must be "workspace { edges { node { id } } }".
+      query: `{
+        organization(ids: ["${orgId}"]) {
+          edges { node {
+            notificationConfiguration {
+              edges { node {
+                id
+                name
+                description
+                channelType
+                destinationUrl
+                active
+                workspace { edges { node { id } } }
+              } }
+            }
+          } }
+        }
+      }`,
+    };
+    apiPost<unknown, any>("/graphql/api/v1", body, { dataWrapped: true, contentType: "application/json" })
+      .then((response: any) => {
+        if (!response?.data) {
+          // A GraphQL error still resolves this promise (HTTP 200 with an
+          // "errors" array, no "data") - fail loudly instead of silently
+          // rendering an empty list.
+          message.error("Failed to load notification configurations");
+          setLoading(false);
+          return;
+        }
+        const edges = response.data?.organization?.edges?.[0]?.node?.notificationConfiguration?.edges || [];
+        const all: NotificationConfiguration[] = edges.map((edge: any) => {
+          const rawWorkspaceNode = edge.node.workspace?.edges?.[0]?.node ?? null;
+          // Defensive: a lazily-fetched Workspace relationship could serialize its id as the
+          // literal string "null" instead of a real UUID or JSON null (see NotificationConfiguration.workspace
+          // for the root cause and fix) - treat that the same as no workspace at all rather than
+          // let it silently fail both branches of the scope filter below.
+          const workspaceNode = rawWorkspaceNode && rawWorkspaceNode.id !== "null" ? rawWorkspaceNode : null;
+          return {
+            id: edge.node.id,
+            attributes: {
+              name: edge.node.name,
+              description: edge.node.description,
+              channelType: edge.node.channelType,
+              destinationUrl: edge.node.destinationUrl,
+              active: edge.node.active,
+            },
+            relationships: { workspace: { data: workspaceNode ? { id: workspaceNode.id } : null } },
+          };
+        });
+        const scoped = workspaceId
+          ? all.filter((c) => c.relationships?.workspace?.data === null || c.relationships?.workspace?.data?.id === workspaceId)
+          : all.filter((c) => c.relationships?.workspace?.data === null);
+        setConfigurations(scoped);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (isPermissionError(err)) {
+          setError(getErrorMessage(err));
+        } else {
+          message.error("Failed to load notification configurations");
+        }
+        setLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgId, workspaceId]);
+
+  // On the org-level page (no workspaceId), "configurations" is already org-scoped only (see
+  // the "scoped" filter in load()), so the primary list there is simply all of them - there's no
+  // "inherited" concept without a workspace to inherit into. Purely additive, no overrides: a
+  // workspace gets both its own configs and every organization-wide default, together.
+  const primaryConfigs = workspaceId
+    ? configurations.filter((c) => c.relationships?.workspace?.data !== null)
+    : configurations;
+  const inheritedConfigs = workspaceId
+    ? configurations.filter((c) => c.relationships?.workspace?.data === null)
+    : [];
+
+  const onDelete = (id: string) => {
+    axiosInstance
+      .delete(`notification_configuration/${id}`, { headers: { "Content-Type": undefined } })
+      .then(() => {
+        message.success("Notification configuration deleted successfully");
+        load();
+      })
+      .catch((err) => message.error(getErrorMessage(err) || "Failed to delete notification configuration"));
+  };
+
+  if (mode !== "list") {
+    return (
+      <EditNotificationConfiguration
+        orgId={orgId}
+        workspaceId={workspaceId}
+        mode={mode}
+        configId={editingId}
+        onDone={() => {
+          setMode("list");
+          setEditingId(undefined);
+          load();
+        }}
+      />
+    );
+  }
+
+  const renderChannelAvatar = (channelType: NotificationConfiguration["attributes"]["channelType"]) => {
+    const meta = CHANNEL_META[channelType];
+    const ChannelIcon = meta.icon;
+    return <Avatar style={{ backgroundColor: `${meta.color}1a` }} icon={<ChannelIcon style={{ color: meta.color }} />} />;
+  };
+
+  return (
+    <div>
+      {error ? (
+        <Alert message="Access Denied" description={error} type="error" showIcon />
+      ) : (
+        <>
+          <Typography.Title level={1} style={{ margin: 0 }}>
+            Notifications
+          </Typography.Title>
+          <Typography.Text type="secondary">
+            {workspaceId
+              ? "Notifications configured specifically for this workspace, plus any organization-wide defaults - both apply together."
+              : "Organization-wide defaults. These apply to every workspace in the organization, in addition to whatever that workspace configures for itself."}
+          </Typography.Text>
+          <SettingsSection maxWidth="100%">
+            <Button
+              type="primary"
+              icon={<PlusOutlined />}
+              disabled={!managePermission}
+              onClick={() => setMode("create")}
+            >
+              {workspaceId ? "Add notification for this workspace" : "Add organization-wide default"}
+            </Button>
+            <Spin spinning={loading}>
+              {workspaceId && (
+                <Typography.Title level={5} style={{ marginTop: 20, marginBottom: 4 }}>
+                  This workspace's notifications
+                </Typography.Title>
+              )}
+              <List
+                itemLayout="horizontal"
+                dataSource={primaryConfigs}
+                locale={{ emptyText: workspaceId ? "No notifications configured specifically for this workspace." : " " }}
+                renderItem={(item) => (
+                  <List.Item
+                    actions={[
+                      <Button
+                        icon={<EditOutlined />}
+                        shape="round"
+                        type="primary"
+                        disabled={!managePermission}
+                        onClick={() => {
+                          setEditingId(item.id);
+                          setMode("edit");
+                        }}
+                      >
+                        Edit
+                      </Button>,
+                      <Popconfirm
+                        title="This will permanently delete this notification configuration. Are you sure?"
+                        onConfirm={() => onDelete(item.id)}
+                        okText="Yes"
+                        cancelText="No"
+                      >
+                        <Button icon={<DeleteOutlined />} shape="round" type="primary" danger disabled={!managePermission}>
+                          Delete
+                        </Button>
+                      </Popconfirm>,
+                    ]}
+                  >
+                    <List.Item.Meta
+                      avatar={renderChannelAvatar(item.attributes.channelType)}
+                      title={item.attributes.name}
+                      description={
+                        <>
+                          <div>
+                            <Tag color={CHANNEL_META[item.attributes.channelType].color} icon={(() => {
+                              const Icon = CHANNEL_META[item.attributes.channelType].icon;
+                              return <Icon />;
+                            })()}>
+                              {CHANNEL_META[item.attributes.channelType].label}
+                            </Tag>
+                            {workspaceId && <Tag color="purple">This workspace</Tag>}
+                            {!item.attributes.active && <Tag color="default">Disabled</Tag>}
+                          </div>
+                          {item.attributes.description && (
+                            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                              {item.attributes.description}
+                            </Typography.Text>
+                          )}
+                        </>
+                      }
+                    />
+                  </List.Item>
+                )}
+              />
+
+              {workspaceId && (
+                <>
+                  <Typography.Title level={5} style={{ marginTop: 20, marginBottom: 4 }}>
+                    Also applies here (organization-wide)
+                  </Typography.Title>
+                  <Typography.Text type="secondary" style={{ display: "block", marginBottom: 8, fontSize: 12 }}>
+                    Managed at the organization level - edit these from the organization's notification settings.
+                  </Typography.Text>
+                  <List
+                    itemLayout="horizontal"
+                    dataSource={inheritedConfigs}
+                    locale={{ emptyText: "No organization-wide defaults apply here." }}
+                    renderItem={(item) => (
+                      <List.Item>
+                        <List.Item.Meta
+                          avatar={renderChannelAvatar(item.attributes.channelType)}
+                          title={item.attributes.name}
+                          description={
+                            <>
+                              <div>
+                                <Tag color={CHANNEL_META[item.attributes.channelType].color} icon={(() => {
+                                  const Icon = CHANNEL_META[item.attributes.channelType].icon;
+                                  return <Icon />;
+                                })()}>
+                                  {CHANNEL_META[item.attributes.channelType].label}
+                                </Tag>
+                                <Tag>Org default</Tag>
+                                {!item.attributes.active && <Tag color="default">Disabled</Tag>}
+                              </div>
+                              {item.attributes.description && (
+                                <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+                                  {item.attributes.description}
+                                </Typography.Text>
+                              )}
+                            </>
+                          }
+                        />
+                      </List.Item>
+                    )}
+                  />
+                </>
+              )}
+            </Spin>
+          </SettingsSection>
+        </>
+      )}
+    </div>
+  );
+};

--- a/ui/src/domain/Notifications/NotificationDeliveryHistory.tsx
+++ b/ui/src/domain/Notifications/NotificationDeliveryHistory.tsx
@@ -1,0 +1,140 @@
+import { CheckCircleFilled, ClockCircleFilled, CloseCircleFilled, LoadingOutlined, SyncOutlined } from "@ant-design/icons";
+import { Button, List, Spin, Tag, Typography, message } from "antd";
+import { useEffect, useState } from "react";
+import axiosInstance, { getErrorMessage } from "@/config/axiosConfig";
+import { NotificationChannelType } from "../types";
+import { CHANNEL_META } from "./channelMeta";
+import SettingsSection from "@/modules/layout/SettingsSection/SettingsSection";
+
+type DeliveryStatus = "PENDING" | "SENDING" | "SENT" | "FAILED";
+
+type Delivery = {
+  id: string;
+  jobId: number;
+  configurationName: string;
+  channelType: NotificationChannelType;
+  status: DeliveryStatus;
+  attemptCount: number;
+  lastAttemptAt: string | null;
+  lastError: string | null;
+  createdDate: string;
+};
+
+type Props = {
+  workspaceId: string;
+};
+
+const STATUS_META: Record<
+  DeliveryStatus,
+  { tagColor: string; iconColor: string; icon: typeof CheckCircleFilled; label: string }
+> = {
+  SENT: { tagColor: "green", iconColor: "#389e0d", icon: CheckCircleFilled, label: "Sent" },
+  PENDING: { tagColor: "orange", iconColor: "#d46b08", icon: ClockCircleFilled, label: "Pending" },
+  SENDING: { tagColor: "blue", iconColor: "#1677ff", icon: LoadingOutlined, label: "Sending" },
+  FAILED: { tagColor: "red", iconColor: "#cf1322", icon: CloseCircleFilled, label: "Failed" },
+};
+
+export const NotificationDeliveryHistory = ({ workspaceId }: Props) => {
+  const [deliveries, setDeliveries] = useState<Delivery[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [retryingId, setRetryingId] = useState<string | null>(null);
+  const origin = new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin;
+
+  const loadDeliveries = () => {
+    setLoading(true);
+    return axiosInstance
+      .get(`${origin}/notification/v1/workspace/${workspaceId}/deliveries?limit=10`)
+      .then((response) => setDeliveries(response.data))
+      .catch((err) => message.error(getErrorMessage(err) || "Failed to load notification delivery history"))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    loadDeliveries();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId]);
+
+  const retryDelivery = (deliveryId: string) => {
+    setRetryingId(deliveryId);
+    axiosInstance
+      .post(`${origin}/notification/v1/workspace/${workspaceId}/deliveries/${deliveryId}/retry`)
+      .then(() => {
+        message.success("Retry queued");
+        return loadDeliveries();
+      })
+      .catch((err) => message.error(getErrorMessage(err) || "Failed to retry delivery"))
+      .finally(() => setRetryingId(null));
+  };
+
+  if (!loading && deliveries.length === 0) {
+    return null;
+  }
+
+  return (
+    <SettingsSection maxWidth="100%">
+      <Typography.Title level={4} style={{ marginTop: 0 }}>
+        Recent Deliveries
+      </Typography.Title>
+      <Typography.Text type="secondary" style={{ display: "block", marginBottom: 12 }}>
+        The last {deliveries.length} notification attempts for this workspace's runs.
+      </Typography.Text>
+      <Spin spinning={loading}>
+        <List
+          size="small"
+          dataSource={deliveries}
+          renderItem={(delivery) => {
+            const statusMeta = STATUS_META[delivery.status];
+            const StatusIcon = statusMeta.icon;
+            const channelMeta = CHANNEL_META[delivery.channelType];
+            const ChannelIcon = channelMeta.icon;
+            return (
+              <List.Item
+                actions={
+                  delivery.status === "FAILED"
+                    ? [
+                        <Button
+                          key="retry"
+                          size="small"
+                          icon={<SyncOutlined />}
+                          loading={retryingId === delivery.id}
+                          onClick={() => retryDelivery(delivery.id)}
+                        >
+                          Retry
+                        </Button>,
+                      ]
+                    : undefined
+                }
+              >
+                <List.Item.Meta
+                  avatar={<StatusIcon style={{ color: statusMeta.iconColor, fontSize: 20 }} />}
+                  title={
+                    <>
+                      <Tag color={statusMeta.tagColor} icon={<StatusIcon />}>
+                        {statusMeta.label}
+                      </Tag>
+                      <Tag color={channelMeta.color} icon={<ChannelIcon />}>
+                        {channelMeta.label}
+                      </Tag>
+                      <Typography.Text>{delivery.configurationName}</Typography.Text>
+                      <Typography.Text type="secondary" style={{ marginLeft: 8, fontSize: 12 }}>
+                        Job #{delivery.jobId} · {new Date(delivery.createdDate).toLocaleString()}
+                        {delivery.attemptCount > 1 && ` · ${delivery.attemptCount} attempts`}
+                      </Typography.Text>
+                    </>
+                  }
+                  description={
+                    delivery.status === "FAILED" && delivery.lastError ? (
+                      <Typography.Text type="danger" style={{ fontSize: 12 }}>
+                        {delivery.lastError.length > 200 ? `${delivery.lastError.slice(0, 200)}...` : delivery.lastError}
+                      </Typography.Text>
+                    ) : undefined
+                  }
+                />
+              </List.Item>
+            );
+          }}
+        />
+      </Spin>
+    </SettingsSection>
+  );
+};

--- a/ui/src/domain/Notifications/__tests__/EditNotificationConfiguration.test.tsx
+++ b/ui/src/domain/Notifications/__tests__/EditNotificationConfiguration.test.tsx
@@ -5,7 +5,10 @@ import { EditNotificationConfiguration } from "../EditNotificationConfiguration"
 
 jest.mock("@/config/axiosConfig", () => ({
   __esModule: true,
-  default: { post: jest.fn(), patch: jest.fn(), get: jest.fn(), delete: jest.fn() },
+  // get() defaults to resolving an empty template list - the component fetches templates for
+  // the "3. Templates" filter unconditionally on mount, so an unconfigured jest.fn() (which
+  // returns undefined, not a Promise) would throw synchronously on the .then() call.
+  default: { post: jest.fn(), patch: jest.fn(), get: jest.fn().mockResolvedValue({ data: { data: [] } }), delete: jest.fn() },
   getErrorMessage: jest.fn(() => "error"),
 }));
 jest.mock("@/modules/api/apiWrapper", () => ({ apiPost: jest.fn() }));

--- a/ui/src/domain/Notifications/__tests__/EditNotificationConfiguration.test.tsx
+++ b/ui/src/domain/Notifications/__tests__/EditNotificationConfiguration.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import axiosInstance from "@/config/axiosConfig";
+import { apiPost } from "@/modules/api/apiWrapper";
+import { EditNotificationConfiguration } from "../EditNotificationConfiguration";
+
+jest.mock("@/config/axiosConfig", () => ({
+  __esModule: true,
+  default: { post: jest.fn(), patch: jest.fn(), get: jest.fn(), delete: jest.fn() },
+  getErrorMessage: jest.fn(() => "error"),
+}));
+jest.mock("@/modules/api/apiWrapper", () => ({ apiPost: jest.fn() }));
+
+// ChannelPicker renders clickable cards (role="radio"), not an antd Select -
+// clicking the card's visible label text bubbles up to its onClick handler.
+const selectChannel = (label: string) => {
+  fireEvent.click(screen.getByText(label));
+};
+
+describe("EditNotificationConfiguration", () => {
+  beforeEach(() => {
+    (axiosInstance.post as jest.Mock).mockReset();
+  });
+
+  it("creates a workspace-scoped configuration with selected triggers", async () => {
+    const onDone = jest.fn();
+    (axiosInstance.post as jest.Mock).mockResolvedValue({ status: 201, data: { data: { id: "new-config" } } });
+
+    render(<EditNotificationConfiguration orgId="org-1" workspaceId="ws-1" mode="create" onDone={onDone} />);
+
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "Prod Alerts" } });
+    selectChannel("Slack");
+    fireEvent.change(screen.getByLabelText("Destination URL"), {
+      target: { value: "https://hooks.slack.com/services/X" },
+    });
+    fireEvent.click(screen.getByRole("checkbox", { name: "Failed" }));
+
+    fireEvent.click(screen.getByRole("button", { name: /create/i }));
+
+    await waitFor(() => expect(axiosInstance.post).toHaveBeenCalled());
+    const [url, body] = (axiosInstance.post as jest.Mock).mock.calls[0];
+    expect(url).toBe("organization/org-1/workspace/ws-1/notificationConfiguration");
+    expect(body.data.attributes.name).toBe("Prod Alerts");
+  });
+
+  it("'select all' toggles every checkbox in that trigger group", async () => {
+    render(<EditNotificationConfiguration orgId="org-1" workspaceId="ws-1" mode="create" onDone={jest.fn()} />);
+
+    const erroredGroup = within(screen.getByTestId("trigger-group-errored"));
+
+    expect(erroredGroup.getByRole("checkbox", { name: "Failed" })).not.toBeChecked();
+    expect(erroredGroup.getByRole("checkbox", { name: "Rejected" })).not.toBeChecked();
+    expect(erroredGroup.getByRole("checkbox", { name: "Cancelled" })).not.toBeChecked();
+
+    fireEvent.click(erroredGroup.getByRole("button", { name: "Select all" }));
+
+    expect(erroredGroup.getByRole("checkbox", { name: "Failed" })).toBeChecked();
+    expect(erroredGroup.getByRole("checkbox", { name: "Rejected" })).toBeChecked();
+    expect(erroredGroup.getByRole("checkbox", { name: "Cancelled" })).toBeChecked();
+
+    fireEvent.click(erroredGroup.getByRole("button", { name: "Clear" }));
+
+    expect(erroredGroup.getByRole("checkbox", { name: "Failed" })).not.toBeChecked();
+  });
+
+  it("sends an ad-hoc test scoped to the organization before the configuration is saved", async () => {
+    (axiosInstance.post as jest.Mock).mockResolvedValue({ status: 200 });
+
+    render(<EditNotificationConfiguration orgId="org-1" workspaceId="ws-1" mode="create" onDone={jest.fn()} />);
+
+    selectChannel("Generic Webhook");
+    fireEvent.change(screen.getByLabelText("Destination URL"), {
+      target: { value: "https://example.com/hook" },
+    });
+
+    // The button's disabled state reads Form.useWatch's channelType/destinationUrl,
+    // which lags a render behind the fireEvent calls above by one tick - wait for it
+    // to actually become enabled instead of racing a click against a stale disabled prop.
+    const sendTestButton = screen.getByRole("button", { name: /send test notification/i });
+    await waitFor(() => expect(sendTestButton).not.toBeDisabled());
+    fireEvent.click(sendTestButton);
+
+    await waitFor(() => expect(axiosInstance.post).toHaveBeenCalled());
+    const [url, body] = (axiosInstance.post as jest.Mock).mock.calls[0];
+    expect(url).toContain("/notification/v1/organization/org-1/configuration/test");
+    expect(body).toMatchObject({ channelType: "WEBHOOK", destinationUrl: "https://example.com/hook" });
+
+    expect(await screen.findByText("Test notification delivered successfully")).toBeInTheDocument();
+  });
+
+  it("blocks the test until Channel and Destination URL are filled in", async () => {
+    render(<EditNotificationConfiguration orgId="org-1" workspaceId="ws-1" mode="create" onDone={jest.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /send test notification/i }));
+
+    await waitFor(() => expect(axiosInstance.post).not.toHaveBeenCalled());
+  });
+
+  it("shows the org-wide-default banner when editing a config with no workspace, regardless of the viewing context", async () => {
+    // Regression test: the config being edited has no workspace (an org-wide default), even
+    // though this render was opened with a workspaceId prop - as it would be if opened from a
+    // workspace's merged list view. The banner must reflect the config's actual scope, not the
+    // prop, or editing an org default from a workspace page looks exactly like a
+    // workspace-only edit and silently changes behavior for every other workspace too.
+    (apiPost as jest.Mock).mockResolvedValue({
+      data: {
+        notification_configuration: {
+          edges: [
+            {
+              node: {
+                name: "Org Default",
+                channelType: "SLACK",
+                destinationUrl: "https://hooks.slack.com/services/X",
+                active: true,
+                workspace: { edges: [] },
+                triggers: { edges: [] },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    render(
+      <EditNotificationConfiguration
+        orgId="org-1"
+        workspaceId="ws-1"
+        mode="edit"
+        configId="config-1"
+        onDone={jest.fn()}
+      />
+    );
+
+    expect(await screen.findByText("Organization-wide default")).toBeInTheDocument();
+    expect(screen.queryByText("This workspace only")).not.toBeInTheDocument();
+  });
+
+  it("shows the workspace-only banner when editing a config that does have a workspace", async () => {
+    (apiPost as jest.Mock).mockResolvedValue({
+      data: {
+        notification_configuration: {
+          edges: [
+            {
+              node: {
+                name: "Team Alerts",
+                channelType: "SLACK",
+                destinationUrl: "https://hooks.slack.com/services/X",
+                active: true,
+                workspace: { edges: [{ node: { id: "ws-1" } }] },
+                triggers: { edges: [] },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    render(
+      <EditNotificationConfiguration
+        orgId="org-1"
+        workspaceId="ws-1"
+        mode="edit"
+        configId="config-1"
+        onDone={jest.fn()}
+      />
+    );
+
+    expect(await screen.findByText("This workspace only")).toBeInTheDocument();
+    expect(screen.queryByText("Organization-wide default")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/domain/Notifications/__tests__/NotificationConfigurationList.test.tsx
+++ b/ui/src/domain/Notifications/__tests__/NotificationConfigurationList.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { apiPost } from "@/modules/api/apiWrapper";
+import { NotificationConfigurationList } from "../NotificationConfigurationList";
+
+jest.mock("@/config/axiosConfig", () => ({
+  __esModule: true,
+  default: { post: jest.fn(), get: jest.fn(), delete: jest.fn() },
+  getErrorMessage: jest.fn(() => "error"),
+  isPermissionError: jest.fn(() => false),
+}));
+jest.mock("@/modules/api/apiWrapper", () => ({ apiPost: jest.fn() }));
+jest.mock("../EditNotificationConfiguration", () => ({
+  EditNotificationConfiguration: () => <div data-testid="edit-notification-configuration" />,
+}));
+
+const graphqlResponse = {
+  isError: false,
+  responseCode: 200,
+  data: {
+    organization: {
+      edges: [
+        {
+          node: {
+            notificationConfiguration: {
+              edges: [
+                {
+                  node: {
+                    id: "config-1",
+                    name: "Org Slack Alerts",
+                    channelType: "SLACK",
+                    destinationUrl: "https://hooks.slack.com/services/X",
+                    active: true,
+                    workspace: { edges: [] },
+                    triggers: { edges: [{ node: { id: "t1", jobStatus: "failed" } }] },
+                  },
+                },
+                {
+                  node: {
+                    id: "config-2",
+                    name: "Workspace Webhook",
+                    channelType: "WEBHOOK",
+                    destinationUrl: "https://example.com/hook",
+                    active: true,
+                    workspace: { edges: [{ node: { id: "ws-1" } }] },
+                    triggers: { edges: [] },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+
+describe("NotificationConfigurationList", () => {
+  beforeEach(() => {
+    (apiPost as jest.Mock).mockResolvedValue(graphqlResponse);
+  });
+
+  it("shows org-level configs plus workspace-scoped configs for the current workspace", async () => {
+    render(
+      <MemoryRouter>
+        <NotificationConfigurationList orgId="org-1" workspaceId="ws-1" managePermission={true} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText("Org Slack Alerts")).toBeInTheDocument());
+    expect(screen.getByText("Workspace Webhook")).toBeInTheDocument();
+  });
+
+  it("shows only org-level configs when no workspaceId is provided", async () => {
+    render(
+      <MemoryRouter>
+        <NotificationConfigurationList orgId="org-1" managePermission={true} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText("Org Slack Alerts")).toBeInTheDocument());
+    expect(screen.queryByText("Workspace Webhook")).not.toBeInTheDocument();
+  });
+
+  it("tags each row as 'Org default' or 'This workspace' when viewing a workspace's page", async () => {
+    render(
+      <MemoryRouter>
+        <NotificationConfigurationList orgId="org-1" workspaceId="ws-1" managePermission={true} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText("Org Slack Alerts")).toBeInTheDocument());
+    expect(screen.getByText("Org default")).toBeInTheDocument();
+    expect(screen.getByText("This workspace")).toBeInTheDocument();
+  });
+
+  it("does not show org/workspace scope tags on the organization-level page", async () => {
+    render(
+      <MemoryRouter>
+        <NotificationConfigurationList orgId="org-1" managePermission={true} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText("Org Slack Alerts")).toBeInTheDocument());
+    expect(screen.queryByText("Org default")).not.toBeInTheDocument();
+    expect(screen.queryByText("This workspace")).not.toBeInTheDocument();
+  });
+
+  it("does not offer an override action - workspace and org configs are purely additive now", async () => {
+    render(
+      <MemoryRouter>
+        <NotificationConfigurationList orgId="org-1" workspaceId="ws-1" managePermission={true} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText("Org Slack Alerts")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: /override/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/already overridden/i)).not.toBeInTheDocument();
+  });
+
+  it("surfaces an error instead of silently rendering an empty list when the GraphQL query fails", async () => {
+    // A GraphQL error still resolves the HTTP call (200 OK with an "errors" array,
+    // no top-level "data") - apiPost's dataWrapped unwrapping then yields undefined.
+    // This is exactly the shape that let a broken query silently render "no
+    // notifications" instead of a visible failure.
+    (apiPost as jest.Mock).mockResolvedValue({ isError: false, responseCode: 200, data: undefined });
+
+    render(
+      <MemoryRouter>
+        <NotificationConfigurationList orgId="org-1" managePermission={true} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(apiPost).toHaveBeenCalled());
+    expect(screen.queryByText("Org Slack Alerts")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/domain/Notifications/__tests__/NotificationDeliveryHistory.test.tsx
+++ b/ui/src/domain/Notifications/__tests__/NotificationDeliveryHistory.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import axiosInstance from "@/config/axiosConfig";
+import { NotificationDeliveryHistory } from "../NotificationDeliveryHistory";
+
+jest.mock("@/config/axiosConfig", () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() },
+  getErrorMessage: jest.fn(() => "error"),
+}));
+
+describe("NotificationDeliveryHistory", () => {
+  it("renders sent and failed deliveries with status and error detail", async () => {
+    (axiosInstance.get as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          id: "d1",
+          jobId: 42,
+          configurationName: "Prod Alerts",
+          channelType: "SLACK",
+          status: "FAILED",
+          attemptCount: 3,
+          lastAttemptAt: "2026-08-12T00:00:00Z",
+          lastError: "connection refused",
+          createdDate: "2026-08-12T00:00:00Z",
+        },
+        {
+          id: "d2",
+          jobId: 41,
+          configurationName: "Prod Alerts",
+          channelType: "SLACK",
+          status: "SENT",
+          attemptCount: 1,
+          lastAttemptAt: "2026-08-11T23:00:00Z",
+          lastError: null,
+          createdDate: "2026-08-11T23:00:00Z",
+        },
+      ],
+    });
+
+    render(<NotificationDeliveryHistory workspaceId="ws-1" />);
+
+    await waitFor(() => expect(screen.getByText("Failed")).toBeInTheDocument());
+    expect(screen.getByText("Sent")).toBeInTheDocument();
+    expect(screen.getByText("connection refused")).toBeInTheDocument();
+    expect(screen.getByText(/Job #42/)).toBeInTheDocument();
+  });
+
+  it("renders nothing when there are no deliveries", async () => {
+    (axiosInstance.get as jest.Mock).mockResolvedValue({ data: [] });
+
+    const { container } = render(<NotificationDeliveryHistory workspaceId="ws-1" />);
+
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it("retries a failed delivery and reloads the list", async () => {
+    const failedDelivery = {
+      id: "d1",
+      jobId: 42,
+      configurationName: "Prod Alerts",
+      channelType: "SLACK",
+      status: "FAILED",
+      attemptCount: 3,
+      lastAttemptAt: "2026-08-12T00:00:00Z",
+      lastError: "connection refused",
+      createdDate: "2026-08-12T00:00:00Z",
+    };
+    (axiosInstance.get as jest.Mock)
+      .mockResolvedValueOnce({ data: [failedDelivery] })
+      .mockResolvedValueOnce({ data: [{ ...failedDelivery, status: "PENDING", lastError: null }] });
+    (axiosInstance.post as jest.Mock).mockResolvedValue({});
+
+    render(<NotificationDeliveryHistory workspaceId="ws-1" />);
+    await waitFor(() => expect(screen.getByText("Failed")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await waitFor(() =>
+      expect(axiosInstance.post).toHaveBeenCalledWith(
+        "https://terrakube-api.test/notification/v1/workspace/ws-1/deliveries/d1/retry"
+      )
+    );
+    await waitFor(() => expect(screen.getByText("Pending")).toBeInTheDocument());
+  });
+});

--- a/ui/src/domain/Notifications/channelMeta.ts
+++ b/ui/src/domain/Notifications/channelMeta.ts
@@ -1,0 +1,53 @@
+import { ApiOutlined, SlackOutlined, TeamOutlined } from "@ant-design/icons";
+import { NotificationChannelType } from "../types";
+
+type ChannelMeta = {
+  value: NotificationChannelType;
+  label: string;
+  description: string;
+  icon: typeof SlackOutlined;
+  color: string;
+  urlPlaceholder: string;
+  urlHelp: string;
+  docsLabel: string;
+  docsUrl: string;
+};
+
+export const CHANNEL_META: Record<NotificationChannelType, ChannelMeta> = {
+  SLACK: {
+    value: "SLACK",
+    label: "Slack",
+    description: "Post to a channel via an Incoming Webhook",
+    icon: SlackOutlined,
+    color: "#611f69",
+    urlPlaceholder: "https://hooks.slack.com/services/...",
+    urlHelp: "Paste the Incoming Webhook URL for the Slack channel you want to notify.",
+    docsLabel: "How to create a Slack Incoming Webhook",
+    docsUrl: "https://api.slack.com/messaging/webhooks",
+  },
+  TEAMS: {
+    value: "TEAMS",
+    label: "Microsoft Teams",
+    description: "Post to a channel via an Incoming Webhook",
+    icon: TeamOutlined,
+    color: "#6264a7",
+    urlPlaceholder: "https://<org>.webhook.office.com/webhookb2/...",
+    urlHelp: "Paste the Incoming Webhook URL for the Teams channel you want to notify.",
+    docsLabel: "How to create a Teams Incoming Webhook",
+    docsUrl:
+      "https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook",
+  },
+  WEBHOOK: {
+    value: "WEBHOOK",
+    label: "Generic Webhook",
+    description: "POST a JSON payload to any HTTPS endpoint",
+    icon: ApiOutlined,
+    color: "#08979c",
+    urlPlaceholder: "https://example.com/hooks/terrakube",
+    urlHelp: "Any HTTPS endpoint that accepts a JSON POST. Add a signing secret to verify authenticity.",
+    docsLabel: "About the webhook payload and signature",
+    docsUrl: "",
+  },
+};
+
+export const CHANNEL_ORDER: NotificationChannelType[] = ["SLACK", "TEAMS", "WEBHOOK"];

--- a/ui/src/domain/Notifications/jobStatusGroups.ts
+++ b/ui/src/domain/Notifications/jobStatusGroups.ts
@@ -1,0 +1,70 @@
+import {
+  CheckCircleOutlined,
+  ClockCircleOutlined,
+  ExclamationCircleOutlined,
+  QuestionCircleOutlined,
+  SyncOutlined,
+} from "@ant-design/icons";
+import { JobStatus } from "../types";
+
+type JobStatusGroup = {
+  key: string;
+  label: string;
+  color: string;
+  icon: typeof CheckCircleOutlined;
+  statuses: { value: JobStatus; label: string }[];
+};
+
+export const JOB_STATUS_GROUPS: JobStatusGroup[] = [
+  {
+    key: "needs-attention",
+    label: "Needs Attention",
+    color: "orange",
+    icon: ClockCircleOutlined,
+    statuses: [{ value: JobStatus.WaitingApproval, label: "Waiting for Approval" }],
+  },
+  {
+    key: "completed",
+    label: "Completed",
+    color: "green",
+    icon: CheckCircleOutlined,
+    statuses: [
+      { value: JobStatus.Completed, label: "Completed" },
+      { value: JobStatus.NoChanges, label: "Completed (No Changes)" },
+    ],
+  },
+  {
+    key: "errored",
+    label: "Errored",
+    color: "red",
+    icon: ExclamationCircleOutlined,
+    statuses: [
+      { value: JobStatus.Failed, label: "Failed" },
+      { value: JobStatus.Rejected, label: "Rejected" },
+      { value: JobStatus.Cancelled, label: "Cancelled" },
+    ],
+  },
+  {
+    key: "in-progress",
+    label: "In Progress",
+    color: "blue",
+    icon: SyncOutlined,
+    statuses: [
+      { value: JobStatus.Pending, label: "Pending" },
+      { value: JobStatus.Approved, label: "Approved" },
+      { value: JobStatus.Queue, label: "Queued" },
+      { value: JobStatus.Running, label: "Running" },
+    ],
+  },
+  {
+    key: "other",
+    label: "Other",
+    color: "default",
+    icon: QuestionCircleOutlined,
+    statuses: [
+      { value: JobStatus.NotExecuted, label: "Not Executed" },
+      { value: JobStatus.Unknown, label: "Unknown" },
+      { value: JobStatus.NeverExecuted, label: "Never Executed" },
+    ],
+  },
+];

--- a/ui/src/domain/Settings/Notifications.tsx
+++ b/ui/src/domain/Settings/Notifications.tsx
@@ -1,0 +1,11 @@
+import { useParams } from "react-router-dom";
+import { NotificationConfigurationList } from "@/domain/Notifications/NotificationConfigurationList";
+
+type Props = {
+  managePermission?: boolean;
+};
+
+export const OrgNotifications = ({ managePermission = true }: Props) => {
+  const { orgid } = useParams();
+  return <NotificationConfigurationList orgId={orgid!} managePermission={managePermission} />;
+};

--- a/ui/src/domain/Settings/Settings.tsx
+++ b/ui/src/domain/Settings/Settings.tsx
@@ -11,6 +11,7 @@ import { AgentSettings } from "./Agents";
 import { TagsSettings } from "./Tags";
 import { TeamSettings } from "./Teams";
 import { FederatedCredentials } from "./FederatedCredentials";
+import { OrgNotifications } from "./Notifications";
 import { TemplatesSettings } from "./Templates";
 import { VCSSettings } from "./VCS";
 import { VariableCollectionsSettings } from "./VariableCollections";
@@ -31,6 +32,7 @@ const SETTINGS_TAB_LABELS: Record<string, string> = {
   "9": "Variable Collections",
   "10": "Actions",
   "11": "Federated Credentials",
+  "12": "Notifications",
 };
 
 type Props = {
@@ -94,6 +96,8 @@ export const OrganizationSettings = ({ selectedTab, vcsMode, collectionMode = "l
         return <ActionSettings managePermission={permissions.managePermission} />;
       case "11":
         return <FederatedCredentials managePermission={permissions.managePermission} />;
+      case "12":
+        return <OrgNotifications managePermission={permissions.managePermission} />;
       default:
         return <GeneralSettings managePermission={permissions.managePermission} />;
     }

--- a/ui/src/domain/Settings/__tests__/Notifications.test.tsx
+++ b/ui/src/domain/Settings/__tests__/Notifications.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { OrgNotifications } from "../Notifications";
+
+jest.mock("@/domain/Notifications/NotificationConfigurationList", () => ({
+  NotificationConfigurationList: ({ orgId, workspaceId }: { orgId: string; workspaceId?: string }) => (
+    <div data-testid="notification-list">
+      {orgId}:{String(workspaceId)}
+    </div>
+  ),
+}));
+
+describe("OrgNotifications", () => {
+  it("renders the shared list scoped to the org only, no workspaceId", () => {
+    render(
+      <MemoryRouter initialEntries={["/organizations/org-1/settings/notifications"]}>
+        <Routes>
+          <Route path="/organizations/:orgid/settings/notifications" element={<OrgNotifications managePermission={true} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId("notification-list")).toHaveTextContent("org-1:undefined");
+  });
+});

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -99,6 +99,7 @@ const WORKSPACE_SETTINGS_SECTION_LABELS: Record<string, string> = {
   locking: "Locking",
   sshkey: "SSH Key",
   webhook: "Webhook",
+  notifications: "Notifications",
   "state-shared": "State Shared",
   "team-access": "Team Access",
   advanced: "Destruction and Deletion",

--- a/ui/src/domain/Workspaces/Settings/Notifications.tsx
+++ b/ui/src/domain/Workspaces/Settings/Notifications.tsx
@@ -1,0 +1,18 @@
+import { NotificationConfigurationList } from "@/domain/Notifications/NotificationConfigurationList";
+import { NotificationDeliveryHistory } from "@/domain/Notifications/NotificationDeliveryHistory";
+import { Workspace } from "../../types";
+
+type Props = {
+  workspace: Workspace;
+  manageWorkspace: boolean;
+};
+
+export const WorkspaceNotifications = ({ workspace, manageWorkspace }: Props) => {
+  const organizationId = workspace.relationships.organization.data.id;
+  return (
+    <>
+      <NotificationConfigurationList orgId={organizationId} workspaceId={workspace.id} managePermission={manageWorkspace} />
+      <NotificationDeliveryHistory workspaceId={workspace.id} />
+    </>
+  );
+};

--- a/ui/src/domain/Workspaces/Settings/WorkspaceSettings.tsx
+++ b/ui/src/domain/Workspaces/Settings/WorkspaceSettings.tsx
@@ -2,6 +2,7 @@ import { WorkspaceGeneral } from "./General";
 import { WorkspaceLocking } from "./Locking";
 import { WorkspaceSSHKey } from "./SSHKey";
 import { WorkspaceWebhook } from "./Webhook";
+import { WorkspaceNotifications } from "./Notifications";
 import { WorkspaceAdvanced } from "./Advanced";
 import { WorkspaceStateShared } from "./StateShared";
 import { WorkspaceTeamAccess } from "./TeamAccess";
@@ -57,6 +58,8 @@ export const WorkspaceSettings = ({
           onWorkspaceUpdate={handleWorkspaceUpdate}
         />
       );
+    case "notifications":
+      return <WorkspaceNotifications workspace={workspace} manageWorkspace={manageWorkspace} />;
     case "advanced":
       return <WorkspaceAdvanced workspace={workspace} manageWorkspace={manageWorkspace} />;
     case "state-shared":

--- a/ui/src/domain/Workspaces/Settings/__tests__/Notifications.test.tsx
+++ b/ui/src/domain/Workspaces/Settings/__tests__/Notifications.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from "@testing-library/react";
+import { WorkspaceNotifications } from "../Notifications";
+
+jest.mock("@/domain/Notifications/NotificationConfigurationList", () => ({
+  NotificationConfigurationList: ({ orgId, workspaceId }: { orgId: string; workspaceId?: string }) => (
+    <div data-testid="notification-list">
+      {orgId}:{workspaceId}
+    </div>
+  ),
+}));
+jest.mock("@/domain/Notifications/NotificationDeliveryHistory", () => ({
+  NotificationDeliveryHistory: ({ workspaceId }: { workspaceId: string }) => (
+    <div data-testid="notification-delivery-history">{workspaceId}</div>
+  ),
+}));
+
+describe("WorkspaceNotifications", () => {
+  it("renders the shared list scoped to this workspace's organization and id", () => {
+    const workspace = {
+      id: "ws-1",
+      relationships: { organization: { data: { id: "org-1" } } },
+    } as any;
+
+    render(<WorkspaceNotifications workspace={workspace} manageWorkspace={true} />);
+
+    expect(screen.getByTestId("notification-list")).toHaveTextContent("org-1:ws-1");
+  });
+});

--- a/ui/src/domain/types.ts
+++ b/ui/src/domain/types.ts
@@ -117,6 +117,7 @@ export enum JobStatus {
   Cancelled = "cancelled",
   Failed = "failed",
   Unknown = "unknown",
+  NeverExecuted = "NeverExecuted",
 }
 
 export enum JobVia {
@@ -368,6 +369,33 @@ export type FederatedClaimAttributes = {
   claimKey: string;
   claimValue: string;
 };
+
+// Notification
+export type NotificationChannelType = "SLACK" | "TEAMS" | "WEBHOOK";
+
+export type NotificationConfiguration = {
+  id: string;
+  attributes: NotificationConfigurationAttributes;
+  relationships?: {
+    workspace?: { data: { id: string } | null };
+  };
+};
+export type NotificationConfigurationAttributes = {
+  name: string;
+  description?: string;
+  channelType: NotificationChannelType;
+  destinationUrl: string;
+  signingSecret?: string;
+  active: boolean;
+};
+export type NotificationTrigger = {
+  id: string;
+  attributes: NotificationTriggerAttributes;
+};
+export type NotificationTriggerAttributes = {
+  jobStatus: JobStatus;
+};
+
 export type ApiWorkspaceTag = {
   id: string;
   attributes: {

--- a/ui/src/domain/types.ts
+++ b/ui/src/domain/types.ts
@@ -372,6 +372,7 @@ export type FederatedClaimAttributes = {
 
 // Notification
 export type NotificationChannelType = "SLACK" | "TEAMS" | "WEBHOOK";
+export type NotificationMessageStyle = "DETAILED" | "SIMPLE";
 
 export type NotificationConfiguration = {
   id: string;
@@ -387,6 +388,7 @@ export type NotificationConfigurationAttributes = {
   destinationUrl: string;
   signingSecret?: string;
   active: boolean;
+  messageStyle?: NotificationMessageStyle;
 };
 export type NotificationTrigger = {
   id: string;

--- a/ui/src/modules/layout/AppSidebar/AppSidebar.tsx
+++ b/ui/src/modules/layout/AppSidebar/AppSidebar.tsx
@@ -2,6 +2,7 @@ import {
   ApiOutlined,
   AppstoreOutlined,
   BankOutlined,
+  BellOutlined,
   BgColorsOutlined,
   BranchesOutlined,
   CloudOutlined,
@@ -253,6 +254,7 @@ export default function AppSidebar({
           path: "actions",
           icon: <ThunderboltOutlined />,
         },
+        { key: "notifications", label: "Notifications", path: "notifications", icon: <BellOutlined /> },
       ],
     },
   ];
@@ -262,6 +264,7 @@ export default function AppSidebar({
     { key: "locking", label: "Locking", path: "locking", icon: <LockOutlined /> },
     { key: "sshkey", label: "SSH Key", path: "sshkey", icon: <KeyOutlined /> },
     { key: "webhook", label: "Webhook", path: "webhook", icon: <ApiOutlined /> },
+    { key: "notifications", label: "Notifications", path: "notifications", icon: <BellOutlined /> },
     { key: "state-shared", label: "State Shared", path: "state-shared", icon: <ShareAltOutlined /> },
     { key: "team-access", label: "Team Access", path: "team-access", icon: <TeamOutlined /> },
     { key: "advanced", label: "Destruction and Deletion", path: "advanced", icon: <DeleteOutlined /> },


### PR DESCRIPTION
## Notifications for job status changes (Slack, Teams, generic webhook)

### What

Notification system so you can get pinged when a run changes status — configurable per organization (applies to every workspace) and/or per workspace, both additive.

- Slack, Microsoft Teams, and generic webhook channels
- Filter by run status and now by template (e.g. notify on "Plan and Apply" but not bare "Plan")
- Per-config message style: Detailed (full card) or Simple (one-line ping)
- Retryable (429/5xx) vs. terminal (other 4xx) failure classification, with a manual retry action for terminal deliveries
- destinationUrl validated against private/loopback/link-local ranges before every send, with an opt-out for self-hosted setups that intentionally target something internal

### Why these choices

- **Additive only, no override/suppression.** Org-wide and workspace configs both fire independently. An earlier draft had an "override for this workspace" concept and it just made state harder to reason about for no real benefit.
- **Transactional outbox instead of sending inline.** Most real status transitions happen via a plain JPA save in the Quartz scheduler, not through Elide, so there's no request/response cycle to hang a synchronous send off anyway — and decoupling enqueue from delivery means a slow or down destination can't block a job's status update.
- **Plain Incoming Webhooks, not an OAuth bot install.** Simpler for a user to set up (paste a URL vs. an app-install flow), at the cost of no message threading/editing-in-place. Worth noting Slack's own TFE integration has the same limitation.
- **Read access to an org-wide config is broader than write access.** Anyone managing a workspace it applies to can see it, even if only org-wide admins can edit it — otherwise a workspace-level manager has no way to know an org-wide notification is about to fire for their runs.
- **Message style is an explicit per-config toggle, not inferred from job status.** First pass tried auto-picking detailed vs. compact based on status; in practice that just meant losing information people wanted, so it's user-controlled now.
- **Template filter narrows, never widens.** An empty selection always means "every template." No way to accidentally configure a notification that silently never fires.

### How it was tested

- Local webhook receiver for the generic webhook channel
- A real Slack workspace for the Slack channel — this is what surfaced the delivery bugs fixed in the second commit (Slack rejecting payloads missing top-level `text`, and reporting some errors as HTTP 200 with a plain-text body instead of a 4xx)
- Full backend and frontend test suites pass

### Related

Slack screenshots:
<img width="772" height="373" alt="image" src="https://github.com/user-attachments/assets/e0f6d856-3890-496c-9209-f5895a30f07c" />
<img width="2084" height="1075" alt="image" src="https://github.com/user-attachments/assets/3b44f5e7-6935-4f60-8ceb-e08749500d89" />
<img width="823" height="1202" alt="image" src="https://github.com/user-attachments/assets/8d6ab51c-0470-4bc4-9f9a-c5b566ab205d" />

Companion Terraform provider terrakube-io/terraform-provider-terrakube#160 in progress to manage these configurations as code — will link that PR here once it's up