### PR TITLE
fix(api): don't log an unconfigured webhook event as an error

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
@@ -115,6 +115,13 @@ public class WebhookService {
 
                 sendCommitStatus(savedJob);
             }
+        } catch (IllegalArgumentException e) {
+            // A provider sends every event its hook is subscribed to, so an event with no
+            // template configured in Terrakube is an ordinary outcome rather than a
+            // failure. Logging it as an error made a working setup look broken. The
+            // polled-push path above already treats this case the same way.
+            log.info("No template configured for webhook event on workspace {}: {}", workspace.getName(),
+                    e.getMessage());
         } catch (Exception e) {
             log.error("Error creating the job", e);
         }

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -35,6 +36,12 @@ import io.terrakube.api.rs.webhook.WebhookEvent;
 import io.terrakube.api.rs.webhook.WebhookEventPathType;
 import io.terrakube.api.rs.webhook.WebhookEventType;
 import io.terrakube.api.rs.workspace.Workspace;
+
+import java.util.UUID;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @ExtendWith(MockitoExtension.class)
 public class WebhookServiceTest {
@@ -101,7 +108,8 @@ public class WebhookServiceTest {
         pullRequestEvent.setPathType(WebhookEventPathType.PATTERN);
         pullRequestEvent.setTemplateId("pr-template-id");
 
-        doReturn(List.of(pullRequestEvent))
+        // lenient: tests that exercise a non-PR event never consult this row.
+        lenient().doReturn(List.of(pullRequestEvent))
                 .when(webhookEventRepository)
                 .findByWebhookAndEventOrderByPriorityAsc(webhook, WebhookEventType.PULL_REQUEST);
     }
@@ -246,5 +254,33 @@ public class WebhookServiceTest {
         subject.handlePrCommentCommand(result, webhook, workspace);
 
         assertEquals("112233", savedJob.getCommandCommentId());
+    }
+
+    @Test
+    public void pushEventWithNoConfiguredTemplateIsNotAnError() throws Exception {
+        // A provider delivers every event its hook is subscribed to. When only PULL_REQUEST
+        // is configured in Terrakube, an incoming push has no template to match and used to
+        // surface as "Error creating the job" in the logs, which made a working setup look
+        // broken (issue #3159). It should be ignored quietly and create no job.
+        UUID webhookId = UUID.randomUUID();
+        workspace.setId(UUID.randomUUID());
+        doReturn(webhook).when(webhookRepository).getReferenceById(webhookId);
+
+        WebhookResult pushResult = new WebhookResult();
+        pushResult.setValid(true);
+        pushResult.setEvent("push");
+        pushResult.setBranch("main");
+        pushResult.setFileChanges(List.of("main.tf"));
+        doReturn(pushResult).when(gitHubWebhookService).processWebhook(any(), any(), any(), any());
+
+        // No PUSH rows are configured, only the PULL_REQUEST row from setup().
+        doReturn(List.of())
+                .when(webhookEventRepository)
+                .findByWebhookAndEventOrderByPriorityAsc(webhook, WebhookEventType.PUSH);
+
+        assertDoesNotThrow(() -> subject.processWebhook(webhookId.toString(), "{}", Map.of()));
+
+        verify(jobRepository, never()).save(any());
+        verify(scheduleJobService, never()).createJobContext(any());
     }
 }


### PR DESCRIPTION
Closes #3159

A provider delivers every event its hook is subscribed to, so a push arriving at a webhook that only has `PULL_REQUEST` configured has no template to match. `findMatchingEvent` throws, the generic catch in `processWebhook` logs `"Error creating the job"`, and a correctly configured setup ends up looking broken in the logs.

The polled-push path a hundred lines below already treats this as an ordinary outcome and logs it at info. This does the same for the webhook path.

Worth being clear that this is a logging change, not a behaviour one. The event was already ignored and no job was created either way, so I don't think it depends on the version the reporter was running, which I think is what the thread was waiting on.

## Testing

Added a case to `WebhookServiceTest` covering a push arriving with only `PULL_REQUEST` configured: it asserts nothing throws and no job is created. It documents the outcome rather than guarding the log level, since asserting on log output would need an appender capture and that felt like more machinery than a change of this size deserves.

One of the shared stubs in `setup()` had to become `lenient()`, because a test that exercises a non-PR event never consults the PR row and Mockito's strict stubbing fails the test for it.

`mvn -pl api -am test -Dtest=WebhookServiceTest` passes, 10 tests.
