### PR TITLE
fix: correct pinned SHA for actions/upload-artifact@v4.6.1 in scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Upload the results as artifacts (optional). Commenting out will still upload to GitHub's code scanning.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb99ba841c # v4.6.1
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
The commit SHA was corrupted (ending in 99ba841c instead of 9dce8ec1). Verified correct SHA via GitHub API: 4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1