### PR TITLE
fix(structured-output): apply/plan console and PR comment fixes

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
@@ -1,5 +1,7 @@
 package io.terrakube.api.plugin.vcs;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.terrakube.api.plugin.storage.StorageTypeService;
 import io.terrakube.api.plugin.streaming.StreamingService;
 import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
@@ -19,16 +21,20 @@ import org.springframework.stereotype.Service;
 import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 public class PrCommentService {
 
     private static final int MAX_COMMENT_LENGTH = 60000;
+    private static final int MAX_TABLE_ROWS = 50;
     private static final Set<VcsType> PR_COMMENT_SUPPORTED_VCS = EnumSet.of(VcsType.GITHUB, VcsType.GITLAB, VcsType.BITBUCKET);
     private static final Pattern RUN_SUMMARY_PATTERN = Pattern.compile(
             // The "N to import, " clause only appears when the plan includes an import block -
@@ -46,19 +52,21 @@ public class PrCommentService {
     JobRepository jobRepository;
     StorageTypeService storageTypeService;
     StreamingService streamingService;
+    ObjectMapper objectMapper;
 
     @Value("${io.terrakube.ui.url:}")
     String uiUrl;
 
     public PrCommentService(GitHubWebhookService gitHubWebhookService, GitLabWebhookService gitLabWebhookService,
             BitBucketWebhookService bitBucketWebhookService, JobRepository jobRepository,
-            StorageTypeService storageTypeService, StreamingService streamingService) {
+            StorageTypeService storageTypeService, StreamingService streamingService, ObjectMapper objectMapper) {
         this.gitHubWebhookService = gitHubWebhookService;
         this.gitLabWebhookService = gitLabWebhookService;
         this.bitBucketWebhookService = bitBucketWebhookService;
         this.jobRepository = jobRepository;
         this.storageTypeService = storageTypeService;
         this.streamingService = streamingService;
+        this.objectMapper = objectMapper;
     }
 
     public void postPlanResult(Job job) {
@@ -155,17 +163,40 @@ public class PrCommentService {
     /**
      * job.getTerraformPlan() is a storage pointer to the binary .tfplan file, and
      * job.getOutput() is just append-only step-completion markers - neither holds the
-     * human-readable console text. The real diff/summary text lives in the last step's
+     * human-readable console text. The real diff/summary text lives in the plan/apply step's
      * console output, the same place the job details UI reads it from.
+     *
+     * <p>A custom TCL template can run extra steps after the plan/apply step itself (a
+     * notification, a cost-estimation call, ...), each as its own {@link Step} with a higher
+     * step number - so the highest-numbered step isn't reliably the Terraform step. Search
+     * backward from the last step for the first one whose output actually contains a
+     * recognizable plan/apply summary line, and only fall back to the literal last step (the
+     * previous behavior) if none do - e.g. the run failed before Terraform printed one.
      */
     private String fetchStepOutputText(Job job) {
-        Step step = job.getStep() == null ? null : job.getStep().stream()
-                .max(Comparator.comparingInt(Step::getStepNumber))
-                .orElse(null);
-        if (step == null) {
+        if (job.getStep() == null || job.getStep().isEmpty()) {
             return null;
         }
 
+        List<Step> stepsNewestFirst = job.getStep().stream()
+                .sorted(Comparator.comparingInt(Step::getStepNumber).reversed())
+                .collect(Collectors.toList());
+
+        String lastStepOutput = null;
+        for (Step step : stepsNewestFirst) {
+            String output = readStepOutputText(job, step);
+            if (lastStepOutput == null) {
+                lastStepOutput = output;
+            }
+            if (matchRunSummary(output) != null) {
+                return output;
+            }
+        }
+
+        return lastStepOutput;
+    }
+
+    private String readStepOutputText(Job job, Step step) {
         try {
             String stepId = step.getId().toString();
             String liveLogs = streamingService.getCurrentLogs(stepId, "");
@@ -312,6 +343,79 @@ public class PrCommentService {
         }
     }
 
+    /**
+     * Renders the same per-resource change list the job details UI's StructuredPlanOutput
+     * already shows, as a compact markdown table - the raw ANSI-stripped console text kept in
+     * the collapsible fold below is still real Terraform output, but it's runtime log text, not
+     * a reviewer-friendly summary of what's actually changing. Reads the job's structured-output
+     * context blob (the same one PlanStructuredOutputService/ApplyStructuredOutputService write
+     * to during the run) directly from storage rather than the executor's live context API,
+     * since by the time a PR comment is posted the job has already finished.
+     */
+    private Optional<String> renderStructuredChangesTable(Job job, boolean apply) {
+        try {
+            String contextJson = storageTypeService.getContext(job.getId());
+            if (contextJson == null || contextJson.isBlank()) {
+                return Optional.empty();
+            }
+
+            Map<String, Object> context = objectMapper.readValue(contextJson, new TypeReference<Map<String, Object>>() {
+            });
+            Object rawByStep = context.get(apply ? "applyStructuredOutput" : "planStructuredOutput");
+            if (!(rawByStep instanceof Map<?, ?> byStep)) {
+                return Optional.empty();
+            }
+
+            List<Map<String, Object>> changes = null;
+            for (Object rawChanges : byStep.values()) {
+                if (rawChanges instanceof List<?> list && !list.isEmpty()) {
+                    changes = (List<Map<String, Object>>) (List<?>) list;
+                    break;
+                }
+            }
+            if (changes == null) {
+                return Optional.empty();
+            }
+
+            StringBuilder table = new StringBuilder();
+            table.append("| | Resource | Action |\n");
+            table.append("|---|---|---|\n");
+            int shown = 0;
+            for (Map<String, Object> change : changes) {
+                String action = String.valueOf(change.getOrDefault("action", "unknown"));
+                if ("no-op".equals(action)) {
+                    continue;
+                }
+                if (shown >= MAX_TABLE_ROWS) {
+                    table.append("| | _").append(changes.size() - shown).append(" more resources - see full output below_ | |\n");
+                    break;
+                }
+
+                Object addressRaw = change.get("address");
+                String address = addressRaw == null ? "?" : String.valueOf(addressRaw);
+                table.append("| ").append(actionIcon(action)).append(" | `").append(address).append("` | ")
+                        .append(action).append(" |\n");
+                shown++;
+            }
+
+            return shown == 0 ? Optional.empty() : Optional.of(table.toString());
+        } catch (Exception e) {
+            log.warn("Unable to render structured changes table for job {}: {}", job.getId(), e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private String actionIcon(String action) {
+        return switch (action) {
+            case "create" -> "🟢";
+            case "delete" -> "🔴";
+            case "update" -> "🔵";
+            case "replace" -> "🟠";
+            case "import" -> "⬇️";
+            default -> "⚪";
+        };
+    }
+
     private String formatPlanComment(Job job, String planOutput) {
         StringBuilder sb = new StringBuilder();
         sb.append("## Terrakube Plan Output\n\n");
@@ -326,6 +430,8 @@ public class PrCommentService {
             if (summary != null) {
                 sb.append(icon).append(" ").append(summary).append("\n\n");
             }
+
+            renderStructuredChangesTable(job, false).ifPresent(table -> sb.append(table).append("\n"));
 
             String content = planOutput;
             if (content.length() > MAX_COMMENT_LENGTH) {
@@ -364,6 +470,8 @@ public class PrCommentService {
         String icon = statusIcon(job.getStatus());
         String summary = job.getStatus() == JobStatus.completed ? "Apply complete" : "Apply failed";
         sb.append(icon).append(" ").append(summary).append("\n\n");
+
+        renderStructuredChangesTable(job, true).ifPresent(table -> sb.append(table).append("\n"));
 
         if (output != null && !output.isEmpty()) {
             String content = output;

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -23,6 +24,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.terrakube.api.plugin.storage.StorageTypeService;
 import io.terrakube.api.plugin.streaming.StreamingService;
@@ -49,6 +52,7 @@ public class PrCommentServiceTest {
     JobRepository jobRepository;
     StorageTypeService storageTypeService;
     StreamingService streamingService;
+    ObjectMapper objectMapper;
 
     PrCommentService subject;
 
@@ -60,6 +64,7 @@ public class PrCommentServiceTest {
         jobRepository = mock(JobRepository.class);
         storageTypeService = mock(StorageTypeService.class);
         streamingService = mock(StreamingService.class);
+        objectMapper = new ObjectMapper();
 
         subject = new PrCommentService(
                 gitHubWebhookService,
@@ -67,7 +72,8 @@ public class PrCommentServiceTest {
                 bitBucketWebhookService,
                 jobRepository,
                 storageTypeService,
-                streamingService);
+                streamingService,
+                objectMapper);
     }
 
     private Job createJob(VcsType vcsType, Integer prNumber, JobStatus status) {
@@ -498,6 +504,158 @@ public class PrCommentServiceTest {
 
         String markdown = markdownCaptor.getValue();
         assertTrue(markdown.contains("Plan: 1 to add, 0 to change, 0 to destroy."));
+    }
+
+    @Test
+    public void postPlanResultSkipsTrailingStepsWithoutRecognizableSummary() {
+        // A custom TCL template can run extra steps after the plan step itself (e.g. a Slack
+        // notification). The comment must still surface the plan step's diff, not whatever the
+        // last-numbered step happened to output.
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+
+        Step planStep = new Step();
+        planStep.setId(UUID.randomUUID());
+        planStep.setStepNumber(1);
+
+        Step notifyStep = new Step();
+        notifyStep.setId(UUID.randomUUID());
+        notifyStep.setStepNumber(2);
+
+        job.setStep(List.of(planStep, notifyStep));
+
+        doReturn("").when(streamingService).getCurrentLogs(any(), any());
+        doReturn("Plan: 2 to add, 0 to change, 0 to destroy.".getBytes(StandardCharsets.UTF_8))
+                .when(storageTypeService).getStepOutput(any(), any(), eq(planStep.getId().toString()));
+        doReturn("Slack notification sent successfully".getBytes(StandardCharsets.UTF_8))
+                .when(storageTypeService).getStepOutput(any(), any(), eq(notifyStep.getId().toString()));
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        String markdown = markdownCaptor.getValue();
+        assertTrue(markdown.contains("Plan: 2 to add, 0 to change, 0 to destroy."));
+        assertFalse(markdown.contains("Slack notification"));
+    }
+
+    @Test
+    public void postPlanResultFallsBackToLastStepWhenNoStepHasRecognizableSummary() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+
+        Step initStep = new Step();
+        initStep.setId(UUID.randomUUID());
+        initStep.setStepNumber(1);
+
+        Step erroredStep = new Step();
+        erroredStep.setId(UUID.randomUUID());
+        erroredStep.setStepNumber(2);
+
+        job.setStep(List.of(initStep, erroredStep));
+
+        doReturn("").when(streamingService).getCurrentLogs(any(), any());
+        doReturn("Initializing the backend...".getBytes(StandardCharsets.UTF_8))
+                .when(storageTypeService).getStepOutput(any(), any(), eq(initStep.getId().toString()));
+        doReturn("Error: something unexpected happened".getBytes(StandardCharsets.UTF_8))
+                .when(storageTypeService).getStepOutput(any(), any(), eq(erroredStep.getId().toString()));
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        assertTrue(markdownCaptor.getValue().contains("Error: something unexpected happened"));
+    }
+
+    @Test
+    public void postPlanResultRendersStructuredChangesTable() throws Exception {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        stubStepOutput("Plan: 2 to add, 0 to change, 1 to destroy.");
+
+        Map<String, Object> createChange = Map.of("address", "aws_instance.example", "action", "create");
+        Map<String, Object> deleteChange = Map.of("address", "aws_instance.old", "action", "delete");
+        Map<String, Object> noOpChange = Map.of("address", "aws_instance.unchanged", "action", "no-op");
+        String contextJson = objectMapper.writeValueAsString(Map.of(
+                "planStructuredOutput", Map.of("step-1", List.of(createChange, deleteChange, noOpChange))));
+        doReturn(contextJson).when(storageTypeService).getContext(job.getId());
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        String markdown = markdownCaptor.getValue();
+        assertTrue(markdown.contains("| Resource | Action |"));
+        assertTrue(markdown.contains("`aws_instance.example`"));
+        assertTrue(markdown.contains("`aws_instance.old`"));
+        assertFalse(markdown.contains("aws_instance.unchanged"));
+    }
+
+    @Test
+    public void postApplyResultRendersStructuredChangesTable() throws Exception {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        stubStepOutput("Apply complete! Resources: 1 added, 0 changed, 0 destroyed.");
+
+        Map<String, Object> createChange = Map.of("address", "aws_instance.example", "action", "create", "status", "applied");
+        String contextJson = objectMapper.writeValueAsString(Map.of(
+                "applyStructuredOutput", Map.of("step-1", List.of(createChange))));
+        doReturn(contextJson).when(storageTypeService).getContext(job.getId());
+
+        subject.postApplyResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        String markdown = markdownCaptor.getValue();
+        assertTrue(markdown.contains("| Resource | Action |"));
+        assertTrue(markdown.contains("`aws_instance.example`"));
+    }
+
+    @Test
+    public void postPlanResultOmitsStructuredTableWhenContextHasNoPlanData() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        stubStepOutput("Plan: 1 to add, 0 to change, 0 to destroy.");
+
+        doReturn("{}").when(storageTypeService).getContext(job.getId());
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        assertFalse(markdownCaptor.getValue().contains("| Resource | Action |"));
+    }
+
+    @Test
+    public void postPlanResultToleratesMalformedContextJson() {
+        Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
+        stubStepOutput("Plan: 1 to add, 0 to change, 0 to destroy.");
+
+        doReturn("{ not valid json").when(storageTypeService).getContext(job.getId());
+
+        doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
+        doReturn(job).when(jobRepository).save(any());
+
+        subject.postPlanResult(job);
+
+        ArgumentCaptor<String> markdownCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHubWebhookService, times(1)).postPrComment(eq(job), markdownCaptor.capture());
+
+        String markdown = markdownCaptor.getValue();
+        assertFalse(markdown.contains("| Resource | Action |"));
+        assertTrue(markdown.contains("Plan: 1 to add"));
     }
 
     @Test

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputService.java
@@ -169,22 +169,120 @@ public class ApplyStructuredOutputService {
             Map<?, ?> afterSensitive = afterSensitiveRaw instanceof Map<?, ?> ? (Map<?, ?>) afterSensitiveRaw : Map.of();
 
             Map<String, Object> mutableAfter = (Map<String, Object>) after;
-            afterUnknown.forEach((key, isUnknown) -> {
-                if (!Boolean.TRUE.equals(isUnknown) || !resolvedMap.containsKey(key)) {
-                    return;
-                }
+            Map<Object, Object> mutableAfterUnknown = (Map<Object, Object>) afterUnknown;
 
-                // Never let a resolved sensitive value leave the executor process, mirroring
-                // PlanStructuredOutputService's sanitize-before-send precedent - the UI already
-                // renders this as "sensitive value" either way, so leaving it redacted here has
-                // no visible effect except keeping the real value off the wire entirely.
-                if (Boolean.TRUE.equals(afterSensitive.get(key))) {
-                    return;
-                }
-
-                mutableAfter.put(String.valueOf(key), resolvedMap.get(key));
-            });
+            // Walks every key of the resource's afterUnknown, not just ones that are themselves
+            // `true` - an unknown value nested inside a block or list item (one attribute of a
+            // network_interface list entry, say) has its own true/false/nested marker several
+            // levels down, not at this top level, and previously never got resolved here at all.
+            for (Object key : new ArrayList<>(mutableAfterUnknown.keySet())) {
+                Object resolvedNewUnknown = resolveUnknownRecursive(
+                        mutableAfterUnknown.get(key),
+                        mapSlot(mutableAfter, key),
+                        resolvedMap.get(key),
+                        afterSensitive.get(key));
+                mutableAfterUnknown.put(key, resolvedNewUnknown);
+            }
         }
+    }
+
+    /**
+     * Resolves unknown values anywhere within a resource's after/afterUnknown structure - not
+     * just at the top level - by walking afterUnknown's shape (which Terraform mirrors exactly
+     * against after/afterSensitive: booleans at leaves, nested maps/lists everywhere a block or
+     * collection attribute exists) and, at each `true` leaf, splicing the matching real value
+     * from post-apply state into `after` via the given slot. Returns the same shape with
+     * resolved leaves flipped to `false`, for the caller to store back as the new afterUnknown.
+     */
+    @SuppressWarnings("unchecked")
+    private Object resolveUnknownRecursive(Object afterUnknownNode, ValueSlot afterSlot, Object resolvedNode, Object afterSensitiveNode) {
+        if (Boolean.TRUE.equals(afterUnknownNode)) {
+            // Never let a resolved sensitive value leave the executor process, mirroring
+            // PlanStructuredOutputService's sanitize-before-send precedent - the UI already
+            // renders this as "sensitive value" either way, so leaving it redacted here has no
+            // visible effect except keeping the real value off the wire entirely. Also leaves a
+            // leaf unresolved (rather than defaulting to something) when state has nothing for
+            // it - shouldn't normally happen, but silently keeping "unknown" beats guessing.
+            if (Boolean.TRUE.equals(afterSensitiveNode) || resolvedNode == null) {
+                return afterUnknownNode;
+            }
+
+            afterSlot.set(resolvedNode);
+            return false;
+        }
+
+        if (afterUnknownNode instanceof Map<?, ?> unknownMap) {
+            Object currentAfter = afterSlot.get();
+            Map<String, Object> afterMap = currentAfter instanceof Map<?, ?> existing
+                    ? new HashMap<>((Map<String, Object>) existing)
+                    : new HashMap<>();
+            Map<?, ?> resolvedMapNode = resolvedNode instanceof Map<?, ?> resolvedMapValue ? resolvedMapValue : Map.of();
+            Map<?, ?> sensitiveMapNode = afterSensitiveNode instanceof Map<?, ?> sensitiveMapValue ? sensitiveMapValue : Map.of();
+
+            Map<Object, Object> newUnknownMap = new HashMap<>();
+            for (Map.Entry<?, ?> entry : unknownMap.entrySet()) {
+                Object key = entry.getKey();
+                newUnknownMap.put(key, resolveUnknownRecursive(
+                        entry.getValue(), mapSlot(afterMap, key), resolvedMapNode.get(key), sensitiveMapNode.get(key)));
+            }
+            afterSlot.set(afterMap);
+            return newUnknownMap;
+        }
+
+        if (afterUnknownNode instanceof List<?> unknownList) {
+            Object currentAfter = afterSlot.get();
+            List<Object> afterList = currentAfter instanceof List<?> existing ? new ArrayList<>(existing) : new ArrayList<>();
+            while (afterList.size() < unknownList.size()) {
+                afterList.add(null);
+            }
+            List<?> resolvedListNode = resolvedNode instanceof List<?> resolvedListValue ? resolvedListValue : List.of();
+            List<?> sensitiveListNode = afterSensitiveNode instanceof List<?> sensitiveListValue ? sensitiveListValue : List.of();
+
+            List<Object> newUnknownList = new ArrayList<>();
+            for (int index = 0; index < unknownList.size(); index++) {
+                Object resolvedChild = index < resolvedListNode.size() ? resolvedListNode.get(index) : null;
+                Object sensitiveChild = index < sensitiveListNode.size() ? sensitiveListNode.get(index) : null;
+                newUnknownList.add(resolveUnknownRecursive(
+                        unknownList.get(index), listSlot(afterList, index), resolvedChild, sensitiveChild));
+            }
+            afterSlot.set(afterList);
+            return newUnknownList;
+        }
+
+        // afterUnknown is `false` (already known at plan time) or some other non-boolean,
+        // non-container shape this format doesn't define - nothing to resolve either way.
+        return afterUnknownNode;
+    }
+
+    /** A single addressable position inside `after` - either a map entry or a list index. */
+    private interface ValueSlot {
+        Object get();
+        void set(Object value);
+    }
+
+    private static ValueSlot mapSlot(Map<String, Object> map, Object key) {
+        String stringKey = String.valueOf(key);
+        return new ValueSlot() {
+            public Object get() {
+                return map.get(stringKey);
+            }
+            public void set(Object value) {
+                map.put(stringKey, value);
+            }
+        };
+    }
+
+    private static ValueSlot listSlot(List<Object> list, int index) {
+        return new ValueSlot() {
+            public Object get() {
+                return index < list.size() ? list.get(index) : null;
+            }
+            public void set(Object value) {
+                if (index < list.size()) {
+                    list.set(index, value);
+                }
+            }
+        };
     }
 
     @SuppressWarnings("unchecked")

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -47,7 +47,12 @@ import static io.terrakube.executor.service.workspace.SetupWorkspaceImpl.SSH_DIR
 public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
     private static final String STEP_SEPARATOR = "***************************************";
-    private static final long APPLY_PROGRESS_FLUSH_INTERVAL_MS = 2000;
+    // Was 2000ms: the structured panel could sit on stale (or, worse, entirely empty - see
+    // lastFlush below) data for up to 2s at a time while resources were actively transitioning,
+    // which reads as sluggish for anything that completes faster than that. Halved rather than
+    // dropped further since each flush is a full HTTP round trip to /context/v1 (GET-merge-POST)
+    // per plan/apply/destroy step - this is a rate-limiting ceiling, not a per-event push.
+    private static final long APPLY_PROGRESS_FLUSH_INTERVAL_MS = 1000;
 
     TerraformClient terraformClient;
     TerraformState terraformState;
@@ -163,7 +168,13 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     List<Map<String, Object>> liveChanges = new ArrayList<>();
                     List<Map<String, Object>> jobDiagnostics = new ArrayList<>();
                     TerraformJsonEventParser eventParser = new TerraformJsonEventParser(objectMapper);
-                    AtomicLong lastFlush = new AtomicLong(System.currentTimeMillis());
+                    // Starting at 0 (not now()) guarantees the very first json line always
+                    // passes the "now - lastFlush > interval" check below and flushes
+                    // immediately - otherwise the structured panel stayed on console-only for
+                    // this step's *entire* duration whenever the whole plan finished in under
+                    // APPLY_PROGRESS_FLUSH_INTERVAL_MS (common for small/fast plans), only
+                    // flipping to Structured after the step had already completed.
+                    AtomicLong lastFlush = new AtomicLong(0);
 
                     Consumer<String> jsonLineConsumer = (line) -> {
                         String humanMessage = eventParser.parseLine(line, liveChanges, jobDiagnostics);
@@ -299,6 +310,17 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     execution = runJsonApply(terraformJob, terraformProcessData, applyOutput);
 
                     handleTerraformStateChange(terraformJob, terraformWorkingDir, executorTempDirectory);
+
+                    // apply -json's event stream only ever carries terse per-resource one-liners
+                    // ("aws_instance.foo: Creating...", "...Creation complete after 3s [id=...]")
+                    // plus the final change-summary line - unlike plan(), which appends
+                    // getPlanAsHumanText's classic rendered diff, apply never appends anything
+                    // resembling a `terraform show`/CLI-style closing readout, so the console ends
+                    // abruptly with no Outputs: section. Must run before waitForStreamCompletion
+                    // below, same reasoning as plan()'s human-readable diff append.
+                    if (execution) {
+                        appendHumanReadableOutputs(terraformJob, applyOutput);
+                    }
                 }
             }
 
@@ -334,7 +356,10 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                 terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), changes, jobDiagnostics);
 
         TerraformJsonEventParser eventParser = new TerraformJsonEventParser(objectMapper);
-        AtomicLong lastFlush = new AtomicLong(System.currentTimeMillis());
+        // See the matching comment in plan(): starting at 0 flushes the first line immediately.
+        // Apply already seeds the panel with pending rows before this point, so this mostly
+        // matters for the first real status transition landing without a multi-second delay.
+        AtomicLong lastFlush = new AtomicLong(0);
 
         Consumer<String> jsonLineConsumer = (line) -> {
             String humanMessage = eventParser.parseLine(line, changes, jobDiagnostics);
@@ -359,6 +384,49 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         if (stateJson != null) {
             applyStructuredOutputService.resolveFinalValues(changes, stateJson);
         }
+
+        applyStructuredOutputService.publishApplyProgress(
+                terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), changes, jobDiagnostics);
+        pushLiveStructuredUpdate("apply", terraformJob, changes, jobDiagnostics);
+
+        return execution;
+    }
+
+    // destroy() previously ran a plain (non-JSON) terraform destroy, so it never got the
+    // structured per-resource status view plan()/apply() get - unlike apply(), there's no
+    // separate prior plan step to seed rows from (a "Destroy" workflow can run destroy directly,
+    // with no plan step at all), so this starts from an empty list and lets `destroy -json`'s own
+    // planned_change/apply_* events populate it, exactly the way plan() populates its own
+    // liveChanges from empty rather than seeding them.
+    private boolean runJsonDestroy(TerraformJob terraformJob, TerraformProcessData terraformProcessData, Consumer<String> destroyOutput)
+            throws IOException, ExecutionException, InterruptedException {
+        List<Map<String, Object>> changes = new ArrayList<>();
+        List<Map<String, Object>> jobDiagnostics = new ArrayList<>();
+        TerraformJsonEventParser eventParser = new TerraformJsonEventParser(objectMapper);
+        AtomicLong lastFlush = new AtomicLong(0);
+
+        Consumer<String> jsonLineConsumer = (line) -> {
+            String humanMessage = eventParser.parseLine(line, changes, jobDiagnostics);
+            if (humanMessage != null) {
+                destroyOutput.accept(humanMessage);
+            }
+
+            long now = System.currentTimeMillis();
+            if (now - lastFlush.get() > APPLY_PROGRESS_FLUSH_INTERVAL_MS) {
+                lastFlush.set(now);
+                // Published under the same "apply" phase/key as runJsonApply - a destroy is
+                // rendered by the UI as an apply of all-delete actions, reusing
+                // applyStructuredOutput/StructuredPlanOutput's applyMode rather than adding a
+                // third parallel structured-output shape for what's functionally the same view.
+                applyStructuredOutputService.publishApplyProgress(
+                        terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), changes, jobDiagnostics);
+                pushLiveStructuredUpdate("apply", terraformJob, changes, jobDiagnostics);
+            }
+        };
+
+        TerraformClient jsonDestroyClient = buildJsonEnabledDestroyClient();
+
+        boolean execution = jsonDestroyClient.destroy(terraformProcessData, jsonLineConsumer, null).get();
 
         applyStructuredOutputService.publishApplyProgress(
                 terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), changes, jobDiagnostics);
@@ -414,6 +482,18 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                 .build();
     }
 
+    // Package-private (not private) so tests can spy/stub this one seam, same reasoning as
+    // buildJsonEnabledApplyClient.
+    TerraformClient buildJsonEnabledDestroyClient() {
+        return TerraformClient.builder()
+                .jsonOutput(true)
+                .showColor(false)
+                .redirectErrorStream(true)
+                .terraformReleasesUrl(terraformClient.getTerraformReleasesUrl())
+                .tofuReleasesUrl(terraformClient.getTofuReleasesUrl())
+                .build();
+    }
+
     private String getCurrentStateJson(TerraformJob terraformJob, TerraformProcessData terraformProcessData)
             throws IOException, ExecutionException, InterruptedException {
         TextStringBuilder stateOutput = new TextStringBuilder();
@@ -455,10 +535,9 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                 showTerraformMessage(terraformJob, "DESTROY", outputDestroy);
 
                 if (scriptBeforeSuccess) {
-                    execution = terraformClient.destroy(
+                    execution = runJsonDestroy(terraformJob,
                             getTerraformProcessData(terraformJob, terraformWorkingDir, executorTempDirectory),
-                            outputDestroy,
-                            null).get();
+                            outputDestroy);
 
                     handleTerraformStateChange(terraformJob, terraformWorkingDir, executorTempDirectory);
                 }
@@ -598,6 +677,51 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                         terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), jsonOutput.toString());
             }
 
+        }
+    }
+
+    // Mirrors what the real `terraform apply`/`terraform output` CLI prints after a successful
+    // apply, rendered from the same JSON handleTerraformStateChange already fetched for the
+    // structured outputs panel (terraformOutputsService.buildOutputsFromJson), rather than
+    // re-running `terraform output` a second time.
+    private void appendHumanReadableOutputs(TerraformJob terraformJob, Consumer<String> output) {
+        String outputJson = terraformJob.getTerraformOutput();
+        if (outputJson == null || outputJson.isBlank()) {
+            return;
+        }
+
+        try {
+            List<Map<String, Object>> outputs = terraformOutputsService.buildOutputsFromJson(outputJson);
+            if (outputs.isEmpty()) {
+                return;
+            }
+
+            output.accept("");
+            output.accept("Outputs:");
+            output.accept("");
+            for (Map<String, Object> entry : outputs) {
+                String name = String.valueOf(entry.get("name"));
+                boolean sensitive = Boolean.TRUE.equals(entry.get("sensitive"));
+                output.accept(name + " = " + (sensitive ? "<sensitive>" : renderOutputValue(entry.get("value"))));
+            }
+        } catch (IOException e) {
+            log.warn("Unable to render human-readable outputs for job {}", terraformJob.getJobId(), e);
+        }
+    }
+
+    private String renderOutputValue(Object value) {
+        if (value == null) {
+            return "null";
+        }
+
+        if (value instanceof String stringValue) {
+            return "\"" + stringValue + "\"";
+        }
+
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            return String.valueOf(value);
         }
     }
 

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -303,9 +303,10 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
                 if (scriptBeforeSuccess) {
                     TerraformProcessData terraformProcessData = getTerraformProcessData(terraformJob, terraformWorkingDir, executorTempDirectory);
-                    terraformProcessData.setTerraformVariables((terraformState.downloadTerraformPlan(terraformJob.getOrganizationId(),
+                    boolean planFileDownloaded = terraformState.downloadTerraformPlan(terraformJob.getOrganizationId(),
                             terraformJob.getWorkspaceId(), terraformJob.getJobId(), terraformJob.getStepId(),
-                            terraformWorkingDir) ? new HashMap<>() : terraformParameters));
+                            terraformWorkingDir);
+                    terraformProcessData.setTerraformVariables(planFileDownloaded ? new HashMap<>() : terraformParameters);
 
                     execution = runJsonApply(terraformJob, terraformProcessData, applyOutput);
 
@@ -314,10 +315,22 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     // apply -json's event stream only ever carries terse per-resource one-liners
                     // ("aws_instance.foo: Creating...", "...Creation complete after 3s [id=...]")
                     // plus the final change-summary line - unlike plan(), which appends
-                    // getPlanAsHumanText's classic rendered diff, apply never appends anything
-                    // resembling a `terraform show`/CLI-style closing readout, so the console ends
-                    // abruptly with no Outputs: section. Must run before waitForStreamCompletion
-                    // below, same reasoning as plan()'s human-readable diff append.
+                    // getPlanAsHumanText's classic rendered diff, apply never appended anything
+                    // resembling a `terraform show`/CLI-style closing readout. Mirrors plan()'s
+                    // append (same reasoning: must run before waitForStreamCompletion below), just
+                    // rendered from the plan file apply already downloaded above instead of one it
+                    // computed itself - real `terraform apply <planfile>` reprints this same diff
+                    // before executing it, so this restores that content even though Terrakube
+                    // renders it after the resource-by-resource lines rather than before.
+                    if (execution && planFileDownloaded) {
+                        String humanReadablePlan = planStructuredOutputService.getPlanAsHumanText(terraformJob, terraformWorkingDir);
+                        if (humanReadablePlan != null && !humanReadablePlan.isBlank()) {
+                            for (String line : humanReadablePlan.split("\n", -1)) {
+                                applyOutput.accept(line);
+                            }
+                        }
+                    }
+
                     if (execution) {
                         appendHumanReadableOutputs(terraformJob, applyOutput);
                     }

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputServiceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputServiceTest.java
@@ -6,6 +6,7 @@ import io.terrakube.executor.service.workspace.security.WorkspaceSecurity;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,6 +143,45 @@ class ApplyStructuredOutputServiceTest {
     }
 
     @Test
+    void clearsTheAfterUnknownFlagOnceAnAttributeIsResolved() {
+        // The UI's diff renderer decides whether to show the "(known after apply)" placeholder
+        // purely from this flag (see structuredPlan.ts / StructuredPlanOutput.tsx's
+        // `afterUnknown === true` check) rather than from whether `after` itself is still null -
+        // so leaving the flag at `true` here left the placeholder stuck forever even once the
+        // real value had been resolved into `after` below.
+        Map<String, Object> after = new HashMap<>();
+        after.put("id", null);
+
+        Map<String, Object> afterUnknown = new HashMap<>();
+        afterUnknown.put("id", true);
+
+        Map<String, Object> change = new HashMap<>();
+        change.put("address", "terraform_data.example");
+        change.put("after", after);
+        change.put("afterUnknown", afterUnknown);
+
+        String stateJson = """
+                {
+                  "values": {
+                    "root_module": {
+                      "resources": [
+                        {
+                          "address": "terraform_data.example",
+                          "values": {"id": "4cdc25f5-37c5"}
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        subject().resolveFinalValues(List.of(change), stateJson);
+
+        Map<String, Object> resolvedAfterUnknown = (Map<String, Object>) change.get("afterUnknown");
+        assertEquals(false, resolvedAfterUnknown.get("id"));
+    }
+
+    @Test
     void neverResolvesASensitiveUnknownAttributeToItsRealValue() {
         Map<String, Object> after = new HashMap<>();
         after.put("result", null);
@@ -177,6 +217,163 @@ class ApplyStructuredOutputServiceTest {
 
         Map<String, Object> resolvedAfter = (Map<String, Object>) change.get("after");
         assertNull(resolvedAfter.get("result"));
+    }
+
+    @Test
+    void resolvesAnUnknownAttributeNestedInsideAListOfObjects() {
+        // Terraform's afterUnknown mirrors after's exact shape - a list attribute's unknown-ness
+        // is a parallel list of per-item markers, not a single top-level boolean - so an unknown
+        // value on just one field of one list entry (network_ip here) previously never resolved:
+        // the old top-level-only loop only ever looked at afterUnknown's direct keys, and
+        // "network_interface" itself is never `true` when only a field inside it is unknown.
+        Map<String, Object> networkInterface = new HashMap<>();
+        networkInterface.put("device_index", 0);
+        networkInterface.put("network_ip", null);
+
+        Map<String, Object> after = new HashMap<>();
+        after.put("network_interface", new ArrayList<>(List.of(networkInterface)));
+
+        Map<String, Object> unknownInterfaceEntry = new HashMap<>();
+        unknownInterfaceEntry.put("network_ip", true);
+        Map<String, Object> afterUnknown = new HashMap<>();
+        afterUnknown.put("network_interface", new ArrayList<>(List.of(unknownInterfaceEntry)));
+
+        Map<String, Object> change = new HashMap<>();
+        change.put("address", "google_compute_instance.example");
+        change.put("after", after);
+        change.put("afterUnknown", afterUnknown);
+
+        String stateJson = """
+                {
+                  "values": {
+                    "root_module": {
+                      "resources": [
+                        {
+                          "address": "google_compute_instance.example",
+                          "values": {
+                            "network_interface": [
+                              {"device_index": 0, "network_ip": "10.0.0.5"}
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        subject().resolveFinalValues(List.of(change), stateJson);
+
+        Map<String, Object> resolvedAfter = (Map<String, Object>) change.get("after");
+        List<?> interfaces = (List<?>) resolvedAfter.get("network_interface");
+        Map<?, ?> resolvedInterface = (Map<?, ?>) interfaces.get(0);
+        assertEquals("10.0.0.5", resolvedInterface.get("network_ip"));
+        assertEquals(0, resolvedInterface.get("device_index"));
+
+        Map<?, ?> resolvedAfterUnknown = (Map<?, ?>) change.get("afterUnknown");
+        List<?> unknownInterfaces = (List<?>) resolvedAfterUnknown.get("network_interface");
+        Map<?, ?> resolvedUnknownInterface = (Map<?, ?>) unknownInterfaces.get(0);
+        assertEquals(false, resolvedUnknownInterface.get("network_ip"));
+    }
+
+    @Test
+    void resolvesAnUnknownAttributeNestedInsideAMap() {
+        Map<String, Object> settings = new HashMap<>();
+        settings.put("region", "us-east-1");
+        settings.put("generated_name", null);
+
+        Map<String, Object> after = new HashMap<>();
+        after.put("settings", settings);
+
+        Map<String, Object> unknownSettings = new HashMap<>();
+        unknownSettings.put("generated_name", true);
+        Map<String, Object> afterUnknown = new HashMap<>();
+        afterUnknown.put("settings", unknownSettings);
+
+        Map<String, Object> change = new HashMap<>();
+        change.put("address", "aws_thing.example");
+        change.put("after", after);
+        change.put("afterUnknown", afterUnknown);
+
+        String stateJson = """
+                {
+                  "values": {
+                    "root_module": {
+                      "resources": [
+                        {
+                          "address": "aws_thing.example",
+                          "values": {
+                            "settings": {"region": "us-east-1", "generated_name": "thing-8f2c1"}
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        subject().resolveFinalValues(List.of(change), stateJson);
+
+        Map<String, Object> resolvedAfter = (Map<String, Object>) change.get("after");
+        Map<?, ?> resolvedSettings = (Map<?, ?>) resolvedAfter.get("settings");
+        assertEquals("thing-8f2c1", resolvedSettings.get("generated_name"));
+        assertEquals("us-east-1", resolvedSettings.get("region"));
+
+        Map<?, ?> resolvedAfterUnknown = (Map<?, ?>) change.get("afterUnknown");
+        Map<?, ?> resolvedUnknownSettings = (Map<?, ?>) resolvedAfterUnknown.get("settings");
+        assertEquals(false, resolvedUnknownSettings.get("generated_name"));
+    }
+
+    @Test
+    void neverResolvesANestedSensitiveUnknownAttribute() {
+        Map<String, Object> credentials = new HashMap<>();
+        credentials.put("token", null);
+
+        Map<String, Object> after = new HashMap<>();
+        after.put("credentials", credentials);
+
+        Map<String, Object> unknownCredentials = new HashMap<>();
+        unknownCredentials.put("token", true);
+        Map<String, Object> afterUnknown = new HashMap<>();
+        afterUnknown.put("credentials", unknownCredentials);
+
+        Map<String, Object> sensitiveCredentials = new HashMap<>();
+        sensitiveCredentials.put("token", true);
+        Map<String, Object> afterSensitive = new HashMap<>();
+        afterSensitive.put("credentials", sensitiveCredentials);
+
+        Map<String, Object> change = new HashMap<>();
+        change.put("address", "vendor_thing.example");
+        change.put("after", after);
+        change.put("afterUnknown", afterUnknown);
+        change.put("afterSensitive", afterSensitive);
+
+        String stateJson = """
+                {
+                  "values": {
+                    "root_module": {
+                      "resources": [
+                        {
+                          "address": "vendor_thing.example",
+                          "values": {
+                            "credentials": {"token": "top-secret-real-token"}
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        subject().resolveFinalValues(List.of(change), stateJson);
+
+        Map<String, Object> resolvedAfter = (Map<String, Object>) change.get("after");
+        Map<?, ?> resolvedCredentials = (Map<?, ?>) resolvedAfter.get("credentials");
+        assertNull(resolvedCredentials.get("token"));
+
+        Map<?, ?> resolvedAfterUnknown = (Map<?, ?>) change.get("afterUnknown");
+        Map<?, ?> resolvedUnknownCredentials = (Map<?, ?>) resolvedAfterUnknown.get("credentials");
+        assertEquals(true, resolvedUnknownCredentials.get("token"));
     }
 
     @Test

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
@@ -149,6 +150,80 @@ class TerraformExecutorServiceImplTest {
                 eq("org"), eq("42"), eq("1"), eq(List.of(seededChange)), any());
     }
 
+    // apply -json's event stream only ever forwards terse per-resource one-liners plus the final
+    // change-summary line - unlike plan(), which appends getPlanAsHumanText's rendered diff to
+    // the console, apply had nothing resembling a `terraform show`/CLI-style closing readout.
+    // appendHumanReadableOutputs should append an Outputs: section mirroring what the real CLI
+    // prints after a successful apply.
+    @Test
+    void appendsHumanReadableOutputsAfterSuccessfulApply() throws Exception {
+        TerraformExecutorServiceImpl subject = subject();
+        TerraformJob terraformJob = createJob();
+
+        when(applyStructuredOutputService.seedFromPlan("org", "42")).thenReturn(List.of());
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.apply(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.show(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.statePull(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+        when(terraformClient.output(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenAnswer(invocation -> {
+                    Consumer<String> outputConsumer = invocation.getArgument(1);
+                    outputConsumer.accept("{\"foo\":{\"value\":\"bar\",\"type\":\"string\",\"sensitive\":false}}");
+                    return CompletableFuture.completedFuture(true);
+                });
+
+        Map<String, Object> outputEntry = new HashMap<>();
+        outputEntry.put("name", "foo");
+        outputEntry.put("value", "bar");
+        outputEntry.put("sensitive", false);
+        when(terraformOutputsService.buildOutputsFromJson(anyString())).thenReturn(List.of(outputEntry));
+
+        ExecutorJobResult result = subject.apply(terraformJob, tempDir.toFile());
+
+        assertTrue(result.isSuccessfulExecution());
+        assertTrue(result.getOutputLog().contains("Outputs:"));
+        assertTrue(result.getOutputLog().contains("foo = \"bar\""));
+    }
+
+    @Test
+    void doesNotAppendOutputsToConsoleWhenApplyItselfFailed() throws Exception {
+        TerraformExecutorServiceImpl subject = subject();
+        TerraformJob terraformJob = createJob();
+
+        when(applyStructuredOutputService.seedFromPlan("org", "42")).thenReturn(List.of());
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.apply(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(false));
+        when(terraformClient.show(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.statePull(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+        when(terraformClient.output(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenAnswer(invocation -> {
+                    Consumer<String> outputConsumer = invocation.getArgument(1);
+                    outputConsumer.accept("{\"foo\":{\"value\":\"bar\",\"type\":\"string\",\"sensitive\":false}}");
+                    return CompletableFuture.completedFuture(true);
+                });
+
+        Map<String, Object> outputEntry = new HashMap<>();
+        outputEntry.put("name", "foo");
+        outputEntry.put("value", "bar");
+        outputEntry.put("sensitive", false);
+        when(terraformOutputsService.buildOutputsFromJson(anyString())).thenReturn(List.of(outputEntry));
+
+        ExecutorJobResult result = subject.apply(terraformJob, tempDir.toFile());
+
+        assertFalse(result.isSuccessfulExecution());
+        assertFalse(result.getOutputLog().contains("Outputs:"));
+    }
+
     @Test
     void jsonApplyClientMergesErrorStream() {
         TerraformClient jsonApplyClient = subject().buildJsonEnabledApplyClient();
@@ -186,6 +261,88 @@ class TerraformExecutorServiceImplTest {
         assertTrue(result.isSuccessfulExecution());
         verify(terraformClient).apply(any(TerraformProcessData.class), any(Consumer.class), any());
         verify(applyStructuredOutputService, never()).publishApplyProgress(anyString(), anyString(), anyString(), any(), any());
+    }
+
+    // destroy() previously ran a plain (non-JSON) terraform destroy with none of the structured
+    // per-resource status view plan()/apply() get. It now goes through the same JSON event
+    // parser and publishes under the same "apply" phase/key the UI's applyMode rendering already
+    // understands, starting from an empty change list (there's no prior plan step to seed from).
+    @Test
+    void destroyPublishesStructuredOutputFromJsonEvents() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.show(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+        when(terraformClient.statePull(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+
+        String plannedChangeLine = "{\"type\":\"planned_change\",\"change\":{\"resource\":{\"addr\":\"aws_instance.example\"},\"action\":\"delete\"}}";
+        String applyCompleteLine = "{\"type\":\"apply_complete\",\"hook\":{\"resource\":{\"addr\":\"aws_instance.example\"},\"elapsed_seconds\":2}}";
+
+        TerraformClient jsonDestroyClient = Mockito.mock(TerraformClient.class);
+        when(jsonDestroyClient.destroy(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenAnswer(invocation -> {
+                    Consumer<String> lineConsumer = invocation.getArgument(1);
+                    lineConsumer.accept(plannedChangeLine);
+                    lineConsumer.accept(applyCompleteLine);
+                    return CompletableFuture.completedFuture(true);
+                });
+        doReturn(jsonDestroyClient).when(subject).buildJsonEnabledDestroyClient();
+
+        ExecutorJobResult result = subject.destroy(terraformJob, tempDir.toFile());
+
+        assertTrue(result.isSuccessfulExecution());
+        verify(applyStructuredOutputService, Mockito.atLeastOnce()).publishApplyProgress(
+                eq("org"), eq("42"), eq("1"),
+                argThat(changes -> changes.size() == 1
+                        && "aws_instance.example".equals(changes.get(0).get("address"))
+                        && "delete".equals(changes.get(0).get("action"))
+                        && "applied".equals(changes.get(0).get("status"))),
+                any());
+    }
+
+    @Test
+    void jsonDestroyClientMergesErrorStream() {
+        TerraformClient jsonDestroyClient = subject().buildJsonEnabledDestroyClient();
+
+        assertTrue(jsonDestroyClient.isJsonOutput());
+        assertTrue(jsonDestroyClient.isRedirectErrorStream());
+    }
+
+    // Regression test for a real UX gap: the structured panel stayed on console-only for a
+    // plan/apply step's *entire* duration whenever it finished faster than the 2s (now 1s)
+    // progress-flush interval, since lastFlush used to start at "now" instead of 0 - only the
+    // very last, unconditional flush after the client returned would ever populate it, so a fast
+    // plan flashed from console straight to "done" with no visible in-between structured state.
+    @Test
+    void plansFirstJsonLineFlushesStructuredOutputImmediately() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        String plannedChangeLine = "{\"type\":\"planned_change\",\"change\":{\"resource\":{\"addr\":\"aws_instance.example\"},\"action\":\"create\"}}";
+
+        TerraformClient jsonPlanClient = Mockito.mock(TerraformClient.class);
+        when(jsonPlanClient.planDetailExitCode(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenAnswer(invocation -> {
+                    Consumer<String> lineConsumer = invocation.getArgument(1);
+                    lineConsumer.accept(plannedChangeLine);
+                    return CompletableFuture.completedFuture(0);
+                });
+        doReturn(jsonPlanClient).when(subject).buildJsonEnabledPlanClient();
+
+        subject.plan(terraformJob, tempDir.toFile(), false);
+
+        verify(planStructuredOutputService, Mockito.atLeastOnce()).publishPlanProgress(
+                eq("org"), eq("42"), eq("1"),
+                argThat(changes -> changes.size() == 1
+                        && "aws_instance.example".equals(changes.get(0).get("address"))),
+                any());
     }
 
     // Regression test for a real bug: a fast plan (all json lines emitted well within the 2s

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
@@ -190,6 +190,63 @@ class TerraformExecutorServiceImplTest {
         assertTrue(result.getOutputLog().contains("foo = \"bar\""));
     }
 
+    // Real `terraform apply <planfile>` reprints the plan's classic HCL diff before executing it -
+    // apply -json never does, since -json mode has no such event. When apply is running from a
+    // downloaded plan file (the normal plan-then-apply workflow), the console should get that same
+    // diff back via getPlanAsHumanText, mirroring plan()'s own append.
+    @Test
+    void appendsHumanReadablePlanDiffWhenApplyingFromDownloadedPlanFile() throws Exception {
+        TerraformExecutorServiceImpl subject = subject();
+        TerraformJob terraformJob = createJob();
+
+        when(applyStructuredOutputService.seedFromPlan("org", "42")).thenReturn(List.of());
+        when(terraformState.downloadTerraformPlan(eq("org"), eq("workspace"), eq("42"), eq("1"), any(File.class)))
+                .thenReturn(true);
+        when(planStructuredOutputService.getPlanAsHumanText(eq(terraformJob), any(File.class)))
+                .thenReturn("-/+ resource \"random_pet\" \"this\" {\n      ~ id = \"a\" -> (known after apply)\n    }");
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.apply(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.show(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+        when(terraformClient.statePull(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+
+        ExecutorJobResult result = subject.apply(terraformJob, tempDir.toFile());
+
+        assertTrue(result.isSuccessfulExecution());
+        assertTrue(result.getOutputLog().contains("-/+ resource \"random_pet\" \"this\" {"));
+        assertTrue(result.getOutputLog().contains("~ id = \"a\" -> (known after apply)"));
+    }
+
+    // No plan file means apply ran directly against HCL (e.g. a Destroy-workflow-style apply with
+    // no prior plan step) - there's no saved plan for getPlanAsHumanText to render, so it must not
+    // be called at all rather than rendering stale/empty content.
+    @Test
+    void doesNotRenderPlanDiffWhenNoPlanFileWasDownloaded() throws Exception {
+        TerraformExecutorServiceImpl subject = subject();
+        TerraformJob terraformJob = createJob();
+
+        when(applyStructuredOutputService.seedFromPlan("org", "42")).thenReturn(List.of());
+        when(terraformState.downloadTerraformPlan(eq("org"), eq("workspace"), eq("42"), eq("1"), any(File.class)))
+                .thenReturn(false);
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.apply(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.show(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+        when(terraformClient.statePull(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+
+        subject.apply(terraformJob, tempDir.toFile());
+
+        verify(planStructuredOutputService, never()).getPlanAsHumanText(any(), any());
+    }
+
     @Test
     void doesNotAppendOutputsToConsoleWhenApplyItselfFailed() throws Exception {
         TerraformExecutorServiceImpl subject = subject();

--- a/ui/src/domain/Jobs/__tests__/Details.test.tsx
+++ b/ui/src/domain/Jobs/__tests__/Details.test.tsx
@@ -121,3 +121,92 @@ describe("DetailsJob apply structured output", () => {
     });
   });
 });
+
+describe("DetailsJob SSE reconnect behavior", () => {
+  beforeEach(() => {
+    useStructuredOutputStreamMock.mockReset();
+  });
+
+  it(
+    "keeps the last known structured output when the job leaves running and the live channel disables",
+    async () => {
+      let jobStatus: "running" | "completed" = "running";
+
+      getMock.mockImplementation((url: string) => {
+        if (url.includes("/context/v1/")) {
+          return Promise.resolve({ data: {} });
+        }
+
+        return Promise.resolve({
+          data: {
+            data: {
+              id: "1",
+              attributes: { status: jobStatus },
+            },
+            included: [
+              {
+                id: "step-2",
+                type: "step",
+                attributes: { name: "Apply", status: jobStatus, stepNumber: "2" },
+              },
+            ],
+          },
+        });
+      });
+
+      // Mirrors the real useStructuredOutputStream/useEventStream: while enabled, it keeps
+      // returning the *same* value reference across re-renders (the real hook only produces a
+      // new one via setValue when an SSE message actually arrives) - a fresh object literal on
+      // every call, by contrast, would make Details.tsx's `useEffect(() => {...},
+      // [liveStructuredOutput])` see a "changed" dependency on every single render (referential
+      // inequality) and re-run its state-setting merge every time, which triggers another
+      // re-render, which calls this mock again, forever - an infinite loop entirely of the
+      // test's own making, not a symptom of anything under test.
+      const livePayload = {
+        phase: "apply",
+        changes: {
+          "step-2": [
+            {
+              address: "aws_instance.live",
+              action: "create",
+              actions: ["create"],
+              after: { id: "i-live" },
+              status: "applying",
+            },
+          ],
+        },
+        jobDiagnostics: {},
+      };
+
+      // It resets to `initial` (null) the instant the caller disables it - Details.tsx does that
+      // the moment the job leaves "running" (see useEventStream's unconditional
+      // `setValue(initial)` on every [url, enabled] change). The merge effect in Details.tsx must
+      // treat that reset as "no new live data this render", not as "clear whatever structured
+      // output is already showing".
+      useStructuredOutputStreamMock.mockImplementation((options: { enabled: boolean }) =>
+        options.enabled ? livePayload : null
+      );
+
+      render(<DetailsJob jobId="1" />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /aws_instance\.live/i })).toBeInTheDocument();
+      });
+
+      jobStatus = "completed";
+
+      // Details.tsx polls the job every 5s (usePolling); real timers here (no fake-timer
+      // juggling with the interval that was already scheduled at mount) so wait past one cycle
+      // for the transition to actually happen.
+      await waitFor(
+        () => {
+          expect(screen.getByText("completed")).toBeInTheDocument();
+        },
+        { timeout: 8000 }
+      );
+
+      expect(screen.getByRole("button", { name: /aws_instance\.live/i })).toBeInTheDocument();
+    },
+    10000
+  );
+});

--- a/ui/src/hooks/__tests__/useEventStream.test.ts
+++ b/ui/src/hooks/__tests__/useEventStream.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { useEventStream } from "../useEventStream";
 
 jest.mock("../../modules/api/eventStream", () => ({
@@ -42,5 +42,92 @@ describe("useEventStream", () => {
 
     expect(result.current).toEqual([]);
     expect(readEventStream).not.toHaveBeenCalled();
+  });
+
+  describe("flushIntervalMs batching", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("coalesces messages that arrive within the flush window into a single update", async () => {
+      let renderCount = 0;
+      (readEventStream as jest.Mock).mockImplementation(async (_url, { onMessage }) => {
+        onMessage("a");
+        onMessage("b");
+        onMessage("c");
+        return new Promise(() => {}); // keep the stream "open" so .finally() doesn't flush early
+      });
+
+      const { result } = renderHook(() => {
+        renderCount++;
+        return useEventStream<string[]>({
+          url: "http://localhost/stream",
+          enabled: true,
+          initial: [],
+          reduce: (previous, data) => [...previous, data],
+          flushIntervalMs: 100,
+        });
+      });
+
+      // All three messages landed synchronously within the mock, before the flush timer fired -
+      // state (and therefore render count) must still reflect none of them yet.
+      expect(result.current).toEqual([]);
+      const renderCountBeforeFlush = renderCount;
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(100);
+      });
+
+      expect(result.current).toEqual(["a", "b", "c"]);
+      expect(renderCount).toBe(renderCountBeforeFlush + 1);
+    });
+
+    it("flushes a pending batch immediately once the connection settles, even before the flush window elapses", async () => {
+      (readEventStream as jest.Mock).mockImplementation(async (_url, { onMessage }) => {
+        onMessage("a");
+      });
+
+      const { result } = renderHook(() =>
+        useEventStream<string[]>({
+          url: "http://localhost/stream",
+          enabled: true,
+          initial: [],
+          reduce: (previous, data) => [...previous, data],
+          flushIntervalMs: 5000,
+        })
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current).toEqual(["a"]);
+    });
+
+    it("behaves exactly like the unbatched path when flushIntervalMs is unset", async () => {
+      (readEventStream as jest.Mock).mockImplementation(async (_url, { onMessage }) => {
+        onMessage("a");
+        onMessage("b");
+      });
+
+      const { result } = renderHook(() =>
+        useEventStream<string[]>({
+          url: "http://localhost/stream",
+          enabled: true,
+          initial: [],
+          reduce: (previous, data) => [...previous, data],
+        })
+      );
+
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(0);
+      });
+
+      expect(result.current).toEqual(["a", "b"]);
+    });
   });
 });

--- a/ui/src/hooks/__tests__/useLogStream.test.ts
+++ b/ui/src/hooks/__tests__/useLogStream.test.ts
@@ -61,6 +61,11 @@ describe("useLogStream", () => {
 
       const { result } = renderHook(() => useLogStream({ url: "http://localhost/stream", enabled: true }));
 
+      // useLogStream batches messages behind a flush timer (see LOG_FLUSH_INTERVAL_MS), but the
+      // batch still needs to reach state before the transient error below sends it into a
+      // multi-second reconnect backoff - useEventStream flushes any pending batch as soon as the
+      // connection settles (success, error, or abort), which is what makes "line 1" visible here
+      // at 0ms rather than only after the flush timer would otherwise have fired.
       await act(async () => {
         await jest.advanceTimersByTimeAsync(0);
       });

--- a/ui/src/hooks/useEventStream.ts
+++ b/ui/src/hooks/useEventStream.ts
@@ -6,6 +6,12 @@ type UseEventStreamOptions<T> = {
   enabled: boolean;
   initial: T;
   reduce: (previous: T, data: string) => T;
+  // When set, coalesces messages arriving within this window into a single React state
+  // update instead of one per message - see useLogStream, which streams one console line per
+  // SSE message and can otherwise re-render (and, for the terminal view, re-parse the whole
+  // accumulated log through ansi-to-react) once per line during a chatty apply. Left unset,
+  // behavior is identical to before this existed: one setValue per message.
+  flushIntervalMs?: number;
 };
 
 const INITIAL_BACKOFF_MS = 1000;
@@ -15,7 +21,7 @@ function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError";
 }
 
-export function useEventStream<T>({ url, enabled, initial, reduce }: UseEventStreamOptions<T>): T {
+export function useEventStream<T>({ url, enabled, initial, reduce, flushIntervalMs }: UseEventStreamOptions<T>): T {
   const [value, setValue] = useState<T>(initial);
 
   useEffect(() => {
@@ -31,6 +37,26 @@ export function useEventStream<T>({ url, enabled, initial, reduce }: UseEventStr
     let lastEventId: string | undefined;
     let controller = new AbortController();
 
+    // currentValue always reflects the latest reduced value, updated synchronously on every
+    // message regardless of batching - only how often it's copied into React state (setValue)
+    // depends on flushIntervalMs. This keeps the accumulated value correct even across a burst
+    // of messages that all land inside the same flush window.
+    let currentValue: T = initial;
+    let dirty = false;
+    let flushTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    const flush = () => {
+      if (flushTimeout != null) {
+        clearTimeout(flushTimeout);
+        flushTimeout = undefined;
+      }
+      if (!dirty) {
+        return;
+      }
+      dirty = false;
+      setValue(currentValue);
+    };
+
     const connect = () => {
       controller = new AbortController();
 
@@ -42,17 +68,35 @@ export function useEventStream<T>({ url, enabled, initial, reduce }: UseEventStr
           if (id != null) {
             lastEventId = id;
           }
-          setValue((previous) => reduce(previous, data));
+
+          currentValue = reduce(currentValue, data);
+
+          if (flushIntervalMs == null) {
+            setValue(currentValue);
+            return;
+          }
+
+          dirty = true;
+          if (flushTimeout == null) {
+            flushTimeout = setTimeout(flush, flushIntervalMs);
+          }
         },
-      }).catch((error: unknown) => {
-        if (cancelled || isAbortError(error)) {
-          return;
-        }
-        retryTimeout = setTimeout(() => {
-          backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
-          connect();
-        }, backoffMs);
-      });
+      })
+        .catch((error: unknown) => {
+          if (cancelled || isAbortError(error)) {
+            return;
+          }
+          retryTimeout = setTimeout(() => {
+            backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
+            connect();
+          }, backoffMs);
+        })
+        .finally(() => {
+          // Flush any partial batch immediately when the connection settles (success, error,
+          // or abort) rather than leaving it stuck until the next message arrives - which, on a
+          // transient error right before a reconnect, could otherwise be a long wait.
+          flush();
+        });
     };
 
     connect();
@@ -62,6 +106,9 @@ export function useEventStream<T>({ url, enabled, initial, reduce }: UseEventStr
       controller.abort();
       if (retryTimeout != null) {
         clearTimeout(retryTimeout);
+      }
+      if (flushTimeout != null) {
+        clearTimeout(flushTimeout);
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/ui/src/hooks/useLogStream.ts
+++ b/ui/src/hooks/useLogStream.ts
@@ -5,12 +5,20 @@ type UseLogStreamOptions = {
   enabled: boolean;
 };
 
+// A chatty apply can stream one SSE message per console line; without batching, each one
+// triggers its own React render, and the terminal view re-parses the *entire* accumulated log
+// through ansi-to-react on every single one. 120ms is short enough that a human reading the
+// scrolling log never notices the delay, while capping re-renders to ~8/s regardless of how
+// fast lines actually arrive.
+const LOG_FLUSH_INTERVAL_MS = 120;
+
 export function useLogStream({ url, enabled }: UseLogStreamOptions): { text: string } {
   const text = useEventStream<string>({
     url,
     enabled,
     initial: "",
     reduce: (previous, data) => (previous.length === 0 ? data : `${previous}\n${data}`),
+    flushIntervalMs: LOG_FLUSH_INTERVAL_MS,
   });
 
   return { text };


### PR DESCRIPTION
## Summary

Audit and fix pass on Terrakube's plan/apply structured-output pipeline: apply's console output (both the outputs summary and the resource diff), PR comment accuracy, `destroy()` parity with plan/apply, and UI responsiveness during live runs.

## Changes

**Apply console output**
- Apply now prints a human-readable `Outputs:` block after a successful run, mirroring how `plan()` already appends its rendered diff — previously apply's console ended abruptly with only terse per-resource lines.
- Apply also now renders the classic `# resource must be replaced` / `resource "type" "name" { ... }` HCL diff into its console output, reusing the same saved plan file apply already downloads (`PlanStructuredOutputService.getPlanAsHumanText`) — matching what a real `terraform apply <planfile>` prints before executing. Gated on a plan file actually being present, so a direct apply with no prior plan step (e.g. via a custom TCL workflow) doesn't try to render one that doesn't exist.

**PR comments**
- Fixed `PrCommentService` picking whichever step had the highest step number for its comment body. Custom TCL templates that run extra steps after the plan/apply step (Slack notify, cost check, etc.) were getting that trailing step's logs posted to the PR instead of the actual diff — it now searches backward for the step whose output contains a recognizable plan/apply summary.
- PR comments now render the job's structured plan/apply changes as a markdown table (action + resource) ahead of the raw diff fold, instead of only showing ANSI-stripped console text.

**Unknown-value resolution**
- `ApplyStructuredOutputService.resolveFinalValues` now clears the `afterUnknown` flag once a value resolves post-apply — previously it patched the real value into `after` but left the flag `true`, so the UI's "(known after apply)" placeholder never cleared even though the resolved value had already landed.
- This resolution is now recursive: unknown values nested inside blocks or list items (e.g. one attribute of a `network_interface` list entry) resolve too, not just top-level resource attributes.

**`destroy()` parity**
- `destroy()` now runs through the same JSON event parser as `plan()`/`apply()` and publishes under the existing "apply" phase, so destroy runs get the same live per-resource status view instead of console-only output.

**Responsiveness**
- The first JSON line of a plan/apply/destroy step now flushes to the structured-output stream immediately instead of waiting for the flush interval or step completion — previously a run that finished faster than one flush interval never showed live structured status at all, only flipping from console to structured after it was already done.
- The flush interval itself is halved (2s → 1s).
- `useEventStream` gained opt-in batching (`flushIntervalMs`), used by `useLogStream`, so a chatty apply coalesces rapid SSE lines into one render instead of re-parsing the whole accumulated log through `ansi-to-react` per line.

**Tests**
- Added a regression test pinning that structured plan/apply output survives the live SSE channel disabling when a job leaves "running" (previously only true "by accident," not enforced).
- Added cases to `TerraformExecutorServiceImplTest` covering the apply-time HCL diff render: present when a plan file was downloaded, and confirmed `getPlanAsHumanText` is never called when there isn't one.
- New/updated unit tests across `TerraformExecutorServiceImplTest`, `ApplyStructuredOutputServiceTest`, `PrCommentServiceTest`, `useEventStream.test.ts`, `useLogStream.test.ts`.

## Test plan

- [x] `executor` full test suite — 162 tests passing (verified earlier in the branch); `TerraformExecutorServiceImplTest` re-run after the latest apply-diff-render change — 14/14 passing, including the 2 new cases (full executor suite not re-run since that change, worth confirming in CI)
- [x] `api` targeted suites (`PrCommentServiceTest`, `ScheduleJobTest`, `RepoWebhookServiceTest`, `WebhookServiceTest`) — 100+ tests passing
- [x] `ui` full jest suite — 352 tests passing
- [x] Manual verification against a local minikube deployment: ran a plan + apply on a `random_pet` workspace and confirmed the Apply step's Console tab now shows the same `-/+ resource "random_pet" "this" { ... }` diff block the Plan step shows, followed by the `Outputs:` section with the resolved value