### PR TITLE
feat(ui): add target/replace resources to New Run's Additional planning options

### DIFF
--- a/api/src/main/java/io/terrakube/api/rs/hooks/job/JobManageHook.java
+++ b/api/src/main/java/io/terrakube/api/rs/hooks/job/JobManageHook.java
@@ -6,7 +6,10 @@ import com.yahoo.elide.core.security.ChangeSpec;
 import com.yahoo.elide.core.security.RequestScope;
 import io.terrakube.api.plugin.subscription.JobStatusEvent;
 import io.terrakube.api.plugin.subscription.JobStatusPublisher;
+import io.terrakube.api.repository.AddressRepository;
 import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.job.address.Address;
+import io.terrakube.api.rs.job.address.AddressType;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import io.terrakube.api.plugin.scheduler.ScheduleJobService;
@@ -16,6 +19,7 @@ import org.quartz.SchedulerException;
 
 import java.text.ParseException;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 @AllArgsConstructor
@@ -25,6 +29,7 @@ public class JobManageHook implements LifeCycleHook<Job> {
     private ScheduleJobService scheduleJobService;
     private WorkspaceRepository workspaceRepository;
     private JobStatusPublisher jobStatusPublisher;
+    private AddressRepository addressRepository;
 
     @Override
     public void execute(LifeCycleHookBinding.Operation operation, LifeCycleHookBinding.TransactionPhase transactionPhase, Job job, RequestScope requestScope, Optional<ChangeSpec> optional) {
@@ -32,6 +37,8 @@ public class JobManageHook implements LifeCycleHook<Job> {
         try {
             switch (operation){
                 case CREATE:
+                    createAddresses(job, job.getTargetAddrs(), AddressType.TARGET);
+                    createAddresses(job, job.getReplaceAddrs(), AddressType.REPLACE);
                     updateWorkspaceStatus(job);
                     scheduleJobService.createJobContext(job);
                     publishStatus(job);
@@ -57,6 +64,26 @@ public class JobManageHook implements LifeCycleHook<Job> {
 
         } catch (ParseException | SchedulerException e) {
             log.error(e.getMessage());
+        }
+    }
+
+    private void createAddresses(Job job, List<String> addressNames, AddressType type) {
+        if (addressNames == null) {
+            return;
+        }
+        for (String addressName : addressNames) {
+            if (addressName == null || addressName.isBlank()) {
+                continue;
+            }
+            Address address = new Address();
+            address.setName(addressName.trim());
+            address.setType(type);
+            address.setJob(job);
+            try {
+                addressRepository.save(address);
+            } catch (RuntimeException e) {
+                log.error("Failed to save {} address {} for job {}: {}", type, addressName, job.getId(), e.getMessage());
+            }
         }
     }
 

--- a/api/src/main/java/io/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/Job.java
@@ -21,6 +21,7 @@ import org.hibernate.annotations.SQLRestriction;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -139,6 +140,18 @@ public class Job extends GenericAuditFields {
 
     @OneToMany(mappedBy = "job", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Address> address;
+
+    // Requested target/replace resource addresses as submitted on job creation. Consumed by
+    // JobManageHook to create the corresponding Address rows (see the `address` relationship
+    // above), which is what ExecutorService actually reads to build the terraform CLI flags -
+    // these columns are a record of what was requested, not the operational source of truth.
+    @Convert(converter = StringListConverter.class)
+    @Column(name = "target_addrs")
+    private List<String> targetAddrs;
+
+    @Convert(converter = StringListConverter.class)
+    @Column(name = "replace_addrs")
+    private List<String> replaceAddrs;
 
 }
 

--- a/api/src/main/java/io/terrakube/api/rs/job/StringListConverter.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/StringListConverter.java
@@ -1,0 +1,40 @@
+package io.terrakube.api.rs.job;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.List;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        try {
+            return MAPPER.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Unable to serialize " + attribute, e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        try {
+            return MAPPER.readValue(dbData, new TypeReference<List<String>>() {
+            });
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Unable to deserialize " + dbData, e);
+        }
+    }
+}

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -119,4 +119,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-canonical-module-versions.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-variable-category-not-null.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-notification.xml" />
+    <include file="/db/changelog/local/changelog-2.33.0-job-target-replace-addrs.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-job-target-replace-addrs.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-job-target-replace-addrs.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-33-0-job-target-replace-addrs" author="jake">
+        <addColumn tableName="job">
+            <column name="target_addrs" type="text">
+                <constraints nullable="true"/>
+            </column>
+            <column name="replace_addrs" type="text">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/rs/hooks/job/JobManageHookTest.java
+++ b/api/src/test/java/io/terrakube/api/rs/hooks/job/JobManageHookTest.java
@@ -4,20 +4,31 @@ import com.yahoo.elide.annotation.LifeCycleHookBinding;
 import io.terrakube.api.plugin.scheduler.ScheduleJobService;
 import io.terrakube.api.plugin.subscription.JobStatusEvent;
 import io.terrakube.api.plugin.subscription.JobStatusPublisher;
+import io.terrakube.api.repository.AddressRepository;
 import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.rs.Organization;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.address.Address;
+import io.terrakube.api.rs.job.address.AddressType;
 import io.terrakube.api.rs.workspace.Workspace;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class JobManageHookTest {
@@ -30,6 +41,9 @@ class JobManageHookTest {
 
     @Mock
     JobStatusPublisher jobStatusPublisher;
+
+    @Mock
+    AddressRepository addressRepository;
 
     @Test
     void publishesOnUpdate() throws Exception {
@@ -48,7 +62,7 @@ class JobManageHookTest {
         job.setOrganization(organization);
         job.setStatus(JobStatus.running);
 
-        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher);
+        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher, addressRepository);
         hook.execute(LifeCycleHookBinding.Operation.UPDATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, job, null, Optional.empty());
 
         verify(jobStatusPublisher).publish(new JobStatusEvent(42, workspaceId.toString(), "running"), organizationId.toString());
@@ -71,9 +85,120 @@ class JobManageHookTest {
         job.setOrganization(organization);
         job.setStatus(JobStatus.pending);
 
-        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher);
+        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher, addressRepository);
         hook.execute(LifeCycleHookBinding.Operation.CREATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, job, null, Optional.empty());
 
         verify(jobStatusPublisher).publish(new JobStatusEvent(43, workspaceId.toString(), "pending"), organizationId.toString());
+    }
+
+    @Test
+    void createsTargetAndReplaceAddressesOnCreate() throws Exception {
+        UUID workspaceId = UUID.randomUUID();
+        Workspace workspace = new Workspace();
+        workspace.setId(workspaceId);
+        workspace.setOrganization(new Organization());
+
+        UUID organizationId = UUID.randomUUID();
+        Organization organization = new Organization();
+        organization.setId(organizationId);
+
+        Job job = new Job();
+        job.setId(44);
+        job.setWorkspace(workspace);
+        job.setOrganization(organization);
+        job.setStatus(JobStatus.pending);
+        job.setTargetAddrs(List.of("aws_instance.foo"));
+        job.setReplaceAddrs(List.of("aws_instance.bar", "module.baz.aws_instance.qux"));
+
+        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher, addressRepository);
+        hook.execute(LifeCycleHookBinding.Operation.CREATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, job, null, Optional.empty());
+
+        ArgumentCaptor<Address> captor = ArgumentCaptor.forClass(Address.class);
+        verify(addressRepository, times(3)).save(captor.capture());
+
+        List<Address> saved = captor.getAllValues();
+        assertEquals(1, saved.stream().filter(a -> a.getType() == AddressType.TARGET && a.getName().equals("aws_instance.foo")).count());
+        assertEquals(1, saved.stream().filter(a -> a.getType() == AddressType.REPLACE && a.getName().equals("aws_instance.bar")).count());
+        assertEquals(1, saved.stream().filter(a -> a.getType() == AddressType.REPLACE && a.getName().equals("module.baz.aws_instance.qux")).count());
+        saved.forEach(a -> assertEquals(job, a.getJob()));
+    }
+
+    @Test
+    void doesNotCreateAddressesWhenNoneProvidedOnCreate() throws Exception {
+        UUID workspaceId = UUID.randomUUID();
+        Workspace workspace = new Workspace();
+        workspace.setId(workspaceId);
+        workspace.setOrganization(new Organization());
+
+        UUID organizationId = UUID.randomUUID();
+        Organization organization = new Organization();
+        organization.setId(organizationId);
+
+        Job job = new Job();
+        job.setId(45);
+        job.setWorkspace(workspace);
+        job.setOrganization(organization);
+        job.setStatus(JobStatus.pending);
+
+        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher, addressRepository);
+        hook.execute(LifeCycleHookBinding.Operation.CREATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, job, null, Optional.empty());
+
+        verify(addressRepository, never()).save(any());
+    }
+
+    @Test
+    void skipsBlankAndNullAddressNames() throws Exception {
+        UUID workspaceId = UUID.randomUUID();
+        Workspace workspace = new Workspace();
+        workspace.setId(workspaceId);
+        workspace.setOrganization(new Organization());
+
+        UUID organizationId = UUID.randomUUID();
+        Organization organization = new Organization();
+        organization.setId(organizationId);
+
+        Job job = new Job();
+        job.setId(46);
+        job.setWorkspace(workspace);
+        job.setOrganization(organization);
+        job.setStatus(JobStatus.pending);
+        job.setTargetAddrs(Arrays.asList(" aws_instance.foo ", "", "   ", null));
+
+        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher, addressRepository);
+        hook.execute(LifeCycleHookBinding.Operation.CREATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, job, null, Optional.empty());
+
+        ArgumentCaptor<Address> captor = ArgumentCaptor.forClass(Address.class);
+        verify(addressRepository, times(1)).save(captor.capture());
+        assertEquals("aws_instance.foo", captor.getValue().getName());
+    }
+
+    @Test
+    void schedulesJobEvenWhenAnAddressFailsToSave() throws Exception {
+        UUID workspaceId = UUID.randomUUID();
+        Workspace workspace = new Workspace();
+        workspace.setId(workspaceId);
+        workspace.setOrganization(new Organization());
+
+        UUID organizationId = UUID.randomUUID();
+        Organization organization = new Organization();
+        organization.setId(organizationId);
+
+        Job job = new Job();
+        job.setId(47);
+        job.setWorkspace(workspace);
+        job.setOrganization(organization);
+        job.setStatus(JobStatus.pending);
+        job.setTargetAddrs(List.of("aws_instance.foo", "aws_instance.bar"));
+
+        when(addressRepository.save(any()))
+                .thenThrow(new RuntimeException("constraint violation"))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher, addressRepository);
+        hook.execute(LifeCycleHookBinding.Operation.CREATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, job, null, Optional.empty());
+
+        verify(addressRepository, times(2)).save(any());
+        verify(scheduleJobService).createJobContext(job);
+        verify(jobStatusPublisher).publish(new JobStatusEvent(47, workspaceId.toString(), "pending"), organizationId.toString());
     }
 }

--- a/ui/src/domain/Jobs/Create.tsx
+++ b/ui/src/domain/Jobs/Create.tsx
@@ -1,10 +1,11 @@
 import { DeleteOutlined, InfoCircleOutlined, PlayCircleOutlined } from "@ant-design/icons";
-import { Button, Form, Input, Modal, Select, Space, Tooltip, message, Typography } from "antd";
-import { useEffect, useState } from "react";
+import { Button, Collapse, Form, Input, Modal, Select, Space, Tooltip, message, Typography } from "antd";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { ORGANIZATION_ARCHIVE, WORKSPACE_ARCHIVE } from "../../config/actionTypes";
 import axiosInstance from "../../config/axiosConfig";
-import { Template } from "../types";
+import { Resource, Template } from "../types";
+import { buildResourceOptions } from "../Workspaces/workspaceDataUtils";
 
 const validateMessages = { required: "${label} is required!" };
 
@@ -14,14 +15,19 @@ type Props = {
   // When set, "Run now" is disabled and this message explains why (e.g. a CLI/API
   // workspace that has no applied configuration to re-run yet).
   disabledReason?: string;
+  // The workspace's current state resources, offered as selectable options for
+  // Target/Replace resources below (in addition to freely typing an address).
+  resources?: Resource[];
 };
 
 type CreateJobForm = {
   templateId: string;
   branchName: string;
+  targetAddrs?: string[];
+  replaceAddrs?: string[];
 };
 
-export const CreateJob = ({ changeJob, planJob = true, disabledReason }: Props) => {
+export const CreateJob = ({ changeJob, planJob = true, disabledReason, resources }: Props) => {
   const navigate = useNavigate();
   const workspaceId = sessionStorage.getItem(WORKSPACE_ARCHIVE);
   const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
@@ -32,6 +38,7 @@ export const CreateJob = ({ changeJob, planJob = true, disabledReason }: Props) 
   const [branchName, setBranchName] = useState([]);
   const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const resourceOptions = useMemo(() => buildResourceOptions(resources ?? []), [resources]);
 
   const onCancel = () => {
     setVisible(false);
@@ -77,6 +84,8 @@ export const CreateJob = ({ changeJob, planJob = true, disabledReason }: Props) 
           templateReference: values.templateId,
           overrideBranch: values.branchName,
           via: "UI",
+          targetAddrs: values.targetAddrs?.length ? values.targetAddrs : undefined,
+          replaceAddrs: values.replaceAddrs?.length ? values.replaceAddrs : undefined,
         },
         relationships: {
           workspace: {
@@ -181,6 +190,43 @@ export const CreateJob = ({ changeJob, planJob = true, disabledReason }: Props) 
             >
               <Input />
             </Form.Item>
+            <Collapse
+              ghost
+              items={[
+                {
+                  key: "additionalPlanningOptions",
+                  label: "Additional planning options",
+                  children: (
+                    <>
+                      <Form.Item
+                        name="targetAddrs"
+                        label="Target resources"
+                        tooltip="Limit the plan to these resource addresses and their dependencies, e.g. aws_instance.example or module.foo.aws_instance.bar. Type an address and press Enter to add it."
+                      >
+                        <Select
+                          mode="tags"
+                          tokenSeparators={[","]}
+                          placeholder="Select or type a resource address"
+                          options={resourceOptions}
+                        />
+                      </Form.Item>
+                      <Form.Item
+                        name="replaceAddrs"
+                        label="Replace resources"
+                        tooltip="Force replacement of these resource addresses on the next apply, e.g. aws_instance.example or module.foo.aws_instance.bar. Type an address and press Enter to add it."
+                      >
+                        <Select
+                          mode="tags"
+                          tokenSeparators={[","]}
+                          placeholder="Select or type a resource address"
+                          options={resourceOptions}
+                        />
+                      </Form.Item>
+                    </>
+                  ),
+                },
+              ]}
+            />
           </Form>
         </Space>
       </Modal>

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -876,6 +876,7 @@ export const WorkspaceDetails = ({
                   <CreateJob
                     changeJob={changeJob}
                     planJob={planJob}
+                    resources={resources}
                     disabledReason={
                       workspace.attributes.source === "empty" &&
                       workspace.attributes.branch === "remote-content"

--- a/ui/src/domain/Workspaces/__tests__/workspaceDataUtils.test.ts
+++ b/ui/src/domain/Workspaces/__tests__/workspaceDataUtils.test.ts
@@ -1,0 +1,44 @@
+import { buildResourceOptions, getResourceAddress } from "../workspaceDataUtils";
+import { Resource } from "../../types";
+
+const baseResource: Resource = {
+  name: "example",
+  provider: "registry.terraform.io/hashicorp/random",
+  type: "random_pet",
+  values: {},
+  depends_on: "",
+  showDrawer: () => {},
+};
+
+describe("getResourceAddress", () => {
+  it("returns type.name for a root module resource", () => {
+    const resource = { ...baseResource, module: "root_module" };
+    expect(getResourceAddress(resource)).toBe("random_pet.example");
+  });
+
+  it("returns module.address.type.name for a child module resource", () => {
+    const resource = { ...baseResource, module: "module.instances" };
+    expect(getResourceAddress(resource)).toBe("module.instances.random_pet.example");
+  });
+});
+
+describe("buildResourceOptions", () => {
+  it("sorts options alphabetically by address, regardless of input order", () => {
+    const resources = [
+      { ...baseResource, name: "zebra", module: "root_module" },
+      { ...baseResource, name: "alpha", module: "root_module" },
+      { ...baseResource, name: "middle", module: "root_module" },
+    ];
+
+    expect(buildResourceOptions(resources).map((option) => option.value)).toEqual([
+      "random_pet.alpha",
+      "random_pet.middle",
+      "random_pet.zebra",
+    ]);
+  });
+
+  it("returns matching value and label for each resource", () => {
+    const resources = [{ ...baseResource, name: "example", module: "root_module" }];
+    expect(buildResourceOptions(resources)).toEqual([{ value: "random_pet.example", label: "random_pet.example" }]);
+  });
+});

--- a/ui/src/domain/Workspaces/workspaceDataUtils.ts
+++ b/ui/src/domain/Workspaces/workspaceDataUtils.ts
@@ -1,10 +1,37 @@
 import { AxiosInstance } from "axios";
 import { DateTime } from "luxon";
 import { ORGANIZATION_ARCHIVE, WORKSPACE_ARCHIVE } from "../../config/actionTypes";
-import { FlatJob, FlatJobHistory, FlatVariable, Schedule, Template, VcsType, StateOutputValue } from "../types";
+import {
+  FlatJob,
+  FlatJobHistory,
+  FlatVariable,
+  Resource,
+  Schedule,
+  Template,
+  VcsType,
+  StateOutputValue,
+} from "../types";
 import { getIaCNameById } from "./Workspaces";
 
 export type StateOutputVariableWithName = { name: string } & StateOutputValue;
+
+// parseState/parseOldState mark root-module resources with module: "root_module" (not a real
+// terraform address prefix), while child-module resources carry the module's actual address
+// (e.g. "module.foo"). Reconstructs the full terraform resource address either way.
+export function getResourceAddress(resource: Resource): string {
+  const typeAndName = `${resource.type}.${resource.name}`;
+  return resource.module && resource.module !== "root_module" ? `${resource.module}.${typeAndName}` : typeAndName;
+}
+
+// Sorted alphabetically so a dropdown built from these options is browsable, not just
+// searchable - state-parse order is otherwise root-module-first then per-module insertion
+// order, which is meaningless to a user scanning the list.
+export function buildResourceOptions(resources: Resource[]): { value: string; label: string }[] {
+  return resources
+    .map((resource) => getResourceAddress(resource))
+    .sort((a, b) => a.localeCompare(b))
+    .map((address) => ({ value: address, label: address }));
+}
 
 export const include = {
   VARIABLE: "variable",

--- a/ui/src/domain/types.ts
+++ b/ui/src/domain/types.ts
@@ -541,6 +541,7 @@ export type Resource = {
   name: string;
   provider: string;
   type: string;
+  module?: string;
   values: Record<string, any>;
   depends_on: string;
   showDrawer: (data: Resource) => void;


### PR DESCRIPTION
## Summary
Closes #3408

Adds Terraform Cloud's [Replace/Target resources](https://developer.hashicorp.com/terraform/cloud-docs/workspaces/run/modes-and-options#replacing-selected-resources) option to the native **New Run** dialog, under a new "Additional planning options" section — letting users target or force-replace specific resource addresses on a plan, matching Terraform Cloud's UX.

The backend/executor already supported `-target=`/`-replace=` via the TFE-compatible CLI/API run-creation path (`RemoteTfeService`). This PR wires the same capability into the native UI's job-creation flow, which didn't have it before.

## Screenshot
<img width="554" height="384" alt="image" src="https://github.com/user-attachments/assets/a8797224-18b1-4c16-8d91-279e74b17dc0" />
<img width="530" height="741" alt="image" src="https://github.com/user-attachments/assets/abfc653c-ab83-45c4-81fa-2711600d0219" />
<img width="530" height="650" alt="image" src="https://github.com/user-attachments/assets/3e672656-6515-46ee-a737-9f57cdef8ba4" />
<img width="890" height="1254" alt="image" src="https://github.com/user-attachments/assets/4e234ec0-d234-42f5-863b-783dff4ea32a" />
<img width="912" height="591" alt="image" src="https://github.com/user-attachments/assets/393d85e7-d121-4fb5-ae9e-2a8573607606" />


## Changes

### Backend

- **`Job`**: adds persisted `target_addrs` / `replace_addrs` columns (JSON-encoded via a new `StringListConverter`), populated from the job-creation request and consumed once by `JobManageHook`.
  - An earlier `@Transient`-field version of this was silently invisible to Elide's entity dictionary in this app's actual Spring+JPA wiring and never worked at all — caught via live testing against the running API before merge, not by static review. Switched to real persisted columns to fix it for good.
- **`JobManageHook`**: on job `CREATE`, creates the corresponding `Address` rows (`AddressType.TARGET` / `REPLACE`) — same mechanism `ExecutorService` already uses to build `TF_CLI_ARGS_plan` for the CLI/API path, so no executor changes were needed.
  - Blank/null address entries are filtered out (defends against the UI's free-text tag input).
  - Per-address save failures are isolated (try/catch per item) so one bad address can't strand a job in `pending` with nothing scheduled.
- New Liquibase migration (`changelog-2.33.0-job-target-replace-addrs.xml`) for the two new nullable `job` columns.

### Frontend

- **`Create.tsx`**: new collapsible "Additional planning options" section with tag inputs for target/replace resource addresses. Options are offered as autocomplete from the workspace's actual state resources (sorted alphabetically, virtualized dropdown) in addition to free typing for resources not yet in state.
- **`workspaceDataUtils.ts`**: `getResourceAddress` / `buildResourceOptions` helpers to turn parsed state resources into sorted `{value, label}` options, reused by `Create.tsx`.
- **`types.ts`**: `Resource` gains a `module` field (already present at runtime, just wasn't typed).
- `resourceOptions` is memoized (`useMemo`) so it doesn't recompute on every unrelated re-render.

### Tests

- New/expanded `JobManageHookTest` coverage: address creation for target/replace, blank/null filtering, and failure-isolation (one bad address doesn't block scheduling).
- New `workspaceDataUtils.test.ts` for the address/option-building helpers.
- Full backend suite (794 tests) and frontend suite (390 tests) pass.

## Verification

Beyond unit tests, this was verified live against a running cluster (not just mocked):

- Confirmed via Elide's live OpenAPI schema that the original `@Transient` approach never registered the fields — the real defect behind switching to persisted columns.
- Created a job through the exact native endpoint the UI calls, with `targetAddrs`/`replaceAddrs` set — confirmed the correct `Address` rows were created and linked.
- Ran a real (plan-only, no changes applied) `terraform plan` through the executor against a real VCS-backed workspace — Terraform itself printed `Warning: Resource targeting is in effect`, confirming the flags reach the actual CLI invocation end-to-end.

## Known limitations / follow-ups (not addressed here)

- `RemoteTfeService`'s CLI/API run-creation path has its own, separate Address-creation loop with different failure semantics (hard-fails on a bad address vs. this path's lenient skip-blank behavior for free-typed UI input) — not merged, to avoid changing behavior on that more sensitive, already-shipped path.
- The resource dropdown sorts lexicographically, not numerically — a `for_each`/`count`-generated set like `worker[10]` vs `worker[2]` won't sort numerically. Fine for typing to filter; would need natural-sort if browsing indexed resources becomes a real pain point.
- No module-grouping in the dropdown (flat sorted list) — matches Terraform Cloud's own UI, which is a plain text field with no grouping either.