### PR TITLE
fix(api): change logic for workspace version constraint

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
@@ -74,6 +74,7 @@ import java.text.ParseException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Service
@@ -112,6 +113,10 @@ public class RemoteTfeService {
     private GlobalVarRepository globalVarRepository;
 
     private RbacService rbacService;
+
+    private static final String LATEST_TERRAFORM_VERSION = "latest";
+
+    private static final Pattern EXACT_TERRAFORM_VERSION_PATTERN = Pattern.compile("^\\d+(\\.\\d+){0,2}(-[0-9A-Za-z.-]+)?$");
 
     public RemoteTfeService(JobRepository jobRepository,
                             ContentRepository contentRepository,
@@ -429,6 +434,16 @@ public class RemoteTfeService {
         return getWorkspace(workspace, otherAttributes, currentUser);
     }
 
+    // The Terraform/OpenTofu CLI remote backend parses this attribute as a strict version for any state operation
+    // and errors on constraints like ">= 1.12.5"; "latest" is the only non-exact value it tolerates.
+    private String toExposedTerraformVersion(String terraformVersion) {
+        if (terraformVersion == null || terraformVersion.isBlank() || LATEST_TERRAFORM_VERSION.equalsIgnoreCase(terraformVersion)) {
+            return terraformVersion;
+        }
+        String trimmed = terraformVersion.trim();
+        return EXACT_TERRAFORM_VERSION_PATTERN.matcher(trimmed).matches() ? trimmed : LATEST_TERRAFORM_VERSION;
+    }
+
     WorkspaceData getWorkspace(Workspace workspace, Map<String, Object> otherAttributes,
                                JwtAuthenticationToken currentUser) {
         if (workspace != null) {
@@ -441,7 +456,7 @@ public class RemoteTfeService {
             workspaceModel.setType("workspaces");
             Map<String, Object> attributes = new HashMap<>();
             attributes.put("name", workspace.getName());
-            attributes.put("terraform-version", workspace.getTerraformVersion());
+            attributes.put("terraform-version", toExposedTerraformVersion(workspace.getTerraformVersion()));
             attributes.put("locked", workspace.isLocked());
             attributes.put("auto-apply", false);
             attributes.put("execution-mode", workspace.getExecutionMode());

--- a/api/src/test/java/io/terrakube/api/plugin/state/RemoteTfeServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/state/RemoteTfeServiceTest.java
@@ -160,6 +160,41 @@ class RemoteTfeServiceTest {
         verify(rbacService).canApproveJob(team);
     }
 
+    @Test
+    void listWorkspaceExposesVersionConstraintAsLatestForTfeCompatibility() {
+        RemoteTfeService service = remoteTfeService();
+        JwtAuthenticationToken currentUser = currentUser();
+        Organization organization = organization("sample-org");
+        Workspace constrained = workspace("constrained", organization);
+        constrained.setTerraformVersion(">= 1.12.5");
+        when(teamTokenService.getCurrentGroups(currentUser)).thenReturn(Collections.emptyList());
+        when(workspaceRepository.findWorkspacesByOrganizationNameAndNameStartingWith("sample-org", "constrained"))
+                .thenReturn(Optional.of(List.of(constrained)));
+        when(jobRepository.findFirstByWorkspaceAndStatusInOrderByIdAsc(any(), anyList()))
+                .thenReturn(Optional.empty());
+
+        WorkspaceList result = service.listWorkspace("sample-org", Optional.empty(), Optional.of("constrained"), currentUser);
+
+        assertEquals("latest", result.getData().get(0).getAttributes().get("terraform-version"));
+    }
+
+    @Test
+    void listWorkspaceKeepsExactVersionUnchanged() {
+        RemoteTfeService service = remoteTfeService();
+        JwtAuthenticationToken currentUser = currentUser();
+        Organization organization = organization("sample-org");
+        Workspace exact = workspace("exact", organization);
+        when(teamTokenService.getCurrentGroups(currentUser)).thenReturn(Collections.emptyList());
+        when(workspaceRepository.findWorkspacesByOrganizationNameAndNameStartingWith("sample-org", "exact"))
+                .thenReturn(Optional.of(List.of(exact)));
+        when(jobRepository.findFirstByWorkspaceAndStatusInOrderByIdAsc(any(), anyList()))
+                .thenReturn(Optional.empty());
+
+        WorkspaceList result = service.listWorkspace("sample-org", Optional.empty(), Optional.of("exact"), currentUser);
+
+        assertEquals("1.6.0", result.getData().get(0).getAttributes().get("terraform-version"));
+    }
+
     private RemoteTfeService remoteTfeService() {
         return new RemoteTfeService(jobRepository, contentRepository, organizationRepository, workspaceRepository,
                 historyRepository, templateRepository, scheduleJobService, "localhost", storageTypeService,


### PR DESCRIPTION
# Summary

Fixes #3403.

Workspaces configured with a Terraform/OpenTofu **version constraint** (e.g. `>= 1.12.5`, `~> 1.10.0`) instead of an exact version broke `terraform state` and other local CLI operations run against the workspace through the remote/TFE-compatible backend:

```
╷
│ Error: Error looking up workspace
│
│ Invalid OpenTofu version: malformed version: >= 1.12.5
╵
```

`RemoteTfeService.getWorkspace()` echoed the workspace's raw configured `terraform-version` verbatim into the TFE-compatible workspace API response. The Terraform/OpenTofu CLI's remote backend parses that attribute as a strict semantic version for any state-related operation and only special-cases the literal `"latest"` as a non-exact value — anything else, including constraint syntax, fails to parse. This is a known limitation on the CLI side (hashicorp/go-tfe#994, hashicorp/terraform#27628, #36225, #36996), not something we can fix upstream, so the workaround belongs on our side.

This looks like a gap left by #2449 / PR #3253, which added first-class support for version constraints in the workspace `terraform-version` field (UI validator + executor resolution) but didn't touch the TFE-compatible workspace read API.

## Changes

- `RemoteTfeService.getWorkspace()` now exposes the workspace's `terraform-version` attribute through a new `toExposedTerraformVersion()` helper: exact versions pass through unchanged, and anything that isn't an exact version (i.e. a constraint) is exposed as `"latest"` instead.
- `"latest"` and version literals are pulled into `private static final` constants (`LATEST_TERRAFORM_VERSION`, `EXACT_TERRAFORM_VERSION_PATTERN`) to avoid duplicated string literals.
- Job scheduling/execution is untouched — the executor still resolves the real constraint stored on the workspace to a concrete binary at run time; only the read-only API attribute consumed by the CLI's remote backend changes.
- Added unit tests in `RemoteTfeServiceTest`:
  - a workspace with a constraint (`>= 1.12.5`) now exposes `terraform-version: "latest"` via `listWorkspace`/`getWorkspace`.
  - a workspace with an exact version (`1.6.0`) is unaffected and still returned as-is.

## Test plan

- [x] `mvn test -Dtest=RemoteTfeServiceTest` — 5/5 passing (3 pre-existing + 2 new).
- [x] Manual verification: configure a workspace with `>= 1.10.0`, run `terraform state list` locally against it via the remote backend, confirm it no longer errors.

## Notes for reviewers

- The regex used to detect an "exact" version (`^\d+(\.\d+){0,2}(-[0-9A-Za-z.-]+)?$`) intentionally allows an optional pre-release suffix (e.g. `1.12.0-beta1`) since `hashicorp/go-version`'s `NewVersion()` (used by the CLI) accepts those too.
- Open question: should we resolve constraints to the *actual* concrete version the executor would pick (rather than falling back to `"latest"`) for a more informative API response? happy to follow up in a separate PR if that's preferred or alternative