### PR TITLE
feat: integrate Syft SBOM generation into UI Dockerfile 

### DIFF
--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+build
+.git
+coverage
+.DS_Store

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -17,6 +17,11 @@ ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 RUN yarn build
 
+# => Generate SBOM
+COPY --from=anchore/syft:latest /syft /usr/local/bin/syft
+RUN mkdir -p /etc/sbom && \
+    syft scan dir:/app -o spdx-json=/etc/sbom/sbom.spdx.json -o cyclonedx-json=/etc/sbom/sbom.cdx.json
+
 # => Run container
 FROM nginxinc/nginx-unprivileged:latest
 
@@ -27,4 +32,5 @@ WORKDIR /usr/share/nginx/html
 
 # Static build
 COPY --from=builder /app/build .
+COPY --from=builder /etc/sbom /etc/sbom
 COPY conf/conf.d/terrakube-ui.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Description

This PR enhances the Terrakube UI Docker image (`terrakube/ui/Dockerfile`) to generate and embed Software Bill of Materials (SBOM) metadata using [Anchore Syft](https://github.com/anchore/syft).

This brings the `ui` component into parity with `api`, `registry`, and `executor` (which use Paketo buildpacks with Syft internally) by generating both standard SBOM formats directly within the container image.

---

## Changes

- **UI Dockerfile (`ui/Dockerfile`)**:
  - Injected the official `anchore/syft` binary into the `builder` stage (`COPY --from=anchore/syft:latest /syft /usr/local/bin/syft`).
  - Automated SBOM generation scanning `/app` (including `yarn.lock`, `package.json`, and dependencies) into:
    - SPDX 2.3 JSON: `/etc/sbom/sbom.spdx.json`
    - CycloneDX 1.7 JSON: `/etc/sbom/sbom.cdx.json`
  - Copied `/etc/sbom` into the final unprivileged NGINX runtime container.
- **Docker Context (`ui/.dockerignore`)**:
  - Added `.dockerignore` to exclude local `node_modules`, `build`, and `.git` from the Docker build context for cleaner and faster builds.

---

## Verification

Built and inspected the container image locally:

```bash
docker build -t terrakube-ui:sbom-test ui/
```

### Inspect Generated SBOMs:
```bash
# Verify files exist in /etc/sbom
docker run --rm terrakube-ui:sbom-test ls -la /etc/sbom
# Output:
# -rw-r--r-- 1 root root  815242 sbom.cdx.json
# -rw-r--r-- 1 root root 1441648 sbom.spdx.json

# Verify SPDX format:
docker run --rm terrakube-ui:sbom-test head -c 300 /etc/sbom/sbom.spdx.json

# Verify CycloneDX format:
docker run --rm terrakube-ui:sbom-test head -c 300 /etc/sbom/sbom.cdx.json
```
