### PR TITLE
fix(api): stop DownloadReleasesService accumulating User-Agent headers

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/json/DownloadReleasesService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/json/DownloadReleasesService.java
@@ -26,7 +26,13 @@ public class DownloadReleasesService {
     }
 
     public void downloadReleasesToFile(String releasesUrl, File releasesFile, String githubToken) {
+        // clone() is essential: webClientBuilder is a field on this singleton bean, and
+        // DefaultWebClientBuilder.defaultHeaders() applies the consumer immediately to the
+        // builder's own HttpHeaders. Mutating the shared builder would make h.add("User-Agent", ..)
+        // below append one more value on every call, growing the header until the remote
+        // rejects the request (api.github.com starts returning 400/500 past ~7KB of headers).
         WebClient webClient = webClientBuilder
+                .clone()
                 .clientConnector(new ReactorClientHttpConnector(
                         HttpClient.create()
                                 .followRedirect(true)

--- a/api/src/test/java/io/terrakube/api/plugin/json/DownloadReleasesServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/json/DownloadReleasesServiceTest.java
@@ -1,0 +1,73 @@
+package io.terrakube.api.plugin.json;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DownloadReleasesServiceTest {
+
+    private HttpServer server;
+    private final List<List<String>> receivedUserAgents = new ArrayList<>();
+    private Path tempDir;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        tempDir = Files.createTempDirectory("releases-test");
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/releases", exchange -> {
+            List<String> userAgents = exchange.getRequestHeaders().get("User-Agent");
+            receivedUserAgents.add(userAgents == null ? List.of() : List.copyOf(userAgents));
+            byte[] body = "[]".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    /**
+     * The builder is a field on this singleton bean and
+     * DefaultWebClientBuilder.defaultHeaders() mutates it in place, so without clone()
+     * every call appends another User-Agent value. Left unchecked the header grows past
+     * what remotes accept - api.github.com answers 400/500 beyond roughly 7KB of headers,
+     * which breaks /tofu/index.json and leaves executor jobs unable to resolve releases.
+     */
+    @Test
+    void repeatedDownloadsMustNotAccumulateHeaders() {
+        DownloadReleasesService service = new DownloadReleasesService(WebClient.builder());
+        String url = "http://127.0.0.1:" + server.getAddress().getPort() + "/releases";
+
+        for (int i = 0; i < 5; i++) {
+            service.downloadReleasesToFile(url, new File(tempDir.toFile(), "releases-" + i + ".json"));
+        }
+
+        assertEquals(5, receivedUserAgents.size(), "expected one request per download");
+        for (int i = 0; i < receivedUserAgents.size(); i++) {
+            List<String> userAgents = receivedUserAgents.get(i);
+            assertEquals(1, userAgents.size(),
+                    "request " + (i + 1) + " sent " + userAgents.size() + " User-Agent values: " + userAgents);
+            assertTrue(userAgents.get(0).equals("releases-downloader"),
+                    "unexpected User-Agent: " + userAgents.get(0));
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`DownloadReleasesService` is a singleton `@Service` that keeps the injected `WebClient.Builder` in a field and calls `defaultHeaders(...)` on it for **every** request:

```java
@Service                                        // singleton
public class DownloadReleasesService {
    private WebClient.Builder webClientBuilder;  // injected once, mutable

    public void downloadReleasesToFile(...) {
        WebClient webClient = webClientBuilder
                .clientConnector(...)
                .defaultHeaders(h -> {
                    h.add("User-Agent", "releases-downloader");   // <-- appends, never replaces
```

`DefaultWebClientBuilder.defaultHeaders()` applies the consumer **immediately** to the builder's own `HttpHeaders`. Because the builder is shared and mutated in place, each call appends *one more* `User-Agent` value. The header grows for the lifetime of the pod. (`setAccept()` uses `set()` and is unaffected — only `add()` leaks.)

Eventually the remote rejects the request. Measured against `api.github.com` from inside an affected cluster:

| `User-Agent` size | Response |
|---|---|
| ≤ 6800 bytes | 200 |
| 7200–7600 bytes | 500 |
| ≥ 8000 bytes | 400 |

## Impact

Once over the threshold, `/tofu/index.json` returns 500 and executors get `tofuReleases == null` in `TerraformDownloader`:

```
ERROR TerraformDownloader : Error fetching tofu releases 500 Internal Server Error
                            from GET http://terrakube-api-service:8080/tofu/index.json
ERROR SimpleAsyncUncaughtExceptionHandler : Unexpected exception occurred invoking
                            async method: ExecutorJobImpl.createJob(TerraformJob)
java.lang.NullPointerException: Cannot invoke "java.util.List.size()"
                            because "this.tofuReleases" is null
```

This is the upstream trigger behind the failure mode described in #3382 and #3376. The stale-cache fallbacks added since help the API survive a failed fetch, but the fetch itself keeps failing until the pod restarts, because the header never shrinks.

Two things make it worse in practice:

- The same service backs both the terraform and tofu endpoints, so the header grows at twice the rate.
- `TerraformDownloader`'s constructor fetches **both** release lists unconditionally, so workspaces using Terraform break on a failing tofu fetch too.

On releases before 2.33.0-beta.7 the NPE escapes the `@Async` `createJob()` uncaught, `SimpleAsyncUncaughtExceptionHandler` merely logs it, and the job stays in `running` forever while the k8s Job reports `Completed`. We hit exactly this on 2.31.3 in production, on both ephemeral and long-lived executors.

## Fix

`clone()` the builder before mutating it, so every call starts from the injected prototype. One line, no behaviour change beyond not leaking state between calls.

## Test

Adds `DownloadReleasesServiceTest`, which performs five downloads against a local `HttpServer` and asserts exactly one `User-Agent` value per request. No new dependencies.

Against the previous code it fails on the second request, which is the bug reproduced directly:

```
org.opentest4j.AssertionFailedError: request 2 sent 2 User-Agent values:
    [releases-downloader, releases-downloader] ==> expected: <1> but was: <2>
```

With the fix:

```
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```