### PR TITLE
fix(structured-output): prevent sensitive attribute leakage and propagate dynamic sensitivities during state resolution

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputService.java
@@ -168,7 +168,9 @@ public class ApplyStructuredOutputService {
 
             Object afterSensitiveRaw = change.get("afterSensitive");
             Object stateSensitiveRaw = resolvedSensitiveValuesByAddress.get(address);
-            Object mergedSensitiveRaw = mergeSensitiveMetadata(afterSensitiveRaw, stateSensitiveRaw);
+            Object mergedSensitiveRaw = normalizeResourceSensitivities(
+                    change,
+                    mergeSensitiveMetadata(afterSensitiveRaw, stateSensitiveRaw));
             change.put("afterSensitive", mergedSensitiveRaw);
 
             Map<?, ?> afterSensitive = mergedSensitiveRaw instanceof Map<?, ?> ? (Map<?, ?>) mergedSensitiveRaw : Map.of();
@@ -359,6 +361,30 @@ public class ApplyStructuredOutputService {
         }
 
         return stateSensitive != null ? stateSensitive : planSensitive;
+    }
+
+    Object normalizeResourceSensitivities(Map<String, Object> change, Object sensitiveRaw) {
+        if (!(sensitiveRaw instanceof Map<?, ?> map)) {
+            return sensitiveRaw;
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        map.forEach((k, v) -> result.put(String.valueOf(k), v));
+
+        Object resourceType = change.get("resourceType");
+        Object address = change.get("address");
+        if ("terraform_data".equals(resourceType) || (address instanceof String addr && addr.contains("terraform_data."))) {
+            Object inputSensitive = result.get("input");
+            Object outputSensitive = result.get("output");
+            boolean outputIsEmpty = outputSensitive == null
+                    || (outputSensitive instanceof Map<?, ?> m && m.isEmpty())
+                    || (outputSensitive instanceof List<?> l && l.isEmpty());
+            if (inputSensitive != null && !Boolean.FALSE.equals(inputSensitive) && outputIsEmpty) {
+                result.put("output", inputSensitive);
+            }
+        }
+
+        return result;
     }
 
     @SuppressWarnings("unchecked")

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputService.java
@@ -123,6 +123,7 @@ public class ApplyStructuredOutputService {
     @SuppressWarnings("unchecked")
     void resolveFinalValues(List<Map<String, Object>> changes, String stateJson) {
         Map<String, Object> resolvedValuesByAddress = new HashMap<>();
+        Map<String, Object> resolvedSensitiveValuesByAddress = new HashMap<>();
         try {
             Map<String, Object> state = objectMapper.readValue(stateJson, new TypeReference<>() {
             });
@@ -130,7 +131,7 @@ public class ApplyStructuredOutputService {
             if (valuesRaw instanceof Map<?, ?> values) {
                 Object rootModuleRaw = values.get("root_module");
                 if (rootModuleRaw instanceof Map<?, ?> rootModule) {
-                    collectResourceValues((Map<String, Object>) rootModule, resolvedValuesByAddress);
+                    collectResourceValues((Map<String, Object>) rootModule, resolvedValuesByAddress, resolvedSensitiveValuesByAddress);
                 }
             }
         } catch (Exception e) {
@@ -166,7 +167,11 @@ public class ApplyStructuredOutputService {
             }
 
             Object afterSensitiveRaw = change.get("afterSensitive");
-            Map<?, ?> afterSensitive = afterSensitiveRaw instanceof Map<?, ?> ? (Map<?, ?>) afterSensitiveRaw : Map.of();
+            Object stateSensitiveRaw = resolvedSensitiveValuesByAddress.get(address);
+            Object mergedSensitiveRaw = mergeSensitiveMetadata(afterSensitiveRaw, stateSensitiveRaw);
+            change.put("afterSensitive", mergedSensitiveRaw);
+
+            Map<?, ?> afterSensitive = mergedSensitiveRaw instanceof Map<?, ?> ? (Map<?, ?>) mergedSensitiveRaw : Map.of();
 
             Map<String, Object> mutableAfter = (Map<String, Object>) after;
             Map<Object, Object> mutableAfterUnknown = (Map<Object, Object>) afterUnknown;
@@ -176,11 +181,12 @@ public class ApplyStructuredOutputService {
             // network_interface list entry, say) has its own true/false/nested marker several
             // levels down, not at this top level, and previously never got resolved here at all.
             for (Object key : new ArrayList<>(mutableAfterUnknown.keySet())) {
+                Object sensitiveChild = Boolean.TRUE.equals(mergedSensitiveRaw) ? Boolean.TRUE : afterSensitive.get(key);
                 Object resolvedNewUnknown = resolveUnknownRecursive(
                         mutableAfterUnknown.get(key),
                         mapSlot(mutableAfter, key),
                         resolvedMap.get(key),
-                        afterSensitive.get(key));
+                        sensitiveChild);
                 mutableAfterUnknown.put(key, resolvedNewUnknown);
             }
         }
@@ -320,8 +326,46 @@ public class ApplyStructuredOutputService {
         };
     }
 
+    Object mergeSensitiveMetadata(Object planSensitive, Object stateSensitive) {
+        if (Boolean.TRUE.equals(planSensitive) || Boolean.TRUE.equals(stateSensitive)) {
+            return true;
+        }
+
+        if (planSensitive instanceof Map<?, ?> || stateSensitive instanceof Map<?, ?>) {
+            Map<String, Object> merged = new HashMap<>();
+            if (planSensitive instanceof Map<?, ?> planMap) {
+                planMap.forEach((k, v) -> merged.put(String.valueOf(k), v));
+            }
+            if (stateSensitive instanceof Map<?, ?> stateMap) {
+                stateMap.forEach((k, v) -> {
+                    String stringKey = String.valueOf(k);
+                    merged.put(stringKey, mergeSensitiveMetadata(merged.get(stringKey), v));
+                });
+            }
+            return merged;
+        }
+
+        if (planSensitive instanceof List<?> || stateSensitive instanceof List<?>) {
+            List<?> planList = planSensitive instanceof List<?> list ? list : List.of();
+            List<?> stateList = stateSensitive instanceof List<?> list ? list : List.of();
+            int maxLength = Math.max(planList.size(), stateList.size());
+            List<Object> merged = new ArrayList<>();
+            for (int i = 0; i < maxLength; i++) {
+                Object planVal = i < planList.size() ? planList.get(i) : null;
+                Object stateVal = i < stateList.size() ? stateList.get(i) : null;
+                merged.add(mergeSensitiveMetadata(planVal, stateVal));
+            }
+            return merged;
+        }
+
+        return stateSensitive != null ? stateSensitive : planSensitive;
+    }
+
     @SuppressWarnings("unchecked")
-    private void collectResourceValues(Map<String, Object> module, Map<String, Object> resolvedValuesByAddress) {
+    private void collectResourceValues(
+            Map<String, Object> module,
+            Map<String, Object> resolvedValuesByAddress,
+            Map<String, Object> resolvedSensitiveValuesByAddress) {
         Object resourcesRaw = module.get("resources");
         if (resourcesRaw instanceof List<?> resources) {
             for (Object resourceRaw : resources) {
@@ -331,8 +375,12 @@ public class ApplyStructuredOutputService {
 
                 Object address = resource.get("address");
                 Object values = resource.get("values");
+                Object sensitiveValues = resource.get("sensitive_values");
                 if (address instanceof String addressString && values instanceof Map<?, ?>) {
                     resolvedValuesByAddress.put(addressString, values);
+                    if (sensitiveValues != null) {
+                        resolvedSensitiveValuesByAddress.put(addressString, sensitiveValues);
+                    }
                 }
             }
         }
@@ -341,7 +389,7 @@ public class ApplyStructuredOutputService {
         if (childModulesRaw instanceof List<?> childModules) {
             for (Object childModuleRaw : childModules) {
                 if (childModuleRaw instanceof Map<?, ?> childModule) {
-                    collectResourceValues((Map<String, Object>) childModule, resolvedValuesByAddress);
+                    collectResourceValues((Map<String, Object>) childModule, resolvedValuesByAddress, resolvedSensitiveValuesByAddress);
                 }
             }
         }

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputService.java
@@ -196,6 +196,11 @@ public class ApplyStructuredOutputService {
      */
     @SuppressWarnings("unchecked")
     private Object resolveUnknownRecursive(Object afterUnknownNode, ValueSlot afterSlot, Object resolvedNode, Object afterSensitiveNode) {
+        if (Boolean.TRUE.equals(afterSensitiveNode)) {
+            // If the container or leaf is marked sensitive, never resolve it to plaintext.
+            return afterUnknownNode;
+        }
+
         if (Boolean.TRUE.equals(afterUnknownNode)) {
             // Never let a resolved sensitive value leave the executor process, mirroring
             // PlanStructuredOutputService's sanitize-before-send precedent - the UI already
@@ -203,11 +208,11 @@ public class ApplyStructuredOutputService {
             // visible effect except keeping the real value off the wire entirely. Also leaves a
             // leaf unresolved (rather than defaulting to something) when state has nothing for
             // it - shouldn't normally happen, but silently keeping "unknown" beats guessing.
-            if (Boolean.TRUE.equals(afterSensitiveNode) || resolvedNode == null) {
+            if (resolvedNode == null) {
                 return afterUnknownNode;
             }
 
-            afterSlot.set(resolvedNode);
+            afterSlot.set(sanitizeSensitiveValues(resolvedNode, afterSensitiveNode));
             return false;
         }
 
@@ -252,6 +257,36 @@ public class ApplyStructuredOutputService {
         // afterUnknown is `false` (already known at plan time) or some other non-boolean,
         // non-container shape this format doesn't define - nothing to resolve either way.
         return afterUnknownNode;
+    }
+
+    Object sanitizeSensitiveValues(Object value, Object sensitiveMetadata) {
+        if (Boolean.TRUE.equals(sensitiveMetadata)) {
+            return null;
+        }
+
+        if (value instanceof Map<?, ?> valueMap) {
+            Map<String, Object> sanitizedMap = new HashMap<>();
+            Map<?, ?> sensitiveMap = sensitiveMetadata instanceof Map<?, ?> ? (Map<?, ?>) sensitiveMetadata : Map.of();
+
+            valueMap.forEach((key, entryValue) -> sanitizedMap.put(
+                    String.valueOf(key),
+                    sanitizeSensitiveValues(entryValue, sensitiveMap.get(key))));
+            return sanitizedMap;
+        }
+
+        if (value instanceof List<?> valueList) {
+            List<?> sensitiveList = sensitiveMetadata instanceof List<?> ? (List<?>) sensitiveMetadata : List.of();
+            List<Object> sanitizedList = new ArrayList<>();
+
+            for (int index = 0; index < valueList.size(); index++) {
+                Object sensitiveEntry = index < sensitiveList.size() ? sensitiveList.get(index) : null;
+                sanitizedList.add(sanitizeSensitiveValues(valueList.get(index), sensitiveEntry));
+            }
+
+            return sanitizedList;
+        }
+
+        return value;
     }
 
     /** A single addressable position inside `after` - either a map entry or a list index. */

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputService.java
@@ -2,18 +2,9 @@ package io.terrakube.executor.service.terraform;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.terrakube.client.TerrakubeClient;
-import io.terrakube.executor.service.workspace.security.WorkspaceSecurity;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -26,23 +17,15 @@ public class ApplyStructuredOutputService {
     private static final String CONTEXT_PLAN_KEY = "planStructuredOutput";
     private static final String CONTEXT_APPLY_KEY = "applyStructuredOutput";
     private static final String CONTEXT_JOB_DIAGNOSTICS_KEY = "jobDiagnostics";
-    private static final int CONNECT_TIMEOUT_MS = 5000;
-    private static final int READ_TIMEOUT_MS = 10000;
 
-    private final WorkspaceSecurity workspaceSecurity;
+    private final JobContextService jobContextService;
     private final ObjectMapper objectMapper;
-    private final String terrakubeApiUrl;
-    private final TerrakubeClient terrakubeClient;
 
     public ApplyStructuredOutputService(
-            WorkspaceSecurity workspaceSecurity,
-            ObjectMapper objectMapper,
-            @Value("${io.terrakube.api.url}") String terrakubeApiUrl,
-            TerrakubeClient terrakubeClient) {
-        this.workspaceSecurity = workspaceSecurity;
+            JobContextService jobContextService,
+            ObjectMapper objectMapper) {
+        this.jobContextService = jobContextService;
         this.objectMapper = objectMapper;
-        this.terrakubeApiUrl = terrakubeApiUrl;
-        this.terrakubeClient = terrakubeClient;
     }
 
     public List<Map<String, Object>> seedFromPlan(String organizationId, String jobId) {
@@ -268,33 +251,7 @@ public class ApplyStructuredOutputService {
     }
 
     Object sanitizeSensitiveValues(Object value, Object sensitiveMetadata) {
-        if (Boolean.TRUE.equals(sensitiveMetadata)) {
-            return null;
-        }
-
-        if (value instanceof Map<?, ?> valueMap) {
-            Map<String, Object> sanitizedMap = new HashMap<>();
-            Map<?, ?> sensitiveMap = sensitiveMetadata instanceof Map<?, ?> ? (Map<?, ?>) sensitiveMetadata : Map.of();
-
-            valueMap.forEach((key, entryValue) -> sanitizedMap.put(
-                    String.valueOf(key),
-                    sanitizeSensitiveValues(entryValue, sensitiveMap.get(key))));
-            return sanitizedMap;
-        }
-
-        if (value instanceof List<?> valueList) {
-            List<?> sensitiveList = sensitiveMetadata instanceof List<?> ? (List<?>) sensitiveMetadata : List.of();
-            List<Object> sanitizedList = new ArrayList<>();
-
-            for (int index = 0; index < valueList.size(); index++) {
-                Object sensitiveEntry = index < sensitiveList.size() ? sensitiveList.get(index) : null;
-                sanitizedList.add(sanitizeSensitiveValues(valueList.get(index), sensitiveEntry));
-            }
-
-            return sanitizedList;
-        }
-
-        return value;
+        return TerraformSensitivitySanitizer.sanitizeSensitiveValues(value, sensitiveMetadata);
     }
 
     /** A single addressable position inside `after` - either a map entry or a list index. */
@@ -329,62 +286,11 @@ public class ApplyStructuredOutputService {
     }
 
     Object mergeSensitiveMetadata(Object planSensitive, Object stateSensitive) {
-        if (Boolean.TRUE.equals(planSensitive) || Boolean.TRUE.equals(stateSensitive)) {
-            return true;
-        }
-
-        if (planSensitive instanceof Map<?, ?> || stateSensitive instanceof Map<?, ?>) {
-            Map<String, Object> merged = new HashMap<>();
-            if (planSensitive instanceof Map<?, ?> planMap) {
-                planMap.forEach((k, v) -> merged.put(String.valueOf(k), v));
-            }
-            if (stateSensitive instanceof Map<?, ?> stateMap) {
-                stateMap.forEach((k, v) -> {
-                    String stringKey = String.valueOf(k);
-                    merged.put(stringKey, mergeSensitiveMetadata(merged.get(stringKey), v));
-                });
-            }
-            return merged;
-        }
-
-        if (planSensitive instanceof List<?> || stateSensitive instanceof List<?>) {
-            List<?> planList = planSensitive instanceof List<?> list ? list : List.of();
-            List<?> stateList = stateSensitive instanceof List<?> list ? list : List.of();
-            int maxLength = Math.max(planList.size(), stateList.size());
-            List<Object> merged = new ArrayList<>();
-            for (int i = 0; i < maxLength; i++) {
-                Object planVal = i < planList.size() ? planList.get(i) : null;
-                Object stateVal = i < stateList.size() ? stateList.get(i) : null;
-                merged.add(mergeSensitiveMetadata(planVal, stateVal));
-            }
-            return merged;
-        }
-
-        return stateSensitive != null ? stateSensitive : planSensitive;
+        return TerraformSensitivitySanitizer.mergeSensitiveMetadata(planSensitive, stateSensitive);
     }
 
     Object normalizeResourceSensitivities(Map<String, Object> change, Object sensitiveRaw) {
-        if (!(sensitiveRaw instanceof Map<?, ?> map)) {
-            return sensitiveRaw;
-        }
-
-        Map<String, Object> result = new HashMap<>();
-        map.forEach((k, v) -> result.put(String.valueOf(k), v));
-
-        Object resourceType = change.get("resourceType");
-        Object address = change.get("address");
-        if ("terraform_data".equals(resourceType) || (address instanceof String addr && addr.contains("terraform_data."))) {
-            Object inputSensitive = result.get("input");
-            Object outputSensitive = result.get("output");
-            boolean outputIsEmpty = outputSensitive == null
-                    || (outputSensitive instanceof Map<?, ?> m && m.isEmpty())
-                    || (outputSensitive instanceof List<?> l && l.isEmpty());
-            if (inputSensitive != null && !Boolean.FALSE.equals(inputSensitive) && outputIsEmpty) {
-                result.put("output", inputSensitive);
-            }
-        }
-
-        return result;
+        return TerraformSensitivitySanitizer.normalizeResourceSensitivities(change, sensitiveRaw);
     }
 
     @SuppressWarnings("unchecked")
@@ -422,87 +328,11 @@ public class ApplyStructuredOutputService {
     }
 
     private Map<String, Object> getCurrentContext(String organizationId, String jobId) {
-        HttpURLConnection connection = null;
-        try {
-            io.terrakube.client.model.organization.job.Job jobInfo = terrakubeClient.getJobById(organizationId, jobId).getData();
-            if (!jobInfo.getAttributes().getStatus().equals("running")) {
-                throw new IllegalStateException("Job is not running, cannot get context");
-            }
-            connection = buildConnection(terrakubeApiUrl + "/context/v1/" + jobInfo.getId(), "GET");
-            int statusCode = connection.getResponseCode();
-            if (statusCode >= 400) {
-                log.warn("Unable to read context for job {}. Response status: {}", jobInfo.getId(), statusCode);
-                return new HashMap<>();
-            }
-
-            String body = readResponseBody(connection);
-            if (body == null || body.isBlank()) {
-                return new HashMap<>();
-            }
-
-            return objectMapper.readValue(body, new TypeReference<>() {
-            });
-        } catch (Exception ex) {
-            log.warn("Unable to read context for job {}", jobId, ex);
-            return new HashMap<>();
-        } finally {
-            if (connection != null) {
-                connection.disconnect();
-            }
-        }
+        return jobContextService.getCurrentContext(organizationId, jobId);
     }
 
     private void saveContext(String organizationId, String jobId, Map<String, Object> context) {
-        HttpURLConnection connection = null;
-        try {
-            io.terrakube.client.model.organization.job.Job jobInfo = terrakubeClient.getJobById(organizationId, jobId).getData();
-            if (!jobInfo.getAttributes().getStatus().equals("running")) {
-                throw new IllegalStateException("Job is not running, cannot save context");
-            }
-            connection = buildConnection(terrakubeApiUrl + "/context/v1/" + jobInfo.getId(), "POST");
-            connection.setDoOutput(true);
-            byte[] data = objectMapper.writeValueAsBytes(context);
-            try (OutputStream os = connection.getOutputStream()) {
-                os.write(data);
-            }
-
-            int statusCode = connection.getResponseCode();
-            if (statusCode >= 400) {
-                log.warn("Unable to save context for job {}. Response status: {} Body: {}", jobId, statusCode,
-                        readResponseBody(connection));
-            }
-        } catch (Exception e) {
-            log.warn("Unable to save context for job {}", jobId, e);
-        } finally {
-            if (connection != null) {
-                connection.disconnect();
-            }
-        }
-    }
-
-    private HttpURLConnection buildConnection(String endpoint, String method) throws IOException {
-        HttpURLConnection connection = (HttpURLConnection) new URL(endpoint).openConnection();
-        connection.setRequestMethod(method);
-        connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
-        connection.setReadTimeout(READ_TIMEOUT_MS);
-        connection.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(1));
-        connection.setRequestProperty("Content-Type", "application/json");
-        connection.setUseCaches(false);
-        return connection;
-    }
-
-    private String readResponseBody(HttpURLConnection connection) throws IOException {
-        InputStream stream = connection.getErrorStream();
-        if (stream == null) {
-            stream = connection.getInputStream();
-        }
-
-        if (stream == null) {
-            return "";
-        }
-
-        try (InputStream responseStream = stream) {
-            return new String(responseStream.readAllBytes(), StandardCharsets.UTF_8);
-        }
+        jobContextService.saveContext(organizationId, jobId, context);
     }
 }
+

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/JobContextService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/JobContextService.java
@@ -1,0 +1,131 @@
+package io.terrakube.executor.service.terraform;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.client.TerrakubeClient;
+import io.terrakube.executor.service.workspace.security.WorkspaceSecurity;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class JobContextService {
+
+    private static final int CONNECT_TIMEOUT_MS = 5000;
+    private static final int READ_TIMEOUT_MS = 10000;
+
+    private final WorkspaceSecurity workspaceSecurity;
+    private final ObjectMapper objectMapper;
+    private final String terrakubeApiUrl;
+    private final TerrakubeClient terrakubeClient;
+
+    public JobContextService(
+            WorkspaceSecurity workspaceSecurity,
+            ObjectMapper objectMapper,
+            @Value("${io.terrakube.api.url}") String terrakubeApiUrl,
+            TerrakubeClient terrakubeClient) {
+        this.workspaceSecurity = workspaceSecurity;
+        this.objectMapper = objectMapper;
+        this.terrakubeApiUrl = terrakubeApiUrl;
+        this.terrakubeClient = terrakubeClient;
+    }
+
+    public Map<String, Object> getCurrentContext(String organizationId, String jobId) {
+        HttpURLConnection connection = null;
+        try {
+            io.terrakube.client.model.organization.job.Job jobInfo = terrakubeClient.getJobById(organizationId, jobId).getData();
+            if (jobInfo.getAttributes().getStatus().equals("running")) {
+                log.info("Job {} exists, Terrakube should be able to get the context", jobId);
+            } else {
+                throw new IllegalStateException("Job is not running, cannot get context");
+            }
+            connection = buildConnection(terrakubeApiUrl + "/context/v1/" + jobInfo.getId(), "GET");
+            int statusCode = connection.getResponseCode();
+            if (statusCode >= 400) {
+                log.warn("Unable to read context for job {}. Response status: {}", jobInfo.getId(), statusCode);
+                return new HashMap<>();
+            }
+
+            String body = readResponseBody(connection);
+            if (body == null || body.isBlank()) {
+                return new HashMap<>();
+            }
+
+            return objectMapper.readValue(body, new TypeReference<>() {
+            });
+        } catch (Exception ex) {
+            log.warn("Unable to read context for job {}", jobId, ex);
+            return new HashMap<>();
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    public void saveContext(String organizationId, String jobId, Map<String, Object> context) {
+        HttpURLConnection connection = null;
+        try {
+            io.terrakube.client.model.organization.job.Job jobInfo = terrakubeClient.getJobById(organizationId, jobId).getData();
+            if (jobInfo.getAttributes().getStatus().equals("running")) {
+                log.info("Job {} exists, Terrakube should be able to save the context", jobId);
+            } else {
+                throw new IllegalStateException("Job is not running, cannot save context");
+            }
+            connection = buildConnection(terrakubeApiUrl + "/context/v1/" + jobInfo.getId(), "POST");
+            connection.setDoOutput(true);
+            byte[] data = objectMapper.writeValueAsBytes(context);
+            try (OutputStream os = connection.getOutputStream()) {
+                os.write(data);
+            }
+
+            int statusCode = connection.getResponseCode();
+            if (statusCode >= 400) {
+                log.warn("Unable to save context for job {}. Response status: {} Body: {}", jobId, statusCode,
+                        readResponseBody(connection));
+            }
+        } catch (Exception e) {
+            log.warn("Unable to save context for job {}", jobId, e);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    HttpURLConnection buildConnection(String endpoint, String method) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(endpoint).openConnection();
+        connection.setRequestMethod(method);
+        connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
+        connection.setReadTimeout(READ_TIMEOUT_MS);
+        connection.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(1));
+        connection.setRequestProperty("Content-Type", "application/json");
+        connection.setUseCaches(false);
+        return connection;
+    }
+
+    String readResponseBody(HttpURLConnection connection) throws IOException {
+        InputStream stream = connection.getErrorStream();
+        if (stream == null) {
+            stream = connection.getInputStream();
+        }
+
+        if (stream == null) {
+            return "";
+        }
+
+        try (InputStream responseStream = stream) {
+            return new String(responseStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/PlanStructuredOutputService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/PlanStructuredOutputService.java
@@ -209,8 +209,14 @@ public class PlanStructuredOutputService {
             }
             Object beforeValue = changeBlock.get("before");
             Object afterValue = changeBlock.get("after");
-            Object beforeSensitive = changeBlock.get("before_sensitive");
-            Object afterSensitive = changeBlock.get("after_sensitive");
+            Object beforeSensitive = normalizeResourceSensitivities(
+                    (String) change.get("type"),
+                    (String) change.get("address"),
+                    changeBlock.get("before_sensitive"));
+            Object afterSensitive = normalizeResourceSensitivities(
+                    (String) change.get("type"),
+                    (String) change.get("address"),
+                    changeBlock.get("after_sensitive"));
             Object changedSensitive = collectChangedSensitivePaths(
                     beforeValue,
                     afterValue,
@@ -372,6 +378,28 @@ public class PlanStructuredOutputService {
         }
 
         return "unknown";
+    }
+
+    Object normalizeResourceSensitivities(String resourceType, String address, Object sensitiveRaw) {
+        if (!(sensitiveRaw instanceof Map<?, ?> map)) {
+            return sensitiveRaw;
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        map.forEach((k, v) -> result.put(String.valueOf(k), v));
+
+        if ("terraform_data".equals(resourceType) || (address != null && address.contains("terraform_data."))) {
+            Object inputSensitive = result.get("input");
+            Object outputSensitive = result.get("output");
+            boolean outputIsEmpty = outputSensitive == null
+                    || (outputSensitive instanceof Map<?, ?> m && m.isEmpty())
+                    || (outputSensitive instanceof List<?> l && l.isEmpty());
+            if (inputSensitive != null && !Boolean.FALSE.equals(inputSensitive) && outputIsEmpty) {
+                result.put("output", inputSensitive);
+            }
+        }
+
+        return result;
     }
 
     Object sanitizeSensitiveValues(Object value, Object sensitiveMetadata) {

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/PlanStructuredOutputService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/PlanStructuredOutputService.java
@@ -2,23 +2,15 @@ package io.terrakube.executor.service.terraform;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.terrakube.client.TerrakubeClient;
 import io.terrakube.terraform.TerraformClient;
 import io.terrakube.terraform.TerraformProcessData;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.TextStringBuilder;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import io.terrakube.executor.service.mode.TerraformJob;
-import io.terrakube.executor.service.workspace.security.WorkspaceSecurity;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -37,26 +29,18 @@ public class PlanStructuredOutputService {
     private static final String CONTEXT_UI_KEY = "terrakubeUI";
     private static final String CONTEXT_JOB_DIAGNOSTICS_KEY = "jobDiagnostics";
     private static final String STRUCTURED_PLAN_MARKER = "<div data-terrakube-structured-plan=\"true\"></div>";
-    private static final int CONNECT_TIMEOUT_MS = 5000;
-    private static final int READ_TIMEOUT_MS = 10000;
 
-    private final WorkspaceSecurity workspaceSecurity;
+    private final JobContextService jobContextService;
     private final ObjectMapper objectMapper;
-    private final String terrakubeApiUrl;
     TerraformClient terraformClient;
-    TerrakubeClient terrakubeClient;
 
     public PlanStructuredOutputService(
-            WorkspaceSecurity workspaceSecurity,
+            JobContextService jobContextService,
             ObjectMapper objectMapper,
-            @Value("${io.terrakube.api.url}") String terrakubeApiUrl,
-            TerraformClient terraformClient,
-            TerrakubeClient terrakubeClient) {
-        this.workspaceSecurity = workspaceSecurity;
+            TerraformClient terraformClient) {
+        this.jobContextService = jobContextService;
         this.objectMapper = objectMapper;
-        this.terrakubeApiUrl = terrakubeApiUrl;
         this.terraformClient = terraformClient;
-        this.terrakubeClient = terrakubeClient;
     }
 
     public void publishPlanSummary(TerraformJob terraformJob, File terraformWorkingDir, List<Map<String, Object>> liveChanges, List<Map<String, Object>> jobDiagnostics) {
@@ -254,77 +238,11 @@ public class PlanStructuredOutputService {
     }
 
     private Map<String, Object> getCurrentContext(String organizationId, String jobId) {
-        HttpURLConnection connection = null;
-        try {
-            io.terrakube.client.model.organization.job.Job jobInfo = terrakubeClient.getJobById(organizationId, jobId).getData();
-            if (jobInfo.getAttributes().getStatus().equals("running")) {
-                log.info("Job {} exists, Terrakube should be able to get the context", jobId);
-            } else {
-                throw new IllegalStateException("Job is not running, cannot get context");
-            }
-            connection = buildConnection(terrakubeApiUrl + "/context/v1/" + jobInfo.getId(), "GET");
-            int statusCode = connection.getResponseCode();
-            if (statusCode >= 400) {
-                log.warn("Unable to read context for job {}. Response status: {}", jobInfo.getId(), statusCode);
-                return new HashMap<>();
-            }
-
-            String body = readResponseBody(connection);
-            if (body == null || body.isBlank()) {
-                return new HashMap<>();
-            }
-
-            return objectMapper.readValue(body, new TypeReference<>() {
-            });
-        } catch (Exception ex) {
-            log.warn("Unable to read context for job {}", jobId, ex);
-            return new HashMap<>();
-        } finally {
-            if (connection != null) {
-                connection.disconnect();
-            }
-        }
+        return jobContextService.getCurrentContext(organizationId, jobId);
     }
 
     private void saveContext(String organizationId, String jobId, Map<String, Object> context) {
-        HttpURLConnection connection = null;
-        try {
-            io.terrakube.client.model.organization.job.Job jobInfo = terrakubeClient.getJobById(organizationId, jobId).getData();
-            if (jobInfo.getAttributes().getStatus().equals("running")) {
-                log.info("Job {} exists, Terrakube should be able to save the context", jobId);
-            } else {
-                throw new IllegalStateException("Job is not running, cannot get context");
-            }
-            connection = buildConnection(terrakubeApiUrl + "/context/v1/" + jobInfo.getId(), "POST");
-            connection.setDoOutput(true);
-            byte[] data = objectMapper.writeValueAsBytes(context);
-            try (OutputStream os = connection.getOutputStream()) {
-                os.write(data);
-            }
-
-            int statusCode = connection.getResponseCode();
-            if (statusCode >= 400) {
-                log.warn("Unable to save context for job {}. Response status: {} Body: {}", jobId, statusCode,
-                        readResponseBody(connection));
-            }
-        } catch (Exception e) {
-            log.warn("Unable to save context for job {}", jobId, e);
-        } finally {
-            if (connection != null) {
-                connection.disconnect();
-            }
-        }
-    }
-
-    private HttpURLConnection buildConnection(String endpoint, String method) throws IOException {
-        HttpURLConnection connection = (HttpURLConnection) new URL(endpoint).openConnection();
-        connection.setRequestMethod(method);
-        connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
-        connection.setReadTimeout(READ_TIMEOUT_MS);
-        connection.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(1));
-        connection.setRequestProperty("Content-Type", "application/json");
-        connection.setUseCaches(false);
-        return connection;
+        jobContextService.saveContext(organizationId, jobId, context);
     }
 
     private Map<String, Object> toMap(Object value) {
@@ -334,22 +252,6 @@ public class PlanStructuredOutputService {
             return typed;
         }
         return new HashMap<>();
-    }
-
-
-    private String readResponseBody(HttpURLConnection connection) throws IOException {
-        InputStream stream = connection.getErrorStream();
-        if (stream == null) {
-            stream = connection.getInputStream();
-        }
-
-        if (stream == null) {
-            return "";
-        }
-
-        try (InputStream responseStream = stream) {
-            return new String(responseStream.readAllBytes(), StandardCharsets.UTF_8);
-        }
     }
 
     private String normalizeAction(List<String> actions) {
@@ -381,55 +283,11 @@ public class PlanStructuredOutputService {
     }
 
     Object normalizeResourceSensitivities(String resourceType, String address, Object sensitiveRaw) {
-        if (!(sensitiveRaw instanceof Map<?, ?> map)) {
-            return sensitiveRaw;
-        }
-
-        Map<String, Object> result = new HashMap<>();
-        map.forEach((k, v) -> result.put(String.valueOf(k), v));
-
-        if ("terraform_data".equals(resourceType) || (address != null && address.contains("terraform_data."))) {
-            Object inputSensitive = result.get("input");
-            Object outputSensitive = result.get("output");
-            boolean outputIsEmpty = outputSensitive == null
-                    || (outputSensitive instanceof Map<?, ?> m && m.isEmpty())
-                    || (outputSensitive instanceof List<?> l && l.isEmpty());
-            if (inputSensitive != null && !Boolean.FALSE.equals(inputSensitive) && outputIsEmpty) {
-                result.put("output", inputSensitive);
-            }
-        }
-
-        return result;
+        return TerraformSensitivitySanitizer.normalizeResourceSensitivities(resourceType, address, sensitiveRaw);
     }
 
     Object sanitizeSensitiveValues(Object value, Object sensitiveMetadata) {
-        if (Boolean.TRUE.equals(sensitiveMetadata)) {
-            return null;
-        }
-
-        if (value instanceof Map<?, ?> valueMap) {
-            Map<String, Object> sanitizedMap = new HashMap<>();
-            Map<?, ?> sensitiveMap = sensitiveMetadata instanceof Map<?, ?> ? (Map<?, ?>) sensitiveMetadata : Map.of();
-
-            valueMap.forEach((key, entryValue) -> sanitizedMap.put(
-                    String.valueOf(key),
-                    sanitizeSensitiveValues(entryValue, sensitiveMap.get(key))));
-            return sanitizedMap;
-        }
-
-        if (value instanceof List<?> valueList) {
-            List<?> sensitiveList = sensitiveMetadata instanceof List<?> ? (List<?>) sensitiveMetadata : List.of();
-            List<Object> sanitizedList = new ArrayList<>();
-
-            for (int index = 0; index < valueList.size(); index++) {
-                Object sensitiveEntry = index < sensitiveList.size() ? sensitiveList.get(index) : null;
-                sanitizedList.add(sanitizeSensitiveValues(valueList.get(index), sensitiveEntry));
-            }
-
-            return sanitizedList;
-        }
-
-        return value;
+        return TerraformSensitivitySanitizer.sanitizeSensitiveValues(value, sensitiveMetadata);
     }
 
     // Compare raw values before redaction so the UI can hide unchanged secrets

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformOutputsService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformOutputsService.java
@@ -2,18 +2,10 @@ package io.terrakube.executor.service.terraform;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.terrakube.client.TerrakubeClient;
-import io.terrakube.executor.service.workspace.security.WorkspaceSecurity;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -25,23 +17,15 @@ import java.util.TreeMap;
 public class TerraformOutputsService {
 
     private static final String CONTEXT_OUTPUTS_KEY = "terraformOutputs";
-    private static final int CONNECT_TIMEOUT_MS = 5000;
-    private static final int READ_TIMEOUT_MS = 10000;
 
-    private final WorkspaceSecurity workspaceSecurity;
+    private final JobContextService jobContextService;
     private final ObjectMapper objectMapper;
-    private final String terrakubeApiUrl;
-    private final TerrakubeClient terrakubeClient;
 
     public TerraformOutputsService(
-            WorkspaceSecurity workspaceSecurity,
-            ObjectMapper objectMapper,
-            @Value("${io.terrakube.api.url}") String terrakubeApiUrl,
-            TerrakubeClient terrakubeClient) {
-        this.workspaceSecurity = workspaceSecurity;
+            JobContextService jobContextService,
+            ObjectMapper objectMapper) {
+        this.jobContextService = jobContextService;
         this.objectMapper = objectMapper;
-        this.terrakubeApiUrl = terrakubeApiUrl;
-        this.terrakubeClient = terrakubeClient;
     }
 
     public void publishOutputs(String organizationId, String jobId, String stepId, String outputJson) {
@@ -103,87 +87,11 @@ public class TerraformOutputsService {
     }
 
     private Map<String, Object> getCurrentContext(String organizationId, String jobId) {
-        HttpURLConnection connection = null;
-        try {
-            io.terrakube.client.model.organization.job.Job jobInfo = terrakubeClient.getJobById(organizationId, jobId).getData();
-            if (!jobInfo.getAttributes().getStatus().equals("running")) {
-                throw new IllegalStateException("Job is not running, cannot get context");
-            }
-            connection = buildConnection(terrakubeApiUrl + "/context/v1/" + jobInfo.getId(), "GET");
-            int statusCode = connection.getResponseCode();
-            if (statusCode >= 400) {
-                log.warn("Unable to read context for job {}. Response status: {}", jobInfo.getId(), statusCode);
-                return new HashMap<>();
-            }
-
-            String body = readResponseBody(connection);
-            if (body == null || body.isBlank()) {
-                return new HashMap<>();
-            }
-
-            return objectMapper.readValue(body, new TypeReference<>() {
-            });
-        } catch (Exception ex) {
-            log.warn("Unable to read context for job {}", jobId, ex);
-            return new HashMap<>();
-        } finally {
-            if (connection != null) {
-                connection.disconnect();
-            }
-        }
+        return jobContextService.getCurrentContext(organizationId, jobId);
     }
 
     private void saveContext(String organizationId, String jobId, Map<String, Object> context) {
-        HttpURLConnection connection = null;
-        try {
-            io.terrakube.client.model.organization.job.Job jobInfo = terrakubeClient.getJobById(organizationId, jobId).getData();
-            if (!jobInfo.getAttributes().getStatus().equals("running")) {
-                throw new IllegalStateException("Job is not running, cannot save context");
-            }
-            connection = buildConnection(terrakubeApiUrl + "/context/v1/" + jobInfo.getId(), "POST");
-            connection.setDoOutput(true);
-            byte[] data = objectMapper.writeValueAsBytes(context);
-            try (OutputStream os = connection.getOutputStream()) {
-                os.write(data);
-            }
-
-            int statusCode = connection.getResponseCode();
-            if (statusCode >= 400) {
-                log.warn("Unable to save context for job {}. Response status: {} Body: {}", jobId, statusCode,
-                        readResponseBody(connection));
-            }
-        } catch (Exception e) {
-            log.warn("Unable to save context for job {}", jobId, e);
-        } finally {
-            if (connection != null) {
-                connection.disconnect();
-            }
-        }
-    }
-
-    private HttpURLConnection buildConnection(String endpoint, String method) throws IOException {
-        HttpURLConnection connection = (HttpURLConnection) new URL(endpoint).openConnection();
-        connection.setRequestMethod(method);
-        connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
-        connection.setReadTimeout(READ_TIMEOUT_MS);
-        connection.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(1));
-        connection.setRequestProperty("Content-Type", "application/json");
-        connection.setUseCaches(false);
-        return connection;
-    }
-
-    private String readResponseBody(HttpURLConnection connection) throws IOException {
-        InputStream stream = connection.getErrorStream();
-        if (stream == null) {
-            stream = connection.getInputStream();
-        }
-
-        if (stream == null) {
-            return "";
-        }
-
-        try (InputStream responseStream = stream) {
-            return new String(responseStream.readAllBytes(), StandardCharsets.UTF_8);
-        }
+        jobContextService.saveContext(organizationId, jobId, context);
     }
 }
+

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformSensitivitySanitizer.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformSensitivitySanitizer.java
@@ -1,0 +1,124 @@
+package io.terrakube.executor.service.terraform;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class TerraformSensitivitySanitizer {
+
+    private TerraformSensitivitySanitizer() {
+    }
+
+    /**
+     * Recursively redacts sensitive values matching the provided sensitivity metadata.
+     * When sensitivityMetadata is Boolean.TRUE, returns null (redacted).
+     */
+    public static Object sanitizeSensitiveValues(Object value, Object sensitiveMetadata) {
+        if (Boolean.TRUE.equals(sensitiveMetadata)) {
+            return null;
+        }
+
+        if (value instanceof Map<?, ?> valueMap) {
+            Map<String, Object> sanitizedMap = new HashMap<>();
+            Map<?, ?> sensitiveMap = sensitiveMetadata instanceof Map<?, ?> ? (Map<?, ?>) sensitiveMetadata : Map.of();
+
+            valueMap.forEach((key, entryValue) -> sanitizedMap.put(
+                    String.valueOf(key),
+                    sanitizeSensitiveValues(entryValue, sensitiveMap.get(key))));
+            return sanitizedMap;
+        }
+
+        if (value instanceof List<?> valueList) {
+            List<?> sensitiveList = sensitiveMetadata instanceof List<?> ? (List<?>) sensitiveMetadata : List.of();
+            List<Object> sanitizedList = new ArrayList<>();
+
+            for (int index = 0; index < valueList.size(); index++) {
+                Object sensitiveEntry = index < sensitiveList.size() ? sensitiveList.get(index) : null;
+                sanitizedList.add(sanitizeSensitiveValues(valueList.get(index), sensitiveEntry));
+            }
+
+            return sanitizedList;
+        }
+
+        return value;
+    }
+
+    /**
+     * Normalizes dynamic resource sensitivities (e.g., terraform_data) by propagating
+     * the 'input' sensitivity to 'output' when 'output' sensitivity is empty or unset.
+     */
+    public static Object normalizeResourceSensitivities(String resourceType, String address, Object sensitiveRaw) {
+        if (!(sensitiveRaw instanceof Map<?, ?> map)) {
+            return sensitiveRaw;
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        map.forEach((k, v) -> result.put(String.valueOf(k), v));
+
+        if ("terraform_data".equals(resourceType) || (address != null && address.contains("terraform_data."))) {
+            Object inputSensitive = result.get("input");
+            Object outputSensitive = result.get("output");
+            boolean outputIsEmpty = outputSensitive == null
+                    || (outputSensitive instanceof Map<?, ?> m && m.isEmpty())
+                    || (outputSensitive instanceof List<?> l && l.isEmpty());
+            if (inputSensitive != null && !Boolean.FALSE.equals(inputSensitive) && outputIsEmpty) {
+                result.put("output", inputSensitive);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Overload for change map entries containing 'resourceType'/'type' and 'address'.
+     */
+    public static Object normalizeResourceSensitivities(Map<String, Object> change, Object sensitiveRaw) {
+        if (change == null) {
+            return sensitiveRaw;
+        }
+        Object resourceTypeObj = change.getOrDefault("resourceType", change.get("type"));
+        String resourceType = resourceTypeObj instanceof String str ? str : null;
+        Object addressObj = change.get("address");
+        String address = addressObj instanceof String str ? str : null;
+        return normalizeResourceSensitivities(resourceType, address, sensitiveRaw);
+    }
+
+    /**
+     * Merges plan-time sensitivity metadata with state-time sensitive values.
+     */
+    public static Object mergeSensitiveMetadata(Object planSensitive, Object stateSensitive) {
+        if (Boolean.TRUE.equals(planSensitive) || Boolean.TRUE.equals(stateSensitive)) {
+            return true;
+        }
+
+        if (planSensitive instanceof Map<?, ?> || stateSensitive instanceof Map<?, ?>) {
+            Map<String, Object> merged = new HashMap<>();
+            if (planSensitive instanceof Map<?, ?> planMap) {
+                planMap.forEach((k, v) -> merged.put(String.valueOf(k), v));
+            }
+            if (stateSensitive instanceof Map<?, ?> stateMap) {
+                stateMap.forEach((k, v) -> {
+                    String stringKey = String.valueOf(k);
+                    merged.put(stringKey, mergeSensitiveMetadata(merged.get(stringKey), v));
+                });
+            }
+            return merged;
+        }
+
+        if (planSensitive instanceof List<?> || stateSensitive instanceof List<?>) {
+            List<?> planList = planSensitive instanceof List<?> list ? list : List.of();
+            List<?> stateList = stateSensitive instanceof List<?> list ? list : List.of();
+            int maxLength = Math.max(planList.size(), stateList.size());
+            List<Object> merged = new ArrayList<>();
+            for (int i = 0; i < maxLength; i++) {
+                Object planVal = i < planList.size() ? planList.get(i) : null;
+                Object stateVal = i < stateList.size() ? stateList.get(i) : null;
+                merged.add(mergeSensitiveMetadata(planVal, stateVal));
+            }
+            return merged;
+        }
+
+        return stateSensitive != null ? stateSensitive : planSensitive;
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputServiceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputServiceTest.java
@@ -19,10 +19,8 @@ class ApplyStructuredOutputServiceTest {
 
     private ApplyStructuredOutputService subject() {
         return new ApplyStructuredOutputService(
-                Mockito.mock(WorkspaceSecurity.class),
-                new ObjectMapper(),
-                "http://terrakube-api",
-                Mockito.mock(TerrakubeClient.class));
+                Mockito.mock(JobContextService.class),
+                new ObjectMapper());
     }
 
     @Test

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputServiceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputServiceTest.java
@@ -673,4 +673,71 @@ class ApplyStructuredOutputServiceTest {
         Map<?, ?> outputSensitive = (Map<?, ?>) resolvedSensitive.get("output");
         assertEquals(true, outputSensitive.get("secret_token"));
     }
+
+    @Test
+    void propagatesTerraformDataInputSensitivityToOutputWhenOutputSensitivityIsEmpty() {
+        // Reproduces the exact environment scenario where terraform_data.output has empty afterSensitive {}
+        // and state.json does not mark output sensitive in sensitive_values.
+        Map<String, Object> after = new HashMap<>();
+        after.put("id", null);
+        after.put("input", null);
+        after.put("output", null);
+
+        Map<String, Object> afterUnknown = new HashMap<>();
+        afterUnknown.put("id", true);
+        afterUnknown.put("input", Map.of("secret_token", true));
+        afterUnknown.put("output", true);
+
+        Map<String, Object> afterSensitive = new HashMap<>();
+        afterSensitive.put("input", true);
+        afterSensitive.put("output", new HashMap<>());
+
+        Map<String, Object> change = new HashMap<>();
+        change.put("address", "terraform_data.db_credentials");
+        change.put("resourceType", "terraform_data");
+        change.put("after", after);
+        change.put("afterUnknown", afterUnknown);
+        change.put("afterSensitive", afterSensitive);
+
+        String stateJson = """
+                {
+                  "values": {
+                    "root_module": {
+                      "resources": [
+                        {
+                          "address": "terraform_data.db_credentials",
+                          "values": {
+                            "id": "130fa94e-30ad-fcd3-76ee-884a8af93d42",
+                            "input": {
+                              "endpoint_port": 5432,
+                              "secret_token": "super-secret-password-123",
+                              "username": "admin"
+                            },
+                            "output": {
+                              "endpoint_port": 5432,
+                              "secret_token": "super-secret-password-123",
+                              "username": "admin"
+                            }
+                          },
+                          "sensitive_values": {
+                            "input": true
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        subject().resolveFinalValues(List.of(change), stateJson);
+
+        Map<String, Object> resolvedAfter = (Map<String, Object>) change.get("after");
+        assertEquals("130fa94e-30ad-fcd3-76ee-884a8af93d42", resolvedAfter.get("id"));
+        assertNull(resolvedAfter.get("input"));
+        assertNull(resolvedAfter.get("output"));
+
+        Map<?, ?> resolvedSensitive = (Map<?, ?>) change.get("afterSensitive");
+        assertEquals(true, resolvedSensitive.get("input"));
+        assertEquals(true, resolvedSensitive.get("output"));
+    }
 }

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputServiceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputServiceTest.java
@@ -599,4 +599,78 @@ class ApplyStructuredOutputServiceTest {
         Map<String, Object> resolvedAfterUnknown = (Map<String, Object>) change.get("afterUnknown");
         assertEquals(false, resolvedAfterUnknown.get("credentials"));
     }
+
+    @Test
+    void sanitizesDynamicallyComputedOutputsFromStateSensitiveValues() {
+        // Plan-time had empty afterSensitive for computed output, but stateJson contains
+        // post-apply sensitive_values computed by Terraform.
+        Map<String, Object> after = new HashMap<>();
+        after.put("id", null);
+        after.put("input", null);
+        after.put("output", null);
+
+        Map<String, Object> afterUnknown = new HashMap<>();
+        afterUnknown.put("id", true);
+        afterUnknown.put("input", Map.of("secret_token", true));
+        afterUnknown.put("output", true);
+
+        Map<String, Object> afterSensitive = new HashMap<>();
+        afterSensitive.put("input", true);
+        afterSensitive.put("output", new HashMap<>());
+
+        Map<String, Object> change = new HashMap<>();
+        change.put("address", "terraform_data.db_credentials");
+        change.put("after", after);
+        change.put("afterUnknown", afterUnknown);
+        change.put("afterSensitive", afterSensitive);
+
+        String stateJson = """
+                {
+                  "values": {
+                    "root_module": {
+                      "resources": [
+                        {
+                          "address": "terraform_data.db_credentials",
+                          "values": {
+                            "id": "130fa94e-30ad-fcd3-76ee-884a8af93d42",
+                            "input": {
+                              "endpoint_port": 5432,
+                              "secret_token": "super-secret-password-123",
+                              "username": "admin"
+                            },
+                            "output": {
+                              "endpoint_port": 5432,
+                              "secret_token": "super-secret-password-123",
+                              "username": "admin"
+                            }
+                          },
+                          "sensitive_values": {
+                            "input": true,
+                            "output": {
+                              "secret_token": true
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        subject().resolveFinalValues(List.of(change), stateJson);
+
+        Map<String, Object> resolvedAfter = (Map<String, Object>) change.get("after");
+        assertEquals("130fa94e-30ad-fcd3-76ee-884a8af93d42", resolvedAfter.get("id"));
+        assertNull(resolvedAfter.get("input"));
+
+        Map<?, ?> resolvedOutput = (Map<?, ?>) resolvedAfter.get("output");
+        assertEquals("admin", resolvedOutput.get("username"));
+        assertEquals(5432, resolvedOutput.get("endpoint_port"));
+        assertNull(resolvedOutput.get("secret_token"));
+
+        Map<?, ?> resolvedSensitive = (Map<?, ?>) change.get("afterSensitive");
+        assertEquals(true, resolvedSensitive.get("input"));
+        Map<?, ?> outputSensitive = (Map<?, ?>) resolvedSensitive.get("output");
+        assertEquals(true, outputSensitive.get("secret_token"));
+    }
 }

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputServiceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputServiceTest.java
@@ -452,4 +452,151 @@ class ApplyStructuredOutputServiceTest {
 
         assertEquals("applied", change.get("status"));
     }
+
+    @Test
+    void neverResolvesNestedAttributesWhenParentContainerIsSensitive() {
+        // Container-level sensitivity: afterSensitive is `true` for a parent map/block,
+        // while afterUnknown contains nested field entries.
+        Map<String, Object> after = new HashMap<>();
+        after.put("input", null);
+
+        Map<String, Object> unknownInput = new HashMap<>();
+        unknownInput.put("secret_token", true);
+        Map<String, Object> afterUnknown = new HashMap<>();
+        afterUnknown.put("input", unknownInput);
+
+        Map<String, Object> afterSensitive = new HashMap<>();
+        afterSensitive.put("input", true);
+
+        Map<String, Object> change = new HashMap<>();
+        change.put("address", "terraform_data.db_credentials");
+        change.put("after", after);
+        change.put("afterUnknown", afterUnknown);
+        change.put("afterSensitive", afterSensitive);
+
+        String stateJson = """
+                {
+                  "values": {
+                    "root_module": {
+                      "resources": [
+                        {
+                          "address": "terraform_data.db_credentials",
+                          "values": {
+                            "input": {
+                              "username": "admin",
+                              "secret_token": "super-secret-password-123",
+                              "endpoint_port": 5432
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        subject().resolveFinalValues(List.of(change), stateJson);
+
+        Map<String, Object> resolvedAfter = (Map<String, Object>) change.get("after");
+        assertNull(resolvedAfter.get("input"));
+
+        Map<String, Object> resolvedAfterUnknown = (Map<String, Object>) change.get("afterUnknown");
+        assertEquals(unknownInput, resolvedAfterUnknown.get("input"));
+    }
+
+    @Test
+    void neverResolvesNestedListAttributesWhenParentListIsSensitive() {
+        Map<String, Object> after = new HashMap<>();
+        after.put("items", null);
+
+        Map<String, Object> unknownItem = new HashMap<>();
+        unknownItem.put("key", true);
+        Map<String, Object> afterUnknown = new HashMap<>();
+        afterUnknown.put("items", new ArrayList<>(List.of(unknownItem)));
+
+        Map<String, Object> afterSensitive = new HashMap<>();
+        afterSensitive.put("items", true);
+
+        Map<String, Object> change = new HashMap<>();
+        change.put("address", "custom_resource.example");
+        change.put("after", after);
+        change.put("afterUnknown", afterUnknown);
+        change.put("afterSensitive", afterSensitive);
+
+        String stateJson = """
+                {
+                  "values": {
+                    "root_module": {
+                      "resources": [
+                        {
+                          "address": "custom_resource.example",
+                          "values": {
+                            "items": [
+                              {"key": "sensitive-item-key"}
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        subject().resolveFinalValues(List.of(change), stateJson);
+
+        Map<String, Object> resolvedAfter = (Map<String, Object>) change.get("after");
+        assertNull(resolvedAfter.get("items"));
+    }
+
+    @Test
+    void sanitizesResolvedNestedSensitiveAttributesWhenLeafIsUnknown() {
+        // Leaf unknown resolving to a map containing sensitive subfields
+        Map<String, Object> after = new HashMap<>();
+        after.put("credentials", null);
+
+        Map<String, Object> afterUnknown = new HashMap<>();
+        afterUnknown.put("credentials", true);
+
+        Map<String, Object> sensitiveCredentials = new HashMap<>();
+        sensitiveCredentials.put("secret_key", true);
+        sensitiveCredentials.put("public_id", false);
+        Map<String, Object> afterSensitive = new HashMap<>();
+        afterSensitive.put("credentials", sensitiveCredentials);
+
+        Map<String, Object> change = new HashMap<>();
+        change.put("address", "custom_vault.example");
+        change.put("after", after);
+        change.put("afterUnknown", afterUnknown);
+        change.put("afterSensitive", afterSensitive);
+
+        String stateJson = """
+                {
+                  "values": {
+                    "root_module": {
+                      "resources": [
+                        {
+                          "address": "custom_vault.example",
+                          "values": {
+                            "credentials": {
+                              "public_id": "pub-12345",
+                              "secret_key": "sec-98765"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """;
+
+        subject().resolveFinalValues(List.of(change), stateJson);
+
+        Map<String, Object> resolvedAfter = (Map<String, Object>) change.get("after");
+        Map<?, ?> resolvedCredentials = (Map<?, ?>) resolvedAfter.get("credentials");
+        assertEquals("pub-12345", resolvedCredentials.get("public_id"));
+        assertNull(resolvedCredentials.get("secret_key"));
+
+        Map<String, Object> resolvedAfterUnknown = (Map<String, Object>) change.get("afterUnknown");
+        assertEquals(false, resolvedAfterUnknown.get("credentials"));
+    }
 }

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/JobContextServiceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/JobContextServiceTest.java
@@ -1,0 +1,68 @@
+package io.terrakube.executor.service.terraform;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.organization.job.Job;
+import io.terrakube.client.model.organization.job.JobAttributes;
+import io.terrakube.client.model.response.ResponseWithInclude;
+import io.terrakube.executor.service.workspace.security.WorkspaceSecurity;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JobContextServiceTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void getCurrentContextReturnsEmptyMapWhenJobNotRunning() {
+        WorkspaceSecurity workspaceSecurity = Mockito.mock(WorkspaceSecurity.class);
+        TerrakubeClient terrakubeClient = Mockito.mock(TerrakubeClient.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        Job job = new Job();
+        job.setId("100");
+        JobAttributes attrs = new JobAttributes();
+        attrs.setStatus("completed");
+        job.setAttributes(attrs);
+
+        ResponseWithInclude<Job, ?> jobDataResponse = new ResponseWithInclude<>();
+        jobDataResponse.setData(job);
+
+        Mockito.when(terrakubeClient.getJobById("org-1", "100")).thenReturn((ResponseWithInclude) jobDataResponse);
+
+        JobContextService service = new JobContextService(workspaceSecurity, objectMapper, "http://localhost:8080", terrakubeClient);
+
+        Map<String, Object> context = service.getCurrentContext("org-1", "100");
+        assertNotNull(context);
+        assertTrue(context.isEmpty());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void saveContextDoesNotThrowWhenJobNotRunning() {
+        WorkspaceSecurity workspaceSecurity = Mockito.mock(WorkspaceSecurity.class);
+        TerrakubeClient terrakubeClient = Mockito.mock(TerrakubeClient.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        Job job = new Job();
+        job.setId("100");
+        JobAttributes attrs = new JobAttributes();
+        attrs.setStatus("failed");
+        job.setAttributes(attrs);
+
+        ResponseWithInclude<Job, ?> jobDataResponse = new ResponseWithInclude<>();
+        jobDataResponse.setData(job);
+
+        Mockito.when(terrakubeClient.getJobById("org-1", "100")).thenReturn((ResponseWithInclude) jobDataResponse);
+
+        JobContextService service = new JobContextService(workspaceSecurity, objectMapper, "http://localhost:8080", terrakubeClient);
+
+        service.saveContext("org-1", "100", Map.of("key", "value"));
+        // Should catch exception and not throw
+    }
+}
+

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/PlanStructuredOutputServiceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/PlanStructuredOutputServiceTest.java
@@ -25,9 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class PlanStructuredOutputServiceTest {
 
     private PlanStructuredOutputService subject() {
-        WorkspaceSecurity workspaceSecurity = Mockito.mock(WorkspaceSecurity.class);
-        TerrakubeClient terrakubeClient = Mockito.mock(TerrakubeClient.class);
-        return new PlanStructuredOutputService(workspaceSecurity, new ObjectMapper(), "http://terrakube-api", new TerraformClient(), terrakubeClient);
+        JobContextService jobContextService = Mockito.mock(JobContextService.class);
+        return new PlanStructuredOutputService(jobContextService, new ObjectMapper(), new TerraformClient());
     }
 
     private TerraformProcessData captureShowPlanJsonData(boolean tofu) throws Exception {
@@ -36,11 +35,9 @@ class PlanStructuredOutputServiceTest {
                 .thenReturn(CompletableFuture.completedFuture(true));
 
         PlanStructuredOutputService service = new PlanStructuredOutputService(
-                Mockito.mock(WorkspaceSecurity.class),
+                Mockito.mock(JobContextService.class),
                 new ObjectMapper(),
-                "http://terrakube-api",
-                terraformClient,
-                Mockito.mock(TerrakubeClient.class));
+                terraformClient);
 
         TerraformJob job = new TerraformJob();
         job.setJobId("1");
@@ -83,11 +80,9 @@ class PlanStructuredOutputServiceTest {
                 .thenReturn(CompletableFuture.completedFuture(true));
 
         PlanStructuredOutputService service = new PlanStructuredOutputService(
-                Mockito.mock(WorkspaceSecurity.class),
+                Mockito.mock(JobContextService.class),
                 new ObjectMapper(),
-                "http://terrakube-api",
-                terraformClient,
-                Mockito.mock(TerrakubeClient.class));
+                terraformClient);
 
         TerraformJob job = new TerraformJob();
         job.setJobId("1");
@@ -356,11 +351,9 @@ class PlanStructuredOutputServiceTest {
                 });
 
         PlanStructuredOutputService service = new PlanStructuredOutputService(
-                Mockito.mock(WorkspaceSecurity.class),
+                Mockito.mock(JobContextService.class),
                 new ObjectMapper(),
-                "http://terrakube-api",
-                terraformClient,
-                Mockito.mock(TerrakubeClient.class));
+                terraformClient);
 
         TerraformJob job = new TerraformJob();
         job.setJobId("1");
@@ -389,11 +382,9 @@ class PlanStructuredOutputServiceTest {
                 .thenReturn(CompletableFuture.completedFuture(false));
 
         PlanStructuredOutputService service = new PlanStructuredOutputService(
-                Mockito.mock(WorkspaceSecurity.class),
+                Mockito.mock(JobContextService.class),
                 new ObjectMapper(),
-                "http://terrakube-api",
-                terraformClient,
-                Mockito.mock(TerrakubeClient.class));
+                terraformClient);
 
         TerraformJob job = new TerraformJob();
         job.setJobId("1");

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformOutputsServiceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformOutputsServiceTest.java
@@ -18,10 +18,8 @@ class TerraformOutputsServiceTest {
 
     private TerraformOutputsService subject() {
         return new TerraformOutputsService(
-                Mockito.mock(WorkspaceSecurity.class),
-                new ObjectMapper(),
-                "http://terrakube-api",
-                Mockito.mock(TerrakubeClient.class));
+                Mockito.mock(JobContextService.class),
+                new ObjectMapper());
     }
 
     @Test

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformSensitivitySanitizerTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformSensitivitySanitizerTest.java
@@ -1,0 +1,150 @@
+package io.terrakube.executor.service.terraform;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TerraformSensitivitySanitizerTest {
+
+    @Test
+    void sanitizeSensitiveValuesRedactsTrueMetadataLeaves() {
+        Map<String, Object> value = Map.of(
+                "public_key", "ssh-rsa AAAAB3...",
+                "secret_key", "super-secret",
+                "nested", Map.of("sub_secret", "secret-123", "sub_public", "public-123"),
+                "list_field", List.of("item1", "item2")
+        );
+
+        Map<String, Object> sensitiveMetadata = Map.of(
+                "secret_key", true,
+                "nested", Map.of("sub_secret", true),
+                "list_field", List.of(false, true)
+        );
+
+        Object sanitizedRaw = TerraformSensitivitySanitizer.sanitizeSensitiveValues(value, sensitiveMetadata);
+        assertTrue(sanitizedRaw instanceof Map<?, ?>);
+        Map<?, ?> sanitized = (Map<?, ?>) sanitizedRaw;
+
+        assertEquals("ssh-rsa AAAAB3...", sanitized.get("public_key"));
+        assertNull(sanitized.get("secret_key"));
+
+        Map<?, ?> nested = (Map<?, ?>) sanitized.get("nested");
+        assertNull(nested.get("sub_secret"));
+        assertEquals("public-123", nested.get("sub_public"));
+
+        List<?> listField = (List<?>) sanitized.get("list_field");
+        assertEquals("item1", listField.get(0));
+        assertNull(listField.get(1));
+    }
+
+    @Test
+    void sanitizeSensitiveValuesRedactsEntireNodeWhenMetadataIsTrue() {
+        assertNull(TerraformSensitivitySanitizer.sanitizeSensitiveValues("secret-string", true));
+        assertNull(TerraformSensitivitySanitizer.sanitizeSensitiveValues(Map.of("a", 1), true));
+        assertNull(TerraformSensitivitySanitizer.sanitizeSensitiveValues(List.of(1, 2), true));
+    }
+
+    @Test
+    void sanitizeSensitiveValuesReturnsUnmodifiedWhenNotSensitive() {
+        assertEquals("plain", TerraformSensitivitySanitizer.sanitizeSensitiveValues("plain", false));
+        assertEquals("plain", TerraformSensitivitySanitizer.sanitizeSensitiveValues("plain", null));
+        assertEquals(123, TerraformSensitivitySanitizer.sanitizeSensitiveValues(123, null));
+    }
+
+    @Test
+    void normalizeResourceSensitivitiesPropagatesInputToOutputForTerraformData() {
+        Map<String, Object> sensitiveMap = new HashMap<>();
+        sensitiveMap.put("input", true);
+        sensitiveMap.put("output", new HashMap<>());
+
+        Object normalized = TerraformSensitivitySanitizer.normalizeResourceSensitivities(
+                "terraform_data", "terraform_data.example", sensitiveMap);
+
+        assertTrue(normalized instanceof Map<?, ?>);
+        Map<?, ?> result = (Map<?, ?>) normalized;
+        assertEquals(true, result.get("output"));
+        assertEquals(true, result.get("input"));
+    }
+
+    @Test
+    void normalizeResourceSensitivitiesPropagatesInputToOutputWhenAddressContainsTerraformData() {
+        Map<String, Object> sensitiveMap = new HashMap<>();
+        sensitiveMap.put("input", true);
+
+        Map<String, Object> change = Map.of("address", "module.sub.terraform_data.foo");
+        Object normalized = TerraformSensitivitySanitizer.normalizeResourceSensitivities(change, sensitiveMap);
+
+        assertTrue(normalized instanceof Map<?, ?>);
+        Map<?, ?> result = (Map<?, ?>) normalized;
+        assertEquals(true, result.get("output"));
+    }
+
+    @Test
+    void normalizeResourceSensitivitiesDoesNotOverrideExistingOutputSensitivity() {
+        Map<String, Object> sensitiveMap = new HashMap<>();
+        sensitiveMap.put("input", true);
+        sensitiveMap.put("output", Map.of("nested", true));
+
+        Object normalized = TerraformSensitivitySanitizer.normalizeResourceSensitivities(
+                "terraform_data", "terraform_data.example", sensitiveMap);
+
+        Map<?, ?> result = (Map<?, ?>) normalized;
+        assertEquals(Map.of("nested", true), result.get("output"));
+    }
+
+    @Test
+    void normalizeResourceSensitivitiesIgnoresNonTerraformDataResources() {
+        Map<String, Object> sensitiveMap = new HashMap<>();
+        sensitiveMap.put("input", true);
+
+        Object normalized = TerraformSensitivitySanitizer.normalizeResourceSensitivities(
+                "aws_instance", "aws_instance.web", sensitiveMap);
+
+        Map<?, ?> result = (Map<?, ?>) normalized;
+        assertNull(result.get("output"));
+    }
+
+    @Test
+    void mergeSensitiveMetadataCombinesPlanAndStateSensitivity() {
+        Map<String, Object> planSensitive = Map.of(
+                "field_a", true,
+                "nested", Map.of("secret_a", true)
+        );
+        Map<String, Object> stateSensitive = Map.of(
+                "field_b", true,
+                "nested", Map.of("secret_b", true)
+        );
+
+        Object mergedRaw = TerraformSensitivitySanitizer.mergeSensitiveMetadata(planSensitive, stateSensitive);
+        assertTrue(mergedRaw instanceof Map<?, ?>);
+        Map<?, ?> merged = (Map<?, ?>) mergedRaw;
+
+        assertEquals(true, merged.get("field_a"));
+        assertEquals(true, merged.get("field_b"));
+
+        Map<?, ?> nested = (Map<?, ?>) merged.get("nested");
+        assertEquals(true, nested.get("secret_a"));
+        assertEquals(true, nested.get("secret_b"));
+    }
+
+    @Test
+    void mergeSensitiveMetadataHandlesLists() {
+        List<Object> planList = List.of(true, false);
+        List<Object> stateList = List.of(false, true, true);
+
+        Object mergedRaw = TerraformSensitivitySanitizer.mergeSensitiveMetadata(planList, stateList);
+        assertTrue(mergedRaw instanceof List<?>);
+        List<?> merged = (List<?>) mergedRaw;
+
+        assertEquals(3, merged.size());
+        assertEquals(true, merged.get(0));
+        assertEquals(true, merged.get(1));
+        assertEquals(true, merged.get(2));
+    }
+}


### PR DESCRIPTION
## Description
Fixes a sensitive data exposure vulnerability in `ApplyStructuredOutputService` and `PlanStructuredOutputService` where sensitive attributes resolved from post-apply state were leaked into `applyStructuredOutput` context blobs, UI views, and SSE streams.

---

## Root Causes

1. **Container-Level Sensitivity Bypass**:
   When Terraform marks an entire block, map, or container as sensitive (`after_sensitive: true`), child keys in `after_unknown` may still be represented as structured maps (e.g. `{"input": {"secret_token": true}}`). During `resolveFinalValues()` -> `resolveUnknownRecursive()`, `afterSensitiveNode` was expected to be an instance of `Map`. When `afterSensitiveNode` was a `Boolean.TRUE`, the child sensitivity lookup defaulted to `null`, causing child leaf resolution to treat the attribute as non-sensitive and write plaintext secrets from `state.json` into `after`.

2. **Omission of State-Level `sensitive_values`**:
   `collectResourceValues()` previously only parsed `values` from `state.json` and completely ignored `sensitive_values`. Dynamic attributes whose sensitivities are calculated during apply were not recognized as sensitive.

3. **`terraform_data` Computed `output` Mirror Leak**:
   In `terraform_data` resources, `output` is a computed mirror of `input`. When `input` is wrapped in `sensitive(...)`, Terraform sets `after_sensitive.input = true` but leaves `after_sensitive.output = {}` in plan and state JSON exports. Without explicit sensitivity propagation, `resolveFinalValues()` treated `output` as non-sensitive and populated `after.output` with plaintext secrets.

---

## Changes Made

### 1. `ApplyStructuredOutputService.java`
- **Container-Level Sensitivity Guard**: In `resolveUnknownRecursive()`, if `afterSensitiveNode` is `Boolean.TRUE`, the recursion immediately returns `afterUnknownNode` without modifying `after` slots.
- **Recursive Sanitization (`sanitizeSensitiveValues`)**: Recursively traverses and sanitizes nested sensitive attributes in maps and lists when an unknown leaf resolves to a complex object.
- **State `sensitive_values` Ingestion (`collectResourceValues`)**: Collects both `values` and `sensitive_values` from `state.json`.
- **Metadata Merging (`mergeSensitiveMetadata`)**: Merges plan-time `afterSensitive` with post-apply `sensitive_values` from state.
- **Sensitivity Propagation (`normalizeResourceSensitivities`)**: Automatically propagates `input` sensitivity metadata to `output` for `terraform_data` resources when `output` sensitivity metadata is empty.

### 2. `PlanStructuredOutputService.java`
- **Plan Sensitivity Propagation**: Added `normalizeResourceSensitivities()` to propagate `input` sensitivity to `output` for `terraform_data` during plan parsing (`buildChangesFromPlanJson`), protecting `planStructuredOutput` identically.

### 3. `ApplyStructuredOutputServiceTest.java`
Added comprehensive unit test coverage:
- `neverResolvesNestedAttributesWhenParentContainerIsSensitive`: Validates map container-level sensitivity protection.
- `neverResolvesNestedListAttributesWhenParentListIsSensitive`: Validates list container-level sensitivity protection.
- `sanitizesResolvedNestedSensitiveAttributesWhenLeafIsUnknown`: Validates leaf unknown resolution with nested sensitive properties.
- `sanitizesDynamicallyComputedOutputsFromStateSensitiveValues`: Validates dynamic `sensitive_values` ingestion from `state.json`.
- `propagatesTerraformDataInputSensitivityToOutputWhenOutputSensitivityIsEmpty`: Validates automatic sensitivity inheritance for `terraform_data.output`.

---

## Reproduction Example (`main.tf`)

Can be tested using [2.33.0-beta.10](https://github.com/terrakube-io/terrakube/releases/tag/2.33.0-beta.10)

```hcl
terraform {
  required_version = ">= 1.4.0"
  required_providers {
    random = {
      source  = "hashicorp/random"
      version = "~> 3.5.0"
    }
  }
}

# 1. Generate an unknown-at-plan-time sensitive secret
resource "random_password" "db_password" {
  length  = 20
  special = true
}

# 2. Pack the unknown secret into a sensitive map
resource "terraform_data" "db_credentials" {
  input = sensitive({
    username      = "admin"
    secret_token  = random_password.db_password.result
    endpoint_port = 5432
  })
}
```

## Verification

### Automated Tests
Executed Maven test suite in executor:

```bash
mvn test -Dtest=ApplyStructuredOutputServiceTest,PlanStructuredOutputServiceTest
```

## Before change

<img width="1412" height="619" alt="imagen" src="https://github.com/user-attachments/assets/1d0ef2ba-29ee-4652-8aee-ad527bab5c76" />

## After change

<img width="1412" height="502" alt="imagen" src="https://github.com/user-attachments/assets/e04d35dd-e8dd-4b63-ae22-93b868db0713" />
