### PR TITLE
feat: add OpenSSF Scorecard security analysis workflow and documentation badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,56 @@
+name: OpenSSF Scorecard
+
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: '0 0 * * 1'
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Public repositories can enable a badge and publish results to OpenSSF API.
+          # For private repositories, set publish_results to false.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will still upload to GitHub's code scanning.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb99ba841c # v4.6.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will still upload such that your repo has a score on scorecards.dev
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Build](https://github.com/terrakube-io/terrakube/actions/workflows/pull_request.yml/badge.svg)](https://github.com/terrakube-io/terrakube/actions/workflows/pull_request.yml)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=AzBuilder_azb-server&metric=coverage)](https://sonarcloud.io/dashboard?id=AzBuilder_azb-server)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/terrakube-io/terrakube/blob/main/LICENSE)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/terrakube-io/terrakube/badge)](https://securityscorecards.dev/viewer/?uri=github.com/terrakube-io/terrakube)
 [![gitbook](https://raw.githubusercontent.com/aleen42/badges/master/src/gitbook_2.svg)](https://gitpod.io/#https://github.com/terrakube-io/terrakube)
 [![Slack](https://img.shields.io/badge/Join%20Our%20Community-Slack-blue)](https://join.slack.com/t/terrakubeworkspace/shared_invite/zt-2cx6yn95t-2CTBGvsQhBQJ5bfbG4peFg)
 


### PR DESCRIPTION
## Description
Integrates the [OpenSSF Scorecard](https://securityscorecards.dev/) automated security analysis workflow into Terrakube and adds the official status badge to the repository `README.md`.
Scorecard assesses supply chain and codebase security posture against industry standards (e.g., SLSA, branch protection, unpinned actions, least-privilege token permissions, vulnerability tracking).
## Changes Made
- **GitHub Actions Workflow** ([`.github/workflows/scorecard.yml`](.github/workflows/scorecard.yml)):
  - Configured weekly scheduled scans (`0 0 * * 1`), runs on push to `main`, and supports `workflow_dispatch`.
  - Enforced top-level read-only permissions (`permissions: read-all`) with minimal scoped job permissions (`security-events: write`, `id-token: write`).
  - Pinned all workflow actions to immutable commit SHAs for supply chain integrity.
  - Configured SARIF export to GitHub Code Scanning and published results to OpenSSF API for badge reporting.
- **README** ([`README.md`](README.md)):
  - Added the OpenSSF Scorecard status badge to the repository header.
## Impact & Verification
- ✅ Validated YAML workflow syntax.
- ✅ Confirmed non-breaking changes isolated to CI and documentation.