### PR TITLE
fix(ui): open organization/workspace rows as real links for ctrl/middle/right-click

### DIFF
--- a/ui/src/__verify_ctrl_click.test.tsx
+++ b/ui/src/__verify_ctrl_click.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import OrganizationTable from "./modules/organizations/components/OrganizationTable/OrganizationTable";
+import OrganizationGridItem from "./modules/organizations/components/OrganizationGrid/OrganizationGridItem";
+import WorkspaceTable from "./modules/workspaces/components/WorkspaceTable/WorkspaceTable";
+
+jest.mock("@/modules/permissions/useOrgPermissions", () => ({
+  useOrgPermissions: () => ({ permissions: { managePermission: false }, loading: false }),
+}));
+
+const org = {
+  id: "org-1",
+  name: "Acme Corp",
+  description: "desc",
+  executionMode: "remote",
+  workspaceCount: 2,
+  icon: null,
+  workspaceStatusCounts: {},
+} as any;
+
+const workspace = {
+  id: "ws-1",
+  name: "My Workspace",
+  description: "",
+  lastStatus: null,
+  lastRun: null,
+  terraformVersion: "1.5.0",
+  iacType: "terraform",
+  normalizedSource: null,
+  branch: "main",
+  locked: false,
+  projectId: null,
+  projectName: null,
+} as any;
+
+test("organization table row is a real anchor pointing at the org workspaces URL", () => {
+  render(
+    <MemoryRouter>
+      <OrganizationTable organizations={[org]} />
+    </MemoryRouter>
+  );
+  const link = screen.getByRole("link", { name: /open organization acme corp/i });
+  expect(link.tagName).toBe("A");
+  expect(link.getAttribute("href")).toBe("/organizations/org-1/workspaces");
+});
+
+test("organization grid card is a real anchor pointing at the org workspaces URL", () => {
+  render(
+    <MemoryRouter>
+      <OrganizationGridItem organization={org} />
+    </MemoryRouter>
+  );
+  const link = screen.getByRole("link");
+  expect(link.tagName).toBe("A");
+  expect(link.getAttribute("href")).toBe("/organizations/org-1/workspaces");
+  expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+});
+
+test("workspace table row is a real anchor pointing at the workspace URL", () => {
+  render(
+    <MemoryRouter>
+      <WorkspaceTable
+        organizationId="org-1"
+        workspaces={[workspace]}
+        onSelectProject={() => {}}
+        sortOption="name_asc"
+        onSortChange={() => {}}
+      />
+    </MemoryRouter>
+  );
+  const link = screen.getByRole("link", { name: /open workspace my workspace/i });
+  expect(link.tagName).toBe("A");
+  expect(link.getAttribute("href")).toBe("/organizations/org-1/workspaces/ws-1");
+});

--- a/ui/src/modules/organizations/OrganizationDetailsPage.tsx
+++ b/ui/src/modules/organizations/OrganizationDetailsPage.tsx
@@ -211,10 +211,12 @@ export default function OrganizationsDetailPage({ organizationName, setOrganizat
             dataSource={sortedWorkspaces}
             pagination={{ showSizeChanger: true, defaultPageSize: 10 }}
             renderItem={(item) => (
-              <List.Item
-                style={{ cursor: "pointer" }}
-                onClick={() => navigate(`/organizations/${id}/workspaces/${item.id}`)}
-              >
+              <List.Item style={{ position: "relative" }}>
+                <Link
+                  to={`/organizations/${id}/workspaces/${item.id}`}
+                  aria-label={`Open workspace ${item.name}`}
+                  style={{ position: "absolute", inset: 0, zIndex: 0 }}
+                />
                 <WorkspaceCard tags={tags} item={item} />
               </List.Item>
             )}

--- a/ui/src/modules/organizations/components/OrganizationGrid/OrganizationGridItem.tsx
+++ b/ui/src/modules/organizations/components/OrganizationGrid/OrganizationGridItem.tsx
@@ -1,5 +1,5 @@
 import { Flex, Typography, Card } from "antd";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { OrganizationModel } from "../../types";
 import { parseIconField, getOrgIcon } from "../../utils/orgIcon";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../../../config/actionTypes";
@@ -9,32 +9,32 @@ type Props = {
 };
 
 export default function OrganizationGridItem({ organization }: Props) {
-  const navigate = useNavigate();
   const { iconName, color } = parseIconField(organization.icon, organization.id);
 
-  const handleOrganizationClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-
-    // Store organization data in session storage
+  const rememberOrganization = () => {
     sessionStorage.setItem(ORGANIZATION_ARCHIVE, organization.id);
     sessionStorage.setItem(ORGANIZATION_NAME, organization.name);
-
-    navigate(`/organizations/${organization.id}/workspaces`);
   };
 
   return (
-    <Card hoverable style={{ width: "100%" }} onClick={handleOrganizationClick}>
-      <Flex gap="small" align="center">
-        <div className="org-card-icon">{getOrgIcon(iconName, color)}</div>
-        <Flex vertical gap="0">
-          <Typography.Text className="org-card-title" ellipsis>
-            {organization.name}
-          </Typography.Text>
-          <Typography.Text type="secondary">
-            {organization.description || "No description set for this organization"}
-          </Typography.Text>
+    <Link
+      to={`/organizations/${organization.id}/workspaces`}
+      onClick={rememberOrganization}
+      style={{ display: "block", color: "inherit" }}
+    >
+      <Card hoverable style={{ width: "100%" }}>
+        <Flex gap="small" align="center">
+          <div className="org-card-icon">{getOrgIcon(iconName, color)}</div>
+          <Flex vertical gap="0">
+            <Typography.Text className="org-card-title" ellipsis>
+              {organization.name}
+            </Typography.Text>
+            <Typography.Text type="secondary">
+              {organization.description || "No description set for this organization"}
+            </Typography.Text>
+          </Flex>
         </Flex>
-      </Flex>
-    </Card>
+      </Card>
+    </Link>
   );
 }

--- a/ui/src/modules/organizations/components/OrganizationTable/OrganizationTable.css
+++ b/ui/src/modules/organizations/components/OrganizationTable/OrganizationTable.css
@@ -119,9 +119,12 @@
   flex-shrink: 0;
   display: flex;
   justify-content: flex-end;
+  position: relative;
+  z-index: 1;
 }
 
 .organization-row {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 12px;
@@ -139,7 +142,13 @@
   background: var(--tk-fill-secondary);
 }
 
-.organization-row:focus-visible,
+.organization-row-link {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.organization-row-link:focus-visible,
 .organization-sortable-header:focus-visible {
   outline: 2px solid #1890ff;
   outline-offset: -2px;

--- a/ui/src/modules/organizations/components/OrganizationTable/OrganizationTable.tsx
+++ b/ui/src/modules/organizations/components/OrganizationTable/OrganizationTable.tsx
@@ -1,7 +1,7 @@
 import { Input, Typography, Pagination } from "antd";
 import { CaretUpOutlined, CaretDownOutlined } from "@ant-design/icons";
 import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { OrganizationModel } from "../../types";
 import { parseIconField, getOrgIcon } from "../../utils/orgIcon";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "@/config/actionTypes";
@@ -112,25 +112,23 @@ function SortableHeader({
 }
 
 function OrganizationRow({ organization }: { organization: OrganizationModel }) {
-  const navigate = useNavigate();
   const { iconName, color } = parseIconField(organization.icon, organization.id);
   const statusCounts = organization.workspaceStatusCounts ?? {};
   const statusBreakdown = BREAKDOWN_STATUSES.filter((entry) => (statusCounts[entry.value] ?? 0) > 0);
 
-  const openOrganization = () => {
+  const rememberOrganization = () => {
     sessionStorage.setItem(ORGANIZATION_ARCHIVE, organization.id);
     sessionStorage.setItem(ORGANIZATION_NAME, organization.name);
-    navigate(`/organizations/${organization.id}/workspaces`);
   };
 
   return (
-    <div
-      className="organization-row"
-      role="button"
-      tabIndex={0}
-      onClick={openOrganization}
-      onKeyDown={(e) => activateOnKey(e, openOrganization)}
-    >
+    <div className="organization-row">
+      <Link
+        to={`/organizations/${organization.id}/workspaces`}
+        onClick={rememberOrganization}
+        className="organization-row-link"
+        aria-label={`Open organization ${organization.name}`}
+      />
       <div className="organization-col-name">
         <div className="organization-col-name-icon">{getOrgIcon(iconName, color, 20)}</div>
         <Typography.Text strong ellipsis title={organization.name}>

--- a/ui/src/modules/workspaces/components/WorkspaceCard.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceCard.tsx
@@ -64,6 +64,7 @@ export default function WorkspaceCard({ item, tags }: Props) {
                 target="_blank"
                 rel="noreferrer"
                 onClick={(e) => e.stopPropagation()}
+                style={{ position: "relative", zIndex: 1 }}
               >
                 {item.normalizedSource ? getVcsNameFromUrl(item.normalizedSource) : "Unknown"}
               </Typography.Link>

--- a/ui/src/modules/workspaces/components/WorkspaceTable/WorkspaceTable.css
+++ b/ui/src/modules/workspaces/components/WorkspaceTable/WorkspaceTable.css
@@ -96,6 +96,7 @@
 }
 
 .workspace-row {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 12px;
@@ -113,7 +114,13 @@
   background: var(--tk-fill-secondary);
 }
 
-.workspace-row:focus-visible,
+.workspace-row-link {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.workspace-row-link:focus-visible,
 .workspace-sortable-header:focus-visible,
 .workspace-group-show-more:focus-visible {
   outline: 2px solid #1890ff;
@@ -138,6 +145,8 @@
 }
 
 .workspace-clickable-tag {
+  position: relative;
+  z-index: 1;
   cursor: pointer;
 }
 
@@ -158,6 +167,8 @@
 }
 
 .workspace-source-link {
+  position: relative;
+  z-index: 1;
   font-size: 13.5px;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/ui/src/modules/workspaces/components/WorkspaceTable/WorkspaceTable.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceTable/WorkspaceTable.tsx
@@ -8,7 +8,7 @@ import {
 } from "@ant-design/icons";
 import { DateTime } from "luxon";
 import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { WorkspaceListItem } from "@/modules/workspaces/types";
 import WorkspaceStatusTag from "@/modules/workspaces/components/WorkspaceStatusTag";
 import { statusColors } from "@/modules/workspaces/utils/workspaceStatusColors";
@@ -102,16 +102,13 @@ function WorkspaceRow({
   organizationId: string;
   onSelectProject: (projectId: string | null) => void;
 }) {
-  const navigate = useNavigate();
-  const openWorkspace = () => navigate(`/organizations/${organizationId}/workspaces/${item.id}`);
   return (
-    <div
-      className="workspace-row"
-      role="button"
-      tabIndex={0}
-      onClick={openWorkspace}
-      onKeyDown={(e) => activateOnKey(e, openWorkspace)}
-    >
+    <div className="workspace-row">
+      <Link
+        to={`/organizations/${organizationId}/workspaces/${item.id}`}
+        className="workspace-row-link"
+        aria-label={`Open workspace ${item.name}`}
+      />
       <div className="workspace-col-name">
         <div className="workspace-name-line1">
           <span


### PR DESCRIPTION
## Summary

Rows in the organization list and workspace list (both table and card views) navigated via `onClick` + `useNavigate()` on a `<div>`/`<Card>`/`<List.Item>` instead of a real anchor. That meant ctrl-click, cmd-click, middle-click, and right-click → "Open in new tab" did nothing — only a plain left click worked.

This swaps those handlers for `react-router-dom` `<Link>` elements, which render real `<a href>` tags, so the browser's native multi-click/new-tab/copy-link behavior works without any custom handling.

## Changes

- **`OrganizationGridItem.tsx`** — the org grid card has no nested interactive elements, so it's now wrapped directly in a `<Link>`.
- **`OrganizationTable.tsx` / `OrganizationTable.css`** — the table row contains a settings `<button>`, so wrapping the whole row in `<a>` would be invalid HTML (and would break the button's own click handling). Uses a "stretched link" instead: an invisible `<Link>` absolutely positioned behind the row, with the settings button raised above it via `z-index`.
- **`WorkspaceTable.tsx` / `WorkspaceTable.css`** — same stretched-link pattern. The row's clickable project tag and its VCS source `<a>` link are raised above the overlay so they keep working independently.
- **`OrganizationDetailsPage.tsx` / `WorkspaceCard.tsx`** — the workspace card view (`List.Item`) gets the same overlay treatment; the card's VCS source link is raised above it.

## Why the "stretched link" pattern

Nesting a `<button>` or `<a>` inside another `<a>` is invalid HTML and breaks the inner control's clickability. The stretched-link technique (the same approach as Bootstrap's `.stretched-link`) keeps one real anchor covering the row for native browser behavior, while nested interactive elements opt back in with `position: relative; z-index: 1`.

## Testing

- `tsc --noEmit` — clean
- `eslint` on changed files — clean
- Component test (`ui/src/__verify_ctrl_click.test.tsx`) asserting the org table row, org grid card, and workspace table row all render as real `<a href="...">` elements pointing at the expected route
- **manually verified in a running browser**