### PR TITLE
fix: re-queue last applied configuration for CLI/API workspace Run now

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.ephemeral.EphemeralExecutorService;
 import io.terrakube.api.plugin.scheduler.job.tcl.executor.persistent.PersistentExecutorService;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.Flow;
+import io.terrakube.api.plugin.scheduler.job.tcl.model.FlowType;
 import io.terrakube.api.plugin.token.dynamic.DynamicCredentialsService;
 import io.terrakube.api.plugin.vcs.TokenService;
 import io.terrakube.api.repository.GlobalVarRepository;
@@ -28,6 +29,7 @@ import io.terrakube.api.repository.ReferenceRepository;
 import io.terrakube.api.repository.SshRepository;
 import io.terrakube.api.repository.VariableRepository;
 import io.terrakube.api.repository.VcsRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.rs.collection.Collection;
 import io.terrakube.api.rs.collection.Reference;
 import io.terrakube.api.rs.collection.item.Item;
@@ -38,6 +40,7 @@ import io.terrakube.api.rs.job.address.AddressType;
 import io.terrakube.api.rs.ssh.Ssh;
 import io.terrakube.api.rs.vcs.Vcs;
 import io.terrakube.api.rs.vcs.VcsConnectionType;
+import io.terrakube.api.rs.workspace.Workspace;
 import io.terrakube.api.rs.workspace.parameters.Category;
 import io.terrakube.api.rs.workspace.parameters.Variable;
 import lombok.extern.slf4j.Slf4j;
@@ -72,6 +75,8 @@ public class ExecutorService {
 
     @Autowired
     TokenService tokenService;
+    @Autowired
+    WorkspaceRepository workspaceRepository;
     @Autowired
     private VariableRepository variableRepository;
     @Autowired
@@ -151,15 +156,23 @@ public class ExecutorService {
 
         // A remote-content workspace requires a tarball URL (job.overrideSource set by
         // the Terraform CLI configuration-version upload, or workspace.source set by the
-        // same flow). A manual UI run against such a workspace will arrive here with both
-        // null and would NPE later inside the executor when constructing the download URL.
+        // same flow). A manual UI run against such a workspace will arrive here with source
+        // null, blank, or the literal "empty" placeholder (the initial value a brand-new
+        // CLI/API workspace is created with) and would NPE later inside the executor when
+        // constructing the download URL. The UI disables "Run now" for this case; this guard
+        // is defense-in-depth for direct API calls / stale clients.
         if ("remote-content".equals(executorContext.getBranch())
-                && (executorContext.getSource() == null || executorContext.getSource().isBlank())) {
+                && (executorContext.getSource() == null || executorContext.getSource().isBlank()
+                        || "empty".equals(executorContext.getSource()))) {
             throw new ExecutionException(
                     "Cannot run job " + job.getId() + ": workspace '" + job.getWorkspace().getName()
                             + "' has branch 'remote-content' but no configuration has been uploaded. "
                             + "Upload configuration via the terraform CLI or attach a VCS connection before running.");
         }
+
+        // For CLI/API driven (remote-content) workspaces, remember the configuration version
+        // being applied so a later UI "Run now" re-queues the last applied configuration.
+        persistAppliedConfigurationSource(job, flow, executorContext.getSource());
 
         if (job.getWorkspace().getModuleSshKey() != null) {
             String moduleSshId = job.getWorkspace().getModuleSshKey();
@@ -228,6 +241,39 @@ public class ExecutorService {
     private boolean iacType(Job job) {
         return job.getWorkspace().getIacType() != null && job.getWorkspace().getIacType().equals("terraform") ? false
                 : true;
+    }
+
+    /**
+     * Persists the configuration version being applied onto workspace.source for CLI/API driven
+     * (remote-content) workspaces. This is only done when a terraformApply flow is dispatched
+     * (i.e. the plan was approved and the apply is being attempted), so the stored source reflects
+     * the last configuration version that reached apply - regardless of whether the apply then
+     * succeeds or fails. This lets a later UI "Run now" re-queue that same configuration version.
+     *
+     * VCS/SSH backed workspaces are intentionally skipped: their source points at a git repository
+     * and must not be overwritten with a configuration-version tarball URL.
+     */
+    void persistAppliedConfigurationSource(Job job, Flow flow, String resolvedSource) {
+        if (flow == null || !FlowType.terraformApply.name().equals(flow.getType())) {
+            return;
+        }
+        Workspace workspace = job.getWorkspace();
+        if (workspace.getVcs() != null || workspace.getSsh() != null) {
+            return;
+        }
+        if (!"remote-content".equals(workspace.getBranch())) {
+            return;
+        }
+        if (resolvedSource == null || resolvedSource.isBlank()) {
+            return;
+        }
+        if (resolvedSource.equals(workspace.getSource())) {
+            return;
+        }
+        log.info("Updating workspace {} source to last applied configuration for remote-content workspace",
+                workspace.getName());
+        workspace.setSource(resolvedSource);
+        workspaceRepository.save(workspace);
     }
 
     private HashMap<String, String> loadOtherEnvironmentVariables(Job job, Flow flow,

--- a/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
@@ -1158,12 +1158,13 @@ public class RemoteTfeService {
         Workspace workspace = workspaceRepository.getReferenceById(UUID.fromString(workspaceId));
         String sourceTarGz = String.format("https://%s/remote/tfe/v2/configuration-versions/%s/terraformContent.tar.gz",
                 hostname, configurationId);
-        // we need to update the source only if the VCS connection is null and the
-        // branch is other than "remote-content"
-        if (workspace.getVcs() == null && workspace.getBranch().equals("remote-content")) {
-            workspace.setSource(sourceTarGz);
-        }
-        workspace = workspaceRepository.save(workspace);
+        // We intentionally do NOT persist this configuration version onto workspace.source
+        // here. Doing so on every run (including speculative plan-only runs and runs that are
+        // later discarded before approval) made workspace.source track the last configuration
+        // *created* rather than the last configuration *applied*, so a subsequent UI "Run now"
+        // could re-queue the wrong configuration. The workspace source pointer is now updated
+        // when an apply is actually dispatched (see ExecutorService.persistAppliedConfigurationSource).
+        // The current run still uses this tarball via job.overrideSource, set below.
         Template template = templateRepository.getByOrganizationNameAndName(
                 workspace.getOrganization().getName(),
                 getTemplateName(configurationId, isDestroy));

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorServiceTest.java
@@ -2,10 +2,17 @@ package io.terrakube.api.plugin.scheduler.job.tcl.executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.terrakube.api.plugin.scheduler.job.tcl.model.Flow;
+import io.terrakube.api.plugin.scheduler.job.tcl.model.FlowType;
 import io.terrakube.api.repository.VariableRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.ssh.Ssh;
+import io.terrakube.api.rs.vcs.Vcs;
 import io.terrakube.api.rs.workspace.Workspace;
 import io.terrakube.api.rs.workspace.parameters.Category;
 import io.terrakube.api.rs.workspace.parameters.Variable;
@@ -25,6 +32,9 @@ class ExecutorServiceTest {
     @Mock
     private VariableRepository variableRepository;
 
+    @Mock
+    private WorkspaceRepository workspaceRepository;
+
     @InjectMocks
     private ExecutorService executorService;
 
@@ -39,6 +49,12 @@ class ExecutorServiceTest {
         job = new Job();
         job.setId(42);
         job.setWorkspace(workspace);
+    }
+
+    private Flow flow(FlowType type) {
+        Flow flow = new Flow();
+        flow.setType(type.name());
+        return flow;
     }
 
     @Test
@@ -89,5 +105,90 @@ class ExecutorServiceTest {
 
         assertThat(terraformVariables).isEmpty();
         assertThat(environmentVariables).isEmpty();
+    }
+
+    @Test
+    void shouldPersistAppliedConfigurationSourceForRemoteContentApply() {
+        workspace.setBranch("remote-content");
+        workspace.setSource("empty");
+        String applied = "https://localhost/remote/tfe/v2/configuration-versions/abc/terraformContent.tar.gz";
+
+        executorService.persistAppliedConfigurationSource(job, flow(FlowType.terraformApply), applied);
+
+        assertThat(workspace.getSource()).isEqualTo(applied);
+        verify(workspaceRepository).save(workspace);
+    }
+
+    @Test
+    void shouldNotPersistSourceForSpeculativePlan() {
+        workspace.setBranch("remote-content");
+        workspace.setSource("empty");
+        String planned = "https://localhost/remote/tfe/v2/configuration-versions/abc/terraformContent.tar.gz";
+
+        executorService.persistAppliedConfigurationSource(job, flow(FlowType.terraformPlan), planned);
+
+        assertThat(workspace.getSource()).isEqualTo("empty");
+        verify(workspaceRepository, never()).save(workspace);
+    }
+
+    @Test
+    void shouldNotPersistSourceForVcsWorkspaceOnApply() {
+        workspace.setBranch("remote-content");
+        workspace.setSource("https://github.com/example/repo.git");
+        workspace.setVcs(new Vcs());
+        String applied = "https://localhost/remote/tfe/v2/configuration-versions/abc/terraformContent.tar.gz";
+
+        executorService.persistAppliedConfigurationSource(job, flow(FlowType.terraformApply), applied);
+
+        assertThat(workspace.getSource()).isEqualTo("https://github.com/example/repo.git");
+        verify(workspaceRepository, never()).save(workspace);
+    }
+
+    @Test
+    void shouldNotPersistSourceForSshWorkspaceOnApply() {
+        workspace.setBranch("remote-content");
+        workspace.setSource("git@github.com:example/repo.git");
+        workspace.setSsh(new Ssh());
+        String applied = "https://localhost/remote/tfe/v2/configuration-versions/abc/terraformContent.tar.gz";
+
+        executorService.persistAppliedConfigurationSource(job, flow(FlowType.terraformApply), applied);
+
+        assertThat(workspace.getSource()).isEqualTo("git@github.com:example/repo.git");
+        verify(workspaceRepository, never()).save(workspace);
+    }
+
+    @Test
+    void shouldNotPersistSourceForNonRemoteContentBranchOnApply() {
+        workspace.setBranch("main");
+        workspace.setSource("https://github.com/example/repo.git");
+        String applied = "https://localhost/remote/tfe/v2/configuration-versions/abc/terraformContent.tar.gz";
+
+        executorService.persistAppliedConfigurationSource(job, flow(FlowType.terraformApply), applied);
+
+        assertThat(workspace.getSource()).isEqualTo("https://github.com/example/repo.git");
+        verify(workspaceRepository, never()).save(workspace);
+    }
+
+    @Test
+    void shouldNotPersistSourceWhenResolvedSourceMatchesCurrentSource() {
+        String applied = "https://localhost/remote/tfe/v2/configuration-versions/abc/terraformContent.tar.gz";
+        workspace.setBranch("remote-content");
+        workspace.setSource(applied);
+
+        executorService.persistAppliedConfigurationSource(job, flow(FlowType.terraformApply), applied);
+
+        assertThat(workspace.getSource()).isEqualTo(applied);
+        verify(workspaceRepository, never()).save(workspace);
+    }
+
+    @Test
+    void shouldNotPersistSourceWhenResolvedSourceIsBlankOnApply() {
+        workspace.setBranch("remote-content");
+        workspace.setSource("empty");
+
+        executorService.persistAppliedConfigurationSource(job, flow(FlowType.terraformApply), "  ");
+
+        assertThat(workspace.getSource()).isEqualTo("empty");
+        verify(workspaceRepository, never()).save(workspace);
     }
 }

--- a/ui/src/domain/Jobs/Create.tsx
+++ b/ui/src/domain/Jobs/Create.tsx
@@ -1,5 +1,5 @@
 import { DeleteOutlined, InfoCircleOutlined, PlayCircleOutlined } from "@ant-design/icons";
-import { Button, Form, Input, Modal, Select, Space, message, Typography } from "antd";
+import { Button, Form, Input, Modal, Select, Space, Tooltip, message, Typography } from "antd";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ORGANIZATION_ARCHIVE, WORKSPACE_ARCHIVE } from "../../config/actionTypes";
@@ -11,6 +11,9 @@ const validateMessages = { required: "${label} is required!" };
 type Props = {
   changeJob: (id: string) => void;
   planJob?: boolean;
+  // When set, "Run now" is disabled and this message explains why (e.g. a CLI/API
+  // workspace that has no applied configuration to re-run yet).
+  disabledReason?: string;
 };
 
 type CreateJobForm = {
@@ -18,7 +21,7 @@ type CreateJobForm = {
   branchName: string;
 };
 
-export const CreateJob = ({ changeJob, planJob = true }: Props) => {
+export const CreateJob = ({ changeJob, planJob = true, disabledReason }: Props) => {
   const navigate = useNavigate();
   const workspaceId = sessionStorage.getItem(WORKSPACE_ARCHIVE);
   const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
@@ -109,19 +112,21 @@ export const CreateJob = ({ changeJob, planJob = true }: Props) => {
 
   return (
     <div>
-      <Button
-        type="primary"
-        htmlType="button"
-        onClick={() => {
-          loadBranch();
-          setVisible(true);
-        }}
-        icon={<PlayCircleOutlined />}
-        disabled={!planJob || submitting}
-        loading={submitting}
-      >
-        Run now
-      </Button>
+      <Tooltip title={disabledReason}>
+        <Button
+          type="primary"
+          htmlType="button"
+          onClick={() => {
+            loadBranch();
+            setVisible(true);
+          }}
+          icon={<PlayCircleOutlined />}
+          disabled={!planJob || submitting || !!disabledReason}
+          loading={submitting}
+        >
+          Run now
+        </Button>
+      </Tooltip>
 
       <Modal
         open={visible}

--- a/ui/src/domain/Jobs/__tests__/Create.test.tsx
+++ b/ui/src/domain/Jobs/__tests__/Create.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { CreateJob } from "../Create";
+
+window._env_ = {
+  REACT_APP_AUTHORITY: "http://localhost/authority",
+  REACT_APP_CLIENT_ID: "client-id",
+  REACT_APP_REDIRECT_URI: "http://localhost/redirect",
+  REACT_APP_SCOPE: "openid",
+  REACT_APP_TERRAKUBE_API_URL: "http://localhost:8080/api/v1",
+  REACT_APP_TERRAKUBE_VERSION: "test",
+  REACT_APP_REGISTRY_URI: "http://localhost:8080/registry",
+};
+
+const getMock = jest.fn();
+
+jest.mock("../../../config/axiosConfig", () => ({
+  __esModule: true,
+  default: { get: (...args: unknown[]) => getMock(...args) },
+  axiosClient: { get: (...args: unknown[]) => getMock(...args) },
+}));
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => jest.fn(),
+}));
+
+describe("CreateJob Run now button", () => {
+  beforeEach(() => {
+    // On mount CreateJob calls loadTemplates() (expects response.data.data to be an array)
+    // and loadBranch() (expects response.data.data.attributes). Return shapes for both.
+    getMock.mockImplementation((url: string) => {
+      if (typeof url === "string" && url.includes("/template")) {
+        return Promise.resolve({ data: { data: [] } });
+      }
+      return Promise.resolve({ data: { data: { attributes: { branch: "main", defaultTemplate: undefined } } } });
+    });
+  });
+
+  const runNowButton = () => screen.getByRole("button", { name: /run now/i });
+
+  it("enables Run now when there is no disabled reason (e.g. VCS workspace)", async () => {
+    render(<CreateJob changeJob={jest.fn()} planJob={true} />);
+    await waitFor(() => expect(runNowButton()).toBeEnabled());
+  });
+
+  it("disables Run now when a disabled reason is provided (unconfigured CLI/API workspace)", async () => {
+    render(
+      <CreateJob
+        changeJob={jest.fn()}
+        planJob={true}
+        disabledReason="This CLI/API driven workspace has no applied configuration yet."
+      />
+    );
+    await waitFor(() => expect(runNowButton()).toBeDisabled());
+  });
+
+  it("disables Run now when the user lacks plan permission", async () => {
+    render(<CreateJob changeJob={jest.fn()} planJob={false} />);
+    await waitFor(() => expect(runNowButton()).toBeDisabled());
+  });
+});

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -872,7 +872,16 @@ export const WorkspaceDetails = ({
                   >
                     {workspace.attributes.locked ? "Unlock" : "Lock"}
                   </Button>
-                  <CreateJob changeJob={changeJob} planJob={planJob} />
+                  <CreateJob
+                    changeJob={changeJob}
+                    planJob={planJob}
+                    disabledReason={
+                      workspace.attributes.source === "empty" &&
+                      workspace.attributes.branch === "remote-content"
+                        ? "This CLI/API driven workspace has no applied configuration yet. Upload and apply a configuration with the terraform CLI/API before using Run now."
+                        : undefined
+                    }
+                  />
                 </Space>
               </div>
               <Space className="workspace-details" direction="vertical">


### PR DESCRIPTION
## Fix "Run now" for CLI/API-driven workspaces

### Problem
For CLI/API-driven workspaces (no VCS connection, `branch = "remote-content"`), clicking
**Run now** in the UI fails. On v2.31.2 it throws a `NullPointerException`; the run cannot
start.

Root cause is how the last configuration-version pointer is tracked. In
`RemoteTfeService.createRun`, `workspace.source` was overwritten with the uploaded
configuration-version's tarball URL on **every** run — including speculative (plan-only)
runs and runs later discarded before approval. So `workspace.source` tracked the last
configuration *created*, not the last configuration *applied*.

The UI "Run now" job carries no `overrideSource`, so the executor falls back to
`workspace.source`. As a result "Run now" could:
- re-queue the **wrong** configuration (a later speculative plan's), or
- fail outright when `workspace.source` was still the initial `"empty"` placeholder
  (never-applied workspace) — the NPE above.

### Fix
Track the "last applied configuration" at the moment an **apply is dispatched** (i.e. the
plan was approved and apply/destroy is being attempted), rather than at run creation:

- **`RemoteTfeService.createRun`** — no longer eagerly writes `workspace.source`. The
  current run is unaffected (it already uses `job.overrideSource`).
- **`ExecutorService`** — new `persistAppliedConfigurationSource(...)`, invoked when a
  `terraformApply` flow is dispatched. It records the configuration-version tarball onto
  `workspace.source` **only** for CLI/API workspaces (`vcs == null && ssh == null &&
  branch == "remote-content"`), and is a no-op if the source is null/blank/unchanged.
  Both the manual-approve and auto-apply paths funnel through this single dispatch point,
  so apply and destroy are covered, success or failure.
- **`ExecutorService` guard** — the existing remote-content guard now also treats the
  literal `"empty"` placeholder as "no configuration uploaded", failing with a clear
  message instead of an NPE (defense-in-depth for direct API calls / stale clients).
- **UI (`CreateJob` / `WorkspaceDetails`)** — "Run now" is disabled with an explanatory
  tooltip when a CLI/API workspace has no applied configuration yet
  (`source === "empty" && branch === "remote-content"`). VCS workspaces are unaffected and
  remain always-enabled, since they always have a git source to run.

### VCS / SSH safety
VCS and SSH workspaces are double-guarded: `persistAppliedConfigurationSource` returns
early when `vcs`/`ssh` is set, and such workspaces never have `branch == "remote-content"`
(the remote-content override lives on the Job, not the Workspace). Their `workspace.source`
(a git repository URL) is never overwritten. The UI change likewise never triggers for them.

### Behavior after this change
- Speculative `terraform plan` runs no longer change the re-run pointer.
- A run that is created but discarded before approval no longer changes it.
- Once a plan is approved and apply/destroy is dispatched, that configuration-version
  becomes the workspace's source, so a later UI **Run now** re-queues that same
  configuration (plan/apply or destroy is chosen fresh at click time).
- A never-applied CLI/API workspace shows a disabled **Run now** with a tooltip instead of
  erroring.

### Tests
- `ExecutorServiceTest` (+7): apply persists the source; speculative plan does not; VCS and
  SSH workspaces are skipped; non-`remote-content` branch is skipped; idempotent when
  unchanged; blank source ignored.
- `Create.test.tsx` (new): "Run now" enabled with no reason (VCS case); disabled with a
  reason (unconfigured CLI/API); disabled without plan permission.

### Validation
- API (JDK 25, Maven): `ExecutorServiceTest` 10/10; regression run across
  `ExecutorServiceTest, RemoteTfeServiceTest, ScheduleJobTest, JobManageHookTest` — 52/52,
  BUILD SUCCESS.
- UI: `Create.test.tsx` 3/3; `tsc --noEmit -p tsconfig.test.json` clean.

### Notes
- No DB migration: `workspace.source` is reused as the "last applied configuration" pointer
  for CLI/API workspaces (consistent with how these workspaces already use `source`).
- Context on why a "vcs"-named resource is used for a CLI workflow: the provider's
  `terrakube_workspace_cli` resource does not expose a `folder` attribute, so workspaces
  needing a subdirectory are created via `terrakube_workspace_vcs` with
  `branch = "remote-content"` and no `vcs_id`. To Terrakube these are indistinguishable from
  `workspace_cli` workspaces, and this fix covers them identically. (A `folder` attribute on
  `terrakube_workspace_cli` would be a reasonable follow-up in the provider repo.)

### Scope / non-goals
- Does not add a `folder` attribute to any provider resource (separate repo).
- Does not change VCS, webhook, or scheduled-run behavior.