### PR TITLE
feat(benchmarks): add automated performance analysis and A/B benchmarking suite for Terrakube Registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,21 @@ variables.auto.tfvars
 liquibase.properties
 
 ui/.yarn/install-state.gz
+
+# Python bytecode and caches
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# Benchmark results and reports
+benchmarks/results/
+benchmark-results/

--- a/benchmarks/registry/README.md
+++ b/benchmarks/registry/README.md
@@ -1,0 +1,171 @@
+# Terrakube Registry Performance Benchmark Suite
+
+This directory contains an automated, reproducible performance analysis and benchmarking suite for the **Terrakube Registry** component.
+
+It supports both **A/B comparative evaluations** between container images (e.g. `azbuilder/open-registry:2.33.0-beta.10` vs `azbuilder/open-registry:2.33.0-beta.10-alpaquita`) and **single-image baseline profiling** when no candidate is specified.
+
+---
+
+## 1. Overview & Architecture
+
+The benchmark harness tests all 7 methods across the 4 core registry controllers:
+
+| Controller | Method | Path | Workload Characteristic |
+| :--- | :--- | :--- | :--- |
+| **`WellKnownWebServiceImpl`** | `GET` | `/.well-known/terraform.json` | Discovery JSON templating (Fast CPU/Memory) |
+| **`ModuleWebServiceImpl`** | `GET` | `/terraform/modules/v1/{org}/{module}/{provider}/versions` | Database query + JSON serialization |
+| **`ModuleWebServiceImpl`** | `GET` | `/terraform/modules/v1/{org}/{module}/{provider}/{version}/download` | DB count increment + `X-Terraform-Get` header |
+| **`ModuleWebServiceImpl`** | `GET` | `/terraform/modules/v1/download/{org}/{module}/{provider}/{version}/module.zip` | Binary zip streaming (SeaweedFS S3) |
+| **`ProviderWebServiceImpl`** | `GET` | `/terraform/providers/v1/{org}/{provider}/versions` | GraphQL/DB provider version listing |
+| **`ProviderWebServiceImpl`** | `GET` | `/terraform/providers/v1/{org}/{provider}/{version}/download/{os}/{arch}` | Provider SHA256 & GPG download metadata |
+| **`ReadMeWebServiceImpl`** | `GET` | `/terraform/readme/v1/{org}/{module}/{provider}/{version}/download` | In-memory ZIP uncompress + Markdown read |
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Engineer as Engineer / CLI
+    participant Harness as Benchmark Runner (Python)
+    participant Reg as Terrakube Registry Pod (:8075)
+    participant Otel as OpenTelemetry JavaAgent (:9464)
+    participant Prom as Prometheus (:9090)
+
+    Engineer->>Harness: python3 run_benchmark.py [options]
+    Harness->>Reg: Deploy Baseline Image & Measure Startup Time
+    Harness->>Reg: Warm-up JVM
+    loop Concurrency Stages (5 -> 10 -> 25 Workers)
+        Harness->>Reg: Concurrent Load on 7 Endpoints
+        Note over Harness,Prom: Background thread collects Prometheus snapshots every 10s
+    end
+    Harness->>Prom: Query Final JVM Snapshot
+    opt A/B mode (--candidate provided)
+        Harness->>Reg: Deploy Candidate Image & Repeat Battery
+    end
+    Harness->>Engineer: Generate Per-Endpoint Bar Charts (SVGs) & REGISTRY_PERFORMANCE_ANALYSIS.md
+```
+
+---
+
+## 2. Prerequisites
+
+1. **Python 3.8+** (Uses standard library; no external dependencies required).
+2. **SSH Access** to the MicroK8s host (`user@192.168.1.150` by default — override with `--ssh-host`).
+3. **Network Access** to `https://terrakube-reg.microk8s.net` (or override with `--registry-url`).
+4. **Authentication**: A valid bearer token supplied via `--token $TERRAKUBE_TOKEN_BENCHMARK` (required).
+
+---
+
+## 3. How to Execute the Benchmark
+
+### A. Baseline-Only Profile (no candidate)
+Profiles a single image without A/B comparison. All 4 charts and the report show only the baseline series:
+
+```bash
+cd /home/user/git/terrakube-io/terrakube/benchmarks/registry
+python3 run_benchmark.py \
+  --registry-url https://terrakube-reg.microk8s.net \
+  --token $TERRAKUBE_TOKEN_BENCHMARK \
+  --baseline azbuilder/open-registry:2.33.0-beta.10
+```
+
+### B. Full A/B Comparison
+Executes automated rolling deployment of Baseline, runs the test battery, rolls out Candidate, runs the identical battery, restores the baseline image, and outputs a complete Markdown report with time-series SVG charts:
+
+```bash
+python3 run_benchmark.py \
+  --registry-url https://terrakube-reg.microk8s.net \
+  --token $TERRAKUBE_TOKEN_BENCHMARK \
+  --baseline azbuilder/open-registry:2.33.0-beta.10 \
+  --candidate azbuilder/open-registry:2.33.0-beta.10-alpaquita
+```
+
+### C. Use Plain `kubectl` Instead of `microk8s kubectl`
+Pass `--kubectl-cmd kubectl` to target a standard cluster:
+
+```bash
+python3 run_benchmark.py \
+  --kubectl-cmd kubectl \
+  --ssh-host user@192.168.1.150 \
+  --token $TERRAKUBE_TOKEN_BENCHMARK
+```
+
+### D. Quick Smoke Test (5s per stage, 10 workers)
+Quick verification that all 7 endpoints, database fixtures, and telemetry queries are operational:
+
+```bash
+python3 run_benchmark.py --quick --token $TERRAKUBE_TOKEN_BENCHMARK
+```
+
+### E. Test Active Pod Without Triggering Image Rollouts
+
+```bash
+python3 run_benchmark.py \
+  --skip-deploy \
+  --registry-url https://terrakube-reg.microk8s.net \
+  --token $TERRAKUBE_TOKEN_BENCHMARK \
+  --workers 5 10 25 \
+  --stage-duration 15
+```
+
+### F. Custom Concurrency and Duration
+
+```bash
+python3 run_benchmark.py \
+  --workers 5 10 25 \
+  --stage-duration 20 \
+  --warmup 15 \
+  --telemetry-interval 10 \
+  --output-dir /home/user/git/terrakube-io/terrakube/benchmarks/results
+```
+
+---
+
+## 4. Command-Line Arguments Reference
+
+| Argument | Default | Description |
+| :--- | :--- | :--- |
+| `--registry-url` | `https://terrakube-reg.microk8s.net` | Registry base URL |
+| `--token` | _(required)_ | Bearer token for authenticated endpoints. Pass via `--token $TERRAKUBE_TOKEN_BENCHMARK`. |
+| `--ssh-host` | `user@192.168.1.150` | MicroK8s SSH target host |
+| `--kubectl-cmd` | `microk8s kubectl` | kubectl command (`"microk8s kubectl"` or `"kubectl"`) |
+| `--baseline` | `azbuilder/open-registry:2.33.0-beta.10` | Baseline container image tag |
+| `--candidate` | _(none — baseline-only mode)_ | Candidate container image tag for A/B comparison |
+| `--restore-image` | `azbuilder/open-registry:2.33.0-beta.10` | Image to restore when benchmark completes |
+| `--workers` | `5 10 25` | Concurrency worker stages |
+| `--stage-duration` | `15` | Test duration in seconds per stage |
+| `--warmup` | `10` | Warm-up duration in seconds per pod |
+| `--warmup-exclusion` | `3` | Duration in seconds discarded at the start of each stage (JIT warmup exclusion) |
+| `--telemetry-interval` | `10` | Seconds between background Prometheus snapshots |
+| `--skip-deploy` | `False` | Skip `kubectl set image` rollouts |
+| `--quick` | `False` | Quick 5-second smoke test (10 workers only) |
+| `--output-dir` | `../results` | Directory to save reports and diagrams |
+
+---
+
+## 5. Output Artifacts
+
+After each run, the suite produces:
+1. **`REGISTRY_PERFORMANCE_ANALYSIS.md`**: Complete performance report with summary tables, latency percentiles (p50, p90, p95, p99), stddev, min/max, throughput (RPS & MB/s), error rates, optional delta calculations (`%` speedup/regression), and telemetry insights.
+2. **`latency_comparison_p95_p99.svg`**: Grouped bar chart — one sub-panel per concurrency level (5w / 10w / 25w), showing p50 / p90 / p95 / p99 bars for each of the 7 endpoints side-by-side.
+3. **`throughput_vs_concurrency.svg`**: Grouped bar chart — one sub-panel per concurrency level, showing the RPS achieved by each endpoint individually.
+4. **`throughput_bytes_sec.svg`**: Grouped bar chart — one sub-panel per concurrency level, showing data transfer throughput (MB/s) for each endpoint individually.
+5. **`jvm_memory_and_gc.svg`**: JVM heap memory, committed memory, GC pause duration, container RSS, and JVM CPU utilization % **over time** (periodic Prometheus snapshots collected every `--telemetry-interval` seconds during the run).
+6. **`container_cpu_and_startup.svg`**: Image size and cold-start bar panels + RSS memory time-series chart.
+
+---
+
+## 6. Directory Structure
+
+```
+terrakube/benchmarks/
+├── registry/
+│   ├── README.md             # This guide
+│   ├── config.py             # Endpoint and cluster configurations
+│   ├── seeder.py             # PostgreSQL and S3 test fixture seeder
+│   ├── k8s_manager.py        # Remote MicroK8s image deployment & startup timing
+│   ├── telemetry.py          # Prometheus & OpenTelemetry metric collector (with time-series support)
+│   ├── load_generator.py     # Concurrent HTTP load engine (latency/status tracker)
+│   ├── visualizer.py         # SVG time-series chart generator
+│   ├── reporter.py           # Markdown report compiler (baseline-only & A/B modes)
+│   └── run_benchmark.py      # Main CLI executable
+└── results/                  # Generated reports and SVG diagrams
+```

--- a/benchmarks/registry/config.py
+++ b/benchmarks/registry/config.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Configuration for Terrakube Registry Performance Benchmark Suite.
+Defines endpoints, concurrency stages (10, 25, 50 workers), image versions, and cluster parameters.
+"""
+
+import os
+from dataclasses import dataclass, field
+from typing import List, Dict
+
+@dataclass
+class EndpointConfig:
+    name: str
+    controller: str
+    method: str
+    path: str
+    authenticated: bool
+    expected_status: int
+    description: str
+
+@dataclass
+class BenchmarkConfig:
+    # Cluster and SSH connection
+    ssh_host: str = "user@192.168.1.150"
+    kubectl_cmd: str = "microk8s kubectl"
+    registry_base_url: str = "https://terrakube-reg.microk8s.net"
+    prometheus_url: str = "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090"
+    otel_metrics_port: int = 9464
+    k8s_namespace: str = "terrakube"
+    deployment_name: str = "terrakube-registry"
+
+    # Container Images to Compare
+    baseline_image: str = "azbuilder/open-registry:2.33.0-beta.10"
+    candidate_image: str = "azbuilder/open-registry:2.33.0-beta.10-alpaquita"
+
+    # Concurrency and Load Stages: 5, 10, 25 workers
+    warmup_duration_seconds: int = 15
+    stage_duration_seconds: int = 20
+    concurrency_stages: List[int] = field(default_factory=lambda: [5, 10, 25])
+
+
+
+    # Output paths
+    output_dir: str = field(default_factory=lambda: os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "benchmark-results")))
+
+    # 7 Registry Endpoints across the 4 Controllers
+    endpoints: List[EndpointConfig] = field(default_factory=lambda: [
+        EndpointConfig(
+            name="well_known",
+            controller="WellKnownWebServiceImpl",
+            method="GET",
+            path="/.well-known/terraform.json",
+            authenticated=False,
+            expected_status=200,
+            description="Service discovery (.well-known/terraform.json)"
+        ),
+        EndpointConfig(
+            name="module_versions",
+            controller="ModuleWebServiceImpl",
+            method="GET",
+            path="/terraform/modules/v1/aws/vpc/aws/versions",
+            authenticated=True,
+            expected_status=200,
+            description="List module versions (DB query + JSON response)"
+        ),
+        EndpointConfig(
+            name="module_download_redirect",
+            controller="ModuleWebServiceImpl",
+            method="GET",
+            path="/terraform/modules/v1/aws/vpc/aws/5.7.2/download",
+            authenticated=True,
+            expected_status=204,
+            description="Module download redirect (DB write + X-Terraform-Get header)"
+        ),
+        EndpointConfig(
+            name="module_zip_stream",
+            controller="ModuleWebServiceImpl",
+            method="GET",
+            path="/terraform/modules/v1/download/aws/vpc/aws/5.7.2/module.zip",
+            authenticated=False,
+            expected_status=200,
+            description="Download module binary zip (SeaweedFS S3 storage stream)"
+        ),
+        EndpointConfig(
+            name="provider_versions",
+            controller="ProviderWebServiceImpl",
+            method="GET",
+            path="/terraform/providers/v1/simple/benchmark/versions",
+            authenticated=True,
+            expected_status=200,
+            description="List provider versions & platforms (GraphQL/DB query)"
+        ),
+        EndpointConfig(
+            name="provider_download_meta",
+            controller="ProviderWebServiceImpl",
+            method="GET",
+            path="/terraform/providers/v1/simple/benchmark/1.0.0/download/linux/amd64",
+            authenticated=True,
+            expected_status=200,
+            description="Provider package download metadata (SHA256 & GPG keys)"
+        ),
+        EndpointConfig(
+            name="readme_markdown",
+            controller="ReadMeWebServiceImpl",
+            method="GET",
+            path="/terraform/readme/v1/aws/vpc/aws/5.7.2/download",
+            authenticated=True,
+            expected_status=200,
+            description="Module README extraction (In-memory zip uncompress + MD read)"
+        ),
+    ])
+
+DEFAULT_CONFIG = BenchmarkConfig()

--- a/benchmarks/registry/k8s_manager.py
+++ b/benchmarks/registry/k8s_manager.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""
+Kubernetes and Container Lifecycle Manager for Terrakube Benchmark Suite.
+Handles remote image switching via MicroK8s (or plain kubectl), measuring rollout
+cold-start duration, and capturing pod metadata.
+"""
+
+import subprocess
+import time
+from typing import Tuple, Dict, Any, Optional
+
+
+class K8sManager:
+    def __init__(
+        self,
+        ssh_host: str = "user@192.168.1.150",
+        namespace: str = "terrakube",
+        deployment: str = "terrakube-registry",
+        kubectl_cmd: str = "microk8s kubectl",
+        registry_base_url: str = "https://terrakube-reg.microk8s.net",
+    ):
+        self.ssh_host = ssh_host
+        self.namespace = namespace
+        self.deployment = deployment
+        self.kubectl_cmd = kubectl_cmd
+        self.registry_base_url = registry_base_url
+
+    def _run_cmd(self, cmd_str: str, timeout: int = 60) -> Tuple[int, str, str]:
+        full_cmd = f'ssh -o ConnectTimeout=10 {self.ssh_host} "{cmd_str}"'
+        res = subprocess.run(full_cmd, shell=True, capture_output=True, text=True, timeout=timeout)
+        return res.returncode, res.stdout.strip(), res.stderr.strip()
+
+    def get_current_image(self) -> str:
+        cmd = (
+            f"{self.kubectl_cmd} get deployment {self.deployment} -n {self.namespace}"
+            f" -o jsonpath='{{.spec.template.spec.containers[0].image}}'"
+        )
+        code, out, _ = self._run_cmd(cmd)
+        if code == 0:
+            return out
+        return ""
+
+    def get_pod_name(self) -> str:
+        cmd = (
+            f"{self.kubectl_cmd} get pods -n {self.namespace}"
+            f" -l app.kubernetes.io/name=terrakube"
+            f" -l app.kubernetes.io/component={self.deployment}"
+            f" -o jsonpath='{{.items[0].metadata.name}}'"
+        )
+        code, out, _ = self._run_cmd(cmd)
+        if code == 0:
+            return out
+        return ""
+
+    def deploy_image(self, image_tag: str, timeout_seconds: int = 120) -> Tuple[bool, float, str]:
+        """
+        Deploys an image tag to the registry deployment and measures time to readiness (cold start).
+        Returns: (success, startup_seconds, pod_name)
+        """
+        current = self.get_current_image()
+        print(f"[*] Deploying image: {image_tag} (Current: {current})")
+
+        start_time = time.time()
+        set_cmd = (
+            f"{self.kubectl_cmd} set image deployment/{self.deployment}"
+            f" {self.deployment}={image_tag} -n {self.namespace}"
+        )
+        code, _, err = self._run_cmd(set_cmd)
+        if code != 0:
+            return False, 0.0, f"Failed to set image: {err}"
+
+        rollout_cmd = (
+            f"{self.kubectl_cmd} rollout status deployment/{self.deployment}"
+            f" -n {self.namespace} --timeout={timeout_seconds}s"
+        )
+        code, out, err = self._run_cmd(rollout_cmd, timeout=timeout_seconds + 10)
+        elapsed = time.time() - start_time
+
+        if code == 0 and "successfully rolled out" in out:
+            pod_name = self.get_pod_name()
+            print(f"[✓] Rollout complete in {elapsed:.2f}s! Active pod: {pod_name}")
+            return True, elapsed, pod_name
+        else:
+            return False, elapsed, f"Rollout failed or timed out: {err or out}"
+
+    def get_image_size_mb(self, image_tag: str) -> float:
+        """
+        Calculates image size in MB on the remote host via docker inspect.
+        """
+        cmd = f"docker inspect {image_tag} --format='{{{{.Size}}}}' 2>/dev/null || echo 0"
+        code, out, _ = self._run_cmd(cmd)
+        if code == 0 and out.isdigit():
+            return round(int(out) / (1024 * 1024), 2)
+        return 0.0
+
+    def warm_up_pod(self, duration_seconds: int = 15):
+        """
+        Executes warm-up requests to trigger JIT compilation and class loading.
+        Uses the registry_base_url configured at construction time.
+        """
+        import urllib.request
+        import ssl
+
+        target_url = f"{self.registry_base_url}/.well-known/terraform.json"
+        print(f"[*] Warming up registry JVM for {duration_seconds}s...")
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
+        end_time = time.time() + duration_seconds
+        req_count = 0
+        while time.time() < end_time:
+            try:
+                req = urllib.request.Request(target_url, headers={"User-Agent": "Terrakube-Benchmark-Warmup"})
+                with urllib.request.urlopen(req, context=ctx, timeout=2) as resp:
+                    resp.read()
+                    req_count += 1
+            except Exception:
+                pass
+            time.sleep(0.05)
+        print(f"[✓] Warmup complete ({req_count} requests executed).")

--- a/benchmarks/registry/load_generator.py
+++ b/benchmarks/registry/load_generator.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+High-Performance Concurrent Load Generator for Terrakube Benchmark Suite.
+Executes stepped load testing against Registry endpoints and records latency percentiles.
+"""
+
+import time
+import ssl
+import math
+import statistics
+import urllib.request
+import urllib.error
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import List, Dict, Any, Optional, Tuple
+
+from config import EndpointConfig
+
+@dataclass
+class StageResult:
+    endpoint_name: str
+    controller: str
+    concurrency: int
+    duration_seconds: float
+    total_requests: int
+    successful_requests: int
+    failed_requests: int
+    status_codes: Dict[int, int]
+    rps: float
+    latency_p50_ms: float
+    latency_p90_ms: float
+    latency_p95_ms: float
+    latency_p99_ms: float
+    latency_avg_ms: float
+    latency_min_ms: float
+    latency_max_ms: float
+    latency_stddev_ms: float
+    total_bytes_transferred: int
+    throughput_bytes_sec: float = 0.0
+    error_rate_pct: float = 0.0
+    error_samples: List[str] = field(default_factory=list)
+
+def _percentile(sorted_list: List[float], pct: float) -> float:
+    if not sorted_list:
+        return 0.0
+    k = (len(sorted_list) - 1) * (pct / 100.0)
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return sorted_list[int(k)]
+    d0 = sorted_list[int(f)] * (c - k)
+    d1 = sorted_list[int(c)] * (k - f)
+    return d0 + d1
+
+class LoadGenerator:
+    def __init__(self, base_url: str = "https://terrakube-reg.microk8s.net", jwt_token: str = ""):
+        self.base_url = base_url.rstrip("/")
+        self.jwt_token = jwt_token
+        self.ssl_context = ssl.create_default_context()
+        self.ssl_context.check_hostname = False
+        self.ssl_context.verify_mode = ssl.CERT_NONE
+
+    def _execute_worker_loop(self, url: str, headers: Dict[str, str], end_time: float) -> List[Tuple[float, float, int, int, Optional[str]]]:
+        """
+        Worker thread loop running until end_time.
+        Returns list of (start_ts, latency_ms, status_code, byte_count, error_msg).
+        """
+        results = []
+        while time.time() < end_time:
+            t_req_start = time.time()
+            t0 = time.perf_counter()
+            req = urllib.request.Request(url, headers=headers)
+            try:
+                with urllib.request.urlopen(req, context=self.ssl_context, timeout=5) as resp:
+                    data = resp.read()
+                    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+                    results.append((t_req_start, elapsed_ms, resp.status, len(data), None))
+            except urllib.error.HTTPError as e:
+                elapsed_ms = (time.perf_counter() - t0) * 1000.0
+                results.append((t_req_start, elapsed_ms, e.code, 0, None))
+            except Exception as ex:
+                elapsed_ms = (time.perf_counter() - t0) * 1000.0
+                results.append((t_req_start, elapsed_ms, 0, 0, str(ex)))
+        return results
+
+    def run_stage(self, endpoint: EndpointConfig, concurrency: int, duration_seconds: int, warmup_exclusion_seconds: int = 3) -> StageResult:
+        """
+        Executes a load testing stage with `concurrency` concurrent workers for `duration_seconds`.
+        Discards the first `warmup_exclusion_seconds` of requests to filter out JIT/connection warm-up spikes.
+        """
+        warmup_ex = min(warmup_exclusion_seconds, max(0, duration_seconds - 1)) if duration_seconds > 1 else 0
+        if warmup_ex > 0:
+            print(f"    -> Running {endpoint.name} ({endpoint.controller}) @ {concurrency} workers for {duration_seconds}s (ignoring first {warmup_ex}s warmup)...")
+        else:
+            print(f"    -> Running {endpoint.name} ({endpoint.controller}) @ {concurrency} workers for {duration_seconds}s...")
+
+        url = f"{self.base_url}{endpoint.path}"
+        headers = {
+            "User-Agent": "Terrakube-Benchmark/1.0",
+            "Accept": "application/json, application/octet-stream, */*",
+        }
+        if endpoint.authenticated and self.jwt_token:
+            headers["Authorization"] = f"Bearer {self.jwt_token}"
+
+        start_time = time.time()
+        end_time = start_time + duration_seconds
+
+        all_records = []
+        with ThreadPoolExecutor(max_workers=concurrency) as executor:
+            futures = [
+                executor.submit(self._execute_worker_loop, url, headers, end_time)
+                for _ in range(concurrency)
+            ]
+            for f in futures:
+                all_records.extend(f.result())
+
+        total_elapsed = time.time() - start_time
+        effective_start = start_time + warmup_ex
+        effective_duration = max(total_elapsed - warmup_ex, 0.001)
+
+        # Filter out records during warmup exclusion window
+        measured_records = [
+            (lat_ms, status, byte_cnt, err)
+            for (req_start, lat_ms, status, byte_cnt, err) in all_records
+            if req_start >= effective_start
+        ] if warmup_ex > 0 else [
+            (lat_ms, status, byte_cnt, err)
+            for (_, lat_ms, status, byte_cnt, err) in all_records
+        ]
+
+        total_requests = len(measured_records)
+
+        latencies = []
+        status_codes = {}
+        successful_requests = 0
+        failed_requests = 0
+        total_bytes = 0
+        error_samples = []
+
+        for lat_ms, status, byte_cnt, err in measured_records:
+            latencies.append(lat_ms)
+            status_codes[status] = status_codes.get(status, 0) + 1
+            total_bytes += byte_cnt
+
+            if status == endpoint.expected_status or (endpoint.expected_status == 200 and status in (200, 204)):
+                successful_requests += 1
+            else:
+                failed_requests += 1
+                if err and len(error_samples) < 5:
+                    error_samples.append(err)
+
+        latencies.sort()
+        rps = round(total_requests / effective_duration, 2) if effective_duration > 0 else 0.0
+        p50 = round(_percentile(latencies, 50), 2)
+        p90 = round(_percentile(latencies, 90), 2)
+        p95 = round(_percentile(latencies, 95), 2)
+        p99 = round(_percentile(latencies, 99), 2)
+        avg = round(statistics.mean(latencies), 2) if latencies else 0.0
+        min_lat = round(min(latencies), 2) if latencies else 0.0
+        max_lat = round(max(latencies), 2) if latencies else 0.0
+        stddev = round(statistics.stdev(latencies), 2) if len(latencies) > 1 else 0.0
+        throughput_bytes_sec = round(total_bytes / effective_duration, 2) if effective_duration > 0 else 0.0
+        error_rate_pct = round((failed_requests / total_requests * 100), 2) if total_requests > 0 else 0.0
+
+        mb_sec = throughput_bytes_sec / (1024 * 1024)
+        print(f"       [Result] RPS: {rps:.1f} | Throughput: {mb_sec:.2f} MB/s | p50: {p50:.1f}ms | p95: {p95:.1f}ms | p99: {p99:.1f}ms | Errors: {failed_requests}/{total_requests} ({error_rate_pct}%)")
+
+        return StageResult(
+            endpoint_name=endpoint.name,
+            controller=endpoint.controller,
+            concurrency=concurrency,
+            duration_seconds=round(effective_duration, 2),
+            total_requests=total_requests,
+            successful_requests=successful_requests,
+            failed_requests=failed_requests,
+            status_codes=status_codes,
+            rps=rps,
+            latency_p50_ms=p50,
+            latency_p90_ms=p90,
+            latency_p95_ms=p95,
+            latency_p99_ms=p99,
+            latency_avg_ms=avg,
+            latency_min_ms=min_lat,
+            latency_max_ms=max_lat,
+            latency_stddev_ms=stddev,
+            total_bytes_transferred=total_bytes,
+            throughput_bytes_sec=throughput_bytes_sec,
+            error_rate_pct=error_rate_pct,
+            error_samples=error_samples
+        )

--- a/benchmarks/registry/reporter.py
+++ b/benchmarks/registry/reporter.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+Performance Analysis Report Compiler for Terrakube Registry.
+Generates comprehensive Markdown report with summary tables, latency percentiles,
+throughput (RPS), optional delta calculations (%), and telemetry insights.
+Candidate image is fully optional — when omitted a baseline-only report is produced.
+"""
+
+import os
+from datetime import datetime
+from typing import Dict, Any, List, Optional
+
+
+class ReportCompiler:
+    def __init__(self, output_dir: str):
+        self.output_dir = output_dir
+
+    def _calc_delta(self, baseline: float, candidate: float, higher_is_better: bool = False) -> str:
+        if baseline == 0:
+            return "N/A"
+        diff = ((candidate - baseline) / baseline) * 100
+        sign = "+" if diff > 0 else ""
+        if diff == 0:
+            return "0.0%"
+        if (higher_is_better and diff > 0) or (not higher_is_better and diff < 0):
+            return f"**{sign}{diff:.1f}%** 🟢"
+        else:
+            return f"**{sign}{diff:.1f}%** 🔴"
+
+    def compile_report(
+        self,
+        baseline_image: str,
+        b_startup: float,
+        b_size: float,
+        b_telemetry: Dict[str, Any],
+        b_results: List[Any],
+        candidate_image: Optional[str] = None,
+        c_startup: Optional[float] = None,
+        c_size: Optional[float] = None,
+        c_telemetry: Optional[Dict[str, Any]] = None,
+        c_results: Optional[List[Any]] = None,
+        registry_url: str = "https://terrakube-reg.microk8s.net",
+        ssh_host: str = "user@192.168.1.150",
+    ) -> str:
+        report_path = os.path.join(self.output_dir, "REGISTRY_PERFORMANCE_ANALYSIS.md")
+        now_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S UTC")
+        ab_mode = candidate_image is not None
+
+        title = (
+            f"# Terrakube Registry Performance Analysis: {baseline_image} vs {candidate_image}"
+            if ab_mode
+            else f"# Terrakube Registry Performance Analysis: {baseline_image}"
+        )
+
+        lines = [
+            title,
+            "",
+            f"> **Report Generated**: {now_str}  ",
+            f"> **Environment**: MicroK8s Remote Cluster (`{ssh_host}`)  ",
+            f"> **Registry URL**: `{registry_url}`  ",
+            f"> **Baseline Image**: `{baseline_image}`  ",
+        ]
+        if ab_mode:
+            lines.append(f"> **Candidate Image**: `{candidate_image}`  ")
+        lines += [
+            "",
+            "---",
+            "",
+            "## 1. Executive Summary",
+            "",
+        ]
+
+        if ab_mode:
+            lines += [
+                "A comprehensive A/B performance evaluation was conducted comparing the baseline image against "
+                "the candidate image across all 7 controller endpoints under stepped concurrency, "
+                "while continuously gathering OpenTelemetry and Prometheus runtime metrics.",
+                "",
+                "### Key Highlights:",
+            ]
+            if b_size and c_size is not None:
+                lines.append(f"- **Container Disk Footprint**: Candidate: **{c_size:.1f} MB** vs Baseline: **{b_size:.1f} MB** ({self._calc_delta(b_size, c_size, False)}).")
+            if b_startup and c_startup is not None:
+                lines.append(f"- **Cold Startup to Ready**: Candidate initialized in **{c_startup:.2f}s** vs **{b_startup:.2f}s** ({self._calc_delta(b_startup, c_startup, higher_is_better=False)}).")
+            if c_telemetry:
+                lines.append(f"- **JVM Heap Footprint Under Load**: Heap memory utilized was **{c_telemetry.get('heap_used_mb', 0):.1f} MB** vs **{b_telemetry.get('heap_used_mb', 0):.1f} MB** ({self._calc_delta(b_telemetry.get('heap_used_mb', 0), c_telemetry.get('heap_used_mb', 0), False)}).")
+                lines.append(f"- **GC Pause Total Duration**: {c_telemetry.get('gc_duration_seconds_total', 0)*1000:.1f}ms (Candidate) vs {b_telemetry.get('gc_duration_seconds_total', 0)*1000:.1f}ms (Baseline).")
+        else:
+            lines += [
+                "A baseline-only performance evaluation was conducted against all 7 controller endpoints "
+                "under stepped concurrency, while continuously gathering OpenTelemetry and Prometheus runtime metrics.",
+                "",
+                "### Baseline Highlights:",
+                f"- **Container Disk Footprint**: **{b_size:.1f} MB**." if b_size else "",
+                f"- **Cold Startup to Ready**: **{b_startup:.2f}s**." if b_startup else "",
+                f"- **JVM Heap Under Load**: **{b_telemetry.get('heap_used_mb', 0):.1f} MB** heap used.",
+                f"- **GC Pause Total**: **{b_telemetry.get('gc_duration_seconds_total', 0)*1000:.1f} ms**.",
+            ]
+
+        lines += [
+            "",
+            "---",
+            "",
+            "## 2. Architecture & Benchmark Telemetry Pipeline",
+            "",
+            "```mermaid",
+            "sequenceDiagram",
+            "    autonumber",
+            "    actor Harness as Python Benchmark Harness",
+            "    participant Reg as Terrakube Registry Pod (:8075)",
+            "    participant Otel as OpenTelemetry JavaAgent (:9464)",
+            "    participant S3 as SeaweedFS S3 Storage",
+            "    participant DB as CloudNativePG PostgreSQL",
+            "    participant Prom as Prometheus (:9090)",
+            "",
+            "    Note over Harness,Prom: Stepped Load Generation (workers staged)",
+            "    Harness->>Reg: HTTP Requests (WellKnown, Modules, Providers, ReadMe)",
+            "    Reg->>DB: SQL Queries & Download Counter Updates",
+            "    Reg->>S3: Binary Module Zip Streaming & In-Memory Unzip",
+            "    Reg->>Otel: Record JVM, Memory, Threads & Latency Metrics",
+            "    Otel->>Prom: Expose /metrics on Port 9464",
+            "    Harness->>Prom: Query Prometheus Instant & Window Telemetry",
+            "```",
+            "",
+            "---",
+            "",
+            "## 3. Container & Operating System Footprint",
+            "",
+        ]
+
+        if ab_mode:
+            lines += [
+                "| Metric | Baseline | Candidate | Delta (%) | Status |",
+                "| :--- | :--- | :--- | :--- | :--- |",
+                f"| **Image Size on Disk** | `{b_size:.1f} MB` | `{c_size:.1f} MB` | {self._calc_delta(b_size, c_size, False)} | {'🟢 Smaller' if (c_size or 0) <= b_size else '🔴 Larger'} |",
+                f"| **Cold Startup to Ready** | `{b_startup:.2f} s` | `{c_startup:.2f} s` | {self._calc_delta(b_startup, c_startup, False)} | {'🟢 Faster' if (c_startup or 0) <= b_startup else '🟡 Comparable'} |",
+                f"| **Container RSS Working Set** | `{b_telemetry.get('container_memory_rss_mb', 0):.1f} MB` | `{(c_telemetry or {}).get('container_memory_rss_mb', 0):.1f} MB` | {self._calc_delta(b_telemetry.get('container_memory_rss_mb', 0), (c_telemetry or {}).get('container_memory_rss_mb', 0), False)} | {'🟢 Efficient' if (c_telemetry or {}).get('container_memory_rss_mb', 0) <= b_telemetry.get('container_memory_rss_mb', 0) else '🟡 Normal'} |",
+            ]
+        else:
+            lines += [
+                "| Metric | Baseline |",
+                "| :--- | :--- |",
+                f"| **Image Size on Disk** | `{b_size:.1f} MB` |",
+                f"| **Cold Startup to Ready** | `{b_startup:.2f} s` |",
+                f"| **Container RSS Working Set** | `{b_telemetry.get('container_memory_rss_mb', 0):.1f} MB` |",
+            ]
+
+        lines += [
+            "",
+            "---",
+            "",
+            "## 4. JVM Runtime & Garbage Collection Telemetry",
+            "",
+        ]
+
+        if ab_mode:
+            lines += [
+                "| Metric | Baseline | Candidate | Delta (%) |",
+                "| :--- | :--- | :--- | :--- |",
+                f"| **JVM Heap Used** | `{b_telemetry.get('heap_used_mb', 0):.1f} MB` | `{(c_telemetry or {}).get('heap_used_mb', 0):.1f} MB` | {self._calc_delta(b_telemetry.get('heap_used_mb', 0), (c_telemetry or {}).get('heap_used_mb', 0), False)} |",
+                f"| **JVM Heap Committed** | `{b_telemetry.get('heap_committed_mb', 0):.1f} MB` | `{(c_telemetry or {}).get('heap_committed_mb', 0):.1f} MB` | {self._calc_delta(b_telemetry.get('heap_committed_mb', 0), (c_telemetry or {}).get('heap_committed_mb', 0), False)} |",
+                f"| **JVM Non-Heap (Metaspace)** | `{b_telemetry.get('non_heap_used_mb', 0):.1f} MB` | `{(c_telemetry or {}).get('non_heap_used_mb', 0):.1f} MB` | {self._calc_delta(b_telemetry.get('non_heap_used_mb', 0), (c_telemetry or {}).get('non_heap_used_mb', 0), False)} |",
+                f"| **Total GC Pause Time** | `{b_telemetry.get('gc_duration_seconds_total', 0)*1000:.1f} ms` | `{(c_telemetry or {}).get('gc_duration_seconds_total', 0)*1000:.1f} ms` | {self._calc_delta(b_telemetry.get('gc_duration_seconds_total', 0), (c_telemetry or {}).get('gc_duration_seconds_total', 0), False)} |",
+                f"| **Average GC Pause Duration** | `{b_telemetry.get('gc_avg_pause_ms', 0):.2f} ms` | `{(c_telemetry or {}).get('gc_avg_pause_ms', 0):.2f} ms` | {self._calc_delta(b_telemetry.get('gc_avg_pause_ms', 0), (c_telemetry or {}).get('gc_avg_pause_ms', 0), False)} |",
+                f"| **Total GC Cycle Count** | `{b_telemetry.get('gc_count_total', 0)}` | `{(c_telemetry or {}).get('gc_count_total', 0)}` | {self._calc_delta(b_telemetry.get('gc_count_total', 0), (c_telemetry or {}).get('gc_count_total', 0), False)} |",
+                f"| **Live Thread Count** | `{b_telemetry.get('thread_count', 0)}` | `{(c_telemetry or {}).get('thread_count', 0)}` | {self._calc_delta(b_telemetry.get('thread_count', 0), (c_telemetry or {}).get('thread_count', 0), False)} |",
+            ]
+        else:
+            lines += [
+                "| Metric | Baseline |",
+                "| :--- | :--- |",
+                f"| **JVM Heap Used** | `{b_telemetry.get('heap_used_mb', 0):.1f} MB` |",
+                f"| **JVM Heap Committed** | `{b_telemetry.get('heap_committed_mb', 0):.1f} MB` |",
+                f"| **JVM Non-Heap (Metaspace)** | `{b_telemetry.get('non_heap_used_mb', 0):.1f} MB` |",
+                f"| **Total GC Pause Time** | `{b_telemetry.get('gc_duration_seconds_total', 0)*1000:.1f} ms` |",
+                f"| **Average GC Pause Duration** | `{b_telemetry.get('gc_avg_pause_ms', 0):.2f} ms` |",
+                f"| **Total GC Cycle Count** | `{b_telemetry.get('gc_count_total', 0)}` |",
+                f"| **Live Thread Count** | `{b_telemetry.get('thread_count', 0)}` |",
+            ]
+
+        lines += [
+            "",
+            "---",
+            "",
+            "## 5. Per-Endpoint Benchmark Results across Concurrency Levels",
+            "",
+        ]
+
+        # ── table header ──
+        if ab_mode:
+            lines += [
+                "| Endpoint | Controller | Workers | Baseline RPS | Candidate RPS | RPS Delta | Baseline MB/s | Candidate MB/s | MB/s Delta | Baseline p95 (ms) | Candidate p95 (ms) | p95 Delta | Baseline p99 (ms) | Candidate p99 (ms) | Base Errors | Cand Errors |",
+                "| :--- | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |",
+            ]
+            b_dict = {(r.endpoint_name, r.concurrency): r for r in b_results}
+            c_dict = {(r.endpoint_name, r.concurrency): r for r in (c_results or [])}
+            for (ep_name, conc), b_r in sorted(b_dict.items(), key=lambda x: (x[0][0], x[0][1])):
+                c_r = c_dict.get((ep_name, conc), b_r)
+                b_mb_s = (b_r.throughput_bytes_sec / (1024 * 1024)) if getattr(b_r, 'throughput_bytes_sec', 0) > 0 else ((b_r.total_bytes_transferred / b_r.duration_seconds) / (1024 * 1024) if b_r.duration_seconds > 0 else 0.0)
+                c_mb_s = (c_r.throughput_bytes_sec / (1024 * 1024)) if getattr(c_r, 'throughput_bytes_sec', 0) > 0 else ((c_r.total_bytes_transferred / c_r.duration_seconds) / (1024 * 1024) if c_r.duration_seconds > 0 else 0.0)
+                rps_delta = self._calc_delta(b_r.rps, c_r.rps, higher_is_better=True)
+                mb_delta = self._calc_delta(b_mb_s, c_mb_s, higher_is_better=True)
+                p95_delta = self._calc_delta(b_r.latency_p95_ms, c_r.latency_p95_ms, higher_is_better=False)
+                lines.append(
+                    f"| `{ep_name}` | `{b_r.controller}` | {conc} | {b_r.rps:.1f} | {c_r.rps:.1f} | {rps_delta} | {b_mb_s:.2f} | {c_mb_s:.2f} | {mb_delta} | {b_r.latency_p95_ms:.1f} | {c_r.latency_p95_ms:.1f} | {p95_delta} | {b_r.latency_p99_ms:.1f} | {c_r.latency_p99_ms:.1f} | {b_r.failed_requests}/{b_r.total_requests} | {c_r.failed_requests}/{c_r.total_requests} |"
+                )
+        else:
+            lines += [
+                "| Endpoint | Controller | Workers | RPS | MB/s | p50 (ms) | p90 (ms) | p95 (ms) | p99 (ms) | StdDev (ms) | Min/Max (ms) | Errors |",
+                "| :--- | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |",
+            ]
+            b_dict = {(r.endpoint_name, r.concurrency): r for r in b_results}
+            for (ep_name, conc), b_r in sorted(b_dict.items(), key=lambda x: (x[0][0], x[0][1])):
+                b_mb_s = (b_r.throughput_bytes_sec / (1024 * 1024)) if getattr(b_r, 'throughput_bytes_sec', 0) > 0 else ((b_r.total_bytes_transferred / b_r.duration_seconds) / (1024 * 1024) if b_r.duration_seconds > 0 else 0.0)
+                err_str = f"{b_r.failed_requests}/{b_r.total_requests} ({b_r.error_rate_pct:.1f}%)" if hasattr(b_r, 'error_rate_pct') else f"{b_r.failed_requests}/{b_r.total_requests}"
+                lines.append(
+                    f"| `{ep_name}` | `{b_r.controller}` | {conc} | {b_r.rps:.1f} | {b_mb_s:.2f} | {b_r.latency_p50_ms:.1f} | {b_r.latency_p90_ms:.1f} | {b_r.latency_p95_ms:.1f} | {b_r.latency_p99_ms:.1f} | {b_r.latency_stddev_ms:.1f} | {b_r.latency_min_ms:.1f}/{b_r.latency_max_ms:.1f} | {err_str} |"
+                )
+
+        lines += [
+            "",
+            "---",
+            "",
+            "## 6. Visual Performance Diagrams",
+            "",
+            "### Latency Percentiles (p50 / p90 / p95 / p99) per Endpoint",
+            "_Grouped bar chart — one sub-panel per concurrency level, 4 bars (p50/p90/p95/p99) per endpoint._",
+            "![Latency Comparison](file://" + os.path.join(self.output_dir, "latency_comparison_p95_p99.svg") + ")",
+            "",
+            "### Throughput (RPS) per Endpoint across Concurrency Levels",
+            "_One sub-panel per concurrency level — RPS bar per endpoint._",
+            "![Throughput Scaling](file://" + os.path.join(self.output_dir, "throughput_vs_concurrency.svg") + ")",
+            "",
+            "### Throughput (MB/s) per Endpoint across Concurrency Levels",
+            "_One sub-panel per concurrency level — MB/s bar per endpoint._",
+            "![Throughput Bytes](file://" + os.path.join(self.output_dir, "throughput_bytes_sec.svg") + ")",
+            "",
+            "### JVM Heap Memory & Garbage Collection — Over Time",
+            "![JVM Footprint](file://" + os.path.join(self.output_dir, "jvm_memory_and_gc.svg") + ")",
+            "",
+            "### Container Footprint & RSS Memory — Over Time",
+            "![Container Footprint](file://" + os.path.join(self.output_dir, "container_cpu_and_startup.svg") + ")",
+            "",
+            "---",
+            "",
+            "## 7. Conclusions & Observations",
+            "",
+        ]
+
+        if ab_mode:
+            lines += [
+                "1. **Container Density & Resource Footprint**: Compare disk footprint and startup metrics above to evaluate deployment density trade-offs.",
+                "2. **Throughput & Latency Resilience**: Review per-endpoint p95/p99 latency and RPS delta columns for regression or improvement signals.",
+                "3. **JVM Runtime Behavior**: Time-series charts reveal GC pressure patterns and heap growth under sustained concurrency load.",
+                "",
+            ]
+        else:
+            lines += [
+                "1. **Baseline Profile Established**: Use these results as the reference for future A/B candidate comparisons.",
+                "2. **JVM Runtime Behavior**: Time-series charts reveal GC pressure patterns and heap growth under sustained concurrency load.",
+                "3. **Re-run with Candidate**: Add `--candidate <image>` to run a comparative A/B analysis against this baseline.",
+                "",
+            ]
+
+        report_content = "\n".join(lines)
+        with open(report_path, "w", encoding="utf-8") as f:
+            f.write(report_content)
+        return report_path

--- a/benchmarks/registry/run_benchmark.py
+++ b/benchmarks/registry/run_benchmark.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+Terrakube Registry Performance Benchmark Runner.
+Automated CLI orchestrator for load-testing all 7 registry controller endpoints
+with OpenTelemetry and Prometheus integration.
+
+Supports:
+  - Configurable registry URL (--registry-url)
+  - Bearer token injection (--token), bypassing JWT generation
+  - Flexible kubectl command (--kubectl-cmd)
+  - Optional A/B candidate comparison (--candidate); omit for baseline-only mode
+  - Time-series telemetry collection (periodic snapshots every 10s)
+"""
+
+import os
+import sys
+import time
+import argparse
+import threading
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from config import DEFAULT_CONFIG, BenchmarkConfig
+
+from seeder import ensure_test_fixtures
+from k8s_manager import K8sManager
+from telemetry import TelemetryExtractor
+from load_generator import LoadGenerator, StageResult
+from visualizer import Visualizer
+from reporter import ReportCompiler
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Terrakube Registry Performance Benchmark Runner",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # ── connection / auth ──────────────────────────────────────────────────
+    parser.add_argument(
+        "--registry-url",
+        default=DEFAULT_CONFIG.registry_base_url,
+        help="Registry base URL (e.g. https://terrakube-reg.microk8s.net)",
+    )
+    parser.add_argument(
+        "--token",
+        required=True,
+        metavar="BEARER_TOKEN",
+        help=(
+            "Bearer token for authenticated endpoints (required). "
+            "Tip: pass via environment variable: --token $TERRAKUBE_TOKEN_BENCHMARK"
+        ),
+    )
+    parser.add_argument(
+        "--ssh-host",
+        default=DEFAULT_CONFIG.ssh_host,
+        help="Remote MicroK8s SSH target (e.g. user@192.168.1.150)",
+    )
+    parser.add_argument(
+        "--kubectl-cmd",
+        default=DEFAULT_CONFIG.kubectl_cmd,
+        metavar="CMD",
+        help='kubectl command to use (e.g. "microk8s kubectl" or "kubectl")',
+    )
+
+    # ── images ─────────────────────────────────────────────────────────────
+    parser.add_argument(
+        "--baseline",
+        default=DEFAULT_CONFIG.baseline_image,
+        help="Baseline Docker image tag",
+    )
+    parser.add_argument(
+        "--candidate",
+        default=None,
+        help=(
+            "Candidate Docker image tag for A/B comparison. "
+            "If omitted, only the baseline is tested (baseline-only mode)."
+        ),
+    )
+    parser.add_argument(
+        "--restore-image",
+        default=DEFAULT_CONFIG.baseline_image,
+        help="Image to restore when benchmark completes (ignored in baseline-only mode)",
+    )
+
+    # ── load profile ───────────────────────────────────────────────────────
+    parser.add_argument("--workers", nargs="+", type=int, default=[5, 10, 25], help="Concurrency worker stages")
+    parser.add_argument("--stage-duration", type=int, default=15, help="Duration in seconds per worker stage")
+    parser.add_argument("--warmup", type=int, default=10, help="Warmup duration in seconds")
+    parser.add_argument(
+        "--warmup-exclusion",
+        type=int,
+        default=3,
+        help="Duration in seconds discarded at the start of each stage to exclude JIT warm-up noise",
+    )
+
+    # ── execution control ──────────────────────────────────────────────────
+    parser.add_argument("--skip-deploy", action="store_true", help="Skip kubectl set image rollouts (test active pod)")
+    parser.add_argument("--quick", action="store_true", help="Quick mode: 5s per stage, 10 workers only")
+    parser.add_argument("--output-dir", default="", help="Directory for reports and SVG diagrams")
+    parser.add_argument(
+        "--telemetry-interval",
+        type=int,
+        default=10,
+        help="Seconds between background telemetry snapshots (time-series charts)",
+    )
+
+    args = parser.parse_args()
+
+    # ── resolve settings ───────────────────────────────────────────────────
+    output_dir = args.output_dir or os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "results")
+    )
+    os.makedirs(output_dir, exist_ok=True)
+
+    stages = [10] if args.quick else args.workers
+    stage_duration = 5 if args.quick else args.stage_duration
+    warmup_duration = 5 if args.quick else args.warmup
+    ab_mode = args.candidate is not None
+
+    # ── banner ─────────────────────────────────────────────────────────────
+    print("=" * 80)
+    print("      TERRAKUBE REGISTRY PERFORMANCE ANALYSIS ENGINE")
+    print("=" * 80)
+    print(f"[*] Registry URL:      {args.registry_url}")
+    print(f"[*] SSH Host:          {args.ssh_host}")
+    print(f"[*] kubectl command:   {args.kubectl_cmd}")
+    print(f"[*] Mode:              {'A/B Comparison' if ab_mode else 'Baseline-only'}")
+    print(f"[*] Baseline Image:    {args.baseline}")
+    if ab_mode:
+        print(f"[*] Candidate Image:   {args.candidate}")
+    print(f"[*] Concurrency Steps: {stages} workers")
+    print(f"[*] Stage Duration:    {stage_duration}s per endpoint")
+    print(f"[*] Output Directory:  {output_dir}")
+    print("=" * 80)
+
+    # ── 1. Test fixtures ───────────────────────────────────────────────────
+    print("\n[Step 1/6] Validating and Seeding Test Fixtures...")
+    ok, msg = ensure_test_fixtures(args.ssh_host)
+    if ok:
+        print(f"[✓] {msg}")
+    else:
+        print(f"[!] Seeding warning: {msg}")
+
+    # ── 2. Authentication ──────────────────────────────────────────────────
+    print("\n[Step 2/6] Preparing Bearer Token...")
+    if not args.token.strip():
+        print("[✗] ERROR: --token must not be empty. Aborting.")
+        sys.exit(1)
+    jwt_token = args.token
+    print("[✓] Using provided --token as Bearer token.")
+
+    # ── infrastructure objects ─────────────────────────────────────────────
+    k8s = K8sManager(
+        ssh_host=args.ssh_host,
+        namespace=DEFAULT_CONFIG.k8s_namespace,
+        deployment=DEFAULT_CONFIG.deployment_name,
+        kubectl_cmd=args.kubectl_cmd,
+        registry_base_url=args.registry_url,
+    )
+    telemetry = TelemetryExtractor(
+        ssh_host=args.ssh_host,
+        prom_service=DEFAULT_CONFIG.prometheus_url,
+        kubectl_cmd=args.kubectl_cmd,
+    )
+    load_gen = LoadGenerator(base_url=args.registry_url, jwt_token=jwt_token)
+
+    # ── helper: execute one full test battery ──────────────────────────────
+    def run_image_test_battery(image_name: str) -> tuple:
+        """
+        Deploys (if requested), warms up, runs stepped load against all endpoints,
+        and collects time-series telemetry snapshots in the background.
+
+        Returns: (startup_sec, size_mb, final_metrics_snapshot, results, timeseries)
+        """
+        print("\n" + "-" * 75)
+        print(f"[*] EXECUTING TEST BATTERY FOR: {image_name}")
+        print("-" * 75)
+
+        startup_sec = 0.0
+        if not args.skip_deploy:
+            success, startup_sec, info = k8s.deploy_image(image_name)
+            if not success:
+                print(f"[!] Error deploying {image_name}: {info}")
+            time.sleep(3)
+        else:
+            print("[*] Skipping deployment rollout (--skip-deploy).")
+
+        size_mb = k8s.get_image_size_mb(image_name)
+        print(f"[*] Image disk size: {size_mb:.1f} MB")
+
+        k8s.warm_up_pod(duration_seconds=warmup_duration)
+
+        # ── start background telemetry thread ──────────────────────────────
+        ts_snapshots: list = []
+        stop_evt = threading.Event()
+        ts_start = time.time()
+
+        def _telemetry_worker():
+            telemetry.capture_jvm_metrics_timeseries(
+                interval_seconds=args.telemetry_interval,
+                stop_event=stop_evt,
+                snapshots=ts_snapshots,
+                start_time=ts_start,
+            )
+
+        ts_thread = threading.Thread(target=_telemetry_worker, daemon=True)
+        ts_thread.start()
+
+        # ── stepped load ───────────────────────────────────────────────────
+        warmup_ex = 1 if args.quick else args.warmup_exclusion
+        results = []
+        for ep in DEFAULT_CONFIG.endpoints:
+            print(f"\n  >> Testing Endpoint: {ep.name} [{ep.method} {ep.path}]")
+            for conc in stages:
+                res = load_gen.run_stage(
+                    ep,
+                    concurrency=conc,
+                    duration_seconds=stage_duration,
+                    warmup_exclusion_seconds=warmup_ex,
+                )
+                results.append(res)
+
+        # ── stop telemetry thread ──────────────────────────────────────────
+        stop_evt.set()
+        ts_thread.join(timeout=args.telemetry_interval + 5)
+
+        # ── final point-in-time snapshot (for tabular report) ─────────────
+        print("\n[*] Capturing final Prometheus & OpenTelemetry runtime metrics...")
+        time.sleep(2)
+        final_metrics = telemetry.capture_jvm_metrics()
+        print(
+            f"[✓] Heap: {final_metrics.get('heap_used_mb', 0)}MB | "
+            f"GC Pause: {final_metrics.get('gc_duration_seconds_total', 0)*1000:.1f}ms | "
+            f"RSS: {final_metrics.get('container_memory_rss_mb', 0)}MB | "
+            f"Telemetry snapshots: {len(ts_snapshots)}"
+        )
+
+        return startup_sec, size_mb, final_metrics, results, ts_snapshots
+
+    # ── 3. Baseline phase ──────────────────────────────────────────────────
+    print("\n[Step 3/6] Starting Baseline Phase...")
+    b_startup, b_size, b_telemetry, b_results, b_timeseries = run_image_test_battery(args.baseline)
+
+    # ── 4. Candidate phase (optional) ─────────────────────────────────────
+    c_startup = c_size = c_telemetry = c_results = c_timeseries = None
+    if ab_mode:
+        print("\n[Step 4/6] Starting Candidate Phase...")
+        c_startup, c_size, c_telemetry, c_results, c_timeseries = run_image_test_battery(args.candidate)
+
+        # Restore original image
+        if not args.skip_deploy and args.restore_image:
+            print(f"\n[*] Restoring deployment to {args.restore_image}...")
+            k8s.deploy_image(args.restore_image)
+    else:
+        print("\n[Step 4/6] Skipped — baseline-only mode (no --candidate provided).")
+
+    # ── 5. Charts ──────────────────────────────────────────────────────────
+    print("\n[Step 5/6] Generating Visual Charts and Diagrams...")
+    viz = Visualizer(output_dir)
+
+    chart1 = viz.generate_latency_chart_svg(b_results, c_results)
+    chart2 = viz.generate_throughput_chart_svg(b_results, c_results)
+    chart2b = viz.generate_throughput_bytes_chart_svg(b_results, c_results)
+    chart3 = viz.generate_jvm_memory_chart_svg(
+        b_telemetry,
+        c_telemetry,
+        b_timeseries=b_timeseries,
+        c_timeseries=c_timeseries,
+    )
+    chart4 = viz.generate_footprint_chart_svg(
+        b_size_mb=b_size,
+        b_start_s=b_startup,
+        b_telemetry=b_telemetry,
+        c_size_mb=c_size,
+        c_start_s=c_startup,
+        c_telemetry=c_telemetry,
+        b_timeseries=b_timeseries,
+        c_timeseries=c_timeseries,
+    )
+    print(f"[✓] Charts generated in: {output_dir}")
+
+    # ── 6. Report ──────────────────────────────────────────────────────────
+    print("\n[Step 6/6] Compiling Markdown Report...")
+    reporter = ReportCompiler(output_dir)
+    report_file = reporter.compile_report(
+        baseline_image=args.baseline,
+        b_startup=b_startup,
+        b_size=b_size,
+        b_telemetry=b_telemetry,
+        b_results=b_results,
+        candidate_image=args.candidate,
+        c_startup=c_startup,
+        c_size=c_size,
+        c_telemetry=c_telemetry,
+        c_results=c_results,
+        registry_url=args.registry_url,
+        ssh_host=args.ssh_host,
+    )
+    print(f"[✓] Analysis Report compiled: {report_file}")
+
+    print("\n" + "=" * 80)
+    print("                 BENCHMARK RUN COMPLETE!")
+    print("=" * 80)
+    print(f"Report File: {report_file}")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/registry/seeder.py
+++ b/benchmarks/registry/seeder.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""
+Test fixture seeder for Terrakube Registry Performance Benchmark.
+Ensures valid PostgreSQL records and SeaweedFS S3 storage fixtures exist
+so all 7 benchmark endpoints return deterministic 200/204 OK responses.
+"""
+
+import subprocess
+from typing import Tuple
+
+def ensure_test_fixtures(ssh_host: str = "user@192.168.1.150") -> Tuple[bool, str]:
+    """
+    Seeds test records into PostgreSQL database on the remote MicroK8s cluster.
+    """
+    sql_statements = [
+        "DELETE FROM implementation WHERE id = 'b0000000-0000-0000-0000-000000000003';",
+        "DELETE FROM version WHERE id = 'b0000000-0000-0000-0000-000000000002';",
+        "DELETE FROM provider WHERE id = 'b0000000-0000-0000-0000-000000000001';",
+        "INSERT INTO provider (id, name, description, organization_id, imported, registry_namespace) VALUES ('b0000000-0000-0000-0000-000000000001', 'benchmark', 'Benchmark test provider', 'd9b58bd3-f3fc-4056-a026-1163297e80a8', false, 'simple');",
+        "INSERT INTO version (id, version_number, protocols, provider_id) VALUES ('b0000000-0000-0000-0000-000000000002', '1.0.0', '5.0', 'b0000000-0000-0000-0000-000000000001');",
+        "INSERT INTO implementation (id, os, arch, filename, download_url, shasums_url, shasums_signature_url, shasum, key_id, ascii_armor, trust_signature, source, source_url, version_id) VALUES ('b0000000-0000-0000-0000-000000000003', 'linux', 'amd64', 'terraform-provider-benchmark_1.0.0_linux_amd64.zip', 'https://terrakube-reg.microk8s.net/download/provider.zip', 'https://terrakube-reg.microk8s.net/download/shasums', 'https://terrakube-reg.microk8s.net/download/sig', 'abcdef123456', 'TESTKEY1', 'armor', 'trust', 'source', 'https://github.com/example/provider', 'b0000000-0000-0000-0000-000000000002');"
+    ]
+    combined_sql = " ".join(sql_statements)
+    cmd = f'ssh {ssh_host} "microk8s kubectl exec -n terrakube terrakube-db-1 -c postgres -- psql -U postgres -d terrakube -c \\"{combined_sql}\\""'
+
+    try:
+        res = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=20)
+        if res.returncode == 0:
+            return True, "Database test fixtures successfully seeded."
+        else:
+            return False, f"Database seeding failed: {res.stderr}"
+    except Exception as e:
+        return False, f"Exception seeding database fixtures: {e}"
+
+if __name__ == "__main__":
+    ok, msg = ensure_test_fixtures()
+    print(f"Seeder status: {ok} -> {msg}")

--- a/benchmarks/registry/telemetry.py
+++ b/benchmarks/registry/telemetry.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Telemetry and Metrics Extractor for Terrakube Benchmark Suite.
+Queries Prometheus and OpenTelemetry JavaAgent metrics via SSH or direct API.
+Supports periodic time-series snapshot collection for rich chart rendering.
+"""
+
+import json
+import subprocess
+import threading
+import time
+import urllib.parse
+from typing import Dict, Any, Optional, List
+
+
+class TelemetryExtractor:
+    def __init__(
+        self,
+        ssh_host: str = "user@192.168.1.150",
+        prom_service: str = "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090",
+        kubectl_cmd: str = "microk8s kubectl",
+    ):
+        self.ssh_host = ssh_host
+        self.prom_service = prom_service
+        self.kubectl_cmd = kubectl_cmd
+
+    def query_prometheus_instant(self, query: str) -> Optional[List[Dict[str, Any]]]:
+        """
+        Executes an instant PromQL query via curl in the releases mirror pod or cluster.
+        """
+        encoded_query = urllib.parse.quote(query)
+        cmd = (
+            f"{self.kubectl_cmd} exec -n terrakube deployment/terraform-releases-mirror"
+            f" -c nginx -- curl -s '{self.prom_service}/api/v1/query?query={encoded_query}'"
+        )
+        full_cmd = f'ssh -o ConnectTimeout=10 {self.ssh_host} "{cmd}"'
+
+        try:
+            res = subprocess.run(full_cmd, shell=True, capture_output=True, text=True, timeout=15)
+            if res.returncode == 0:
+                data = json.loads(res.stdout)
+                if data.get("status") == "success":
+                    return data.get("data", {}).get("result", [])
+        except Exception as e:
+            print(f"[Warning] Prometheus query failed for '{query}': {e}")
+        return None
+
+    def capture_jvm_metrics(self) -> Dict[str, Any]:
+        """
+        Captures a comprehensive single-point snapshot of JVM memory, GC, CPU, and thread
+        metrics for terrakube-registry.
+        """
+        metrics: Dict[str, Any] = {
+            "heap_used_mb": 0.0,
+            "heap_committed_mb": 0.0,
+            "non_heap_used_mb": 0.0,
+            "gc_count_total": 0,
+            "gc_duration_seconds_total": 0.0,
+            "gc_avg_pause_ms": 0.0,
+            "thread_count": 0,
+            "cpu_recent_utilization_pct": 0.0,
+            "container_memory_rss_mb": 0.0,
+            "container_cpu_millicores": 0.0,
+        }
+
+        # 1. Heap Used
+        res = self.query_prometheus_instant('sum(jvm_memory_used_bytes{jvm_memory_type="heap"})')
+        if res and len(res) > 0:
+            val = float(res[0]["value"][1])
+            metrics["heap_used_mb"] = round(val / (1024 * 1024), 2)
+
+        # 2. Heap Committed
+        res = self.query_prometheus_instant('sum(jvm_memory_committed_bytes{jvm_memory_type="heap"})')
+        if res and len(res) > 0:
+            val = float(res[0]["value"][1])
+            metrics["heap_committed_mb"] = round(val / (1024 * 1024), 2)
+
+        # 3. Non-Heap Used (Metaspace + Code Cache)
+        res = self.query_prometheus_instant('sum(jvm_memory_used_bytes{jvm_memory_type="non_heap"})')
+        if res and len(res) > 0:
+            val = float(res[0]["value"][1])
+            metrics["non_heap_used_mb"] = round(val / (1024 * 1024), 2)
+
+        # 4. GC Duration & Counts
+        res_sum = self.query_prometheus_instant("sum(jvm_gc_duration_seconds_sum)")
+        res_cnt = self.query_prometheus_instant("sum(jvm_gc_duration_seconds_count)")
+        if res_sum and len(res_sum) > 0 and res_cnt and len(res_cnt) > 0:
+            sum_sec = float(res_sum[0]["value"][1])
+            cnt = int(float(res_cnt[0]["value"][1]))
+            metrics["gc_duration_seconds_total"] = round(sum_sec, 3)
+            metrics["gc_count_total"] = cnt
+            if cnt > 0:
+                metrics["gc_avg_pause_ms"] = round((sum_sec / cnt) * 1000, 2)
+
+        # 5. Thread Count
+        res = self.query_prometheus_instant("sum(jvm_thread_count)")
+        if res and len(res) > 0:
+            metrics["thread_count"] = int(float(res[0]["value"][1]))
+
+        # 6. CPU Recent Utilization
+        res = self.query_prometheus_instant("avg(jvm_cpu_recent_utilization)")
+        if res and len(res) > 0:
+            metrics["cpu_recent_utilization_pct"] = round(float(res[0]["value"][1]) * 100, 2)
+
+        # 7. Container Working Set Memory from cAdvisor
+        res = self.query_prometheus_instant(
+            'sum(container_memory_working_set_bytes{namespace="terrakube", container="terrakube-registry"})'
+        )
+        if res and len(res) > 0:
+            metrics["container_memory_rss_mb"] = round(float(res[0]["value"][1]) / (1024 * 1024), 2)
+
+        # 8. Container CPU Usage (millicores) from cAdvisor
+        res = self.query_prometheus_instant(
+            'sum(rate(container_cpu_usage_seconds_total{namespace="terrakube", container="terrakube-registry"}[1m])) * 1000'
+        )
+        if res and len(res) > 0:
+            metrics["container_cpu_millicores"] = round(float(res[0]["value"][1]), 2)
+
+        return metrics
+
+    def capture_jvm_metrics_timeseries(
+        self,
+        interval_seconds: int = 10,
+        stop_event: Optional[threading.Event] = None,
+        snapshots: Optional[List[Dict[str, Any]]] = None,
+        start_time: Optional[float] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Continuously captures JVM metric snapshots every `interval_seconds` until
+        `stop_event` is set. Each snapshot is appended to `snapshots` (in-place) and
+        also returned as the final list.
+
+        Intended to be run inside a background thread:
+
+            stop_evt = threading.Event()
+            snapshots = []
+            t = threading.Thread(
+                target=telemetry.capture_jvm_metrics_timeseries,
+                kwargs=dict(interval_seconds=10, stop_event=stop_evt,
+                            snapshots=snapshots, start_time=time.time()),
+                daemon=True,
+            )
+            t.start()
+            # ... run load stages ...
+            stop_evt.set()
+            t.join(timeout=15)
+        """
+        if snapshots is None:
+            snapshots = []
+        if start_time is None:
+            start_time = time.time()
+        if stop_event is None:
+            stop_event = threading.Event()
+
+        while not stop_event.is_set():
+            snapshot = self.capture_jvm_metrics()
+            snapshot["t"] = round(time.time() - start_time, 1)
+            snapshots.append(snapshot)
+            # Wait for the interval or until stop is requested
+            stop_event.wait(timeout=interval_seconds)
+
+        return snapshots
+
+
+if __name__ == "__main__":
+    t = TelemetryExtractor()
+    m = t.capture_jvm_metrics()
+    print("Captured Live Metrics Snapshot:")
+    print(json.dumps(m, indent=2))

--- a/benchmarks/registry/visualizer.py
+++ b/benchmarks/registry/visualizer.py
@@ -1,0 +1,796 @@
+#!/usr/bin/env python3
+"""
+Visualization Generator for Terrakube Registry Performance Benchmark.
+Generates vector SVG time-series and comparison diagrams for latency, throughput,
+JVM memory/GC, and container footprint.
+
+All chart generators accept optional candidate data; when omitted only the baseline
+series is rendered. JVM memory and container RSS charts use periodic time-series
+snapshots collected during the run for rich over-time plots.
+"""
+
+import os
+from typing import Dict, Any, List, Optional
+
+# ── colour palette ────────────────────────────────────────────────────────────
+_BG          = "#0d1117"
+_PANEL       = "#161b22"
+_GRID        = "#21262d"
+_AXIS        = "#30363d"
+_TEXT        = "#c9d1d9"
+_MUTED       = "#8b949e"
+_BLUE        = "#388bfd"
+_BLUE_LIGHT  = "#58a6ff"
+_GREEN       = "#2ea043"
+_GREEN_LIGHT = "#3fb950"
+_PURPLE      = "#8957e5"
+_PURPLE_L    = "#bc8cff"
+_ORANGE      = "#f0883e"
+_ORANGE_L    = "#ffa657"
+_RED         = "#f85149"
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _svg_open(w: int, h: int) -> str:
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" '
+        f'width="100%" height="{h}" '
+        f'style="background:{_BG}; font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif;">'
+    )
+
+
+def _title(cx: float, text: str) -> str:
+    return f'<text x="{cx}" y="35" text-anchor="middle" fill="{_BLUE_LIGHT}" font-size="18" font-weight="bold">{text}</text>'
+
+
+def _grid_h(x1: float, x2: float, y: float) -> str:
+    return f'<line x1="{x1}" y1="{y}" x2="{x2}" y2="{y}" stroke="{_GRID}" stroke-dasharray="4"/>'
+
+
+def _grid_v(x: float, y1: float, y2: float) -> str:
+    return f'<line x1="{x}" y1="{y1}" x2="{x}" y2="{y2}" stroke="{_GRID}" stroke-dasharray="4"/>'
+
+
+def _axis_h(x1: float, y: float, x2: float) -> str:
+    return f'<line x1="{x1}" y1="{y}" x2="{x2}" y2="{y}" stroke="{_AXIS}" stroke-width="2"/>'
+
+
+def _axis_v(x: float, y1: float, y2: float) -> str:
+    return f'<line x1="{x}" y1="{y1}" x2="{x}" y2="{y2}" stroke="{_AXIS}" stroke-width="2"/>'
+
+
+def _polyline(points: List, stroke: str, width: int = 3, dash: str = "") -> str:
+    pts = " ".join(f"{x:.1f},{y:.1f}" for x, y in points)
+    da = f' stroke-dasharray="{dash}"' if dash else ""
+    return f'<polyline points="{pts}" fill="none" stroke="{stroke}" stroke-width="{width}"{da} stroke-linejoin="round"/>'
+
+
+def _dot(cx: float, cy: float, r: int, fill: str) -> str:
+    return f'<circle cx="{cx:.1f}" cy="{cy:.1f}" r="{r}" fill="{fill}"/>'
+
+
+def _label(x: float, y: float, text: str, fill: str, size: int = 11,
+           anchor: str = "middle", weight: str = "normal") -> str:
+    return (
+        f'<text x="{x:.1f}" y="{y:.1f}" text-anchor="{anchor}" '
+        f'fill="{fill}" font-size="{size}" font-weight="{weight}">{text}</text>'
+    )
+
+
+def _rect_panel(x: float, y: float, w: float, h: float) -> str:
+    return f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="8" fill="{_PANEL}" stroke="{_AXIS}"/>'
+
+
+def _badge(cx: float, cy: float, w: float, delta: float) -> str:
+    color = _GREEN if delta <= 0 else _RED
+    sign = "+" if delta > 0 else ""
+    x = cx - w / 2
+    return (
+        f'<rect x="{x:.1f}" y="{cy:.1f}" width="{w:.1f}" height="18" rx="9" fill="{color}" fill-opacity="0.2"/>'
+        f'<text x="{cx:.1f}" y="{cy + 13:.1f}" text-anchor="middle" fill="{color}" '
+        f'font-size="11" font-weight="bold">{sign}{delta:.1f}%</text>'
+    )
+
+
+def _legend_line(x: float, y: float, stroke: str, dash: str, label: str) -> str:
+    da = f' stroke-dasharray="{dash}"' if dash else ""
+    return (
+        f'<line x1="{x}" y1="{y}" x2="{x + 36}" y2="{y}" stroke="{stroke}" stroke-width="3"{da}/>'
+        f'<text x="{x + 44}" y="{y + 4}" fill="{_MUTED}" font-size="12">{label}</text>'
+    )
+
+
+# ── main class ────────────────────────────────────────────────────────────────
+
+class Visualizer:
+    def __init__(self, output_dir: str):
+        self.output_dir = output_dir
+        os.makedirs(self.output_dir, exist_ok=True)
+
+    # ── 1. Latency chart ─────────────────────────────────────────────────────
+
+    def generate_latency_chart_svg(
+        self,
+        baseline_results: List[Any],
+        candidate_results: Optional[List[Any]] = None,
+    ) -> str:
+        """
+        Generates a grouped bar chart of p50/p90/p95/p99 latency per endpoint,
+        with one stacked sub-panel per concurrency level.
+        Candidate bars are added alongside baseline bars when provided.
+        """
+        svg_path = os.path.join(self.output_dir, "latency_comparison_p95_p99.svg")
+
+        concurrencies = sorted(set(r.concurrency for r in baseline_results))
+        if not concurrencies:
+            concurrencies = [5, 10, 25]
+
+        endpoints = list(dict.fromkeys(r.endpoint_name for r in baseline_results))
+        has_candidate = bool(candidate_results)
+
+        # Colour scheme: p50=blue, p90=purple, p95=orange, p99=red; candidate variant uses lighter shades
+        _pct_colors = [_BLUE, _PURPLE, _ORANGE, _RED]
+        _pct_labels = ["p50", "p90", "p95", "p99"]
+        _pct_keys   = ["latency_p50_ms", "latency_p90_ms", "latency_p95_ms", "latency_p99_ms"]
+        _cand_colors = [_BLUE_LIGHT, _PURPLE_L, _ORANGE_L, _GREEN_LIGHT]
+
+        n_pct      = 4
+        n_ep       = len(endpoints)
+        n_series   = 2 if has_candidate else 1  # baseline + optional candidate
+
+        # Layout constants
+        cw            = 1100
+        pl, pr        = 72, 24
+        pt_header     = 54        # space for overall title
+        panel_h       = 220       # height of each concurrency sub-panel
+        panel_gap     = 32
+        pb            = 28        # bottom padding
+        ep_label_h    = 52        # space below bars for rotated endpoint labels
+        bar_area_h    = panel_h - ep_label_h
+        pw            = cw - pl - pr
+        n_panels      = len(concurrencies)
+        ch            = pt_header + n_panels * panel_h + (n_panels - 1) * panel_gap + pb
+
+        # Width of one endpoint slot
+        slot_w = pw / n_ep
+        # Bars inside a slot: n_pct bars × n_series side-by-side, small gap between series
+        series_gap   = 4
+        total_bar_w  = slot_w * 0.82
+        bar_w        = total_bar_w / (n_pct * n_series + (n_series - 1) * 0.5)
+
+        svg = [_svg_open(cw, ch),
+               _title(cw / 2, "Latency Percentiles (p50 / p90 / p95 / p99) per Endpoint")]
+
+        b_lookup = {(r.endpoint_name, r.concurrency): r for r in baseline_results}
+        c_lookup = {(r.endpoint_name, r.concurrency): r for r in (candidate_results or [])}
+
+        for pi, conc in enumerate(concurrencies):
+            py = pt_header + pi * (panel_h + panel_gap)
+
+            # Gather max value for Y scale in this panel
+            panel_vals = []
+            for ep in endpoints:
+                for key in _pct_keys:
+                    br = b_lookup.get((ep, conc))
+                    if br:
+                        panel_vals.append(getattr(br, key, 0.0))
+                    if has_candidate:
+                        cr = c_lookup.get((ep, conc))
+                        if cr:
+                            panel_vals.append(getattr(cr, key, 0.0))
+            max_v = max(max(panel_vals) * 1.18, 10.0) if panel_vals else 10.0
+
+            svg.append(f'<g transform="translate({pl},{py:.1f})">')
+
+            # Panel background
+            svg.append(f'<rect x="0" y="0" width="{pw}" height="{panel_h}" rx="6" fill="{_PANEL}" stroke="{_AXIS}"/>')
+
+            # Panel title
+            svg.append(_label(pw / 2, 18, f"{conc} Workers", _BLUE_LIGHT, size=13, weight="bold"))
+
+            # Y grid lines (4 lines)
+            for gi in range(5):
+                gv  = (max_v / 4) * gi
+                gy  = bar_area_h - (gv / max_v) * (bar_area_h - 26) + 24
+                svg.append(_grid_h(0, pw, gy))
+                svg.append(_label(-4, gy + 4, f"{gv:.0f}ms", _MUTED, size=8, anchor="end"))
+
+            # Axes
+            svg.append(_axis_v(0, 24, panel_h - ep_label_h))
+            svg.append(_axis_h(0, panel_h - ep_label_h, pw))
+
+            # Draw bars per endpoint
+            for ei, ep in enumerate(endpoints):
+                slot_cx  = (ei + 0.5) * slot_w
+                slot_x0  = slot_cx - total_bar_w / 2
+
+                br = b_lookup.get((ep, conc))
+                cr = c_lookup.get((ep, conc)) if has_candidate else None
+
+                for si, (series_r, colors) in enumerate([
+                    (br, _pct_colors),
+                    *([(cr, _cand_colors)] if has_candidate else []),
+                ]):
+                    series_offset = si * (n_pct * bar_w + series_gap)
+                    for ki, (key, col) in enumerate(zip(_pct_keys, colors)):
+                        bx = slot_x0 + series_offset + ki * bar_w
+                        val = getattr(series_r, key, 0.0) if series_r else 0.0
+                        bh = (val / max_v) * (bar_area_h - 26) if max_v > 0 else 0
+                        by = bar_area_h - bh + 24
+                        svg.append(f'<rect x="{bx:.1f}" y="{by:.1f}" width="{bar_w:.1f}" height="{bh:.1f}" rx="2" fill="{col}" fill-opacity="0.88"/>')
+                        if bh > 14:
+                            svg.append(_label(bx + bar_w / 2, by - 2, f"{val:.0f}", col, size=7))
+
+                # Rotated endpoint label below axis
+                lx = slot_cx
+                ly = panel_h - ep_label_h + 8
+                short = ep.replace("_", " ")
+                svg.append(
+                    f'<text x="{lx:.1f}" y="{ly:.1f}" text-anchor="end" '
+                    f'fill="{_TEXT}" font-size="9" '
+                    f'transform="rotate(-38,{lx:.1f},{ly:.1f})">{short}</text>'
+                )
+
+            svg.append("</g>")
+
+        # Legend
+        ly   = ch - 14
+        lgap = 56
+        lx0  = pl
+        series_labels = ["Baseline", "Candidate"] if has_candidate else ["Baseline"]
+        for si, (sl, sc_set) in enumerate(zip(series_labels, [_pct_colors, _cand_colors])):
+            base_x = lx0 + si * (n_pct * lgap + 60)
+            svg.append(_label(base_x, ly, sl + ":", _MUTED, size=10, anchor="start"))
+            for ki, (lbl, col) in enumerate(zip(_pct_labels, sc_set)):
+                rx = base_x + 52 + ki * lgap
+                svg.append(f'<rect x="{rx}" y="{ly - 9}" width="12" height="10" rx="2" fill="{col}"/>')
+                svg.append(_label(rx + 16, ly, lbl, _TEXT, size=10, anchor="start"))
+
+        svg.append("</svg>")
+        with open(svg_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(svg))
+        return svg_path
+
+    # ── 2. Throughput chart ──────────────────────────────────────────────────
+
+    def generate_throughput_chart_svg(
+        self,
+        baseline_results: List[Any],
+        candidate_results: Optional[List[Any]] = None,
+    ) -> str:
+        """
+        Generates RPS bar charts per endpoint, with one stacked sub-panel per
+        concurrency level. Candidate bars are rendered alongside baseline bars
+        when provided.
+        """
+        svg_path = os.path.join(self.output_dir, "throughput_vs_concurrency.svg")
+
+        concurrencies = sorted(set(r.concurrency for r in baseline_results))
+        if not concurrencies:
+            concurrencies = [5, 10, 25]
+
+        endpoints     = list(dict.fromkeys(r.endpoint_name for r in baseline_results))
+        has_candidate = bool(candidate_results)
+
+        # Layout constants
+        cw            = 1100
+        pl, pr        = 72, 24
+        pt_header     = 54
+        panel_h       = 220
+        panel_gap     = 32
+        pb            = 28
+        ep_label_h    = 52
+        bar_area_h    = panel_h - ep_label_h
+        pw            = cw - pl - pr
+        n_panels      = len(concurrencies)
+        ch            = pt_header + n_panels * panel_h + (n_panels - 1) * panel_gap + pb
+
+        slot_w        = pw / len(endpoints)
+        n_series      = 2 if has_candidate else 1
+        bar_w         = slot_w * 0.35
+        series_gap    = slot_w * 0.08
+
+        b_lookup = {(r.endpoint_name, r.concurrency): r.rps for r in baseline_results}
+        c_lookup = {(r.endpoint_name, r.concurrency): r.rps for r in (candidate_results or [])}
+
+        svg = [_svg_open(cw, ch),
+               _title(cw / 2, "Throughput (RPS) per Endpoint across Concurrency Levels")]
+
+        for pi, conc in enumerate(concurrencies):
+            py = pt_header + pi * (panel_h + panel_gap)
+
+            panel_vals = [b_lookup.get((ep, conc), 0.0) for ep in endpoints]
+            if has_candidate:
+                panel_vals += [c_lookup.get((ep, conc), 0.0) for ep in endpoints]
+            max_v = max(max(panel_vals) * 1.18, 1.0) if panel_vals else 1.0
+
+            svg.append(f'<g transform="translate({pl},{py:.1f})">')
+            svg.append(f'<rect x="0" y="0" width="{pw}" height="{panel_h}" rx="6" fill="{_PANEL}" stroke="{_AXIS}"/>')
+            svg.append(_label(pw / 2, 18, f"{conc} Workers", _BLUE_LIGHT, size=13, weight="bold"))
+
+            # Y grid
+            for gi in range(5):
+                gv = (max_v / 4) * gi
+                gy = bar_area_h - (gv / max_v) * (bar_area_h - 26) + 24
+                svg.append(_grid_h(0, pw, gy))
+                svg.append(_label(-4, gy + 4, f"{gv:.0f}", _MUTED, size=8, anchor="end"))
+
+            svg.append(_axis_v(0, 24, panel_h - ep_label_h))
+            svg.append(_axis_h(0, panel_h - ep_label_h, pw))
+
+            for ei, ep in enumerate(endpoints):
+                slot_cx   = (ei + 0.5) * slot_w
+                total_bars_w = bar_w * n_series + (series_gap if has_candidate else 0)
+                bx_base   = slot_cx - total_bars_w / 2
+
+                # Baseline bar
+                b_val = b_lookup.get((ep, conc), 0.0)
+                bh    = (b_val / max_v) * (bar_area_h - 26) if max_v > 0 else 0
+                by    = bar_area_h - bh + 24
+                svg.append(f'<rect x="{bx_base:.1f}" y="{by:.1f}" width="{bar_w:.1f}" height="{bh:.1f}" rx="2" fill="{_BLUE}" fill-opacity="0.88"/>')
+                if bh > 14:
+                    svg.append(_label(bx_base + bar_w / 2, by - 3, f"{b_val:.1f}", _BLUE_LIGHT, size=8, weight="bold"))
+
+                # Candidate bar (if present)
+                if has_candidate:
+                    c_val = c_lookup.get((ep, conc), 0.0)
+                    ch_b  = (c_val / max_v) * (bar_area_h - 26) if max_v > 0 else 0
+                    cy_b  = bar_area_h - ch_b + 24
+                    cx_b  = bx_base + bar_w + series_gap
+                    svg.append(f'<rect x="{cx_b:.1f}" y="{cy_b:.1f}" width="{bar_w:.1f}" height="{ch_b:.1f}" rx="2" fill="{_GREEN}" fill-opacity="0.88"/>')
+                    if ch_b > 14:
+                        svg.append(_label(cx_b + bar_w / 2, cy_b - 3, f"{c_val:.1f}", _GREEN_LIGHT, size=8, weight="bold"))
+
+                # Rotated endpoint label
+                lx = slot_cx
+                ly = panel_h - ep_label_h + 8
+                short = ep.replace("_", " ")
+                svg.append(
+                    f'<text x="{lx:.1f}" y="{ly:.1f}" text-anchor="end" '
+                    f'fill="{_TEXT}" font-size="9" '
+                    f'transform="rotate(-38,{lx:.1f},{ly:.1f})">{short}</text>'
+                )
+
+            svg.append("</g>")
+
+        # Legend
+        ly  = ch - 14
+        svg.append(f'<rect x="{pl}" y="{ly - 9}" width="12" height="10" rx="2" fill="{_BLUE}"/>')
+        svg.append(_label(pl + 16, ly, "Baseline RPS", _TEXT, size=10, anchor="start"))
+        if has_candidate:
+            svg.append(f'<rect x="{pl + 110}" y="{ly - 9}" width="12" height="10" rx="2" fill="{_GREEN}"/>')
+            svg.append(_label(pl + 126, ly, "Candidate RPS", _TEXT, size=10, anchor="start"))
+
+        svg.append("</svg>")
+        with open(svg_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(svg))
+        return svg_path
+
+    # ── 2b. Throughput Bytes/sec chart ──────────────────────────────────────
+
+    def generate_throughput_bytes_chart_svg(
+        self,
+        baseline_results: List[Any],
+        candidate_results: Optional[List[Any]] = None,
+    ) -> str:
+        """
+        Generates throughput (MB/s) bar charts per endpoint, with one stacked sub-panel
+        per concurrency level. Candidate bars are rendered alongside baseline bars when provided.
+        """
+        svg_path = os.path.join(self.output_dir, "throughput_bytes_sec.svg")
+
+        concurrencies = sorted(set(r.concurrency for r in baseline_results))
+        if not concurrencies:
+            concurrencies = [5, 10, 25]
+
+        endpoints     = list(dict.fromkeys(r.endpoint_name for r in baseline_results))
+        has_candidate = bool(candidate_results)
+
+        # Layout constants
+        cw            = 1100
+        pl, pr        = 72, 24
+        pt_header     = 54
+        panel_h       = 220
+        panel_gap     = 32
+        pb            = 28
+        ep_label_h    = 52
+        bar_area_h    = panel_h - ep_label_h
+        pw            = cw - pl - pr
+        n_panels      = len(concurrencies)
+        ch            = pt_header + n_panels * panel_h + (n_panels - 1) * panel_gap + pb
+
+        slot_w        = pw / len(endpoints)
+        n_series      = 2 if has_candidate else 1
+        bar_w         = slot_w * 0.35
+        series_gap    = slot_w * 0.08
+
+        def get_mb_s(r_obj: Any) -> float:
+            tb = getattr(r_obj, "throughput_bytes_sec", 0.0)
+            if tb > 0:
+                return round(tb / (1024 * 1024), 2)
+            dur = getattr(r_obj, "duration_seconds", 0.0)
+            tot_bytes = getattr(r_obj, "total_bytes_transferred", 0)
+            return round((tot_bytes / dur) / (1024 * 1024), 2) if dur > 0 else 0.0
+
+        b_lookup = {(r.endpoint_name, r.concurrency): get_mb_s(r) for r in baseline_results}
+        c_lookup = {(r.endpoint_name, r.concurrency): get_mb_s(r) for r in (candidate_results or [])}
+
+        svg = [_svg_open(cw, ch),
+               _title(cw / 2, "Throughput (MB/s) per Endpoint across Concurrency Levels")]
+
+        for pi, conc in enumerate(concurrencies):
+            py = pt_header + pi * (panel_h + panel_gap)
+
+            panel_vals = [b_lookup.get((ep, conc), 0.0) for ep in endpoints]
+            if has_candidate:
+                panel_vals += [c_lookup.get((ep, conc), 0.0) for ep in endpoints]
+            max_v = max(max(panel_vals) * 1.18, 0.5) if panel_vals else 0.5
+
+            svg.append(f'<g transform="translate({pl},{py:.1f})">')
+            svg.append(f'<rect x="0" y="0" width="{pw}" height="{panel_h}" rx="6" fill="{_PANEL}" stroke="{_AXIS}"/>')
+            svg.append(_label(pw / 2, 18, f"{conc} Workers", _BLUE_LIGHT, size=13, weight="bold"))
+
+            # Y grid
+            for gi in range(5):
+                gv = (max_v / 4) * gi
+                gy = bar_area_h - (gv / max_v) * (bar_area_h - 26) + 24
+                svg.append(_grid_h(0, pw, gy))
+                svg.append(_label(-4, gy + 4, f"{gv:.2f} MB/s", _MUTED, size=8, anchor="end"))
+
+            svg.append(_axis_v(0, 24, panel_h - ep_label_h))
+            svg.append(_axis_h(0, panel_h - ep_label_h, pw))
+
+            for ei, ep in enumerate(endpoints):
+                slot_cx   = (ei + 0.5) * slot_w
+                total_bars_w = bar_w * n_series + (series_gap if has_candidate else 0)
+                bx_base   = slot_cx - total_bars_w / 2
+
+                # Baseline bar
+                b_val = b_lookup.get((ep, conc), 0.0)
+                bh    = (b_val / max_v) * (bar_area_h - 26) if max_v > 0 else 0
+                by    = bar_area_h - bh + 24
+                svg.append(f'<rect x="{bx_base:.1f}" y="{by:.1f}" width="{bar_w:.1f}" height="{bh:.1f}" rx="2" fill="{_BLUE}" fill-opacity="0.88"/>')
+                if bh > 14:
+                    svg.append(_label(bx_base + bar_w / 2, by - 3, f"{b_val:.2f}", _BLUE_LIGHT, size=8, weight="bold"))
+
+                # Candidate bar (if present)
+                if has_candidate:
+                    c_val = c_lookup.get((ep, conc), 0.0)
+                    ch_b  = (c_val / max_v) * (bar_area_h - 26) if max_v > 0 else 0
+                    cy_b  = bar_area_h - ch_b + 24
+                    cx_b  = bx_base + bar_w + series_gap
+                    svg.append(f'<rect x="{cx_b:.1f}" y="{cy_b:.1f}" width="{bar_w:.1f}" height="{ch_b:.1f}" rx="2" fill="{_GREEN}" fill-opacity="0.88"/>')
+                    if ch_b > 14:
+                        svg.append(_label(cx_b + bar_w / 2, cy_b - 3, f"{c_val:.2f}", _GREEN_LIGHT, size=8, weight="bold"))
+
+                # Rotated endpoint label
+                lx = slot_cx
+                ly = panel_h - ep_label_h + 8
+                short = ep.replace("_", " ")
+                svg.append(
+                    f'<text x="{lx:.1f}" y="{ly:.1f}" text-anchor="end" '
+                    f'fill="{_TEXT}" font-size="9" '
+                    f'transform="rotate(-38,{lx:.1f},{ly:.1f})">{short}</text>'
+                )
+
+            svg.append("</g>")
+
+        # Legend
+        ly  = ch - 14
+        svg.append(f'<rect x="{pl}" y="{ly - 9}" width="12" height="10" rx="2" fill="{_BLUE}"/>')
+        svg.append(_label(pl + 16, ly, "Baseline MB/s", _TEXT, size=10, anchor="start"))
+        if has_candidate:
+            svg.append(f'<rect x="{pl + 120}" y="{ly - 9}" width="12" height="10" rx="2" fill="{_GREEN}"/>')
+            svg.append(_label(pl + 136, ly, "Candidate MB/s", _TEXT, size=10, anchor="start"))
+
+        svg.append("</svg>")
+        with open(svg_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(svg))
+        return svg_path
+
+
+    # ── 3. JVM memory & GC time-series chart ─────────────────────────────────
+
+    def generate_jvm_memory_chart_svg(
+        self,
+        b_telemetry: Dict[str, Any],
+        c_telemetry: Optional[Dict[str, Any]] = None,
+        b_timeseries: Optional[List[Dict[str, Any]]] = None,
+        c_timeseries: Optional[List[Dict[str, Any]]] = None,
+    ) -> str:
+        """
+        Generates a time-series line chart for JVM heap, committed memory, and GC pause.
+        When timeseries data is available it is plotted as smooth curves over elapsed time.
+        Candidate series omitted when not provided. Falls back to bar comparison when no
+        timeseries data is available.
+        """
+        svg_path = os.path.join(self.output_dir, "jvm_memory_and_gc.svg")
+
+        has_ts = bool(b_timeseries)
+        has_candidate = c_telemetry is not None
+
+        if has_ts:
+            svg_path = self._jvm_timeseries_svg(svg_path, b_timeseries, c_timeseries if has_candidate else None)
+        else:
+            svg_path = self._jvm_bar_svg(svg_path, b_telemetry, c_telemetry if has_candidate else None)
+        return svg_path
+
+    def _jvm_timeseries_svg(
+        self,
+        svg_path: str,
+        b_ts: List[Dict[str, Any]],
+        c_ts: Optional[List[Dict[str, Any]]],
+    ) -> str:
+        """SVG time-series line chart — one sub-panel per metric."""
+
+        metrics_cfg = [
+            ("Heap Used (MB)",      "heap_used_mb",              1.0),
+            ("Heap Committed (MB)", "heap_committed_mb",         1.0),
+            ("GC Pause Total (ms)", "gc_duration_seconds_total", 1000.0),
+            ("RSS Memory (MB)",     "container_memory_rss_mb",   1.0),
+            ("JVM CPU Util (%)",    "cpu_recent_utilization_pct", 1.0),
+        ]
+
+        cw, ch = 920, 680
+        pl, pr, pt_top, pb = 72, 30, 55, 50
+        n_panels = len(metrics_cfg)
+        gap = 14
+        panel_h = (ch - pt_top - pb - gap * (n_panels - 1)) / n_panels
+        pw = cw - pl - pr
+        has_candidate = c_ts is not None and len(c_ts) > 0
+
+        svg = [_svg_open(cw, ch), _title(cw / 2, "JVM Runtime &amp; GC Metrics — Over Time")]
+
+        for pi, (title, key, scale) in enumerate(metrics_cfg):
+            py = pt_top + pi * (panel_h + gap)
+
+            b_vals = [s.get(key, 0.0) * scale for s in b_ts]
+            b_times = [s.get("t", 0.0) for s in b_ts]
+            c_vals = [s.get(key, 0.0) * scale for s in c_ts] if has_candidate else []
+            c_times = [s.get("t", 0.0) for s in c_ts] if has_candidate else []
+
+            all_vals = b_vals + c_vals
+            max_v = max(max(all_vals) * 1.2, 1.0) if all_vals else 1.0
+            all_t = b_times + c_times
+            max_t = max(max(all_t), 1.0) if all_t else 1.0
+
+            svg.append(f'<g transform="translate({pl},{py:.1f})">')
+            svg.append(_rect_panel(0, 0, pw, panel_h))
+            svg.append(_label(pw / 2, 18, title, _TEXT, size=12, weight="bold"))
+
+            # Y grid (3 lines)
+            for gi in range(4):
+                gv = (max_v / 3) * gi
+                gy = panel_h - (gv / max_v) * (panel_h - 26) - 8
+                svg.append(_grid_h(0, pw, gy))
+                svg.append(_label(-6, gy + 4, f"{gv:.0f}", _MUTED, size=9, anchor="end"))
+
+            # Baseline series
+            if b_vals and b_times:
+                pts_b = [
+                    (
+                        (t / max_t) * pw,
+                        panel_h - (v / max_v) * (panel_h - 26) - 8,
+                    )
+                    for t, v in zip(b_times, b_vals)
+                ]
+                svg.append(_polyline(pts_b, _BLUE, width=2))
+                for x, y in pts_b:
+                    svg.append(_dot(x, y, 3, _BLUE_LIGHT))
+
+            # Candidate series
+            if has_candidate and c_vals and c_times:
+                pts_c = [
+                    (
+                        (t / max_t) * pw,
+                        panel_h - (v / max_v) * (panel_h - 26) - 8,
+                    )
+                    for t, v in zip(c_times, c_vals)
+                ]
+                svg.append(_polyline(pts_c, _GREEN, width=2, dash="5,3"))
+                for x, y in pts_c:
+                    svg.append(_dot(x, y, 3, _GREEN_LIGHT))
+
+            # X axis time labels at start / mid / end
+            for frac, t_label in [(0.0, "0s"), (0.5, f"{max_t/2:.0f}s"), (1.0, f"{max_t:.0f}s")]:
+                svg.append(_label(frac * pw, panel_h + 2, t_label, _MUTED, size=9))
+
+            svg.append("</g>")
+
+        # Legend
+        ly = ch - 18
+        svg.append(_legend_line(pl, ly, _BLUE, "", "Baseline"))
+        if has_candidate:
+            svg.append(_legend_line(pl + 180, ly, _GREEN, "5,3", "Candidate"))
+
+        svg.append("</svg>")
+        with open(svg_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(svg))
+        return svg_path
+
+    def _jvm_bar_svg(
+        self,
+        svg_path: str,
+        b_telemetry: Dict[str, Any],
+        c_telemetry: Optional[Dict[str, Any]],
+    ) -> str:
+        """Fallback bar chart when no timeseries data is available."""
+        has_candidate = c_telemetry is not None
+        cw, ch = 880, 420
+        svg = [
+            _svg_open(cw, ch),
+            _title(cw / 2, "JVM Runtime &amp; Garbage Collection Footprint"),
+        ]
+        metrics = [
+            ("Heap Used (MB)",       "heap_used_mb",              1.0),
+            ("Heap Committed (MB)",  "heap_committed_mb",         1.0),
+            ("GC Pause Total (ms)",  "gc_duration_seconds_total", 1000.0),
+            ("Avg GC Pause (ms)",    "gc_avg_pause_ms",           1.0),
+        ]
+        panel_w = 175
+        panel_h = 300
+        start_y = 65
+        for i, (title, key, scale) in enumerate(metrics):
+            b_val = b_telemetry.get(key, 0.0) * scale
+            c_val = c_telemetry.get(key, 0.0) * scale if has_candidate else 0.0
+            px = 50 + i * 200
+            svg.append(f'<g transform="translate({px},{start_y})">')
+            svg.append(_rect_panel(0, 0, panel_w, panel_h))
+            svg.append(_label(panel_w / 2, 28, title, _TEXT, size=13, weight="bold"))
+            panel_max = max(b_val, c_val, 1.0) * 1.3
+            bar_max_h = 170
+            b_h = (b_val / panel_max) * bar_max_h
+            svg.append(f'<rect x="25" y="{240 - b_h:.1f}" width="50" height="{b_h:.1f}" rx="4" fill="{_BLUE}"/>')
+            svg.append(_label(50, 230 - b_h, f"{b_val:.1f}", _BLUE_LIGHT, size=12, weight="bold"))
+            svg.append(_label(50, 260, "Baseline", _MUTED, size=11))
+            if has_candidate:
+                c_h = (c_val / panel_max) * bar_max_h
+                svg.append(f'<rect x="100" y="{240 - c_h:.1f}" width="50" height="{c_h:.1f}" rx="4" fill="{_GREEN}"/>')
+                svg.append(_label(125, 230 - c_h, f"{c_val:.1f}", _GREEN_LIGHT, size=12, weight="bold"))
+                svg.append(_label(125, 260, "Candidate", _MUTED, size=11))
+                delta = ((c_val - b_val) / b_val * 100) if b_val > 0 else 0.0
+                svg.append(_badge(87, 275, 105, delta))
+            svg.append("</g>")
+        svg.append("</svg>")
+        with open(svg_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(svg))
+        return svg_path
+
+    # ── 4. Container footprint chart ─────────────────────────────────────────
+
+    def generate_footprint_chart_svg(
+        self,
+        b_size_mb: float,
+        b_start_s: float,
+        b_telemetry: Dict[str, Any],
+        c_size_mb: Optional[float] = None,
+        c_start_s: Optional[float] = None,
+        c_telemetry: Optional[Dict[str, Any]] = None,
+        b_timeseries: Optional[List[Dict[str, Any]]] = None,
+        c_timeseries: Optional[List[Dict[str, Any]]] = None,
+    ) -> str:
+        """
+        Generates container footprint chart.
+        - Image size and cold startup: static bar panels.
+        - RSS working-set memory: time-series line chart from periodic snapshots.
+        Candidate panels/series omitted when not provided.
+        """
+        svg_path = os.path.join(self.output_dir, "container_cpu_and_startup.svg")
+        has_candidate = c_size_mb is not None and c_start_s is not None
+        has_ts = bool(b_timeseries)
+
+        cw, ch = 920, 460
+        pl, pr, pt, pb = 50, 30, 55, 55
+        pw = cw - pl - pr
+        ph = ch - pt - pb
+
+        svg = [_svg_open(cw, ch), _title(cw / 2, "Container Footprint &amp; Startup Performance")]
+        svg.append(f'<g transform="translate({pl},{pt})">')
+
+        # ── static bars (left 40% of plot width) ──
+        bar_section_w = pw * 0.38
+        bar_panel_w = bar_section_w / (2 if has_candidate else 1) - 10
+        panels_static = [
+            ("Image Size on Disk", b_size_mb, c_size_mb if has_candidate else None, "MB"),
+            ("Cold Startup to Ready", b_start_s, c_start_s if has_candidate else None, "s"),
+        ]
+        bp_w = 220  # each static panel width
+        for pi, (title, b_val, c_val, unit) in enumerate(panels_static):
+            px = pi * (bp_w + 20)
+            panel_max = max(b_val, c_val or 0.0, 1.0) * 1.3
+            bar_max_h = ph - 80
+            svg.append(f'<g transform="translate({px},0)">')
+            svg.append(_rect_panel(0, 0, bp_w, ph))
+            svg.append(_label(bp_w / 2, 24, title, _TEXT, size=13, weight="bold"))
+            b_h = (b_val / panel_max) * bar_max_h
+            svg.append(f'<rect x="30" y="{ph - 60 - b_h:.1f}" width="65" height="{b_h:.1f}" rx="4" fill="{_BLUE}"/>')
+            svg.append(_label(62, ph - 62 - b_h, f"{b_val:.1f} {unit}", _BLUE_LIGHT, size=12, weight="bold"))
+            svg.append(_label(62, ph - 38, "Baseline", _MUTED, size=12))
+            if has_candidate and c_val is not None:
+                c_h = (c_val / panel_max) * bar_max_h
+                svg.append(f'<rect x="125" y="{ph - 60 - c_h:.1f}" width="65" height="{c_h:.1f}" rx="4" fill="{_GREEN}"/>')
+                svg.append(_label(158, ph - 62 - c_h, f"{c_val:.1f} {unit}", _GREEN_LIGHT, size=12, weight="bold"))
+                svg.append(_label(158, ph - 38, "Candidate", _MUTED, size=12))
+                delta = ((c_val - b_val) / b_val * 100) if b_val > 0 else 0.0
+                svg.append(_badge(bp_w / 2, ph - 22, 110, delta))
+            svg.append("</g>")
+
+        # ── RSS time-series (right 55% of plot width) ──
+        ts_x = (bp_w + 20) * len(panels_static) + 20
+        ts_w = pw - ts_x
+        svg.append(f'<g transform="translate({ts_x},0)">')
+        svg.append(_rect_panel(0, 0, ts_w, ph))
+        svg.append(_label(ts_w / 2, 24, "Container RSS Memory — Over Time", _TEXT, size=13, weight="bold"))
+
+        if has_ts and b_timeseries:
+            b_rss = [s.get("container_memory_rss_mb", 0.0) for s in b_timeseries]
+            b_times = [s.get("t", 0.0) for s in b_timeseries]
+            c_rss = [s.get("container_memory_rss_mb", 0.0) for s in c_timeseries] if c_timeseries else []
+            c_times = [s.get("t", 0.0) for s in c_timeseries] if c_timeseries else []
+
+            all_rss = b_rss + c_rss
+            max_rss = max(max(all_rss) * 1.2, 1.0) if all_rss else 1.0
+            all_t = b_times + c_times
+            max_t = max(max(all_t), 1.0) if all_t else 1.0
+
+            inner_h = ph - 44
+            inner_w = ts_w - 20
+
+            # Y grid
+            for gi in range(4):
+                gv = (max_rss / 3) * gi
+                gy = inner_h - (gv / max_rss) * (inner_h - 10)
+                svg.append(_grid_h(10, ts_w - 10, gy + 32))
+                svg.append(_label(8, gy + 36, f"{gv:.0f}", _MUTED, size=9, anchor="end"))
+
+            def to_xy(times, vals):
+                return [
+                    (
+                        10 + (t / max_t) * (inner_w - 10),
+                        32 + inner_h - (v / max_rss) * (inner_h - 10),
+                    )
+                    for t, v in zip(times, vals)
+                ]
+
+            pts_b = to_xy(b_times, b_rss)
+            svg.append(_polyline(pts_b, _BLUE, width=2))
+            for x, y in pts_b:
+                svg.append(_dot(x, y, 3, _BLUE_LIGHT))
+
+            if c_rss and c_times:
+                pts_c = to_xy(c_times, c_rss)
+                svg.append(_polyline(pts_c, _GREEN, width=2, dash="5,3"))
+                for x, y in pts_c:
+                    svg.append(_dot(x, y, 3, _GREEN_LIGHT))
+
+            # X time labels
+            for frac, lbl in [(0.0, "0s"), (0.5, f"{max_t/2:.0f}s"), (1.0, f"{max_t:.0f}s")]:
+                svg.append(_label(10 + frac * (inner_w - 10), ph - 4, lbl, _MUTED, size=9))
+        else:
+            # Fallback: single bar for RSS
+            b_rss_val = b_telemetry.get("container_memory_rss_mb", 0.0) if b_telemetry else 0.0
+            c_rss_val = c_telemetry.get("container_memory_rss_mb", 0.0) if c_telemetry else 0.0
+            panel_max = max(b_rss_val, c_rss_val, 1.0) * 1.3
+            bar_max_h = ph - 80
+            b_h = (b_rss_val / panel_max) * bar_max_h
+            svg.append(f'<rect x="30" y="{ph - 60 - b_h:.1f}" width="65" height="{b_h:.1f}" rx="4" fill="{_BLUE}"/>')
+            svg.append(_label(62, ph - 62 - b_h, f"{b_rss_val:.1f} MB", _BLUE_LIGHT, size=12, weight="bold"))
+            svg.append(_label(62, ph - 38, "Baseline", _MUTED, size=12))
+            if has_candidate:
+                c_h = (c_rss_val / panel_max) * bar_max_h
+                svg.append(f'<rect x="ts_w - 100" y="{ph - 60 - c_h:.1f}" width="65" height="{c_h:.1f}" rx="4" fill="{_GREEN}"/>')
+                svg.append(_label(ts_w - 67, ph - 62 - c_h, f"{c_rss_val:.1f} MB", _GREEN_LIGHT, size=12, weight="bold"))
+
+        svg.append("</g>")
+        svg.append("</g>")
+
+        # Legend
+        ly = ch - 18
+        svg.append(_legend_line(pl, ly, _BLUE, "", "Baseline"))
+        if has_candidate:
+            svg.append(_legend_line(pl + 180, ly, _GREEN, "5,3", "Candidate"))
+
+        svg.append("</svg>")
+        with open(svg_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(svg))
+        return svg_path


### PR DESCRIPTION
## Summary
Introduces a standalone, automated, zero-external-dependency performance benchmarking and analysis engine for the **Terrakube Registry** service under `terrakube/benchmarks/registry/`.

The suite supports both **single-image baseline profiling** and **automated A/B comparative evaluations** between container images (e.g., standard vs. alternative base images/distributions), measuring throughput, latency percentiles, JVM metrics, and Kubernetes deployment startup timings.

---

## Key Features & Components

### 1. Workload Coverage (7 Endpoints Across 4 Controllers)
- **`WellKnownWebServiceImpl`**: `GET /.well-known/terraform.json` (Service discovery & JSON templating)
- **`ModuleWebServiceImpl`**:
  - `GET /terraform/modules/v1/{org}/{module}/{provider}/versions` (DB query + JSON serialization)
  - `GET /terraform/modules/v1/{org}/{module}/{provider}/{version}/download` (Download count increment + `X-Terraform-Get` header)
  - `GET /terraform/modules/v1/download/{org}/{module}/{provider}/{version}/module.zip` (Binary ZIP streaming from SeaweedFS S3)
- **`ProviderWebServiceImpl`**:
  - `GET /terraform/providers/v1/{org}/{provider}/versions` (Provider version and platform listing)
  - `GET /terraform/providers/v1/{org}/{provider}/{version}/download/{os}/{arch}` (SHA256 checksum & GPG key download metadata)
- **`ReadMeWebServiceImpl`**: `GET /terraform/readme/v1/{org}/{module}/{provider}/{version}/download` (In-memory ZIP decompression + Markdown extraction)

### 2. Multi-Stage Load & Latency Engine (`load_generator.py`)
- Concurrent multi-worker HTTP execution across configurable concurrency stages (`5`, `10`, `25` workers).
- Computes comprehensive latency percentiles (`p50`, `p90`, `p95`, `p99`, min, max, stddev), requests per second (RPS), throughput (MB/s), and error rates.
- Includes automatic warm-up periods and JIT warm-up exclusion filtering.

### 3. Kubernetes Lifecycle & Image Rollouts (`k8s_manager.py`)
- Automates remote image deployments via `kubectl set image`, watches rollout status, and records exact cold-start / readiness times.
- Automatically restores original baseline image post-benchmark.
- Supports `--skip-deploy` for profiling currently active pods without triggering cluster rollouts.

### 4. OpenTelemetry & Prometheus Telemetry Collector (`telemetry.py`)
- Background polling thread captures live Prometheus metric snapshots during the load phase:
  - JVM Heap used vs. committed memory (`jvm_memory_used_bytes`, `jvm_memory_committed_bytes`)
  - JVM Garbage Collection pause durations and frequency (`jvm_gc_pause_seconds_sum`)
  - Container Resident Set Size (`container_memory_rss`)
  - Process CPU utilization (`process_cpu_usage` / `jvm_cpu_utilization`)

### 5. Pure SVG Visualizer & Markdown Reporter (`visualizer.py`, `reporter.py`)
- Generates high-resolution, zero-dependency SVG charts:
  - `latency_comparison_p95_p99.svg` (Grouped multi-stage latency percentiles)
  - `throughput_vs_concurrency.svg` (Endpoint RPS scaling)
  - `throughput_bytes_sec.svg` (Network throughput in MB/s)
  - `jvm_memory_and_gc.svg` (JVM Heap, GC pause, RSS time series)
  - `container_cpu_and_startup.svg` (Image size, startup time, and CPU footprint)
- Compiles `REGISTRY_PERFORMANCE_ANALYSIS.md` with complete tabular summaries, delta comparisons (`%` speedup/regression), and telemetry insights.

### 6. Git Hygiene (`.gitignore`)
- Updated `terrakube/.gitignore` to ignore transient benchmark output directories (`benchmarks/results/`, `benchmark-results/`), Python bytecode caches (`__pycache__/`, `*.pyc`), and virtual environments.

---

## Directory Structure
```
terrakube/benchmarks/
└── registry/
    ├── README.md             # Complete benchmark documentation and CLI reference
    ├── config.py             # Endpoint and cluster configurations
    ├── seeder.py             # PostgreSQL and SeaweedFS S3 test fixture seeder
    ├── k8s_manager.py        # MicroK8s image deployment & startup timing
    ├── telemetry.py          # Prometheus & OpenTelemetry metric collector
    ├── load_generator.py     # Concurrent HTTP load engine
    ├── visualizer.py         # SVG chart generator
    ├── reporter.py           # Markdown report compiler
    └── run_benchmark.py      # Main CLI entrypoint
```

---

## How to Test / Verify

1. **Quick Smoke Test**:
   ```bash
   python3 terrakube/benchmarks/registry/run_benchmark.py \
     --quick \
     --token $TERRAKUBE_TOKEN_BENCHMARK
   ```

2. **Single Baseline Profile (Active Pod)**:
   ```bash
   python3 terrakube/benchmarks/registry/run_benchmark.py \
     --skip-deploy \
     --registry-url https://terrakube-reg.microk8s.net \
     --token $TERRAKUBE_TOKEN_BENCHMARK \
     --workers 5 \
     --stage-duration 60
   ```

3. **Full A/B Rollout Evaluation**:
   ```bash
   python3 terrakube/benchmarks/registry/run_benchmark.py \
     --token $TERRAKUBE_TOKEN_BENCHMARK \
     --baseline azbuilder/open-registry:2.33.0-beta.10 \
     --candidate azbuilder/open-registry:2.33.0-beta.10-alpaquita \
     --workers 5 10 25 \
     --stage-duration 20
   ```

---

## Checklist
- [x] Standard library only (no external Python dependencies required)
- [x] Automated test fixture seeding (PostgreSQL + S3)
- [x] Tested against live MicroK8s cluster
- [x] Validated `.gitignore` ignores dynamic results and caches
- [x] Comprehensive documentation included in `README.md`


# Example Result

# Terrakube Registry Performance Analysis: azbuilder/open-registry:2.33.0-beta.10

> **Report Generated**: 2026-08-16 13:11:15 UTC  
> **Environment**: MicroK8s Remote Cluster (`user@192.168.1.150`)  
> **Registry URL**: `https://terrakube-reg.microk8s.net`  
> **Baseline Image**: `azbuilder/open-registry:2.33.0-beta.10`  

---

## 1. Executive Summary

A baseline-only performance evaluation was conducted against all 7 controller endpoints under stepped concurrency, while continuously gathering OpenTelemetry and Prometheus runtime metrics.

### Baseline Highlights:
- **Container Disk Footprint**: **241.2 MB**.

- **JVM Heap Under Load**: **524.8 MB** heap used.
- **GC Pause Total**: **12823.0 ms**.

---

## 2. Architecture & Benchmark Telemetry Pipeline

```mermaid
sequenceDiagram
    autonumber
    actor Harness as Python Benchmark Harness
    participant Reg as Terrakube Registry Pod (:8075)
    participant Otel as OpenTelemetry JavaAgent (:9464)
    participant S3 as SeaweedFS S3 Storage
    participant DB as CloudNativePG PostgreSQL
    participant Prom as Prometheus (:9090)

    Note over Harness,Prom: Stepped Load Generation (workers staged)
    Harness->>Reg: HTTP Requests (WellKnown, Modules, Providers, ReadMe)
    Reg->>DB: SQL Queries & Download Counter Updates
    Reg->>S3: Binary Module Zip Streaming & In-Memory Unzip
    Reg->>Otel: Record JVM, Memory, Threads & Latency Metrics
    Otel->>Prom: Expose /metrics on Port 9464
    Harness->>Prom: Query Prometheus Instant & Window Telemetry
```

---

## 3. Container & Operating System Footprint

| Metric | Baseline |
| :--- | :--- |
| **Image Size on Disk** | `241.2 MB` |
| **Cold Startup to Ready** | `0.00 s` |
| **Container RSS Working Set** | `796.9 MB` |

---

## 4. JVM Runtime & Garbage Collection Telemetry

| Metric | Baseline |
| :--- | :--- |
| **JVM Heap Used** | `524.8 MB` |
| **JVM Heap Committed** | `1184.0 MB` |
| **JVM Non-Heap (Metaspace)** | `518.0 MB` |
| **Total GC Pause Time** | `12823.0 ms` |
| **Average GC Pause Duration** | `16.03 ms` |
| **Total GC Cycle Count** | `800` |
| **Live Thread Count** | `128` |

---

## 5. Per-Endpoint Benchmark Results across Concurrency Levels

| Endpoint | Controller | Workers | RPS | MB/s | p50 (ms) | p90 (ms) | p95 (ms) | p99 (ms) | StdDev (ms) | Min/Max (ms) | Errors |
| :--- | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| `module_download_redirect` | `ModuleWebServiceImpl` | 5 | 10.4 | 0.00 | 439.1 | 657.0 | 751.4 | 927.7 | 140.7 | 272.0/1127.9 | 0/592 (0.0%) |
| `module_versions` | `ModuleWebServiceImpl` | 5 | 162.6 | 0.78 | 27.3 | 38.3 | 46.3 | 140.3 | 19.0 | 15.3/1091.9 | 0/9272 (0.0%) |
| `module_zip_stream` | `ModuleWebServiceImpl` | 5 | 8.3 | 11.85 | 588.9 | 741.0 | 797.8 | 1008.8 | 131.2 | 303.0/1761.5 | 0/474 (0.0%) |
| `provider_download_meta` | `ProviderWebServiceImpl` | 5 | 72.7 | 0.04 | 57.7 | 104.5 | 152.7 | 202.5 | 32.9 | 35.5/327.4 | 0/4146 (0.0%) |
| `provider_versions` | `ProviderWebServiceImpl` | 5 | 75.2 | 0.01 | 56.4 | 100.4 | 147.2 | 178.5 | 32.5 | 34.3/409.7 | 0/4285 (0.0%) |
| `readme_markdown` | `ReadMeWebServiceImpl` | 5 | 23.9 | 3.11 | 195.5 | 288.7 | 349.2 | 433.7 | 65.2 | 101.9/591.2 | 0/1366 (0.0%) |
| `well_known` | `WellKnownWebServiceImpl` | 5 | 171.1 | 0.08 | 24.8 | 36.2 | 48.0 | 141.1 | 21.5 | 14.6/1078.7 | 0/9753 (0.0%) |

---

## 6. Visual Performance Diagrams

### Latency Percentiles (p50 / p90 / p95 / p99) per Endpoint



### Throughput (RPS) per Endpoint across Concurrency Levels

<img width="1121" height="319" alt="imagen" src="https://github.com/user-attachments/assets/e48b6744-b818-46fc-84e1-956e90bcdeac" />

### Throughput (MB/s) per Endpoint across Concurrency Levels

<img width="1121" height="319" alt="imagen" src="https://github.com/user-attachments/assets/9c0d20bf-f3ed-4fa5-bb69-5cea43d8d5b4" />


### JVM Heap Memory & Garbage Collection — Over Time

<img width="944" height="698" alt="imagen" src="https://github.com/user-attachments/assets/e8425013-9aee-4a94-99ef-b9cca60900ac" />

### Container Footprint & RSS Memory — Over Time

<img width="934" height="481" alt="imagen" src="https://github.com/user-attachments/assets/c0f4aea2-5ae7-4c5a-a0bf-9d4c31437605" />

---

## 7. Conclusions & Observations

1. **Baseline Profile Established**: Use these results as the reference for future A/B candidate comparisons.
2. **JVM Runtime Behavior**: Time-series charts reveal GC pressure patterns and heap growth under sustained concurrency load.
3. **Re-run with Candidate**: Add `--candidate <image>` to run a comparative A/B analysis against this baseline.
