### PR TITLE
chore: add Docker ecosystem entries to Dependabot for automatic image digest updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,29 @@ updates:
           - "patch"
     commit-message:
       prefix: "deps"
+
+  # Docker: UI Dockerfile (node builder, nginx runtime, syft SBOM)
+  - package-ecosystem: "docker"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      ui-docker-images:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "deps"
+
+  # Docker: Dev Container Dockerfile (java devcontainer base image)
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      devcontainer-docker-images:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
## Summary

Following the introduction of digest-pinned container images in the Dockerfiles (`fix/scorecard-pinned-dependencies`), this PR closes the maintenance loop by teaching **Dependabot** to automatically open weekly PRs whenever a new digest is available for any of the pinned base images.

Dependabot already manages npm and Maven dependencies on a weekly schedule. This PR adds the same automation for Docker images, keeping all dependency management consistent in a single configuration file.

---

## Changes

### [`.github/dependabot.yml`](.github/dependabot.yml)

Two new `docker` ecosystem entries are added:

#### Entry 1 — `/ui` (UI Dockerfile)

Covers the three images in [`ui/Dockerfile`](ui/Dockerfile):
| Image | Current pinned digest |
|---|---|
| `node:24-alpine` | `sha256:d32cdf61...` |
| `anchore/syft:latest` | `sha256:678bfa56...` |
| `nginxinc/nginx-unprivileged:latest` | `sha256:1ab63ed6...` |

All three images are grouped into a **single PR** (`ui-docker-images`) to reduce noise.

#### Entry 2 — `/.devcontainer` (Dev Container Dockerfile)

Covers the one image in [`.devcontainer/Dockerfile`](.devcontainer/Dockerfile):
| Image | Current pinned digest |
|---|---|
| `mcr.microsoft.com/devcontainers/java:dev-17-bookworm` | `sha256:912bee33...` |

Updates are grouped into a single PR (`devcontainer-docker-images`).

---

## Configuration summary

| Setting | Value | Rationale |
|---|---|---|
| `schedule.interval` | `weekly` | Matches the existing npm and maven cadence |
| `commit-message.prefix` | `deps` | Matches the existing npm and maven prefix |
| `open-pull-requests-limit` | `5` | Slightly lower than npm/maven (fewer Docker images) |
| Grouping | One PR per directory | Prevents separate PRs for each individual image |

---

## How it works once merged

1. Every week, Dependabot checks Docker Hub / MCR for new digests for each pinned image.
2. If a newer digest is available for a tag, Dependabot opens a single grouped PR per Dockerfile directory with the updated `FROM image:tag@sha256:newdigest` lines.
3. CI runs on the PR. If it passes, you merge as usual.

> **Note:** Dependabot updates the digest _for the same tag_. If you want to upgrade to a new major tag (e.g., `node:24` → `node:26`), you still need to do that manually and then let Dependabot take over digest tracking for the new tag.

---

## Merge order recommendation

This PR should be merged **after** `fix/scorecard-pinned-dependencies`, since the Dependabot Docker entries only make sense once the images are pinned by digest. Both branches are independent and will not conflict.

---

## References

- [Dependabot Docker ecosystem docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)
- [OpenSSF Scorecard – Pinned-Dependencies check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)