### PR TITLE
fix: pin all container image references by digest for Scorecard Pinned-Dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/java:dev-17-bookworm
+FROM mcr.microsoft.com/devcontainers/java:dev-17-bookworm@sha256:912bee33a9ff003b2d045218369760b5aa848045a57f5111a0769f44266289ae # dev-17-bookworm
 
 # Install necessary packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,5 +1,5 @@
 #=> Build container
-FROM node:24-alpine AS builder
+FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS builder # 24-alpine
 WORKDIR /app
 
 # Enable Corepack so it picks up the Yarn version pinned in
@@ -18,12 +18,12 @@ ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN yarn build
 
 # => Generate SBOM
-COPY --from=anchore/syft:latest /syft /usr/local/bin/syft
+COPY --from=anchore/syft:latest@sha256:678bfa565b60f747aac0f8e964fe5588a24445b8d0a480e91f6efd70020dfbb0 /syft /usr/local/bin/syft # latest
 RUN mkdir -p /etc/sbom && \
     syft scan dir:/app -o spdx-json=/etc/sbom/sbom.spdx.json -o cyclonedx-json=/etc/sbom/sbom.cdx.json
 
 # => Run container
-FROM nginxinc/nginx-unprivileged:latest
+FROM nginxinc/nginx-unprivileged:latest@sha256:1ab63ed666197d757cd3ce0ad84c5136f18f774465345785f33423bd1bba4353 # latest
 
 # Default Terraform version, updated at build time
 ARG REACT_APP_TERRAKUBE_VERSION=2.0.0


### PR DESCRIPTION
## Summary

The [OpenSSF Scorecard](https://securityscorecards.dev/) **Pinned-Dependencies** check reported that 3 out of 3 container image dependencies were not pinned by digest, reducing the score. Referencing images only by mutable tags (e.g., `latest`, `24-alpine`) means a compromised or accidentally overwritten tag could silently change the base image used in builds — a classic supply-chain attack vector.

This PR pins all 4 container image references across both affected Dockerfiles using their immutable `sha256` digests. The human-readable tag is preserved as an inline comment so it remains obvious which version each digest corresponds to.

---

## Changes

### [`.devcontainer/Dockerfile`](.devcontainer/Dockerfile)

| Line | Before | After |
|---|---|---|
| 1 | `mcr.microsoft.com/devcontainers/java:dev-17-bookworm` | `mcr.microsoft.com/devcontainers/java:dev-17-bookworm@sha256:912bee33a9ff003b2d045218369760b5aa848045a57f5111a0769f44266289ae # dev-17-bookworm` |

### [`ui/Dockerfile`](ui/Dockerfile)

| Line | Before | After |
|---|---|---|
| 2 | `node:24-alpine` | `node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 # 24-alpine` |
| 21 | `COPY --from=anchore/syft:latest` | `COPY --from=anchore/syft:latest@sha256:678bfa565b60f747aac0f8e964fe5588a24445b8d0a480e91f6efd70020dfbb0 # latest` |
| 26 | `nginxinc/nginx-unprivileged:latest` | `nginxinc/nginx-unprivileged:latest@sha256:1ab63ed666197d757cd3ce0ad84c5136f18f774465345785f33423bd1bba4353 # latest` |

> The `anchore/syft` image (line 21) is also pinned even though Scorecard did not explicitly flag it — it is a third container pull in the `COPY --from=` form and carries the same supply-chain risk as a `FROM` reference.

---

## Scorecard impact

Before this PR:

```
Warn: containerImage not pinned by hash: .devcontainer/Dockerfile:1
Warn: containerImage not pinned by hash: ui/Dockerfile:2
Warn: containerImage not pinned by hash: ui/Dockerfile:26
Info: 0 out of 3 containerImage dependencies pinned
```

After this PR, all container images are pinned by digest → **3 out of 3 (or 4 out of 4 including syft) containerImage dependencies pinned**, and the Scorecard score for the Pinned-Dependencies check should reach 10/10.

---

## How to update digests in the future

When you want to update to a newer image version:

```bash
# Example: update node:24-alpine
docker buildx imagetools inspect node:24-alpine \
  --format '{{json .Manifest}}' | jq -r '.digest'
```

Then replace the `sha256:...` in the Dockerfile with the new digest and update the tag comment if the tag has also changed.

---

## References

- [OpenSSF Scorecard – Pinned-Dependencies check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
- [Docker best practices – pin images by digest](https://docs.docker.com/build/building/best-practices/#pin-base-image-versions)