### PR TITLE
fix: add top-level `read-all` permissions to resolve Scorecard Token-Permissions warning

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -17,6 +17,8 @@ on:
           - minor
           - major
 
+permissions: read-all
+
 env:
   REGISTRY: ghcr.io
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions: read-all
+
 jobs:
   build-jammy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request_ui.yml
+++ b/.github/workflows/pull_request_ui.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - 'ui/**'
 
+permissions: read-all
+
 jobs:
   buildui:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [created]
 
+permissions: read-all
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
## Summary

The [OpenSSF Scorecard](https://securityscorecards.dev/) **Token-Permissions** check flagged four GitHub Actions workflows because they had no top-level `permissions:` block. Without an explicit block, GitHub defaults to the repository-level permission setting, which may grant write access to all scopes — violating the principle of least privilege.

This PR adds `permissions: read-all` at the top level of every affected workflow, matching the pattern already established in [`scorecard.yml`](.github/workflows/scorecard.yml).

---

## Changes

| Workflow | Problem | Fix applied |
|---|---|---|
| `manual_release.yml` | No top-level permissions; `create-release` job had `contents: write` (flagged as Warn) | Added top-level `permissions: read-all`; kept all existing job-level overrides unchanged |
| `pull_request.yml` | No top-level permissions (flagged as Warn) | Added top-level `permissions: read-all`; no job-level changes needed |
| `pull_request_ui.yml` | No top-level permissions (flagged as Warn) | Added top-level `permissions: read-all`; no job-level changes needed |
| `release.yml` | No top-level permissions (flagged as Warn) | Added top-level `permissions: read-all`; no job-level changes needed |

### Why `read-all` and not `{}`?

`permissions: read-all` is the safest top-level default: it explicitly grants read access to all scopes and revokes write access. Jobs that legitimately need write access (e.g., `create-release` in `manual_release.yml`, which calls `gh release create` via `GITHUB_TOKEN`) already override permissions at the job level with `contents: write`.

`release.yml` pushes images to Docker Hub using repository secrets (`DOCKER_USER` / `DOCKER_PASSWORD`), **not** `GITHUB_TOKEN` write access, so no job-level overrides are needed there.

---

## Scorecard impact

Before this PR, the Scorecard output included:

```
Warn: no topLevel permission defined: .github/workflows/manual_release.yml:1
Warn: no topLevel permission defined: .github/workflows/pull_request.yml:1
Warn: no topLevel permission defined: .github/workflows/pull_request_ui.yml:1
Warn: no topLevel permission defined: .github/workflows/release.yml:1
```

After this PR, all four `Warn` lines should become `Info` entries (similar to the existing `Info: topLevel permissions set to 'read-all': .github/workflows/scorecard.yml:16`), and the `contents: write` on `create-release` remains the only intentional write permission in the entire workflow suite.

---

## Testing

- No functional logic was changed — only `permissions:` blocks were added/kept.
- The existing CI jobs (`pull_request.yml`, `pull_request_ui.yml`) will run on this PR and validate that `read-all` does not break checkout or build steps.
- The `manual_release.yml` `create-release` job already has `contents: write` at the job level, which overrides the top-level `read-all`, so GitHub Release creation continues to work.

---

## References

- [OpenSSF Scorecard – Token-Permissions check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions)
- [GitHub Docs – Assigning permissions to jobs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token)