### PR TITLE
fix(#3412): Mirrored providers with trust_signature fail due to truncation

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/provider/ProviderRefreshJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/provider/ProviderRefreshJob.java
@@ -263,7 +263,7 @@ public class ProviderRefreshJob implements Job {
                 JsonNode key = gpgKeys.get(0);
                 impl.setKeyId(truncate(key.path("key_id").asText(""), 32));
                 impl.setAsciiArmor(key.path("ascii_armor").asText(""));
-                impl.setTrustSignature(truncate(key.path("trust_signature").asText(""), 32));
+                impl.setTrustSignature(key.path("trust_signature").asText(""));
                 impl.setSource(truncate(key.path("source").asText("unknown"), 64));
                 impl.setSourceUrl(truncate(key.path("source_url").asText("https://unknown"), 512));
             } else {

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -120,4 +120,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-variable-category-not-null.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-notification.xml" />
     <include file="/db/changelog/local/changelog-2.33.0-job-target-replace-addrs.xml"/>
+    <include file="/db/changelog/local/changelog-2.33.0-provider-trust-signature.xml"/>
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-provider-trust-signature.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-provider-trust-signature.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-33-0-provider-trust-signature" author="7487">
+        <modifyDataType tableName="implementation" columnName="trust_signature" newDataType="clob"/>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/provider/ProviderRefreshJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/provider/ProviderRefreshJobTest.java
@@ -1,0 +1,83 @@
+package io.terrakube.api.plugin.scheduler.provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.api.repository.ProviderImplementationRepository;
+import io.terrakube.api.repository.ProviderRepository;
+import io.terrakube.api.repository.ProviderVersionRepository;
+import io.terrakube.api.rs.provider.Provider;
+import io.terrakube.api.rs.provider.implementation.Implementation;
+import io.terrakube.api.rs.provider.implementation.Version;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ProviderRefreshJobTest {
+
+    @Test
+    void preservesFullTrustSignature() throws Exception {
+        UUID providerId = UUID.randomUUID();
+        String trustSignature = "-----BEGIN PGP SIGNATURE-----" + "a".repeat(80) + "-----END PGP SIGNATURE-----";
+        ObjectMapper objectMapper = new ObjectMapper();
+        String versionsResponse = objectMapper.writeValueAsString(Map.of(
+                "versions", List.of(Map.of(
+                        "version", "0.0.22",
+                        "protocols", List.of("5.0"),
+                        "platforms", List.of(Map.of("os", "linux", "arch", "amd64"))
+                ))
+        ));
+        String downloadResponse = objectMapper.writeValueAsString(Map.of(
+                "os", "linux",
+                "arch", "amd64",
+                "signing_keys", Map.of("gpg_public_keys", List.of(Map.of("trust_signature", trustSignature)))
+        ));
+        WebClient webClient = WebClient.builder()
+                .exchangeFunction(request -> Mono.just(ClientResponse.create(HttpStatus.OK)
+                        .body(request.url().getPath().endsWith("/versions") ? versionsResponse : downloadResponse)
+                        .build()))
+                .build();
+        ProviderRepository providerRepository = mock(ProviderRepository.class);
+        ProviderVersionRepository versionRepository = mock(ProviderVersionRepository.class);
+        ProviderImplementationRepository implementationRepository = mock(ProviderImplementationRepository.class);
+        Provider provider = mock(Provider.class);
+        when(provider.getId()).thenReturn(providerId);
+        when(provider.getName()).thenReturn("coderd");
+        when(provider.getRegistryNamespace()).thenReturn("coder");
+        when(provider.isImported()).thenReturn(true);
+        when(providerRepository.findById(providerId)).thenReturn(Optional.of(provider));
+        when(versionRepository.findAllByProviderId(providerId)).thenReturn(List.of());
+        when(versionRepository.save(any(Version.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        JobExecutionContext context = mock(JobExecutionContext.class);
+        JobDetail jobDetail = mock(JobDetail.class);
+        when(context.getJobDetail()).thenReturn(jobDetail);
+        when(jobDetail.getJobDataMap()).thenReturn(new JobDataMap(Map.of("providerId", providerId.toString())));
+
+        ProviderRefreshJob job = new ProviderRefreshJob();
+        ReflectionTestUtils.setField(job, "webClient", webClient);
+        ReflectionTestUtils.setField(job, "providerRepository", providerRepository);
+        ReflectionTestUtils.setField(job, "providerVersionRepository", versionRepository);
+        ReflectionTestUtils.setField(job, "providerImplementationRepository", implementationRepository);
+        job.execute(context);
+
+        ArgumentCaptor<Implementation> implementation = ArgumentCaptor.forClass(Implementation.class);
+        verify(implementationRepository).save(implementation.capture());
+        assertThat(implementation.getValue().getTrustSignature()).isEqualTo(trustSignature);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/provider/ProviderTrustSignatureMigrationTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/provider/ProviderTrustSignatureMigrationTest.java
@@ -1,0 +1,59 @@
+package io.terrakube.api.plugin.scheduler.provider;
+
+import liquibase.Contexts;
+import liquibase.Liquibase;
+import liquibase.database.Database;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProviderTrustSignatureMigrationTest {
+
+    private Connection connection;
+    private Database database;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        connection = DriverManager.getConnection("jdbc:h2:mem:provider-signature-" + UUID.randomUUID());
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE implementation (trust_signature VARCHAR(32))");
+        }
+        database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(connection));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        connection.close();
+    }
+
+    @Test
+    void widensTrustSignatureColumn() throws Exception {
+        Liquibase liquibase = new Liquibase(
+                "db/changelog/local/changelog-2.33.0-provider-trust-signature.xml",
+                new ClassLoaderResourceAccessor(),
+                database
+        );
+        liquibase.update(new Contexts());
+
+        String trustSignature = "a".repeat(128);
+        try (var statement = connection.prepareStatement("INSERT INTO implementation (trust_signature) VALUES (?)")) {
+            statement.setString(1, trustSignature);
+            statement.executeUpdate();
+        }
+        try (var statement = connection.createStatement();
+             var result = statement.executeQuery("SELECT trust_signature FROM implementation")) {
+            result.next();
+            assertThat(result.getString(1)).isEqualTo(trustSignature);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3412.

Terraform Registry trust signatures are armored values that can exceed 32 characters. Provider refresh truncated them to 32 characters and the database column enforced the same limit, so Terraform received an incomplete signature and failed with `unexpected EOF`.

This PR:

- preserves the complete upstream `trust_signature`;
- widens `implementation.trust_signature` to a Liquibase `clob`, matching `ascii_armor`;
- adds regression coverage for registry ingestion and the schema migration.

## Verification

- [x] Red test reproduced the 32-character truncation (expected 132 characters).
- [x] `mvn -q -pl api -Dtest=ProviderRefreshJobTest,ProviderTrustSignatureMigrationTest test`
- [x] `mvn -q -pl api -Dtest='*,!MSSQLStartupTests' test` — 809 tests, 0 failures/errors/skips.
- [x] `mvn -q -DskipTests test-compile`
- [x] `mvn -q clean install -DskipTests -Dspring-boot.build-image.skip=true`
- [x] `git diff --check`
- [x] Liquibase 4.31.1 offline SQL Server validation generated `ALTER COLUMN trust_signature varchar(MAX)`.

The repository has no dedicated lint command. The SQL Server container startup test cannot execute on the local ARM host because the upstream image is amd64-only; PostgreSQL container tests passed, and the SQL Server migration was validated through Liquibase's SQL Server dialect. No UI is changed.

## Scope

Previously truncated stored values cannot be reconstructed. A provider refresh or re-import after upgrade will fetch the complete signature.
