### PR TITLE
fix: make webhook delivery and scheduler processing scale to large shared webhooks

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -122,6 +122,10 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>

--- a/api/src/main/java/io/terrakube/api/plugin/datasource/DataSourceAutoConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/datasource/DataSourceAutoConfiguration.java
@@ -20,13 +20,22 @@ import javax.sql.DataSource;
 public class DataSourceAutoConfiguration {
 
     @Bean
-    public DataSource getDataSource(DataSourceConfigurationProperties dataSourceConfigurationProperties) {
+    public DataSource getDataSource(DataSourceConfigurationProperties dataSourceConfigurationProperties,
+            io.micrometer.core.instrument.MeterRegistry meterRegistry) {
         HikariConfig config = new HikariConfig();
         config.setMaximumPoolSize(dataSourceConfigurationProperties.getPoolSize());
         config.setMinimumIdle(dataSourceConfigurationProperties.getPoolMinIdle());
         config.setConnectionTimeout(dataSourceConfigurationProperties.getPoolConnectionTimeout());
         config.setIdleTimeout(dataSourceConfigurationProperties.getPoolIdleTimeout());
         config.setMaxLifetime(dataSourceConfigurationProperties.getPoolMaxLifetime());
+        // Exposes hikaricp.connections.active/idle/pending/max/min as Prometheus gauges. This
+        // MicrometerMetricsTrackerFactory ships inside HikariCP itself (com.zaxxer.hikari.metrics.
+        // micrometer), not Micrometer - already on the classpath via the existing HikariCP
+        // dependency, no new pom.xml entry needed for it specifically. Set on the config, not the
+        // constructed HikariDataSource, since the pool starts eagerly inside the
+        // HikariDataSource(config) constructor below.
+        config.setMetricsTrackerFactory(
+                new com.zaxxer.hikari.metrics.micrometer.MicrometerMetricsTrackerFactory(meterRegistry));
 
         switch (dataSourceConfigurationProperties.getType()) {
             case SQL_AZURE:

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ExecutorAvailabilityListener.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ExecutorAvailabilityListener.java
@@ -1,8 +1,11 @@
 package io.terrakube.api.plugin.scheduler;
 
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.terrakube.api.repository.JobRepository;
 import jakarta.annotation.PostConstruct;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.SchedulerException;
 import org.springframework.dao.DataAccessException;
@@ -14,7 +17,6 @@ import org.springframework.stereotype.Component;
 
 // Reacts to the executor module's "capacity available" doorbell by immediately waking the
 // current front of the FIFO dispatch queue, instead of waiting for its next 30s Quartz retry.
-@AllArgsConstructor
 @Component
 @Slf4j
 public class ExecutorAvailabilityListener implements MessageListener {
@@ -23,9 +25,23 @@ public class ExecutorAvailabilityListener implements MessageListener {
     // shared module for this constant.
     public static final String CHANNEL = "terrakube:executor-available";
 
-    RedisMessageListenerContainer redisMessageListenerContainer;
-    JobRepository jobRepository;
-    ScheduleJobService scheduleJobService;
+    private final RedisMessageListenerContainer redisMessageListenerContainer;
+    private final JobRepository jobRepository;
+    private final ScheduleJobService scheduleJobService;
+    // Initialized to "now" at startup, not zero, so the gauge below doesn't report a huge bogus
+    // age before the very first real signal arrives after a fresh deploy.
+    private final AtomicLong lastSignalEpochMillis = new AtomicLong(System.currentTimeMillis());
+
+    public ExecutorAvailabilityListener(RedisMessageListenerContainer redisMessageListenerContainer,
+            JobRepository jobRepository, ScheduleJobService scheduleJobService, MeterRegistry meterRegistry) {
+        this.redisMessageListenerContainer = redisMessageListenerContainer;
+        this.jobRepository = jobRepository;
+        this.scheduleJobService = scheduleJobService;
+        Gauge.builder("executor.availability.age.seconds", lastSignalEpochMillis,
+                        signal -> (System.currentTimeMillis() - signal.get()) / 1000.0)
+                .description("Seconds since the executor module last signalled it has capacity available")
+                .register(meterRegistry);
+    }
 
     @PostConstruct
     public void subscribe() {
@@ -34,6 +50,7 @@ public class ExecutorAvailabilityListener implements MessageListener {
 
     @Override
     public void onMessage(Message message, byte[] pattern) {
+        lastSignalEpochMillis.set(System.currentTimeMillis());
         try {
             Integer nextJobId = jobRepository.findNextDispatchableJobId();
             if (nextJobId != null) {

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/QuartzMetrics.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/QuartzMetrics.java
@@ -1,0 +1,39 @@
+package io.terrakube.api.plugin.scheduler;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class QuartzMetrics {
+
+    private final Scheduler scheduler;
+    private final MeterRegistry meterRegistry;
+
+    public QuartzMetrics(Scheduler scheduler, MeterRegistry meterRegistry) {
+        this.scheduler = scheduler;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @PostConstruct
+    public void registerGauge() {
+        Gauge.builder("quartz.jobs.executing", scheduler, QuartzMetrics::currentlyExecutingCount)
+                .description("Number of Quartz jobs currently executing across this scheduler instance")
+                .register(meterRegistry);
+    }
+
+    static double currentlyExecutingCount(Scheduler scheduler) {
+        try {
+            return scheduler.getCurrentlyExecutingJobs().size();
+        } catch (SchedulerException e) {
+            log.warn("Could not read currently executing Quartz jobs: {}", e.getMessage());
+            return -1;
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -33,6 +33,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.time.DateUtils;
+import org.hibernate.LazyInitializationException;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -41,8 +42,6 @@ import org.quartz.SchedulerException;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.support.TransactionTemplate;
 
 import java.text.ParseException;
 import java.time.Duration;
@@ -74,14 +73,17 @@ public class ScheduleJob implements org.quartz.Job {
     private final GitLabWebhookService gitLabWebhookService;
 
     // Guarantees only one worker (in this pod or any other replica) processes a given job id at a
-    // time - held via withExecutionLock for the entire duration of execute()'s explicit
-    // transaction, not just around dispatch. A second overlapping firing that reaches this after
-    // the first has already dispatched and moved on would otherwise redo status checks, VCS
-    // notifications, PR comments and history cleanup against stale (pre-commit) state, and - since
-    // a step is only marked queue/running after the fact - could re-dispatch a terraform apply
-    // against an already-changed state. TTL comfortably covers the slowest thing execute() does
-    // (PersistentExecutorService's connect+response timeout, 10s + 60s), so an orphaned lock (e.g.
-    // a pod crash mid-run) self-heals well before the next 30s retry needs it.
+    // time - held via withExecutionLock for the entire duration of doRunExecution, not just around
+    // a single write. A second overlapping firing that reaches this after the first has already
+    // dispatched and moved on would otherwise redo status checks, VCS notifications, PR comments
+    // and history cleanup against stale state, and - since a step is only marked queue/running
+    // after the fact - could re-dispatch a terraform apply against an already-changed state.
+    // doRunExecution runs with no single transaction wrapping it (see execute()) - every write it
+    // makes is its own already-committed Spring Data JPA call by the time it returns, so by the
+    // time this lock releases, everything doRunExecution wrote is already durably visible to
+    // whichever worker acquires the lock next. TTL comfortably covers the slowest thing
+    // execute() does (PersistentExecutorService's connect+response timeout, 10s + 60s), so an
+    // orphaned lock (e.g. a pod crash mid-run) self-heals well before the next 30s retry needs it.
     private static final String EXECUTION_LOCK_PREFIX = "job-execution-lock:";
     private static final Duration EXECUTION_LOCK_TTL = Duration.ofSeconds(90);
 
@@ -105,7 +107,6 @@ public class ScheduleJob implements org.quartz.Job {
     GlobalVarRepository globalVarRepository;
     VariableRepository variableRepository;
     WorkspaceVariableValidationService workspaceVariableValidationService;
-    PlatformTransactionManager transactionManager;
     // Real job status transitions happen here via plain jobRepository.save(), never through an
     // Elide JSON:API/GraphQL request - JobNotificationHook (an Elide LifeCycleHook) never sees
     // them. Every save below that follows a job.setStatus(...) call is followed by a call to
@@ -117,20 +118,39 @@ public class ScheduleJob implements org.quartz.Job {
     public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
         int jobId = jobExecutionContext.getJobDetail().getJobDataMap().getInt(JOB_ID);
         withExecutionLock(jobId, () -> {
-            // Explicit TransactionTemplate, not @Transactional on this method: an annotation-
-            // driven transaction commits after withExecutionLock releases the lock (which
-            // happens inside this method), reopening the exact race the lock exists to close -
-            // a second overlapping trigger acquiring the freed lock and reading pre-commit state.
-            Boolean deschedule = new TransactionTemplate(transactionManager).execute(status -> {
-                Job job = jobRepository.getReferenceById(jobId);
-                boolean shouldDeschedule = doRunExecution(job);
-                if (shouldDeschedule) {
-                    redisTemplate.delete(String.valueOf(job.getId()));
-                    removeJobContext(job, jobExecutionContext);
-                }
-                return shouldDeschedule;
-            });
-            return Boolean.TRUE.equals(deschedule);
+            // findById() (not getReferenceById()) issues a real SELECT immediately, so job -
+            // along with workspace/organization/vcs, all plain @ManyToOne with no fetch override
+            // and therefore JPA-default EAGER - is fully materialized here, in the one place this
+            // method still needs an open Hibernate session. Everything doRunExecution reads off
+            // job afterwards is safe even once this repository call's own transaction has closed.
+            Job job = jobRepository.findById(jobId)
+                    .orElseThrow(() -> new IllegalStateException("Job " + jobId + " not found"));
+
+            boolean shouldDeschedule;
+            try {
+                // No transaction wraps this call - see the EXECUTION_LOCK_PREFIX comment above and
+                // this class's top-of-file comment for why that's safe for the execution lock's
+                // invariant. Every jobRepository/stepRepository/workspaceRepository.save() call
+                // doRunExecution (or something it calls) makes now runs, and commits, on its own.
+                shouldDeschedule = doRunExecution(job);
+            } catch (LazyInitializationException e) {
+                // Safety net: doRunExecution's own extensive test suite (ScheduleJobTest) mocks
+                // every repository, so it cannot catch a real Hibernate lazy-loading regression -
+                // if some association gets touched here that isn't one of the eagerly-fetched ones
+                // findById() already materialized (or the job.getStep() collection this class's
+                // errorJobAtStep fixed the one known touch-point for), fail this attempt safely
+                // instead of letting a confusing unhandled exception surface. The existing 30s
+                // recurring trigger retries it.
+                log.error("Job {} hit a lazy-loading error outside its expected transaction "
+                        + "boundary, will retry: {}", jobId, e.getMessage(), e);
+                return false;
+            }
+
+            if (shouldDeschedule) {
+                redisTemplate.delete(String.valueOf(job.getId()));
+                removeJobContext(job, jobExecutionContext);
+            }
+            return shouldDeschedule;
         });
     }
 
@@ -515,7 +535,7 @@ public class ScheduleJob implements org.quartz.Job {
         String logMessage = String.format(
             "Error when sending context to executor marking job %s as failed, step count %s",
             job.getId(),
-            job.getStep().size()
+            stepRepository.findByJobId(job.getId()).size()
         );
         log.error(logMessage, e);
         job.setStatus(JobStatus.failed);

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/SchedulerThreadPoolValidation.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/SchedulerThreadPoolValidation.java
@@ -1,0 +1,34 @@
+package io.terrakube.api.plugin.scheduler;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.terrakube.api.plugin.datasource.DataSourceConfigurationProperties;
+
+import lombok.extern.slf4j.Slf4j;
+
+// Every Quartz worker thread that picks up a job may open its own DB connection (Job/Step/
+// Workspace reads and writes inside ScheduleJob.execute) - if the Quartz thread pool is sized at
+// or above the Hikari pool, a burst of jobs firing at once can starve every other consumer of the
+// same pool (webhook ingestion, the workspace-fanout executor, plain API requests) of a connection
+// entirely. Throwing from the constructor fails Spring context startup, catching a
+// misconfiguration before it becomes a production outage instead of after.
+@Slf4j
+@Component
+public class SchedulerThreadPoolValidation {
+
+    public SchedulerThreadPoolValidation(
+            @Value("${io.terrakube.scheduler.thread-count:8}") int schedulerThreadCount,
+            DataSourceConfigurationProperties dataSourceConfigurationProperties) {
+        int poolSize = dataSourceConfigurationProperties.getPoolSize();
+        if (schedulerThreadCount >= poolSize) {
+            throw new IllegalStateException(String.format(
+                    "io.terrakube.scheduler.thread-count (%d) must be less than "
+                            + "io.terrakube.api.plugin.datasource.poolSize (%d) - a Quartz thread pool at or "
+                            + "above the DB connection pool size can starve every other consumer of that pool.",
+                    schedulerThreadCount, poolSize));
+        }
+        log.info("Quartz thread pool size {} validated against DB connection pool size {}", schedulerThreadCount,
+                poolSize);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/TclService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/TclService.java
@@ -275,7 +275,12 @@ public class TclService {
     }
 
     private String getTemplateTcl(String templateId) {
-        return templateRepository.getReferenceById(UUID.fromString(templateId)).getTcl();
+        // findById (not getReferenceById): isTemplatePlanOnly is called from ScheduleJob's
+        // doRunExecution path, which runs with no open Hibernate session - a lazy
+        // getReferenceById proxy would throw "no session" the moment getTcl() is read.
+        return templateRepository.findById(UUID.fromString(templateId))
+                .map(Template::getTcl)
+                .orElse(null);
     }
 
     public String getFlowTypeForStep(Job job, int stepNumber) {

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -409,7 +409,10 @@ public class ExecutorService {
             }
         }
 
-        List<Reference> referenceList = referenceRepository.findByWorkspace(job.getWorkspace()).orElse(new ArrayList<>());
+        // This runs after ScheduleJob has deliberately released its transaction before making
+        // external calls. The repository query fetches Collection.item, preventing a detached
+        // collection proxy from trying to acquire a session here.
+        List<Reference> referenceList = referenceRepository.findByWorkspaceWithCollectionItems(job.getWorkspace());
 
         List<Collection> collectionList = new ArrayList();
         for (Reference reference : referenceList) {

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -24,6 +24,7 @@ import io.terrakube.api.plugin.scheduler.job.tcl.model.Flow;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.FlowType;
 import io.terrakube.api.plugin.token.dynamic.DynamicCredentialsService;
 import io.terrakube.api.plugin.vcs.TokenService;
+import io.terrakube.api.repository.AddressRepository;
 import io.terrakube.api.repository.GlobalVarRepository;
 import io.terrakube.api.repository.ReferenceRepository;
 import io.terrakube.api.repository.SshRepository;
@@ -81,6 +82,8 @@ public class ExecutorService {
     private VariableRepository variableRepository;
     @Autowired
     private ReferenceRepository referenceRepository;
+    @Autowired
+    private AddressRepository addressRepository;
 
     public void execute(Job job, String stepId, Flow flow) throws ExecutionException {
         log.info("Pending Job: {} WorkspaceId: {}", job.getId(), job.getWorkspace().getId());
@@ -216,8 +219,12 @@ public class ExecutorService {
     }
 
     ExecutorContext validateJobAddress(ExecutorContext executorContext, Job job) {
-        if (job.getAddress() != null && !job.getAddress().isEmpty() && (job.getTerraformPlan() == null || job.getTerraformPlan().isEmpty())) {
-            List<Address> addressList = job.getAddress();
+        // Queried, not job.getAddress(): this runs after ScheduleJob has deliberately released its
+        // transaction before making external calls (see ScheduleJob's class comment), and
+        // Job.address is a lazy @OneToMany with no fetch override - job.getAddress() would throw
+        // LazyInitializationException here with no session left to initialize the proxy through.
+        List<Address> addressList = addressRepository.findByJob(job);
+        if (!addressList.isEmpty() && (job.getTerraformPlan() == null || job.getTerraformPlan().isEmpty())) {
             StringBuilder tfCliArgsPlan= new StringBuilder();
             for(Address address : addressList) {
                 if (address.getType().equals(AddressType.TARGET)) {

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/webhook/RepoWebhookDeliveryPollerJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/webhook/RepoWebhookDeliveryPollerJob.java
@@ -1,0 +1,86 @@
+package io.terrakube.api.plugin.scheduler.webhook;
+
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Component;
+
+import io.terrakube.api.plugin.vcs.RepoWebhookDeliveryTransactions;
+import io.terrakube.api.plugin.vcs.RepoWebhookDispatchService;
+import io.terrakube.api.repository.RepoWebhookDeliveryRepository;
+import io.terrakube.api.rs.webhook.RepoWebhookDelivery;
+import io.terrakube.api.rs.webhook.RepoWebhookDeliveryStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+// Safety net for the immediate-dispatch path (RepoWebhookService.acceptV2Webhook /
+// RepoWebhookDispatchService.dispatchAsync): picks up any delivery that's still PENDING because
+// the dispatch executor's queue was full, the instance that accepted it crashed before dispatching,
+// or a retry's backoff (nextAttemptAt) has now elapsed. Also reclaims deliveries stuck PROCESSING
+// from a crashed fan-out.
+@Slf4j
+@Component
+@DisallowConcurrentExecution
+public class RepoWebhookDeliveryPollerJob implements Job {
+
+    private static final int MAX_ATTEMPTS = 3;
+
+    private final RepoWebhookDeliveryRepository repoWebhookDeliveryRepository;
+    private final RepoWebhookDispatchService repoWebhookDispatchService;
+    private final RepoWebhookDeliveryTransactions repoWebhookDeliveryTransactions;
+    private final int batchSize;
+    private final long stuckProcessingThresholdMillis;
+
+    public RepoWebhookDeliveryPollerJob(RepoWebhookDeliveryRepository repoWebhookDeliveryRepository,
+            RepoWebhookDispatchService repoWebhookDispatchService,
+            RepoWebhookDeliveryTransactions repoWebhookDeliveryTransactions,
+            @Value("${io.terrakube.webhook.poller.batchSize:200}") int batchSize,
+            @Value("${io.terrakube.webhook.poller.stuckProcessingThresholdMinutes:5}") long stuckProcessingThresholdMinutes) {
+        this.repoWebhookDeliveryRepository = repoWebhookDeliveryRepository;
+        this.repoWebhookDispatchService = repoWebhookDispatchService;
+        this.repoWebhookDeliveryTransactions = repoWebhookDeliveryTransactions;
+        this.batchSize = batchSize;
+        this.stuckProcessingThresholdMillis = stuckProcessingThresholdMinutes * 60_000L;
+    }
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        // Quartz's SchedulerFactoryBean instantiates and field-autowires Job instances directly
+        // rather than looking them up from the ApplicationContext, so this class never gets an
+        // AOP proxy of its own - any @Transactional declared directly here would silently never
+        // apply. Both DB-mutating steps below are therefore delegated to
+        // RepoWebhookDeliveryTransactions, a real Spring-managed bean whose own proxy the calls
+        // below go through.
+        repoWebhookDeliveryTransactions.sweepStuckProcessingRows(
+                new Date(System.currentTimeMillis() - stuckProcessingThresholdMillis), MAX_ATTEMPTS);
+        dispatchDueRows();
+    }
+
+    private void dispatchDueRows() {
+        List<RepoWebhookDelivery> due = repoWebhookDeliveryRepository.findDueForDispatch(RepoWebhookDeliveryStatus.PENDING,
+                new Date(), PageRequest.of(0, batchSize));
+
+        int dispatched = 0;
+        for (RepoWebhookDelivery delivery : due) {
+            try {
+                repoWebhookDispatchService.dispatchAsync(delivery.getId());
+                dispatched++;
+            } catch (RejectedExecutionException e) {
+                // The dispatch executor's queue is full - this row is still PENDING (this
+                // submission never claimed it) and will be picked up again on the next tick.
+                log.warn("Repo webhook dispatch executor rejected delivery {}, will retry next poll cycle",
+                        delivery.getId());
+            }
+        }
+        if (dispatched > 0) {
+            log.info("Repo webhook delivery poller dispatched {} pending row(s)", dispatched);
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/webhook/RepoWebhookDeliveryPollerScheduler.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/webhook/RepoWebhookDeliveryPollerScheduler.java
@@ -1,0 +1,66 @@
+package io.terrakube.api.plugin.scheduler.webhook;
+
+import java.text.ParseException;
+
+import org.quartz.CronExpression;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+public class RepoWebhookDeliveryPollerScheduler {
+
+    private static final String PREFIX_REPO_WEBHOOK_DELIVERY_POLLER = "TerrakubeV2_RepoWebhookDeliveryPoller";
+
+    private Scheduler scheduler;
+
+    @PostConstruct
+    public void initRepoWebhookDeliveryPoller() {
+        try {
+            log.info("Setup repo webhook delivery poller");
+            JobDetail jobDetail = scheduler.getJobDetail(new JobKey(PREFIX_REPO_WEBHOOK_DELIVERY_POLLER));
+            if (jobDetail != null) {
+                scheduler.deleteJob(new JobKey(PREFIX_REPO_WEBHOOK_DELIVERY_POLLER));
+            }
+            setupRepoWebhookDeliveryPoller("0 * * ? * *");
+        } catch (Exception ex) {
+            log.error(ex.getMessage());
+        }
+    }
+
+    public void setupRepoWebhookDeliveryPoller(String quartzSchedule) throws ParseException, SchedulerException {
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put("RepoWebhookDeliveryPoller", "RepoWebhookDeliveryPollerV1");
+
+        JobDetail jobDetail = JobBuilder.newJob().ofType(RepoWebhookDeliveryPollerJob.class)
+                .storeDurably()
+                .setJobData(jobDataMap)
+                .withIdentity(PREFIX_REPO_WEBHOOK_DELIVERY_POLLER)
+                .withDescription("RepoWebhookDeliveryPollerV1")
+                .build();
+
+        Trigger trigger = TriggerBuilder.newTrigger()
+                .startNow()
+                .forJob(jobDetail)
+                .withIdentity(PREFIX_REPO_WEBHOOK_DELIVERY_POLLER)
+                .withDescription("RepoWebhookDeliveryPollerV1")
+                .withSchedule(CronScheduleBuilder.cronSchedule(new CronExpression(quartzSchedule)))
+                .build();
+
+        log.info("Create schedule job trigger for repo webhook delivery poller {}", jobDetail.getKey());
+        scheduler.scheduleJob(jobDetail, trigger);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/webhook/RepoWebhookDeliveryRetentionJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/webhook/RepoWebhookDeliveryRetentionJob.java
@@ -1,0 +1,39 @@
+package io.terrakube.api.plugin.scheduler.webhook;
+
+import java.util.Date;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.terrakube.api.plugin.vcs.RepoWebhookDeliveryTransactions;
+
+import lombok.extern.slf4j.Slf4j;
+
+// Runs far less often than RepoWebhookDeliveryPollerJob (daily, not every minute) - this is
+// housekeeping, not delivery, so there's no reason to pay a DELETE's cost on the hot dispatch
+// cadence. Same reasoning as RepoWebhookDeliveryPollerJob for why the actual DB work is delegated
+// to RepoWebhookDeliveryTransactions rather than done directly here: Quartz Jobs never get an AOP
+// proxy of their own, so a @Transactional method declared directly on this class would be a no-op.
+@Slf4j
+@Component
+@DisallowConcurrentExecution
+public class RepoWebhookDeliveryRetentionJob implements Job {
+
+    private final RepoWebhookDeliveryTransactions repoWebhookDeliveryTransactions;
+    private final long retentionMillis;
+
+    public RepoWebhookDeliveryRetentionJob(RepoWebhookDeliveryTransactions repoWebhookDeliveryTransactions,
+            @Value("${io.terrakube.webhook.delivery.retentionDays:30}") long retentionDays) {
+        this.repoWebhookDeliveryTransactions = repoWebhookDeliveryTransactions;
+        this.retentionMillis = retentionDays * 24 * 60 * 60 * 1000L;
+    }
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        repoWebhookDeliveryTransactions.pruneTerminalRowsOlderThan(new Date(System.currentTimeMillis() - retentionMillis));
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/webhook/RepoWebhookDeliveryRetentionScheduler.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/webhook/RepoWebhookDeliveryRetentionScheduler.java
@@ -1,0 +1,68 @@
+package io.terrakube.api.plugin.scheduler.webhook;
+
+import java.text.ParseException;
+
+import org.quartz.CronExpression;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+public class RepoWebhookDeliveryRetentionScheduler {
+
+    private static final String PREFIX_REPO_WEBHOOK_DELIVERY_RETENTION = "TerrakubeV2_RepoWebhookDeliveryRetention";
+
+    private Scheduler scheduler;
+
+    @PostConstruct
+    public void initRepoWebhookDeliveryRetention() {
+        try {
+            log.info("Setup repo webhook delivery retention sweep");
+            JobDetail jobDetail = scheduler.getJobDetail(new JobKey(PREFIX_REPO_WEBHOOK_DELIVERY_RETENTION));
+            if (jobDetail != null) {
+                scheduler.deleteJob(new JobKey(PREFIX_REPO_WEBHOOK_DELIVERY_RETENTION));
+            }
+            // Once a day at 03:30 - offset from the notification outbox retention sweep's 03:00
+            // so the two DELETE sweeps don't contend for the same tables at the same instant.
+            setupRepoWebhookDeliveryRetention("0 30 3 * * ?");
+        } catch (Exception ex) {
+            log.error(ex.getMessage());
+        }
+    }
+
+    public void setupRepoWebhookDeliveryRetention(String quartzSchedule) throws ParseException, SchedulerException {
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put("RepoWebhookDeliveryRetention", "RepoWebhookDeliveryRetentionV1");
+
+        JobDetail jobDetail = JobBuilder.newJob().ofType(RepoWebhookDeliveryRetentionJob.class)
+                .storeDurably()
+                .setJobData(jobDataMap)
+                .withIdentity(PREFIX_REPO_WEBHOOK_DELIVERY_RETENTION)
+                .withDescription("RepoWebhookDeliveryRetentionV1")
+                .build();
+
+        Trigger trigger = TriggerBuilder.newTrigger()
+                .startNow()
+                .forJob(jobDetail)
+                .withIdentity(PREFIX_REPO_WEBHOOK_DELIVERY_RETENTION)
+                .withDescription("RepoWebhookDeliveryRetentionV1")
+                .withSchedule(CronScheduleBuilder.cronSchedule(new CronExpression(quartzSchedule)))
+                .build();
+
+        log.info("Create schedule job trigger for repo webhook delivery retention {}", jobDetail.getKey());
+        scheduler.scheduleJob(jobDetail, trigger);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/streaming/StreamingService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/streaming/StreamingService.java
@@ -36,7 +36,10 @@ public class StreamingService {
     public String getCurrentLogs(String stepId, String streamKeySuffix){
         TextStringBuilder currentLogs = new TextStringBuilder();
         try {
-            Step step = stepRepository.getReferenceById(UUID.fromString(stepId));
+            // findById (not getReferenceById): callers include ScheduleJob's doRunExecution path,
+            // which reads Job/Step outside any open Hibernate session - a lazy getReferenceById
+            // proxy would throw "no session" the moment a field like getStatus() below is touched.
+            Step step = stepRepository.findById(UUID.fromString(stepId)).orElseThrow();
             if(!step.getStatus().equals(JobStatus.completed) && !step.getStatus().equals(JobStatus.failed)) {
                 String streamKey = step.getJob().getId() + streamKeySuffix;
                 List<MapRecord> streamData = redisTemplate.opsForStream().read(StreamOffset.fromStart(streamKey), StreamOffset.latest(streamKey));

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/ClaimedDelivery.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/ClaimedDelivery.java
@@ -1,0 +1,8 @@
+package io.terrakube.api.plugin.vcs;
+
+import java.util.Date;
+
+import io.terrakube.api.rs.webhook.RepoWebhook;
+
+record ClaimedDelivery(RepoWebhook repoWebhook, String payload, String headers, int attemptCount, Date lastAttemptAt) {
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
@@ -8,6 +8,7 @@ import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
 import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
 import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.repository.StepRepository;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.vcs.VcsType;
@@ -50,6 +51,7 @@ public class PrCommentService {
     GitLabWebhookService gitLabWebhookService;
     BitBucketWebhookService bitBucketWebhookService;
     JobRepository jobRepository;
+    StepRepository stepRepository;
     StorageTypeService storageTypeService;
     StreamingService streamingService;
     ObjectMapper objectMapper;
@@ -58,12 +60,13 @@ public class PrCommentService {
     String uiUrl;
 
     public PrCommentService(GitHubWebhookService gitHubWebhookService, GitLabWebhookService gitLabWebhookService,
-            BitBucketWebhookService bitBucketWebhookService, JobRepository jobRepository,
+            BitBucketWebhookService bitBucketWebhookService, JobRepository jobRepository, StepRepository stepRepository,
             StorageTypeService storageTypeService, StreamingService streamingService, ObjectMapper objectMapper) {
         this.gitHubWebhookService = gitHubWebhookService;
         this.gitLabWebhookService = gitLabWebhookService;
         this.bitBucketWebhookService = bitBucketWebhookService;
         this.jobRepository = jobRepository;
+        this.stepRepository = stepRepository;
         this.storageTypeService = storageTypeService;
         this.streamingService = streamingService;
         this.objectMapper = objectMapper;
@@ -174,11 +177,15 @@ public class PrCommentService {
      * previous behavior) if none do - e.g. the run failed before Terraform printed one.
      */
     private String fetchStepOutputText(Job job) {
-        if (job.getStep() == null || job.getStep().isEmpty()) {
+        // job.getStep() is a lazy collection: callers here include ScheduleJob's
+        // doRunExecution path, which reads the job outside any open Hibernate session, so
+        // touching the proxy throws LazyInitializationException. Load steps explicitly instead.
+        List<Step> steps = stepRepository.findByJobId(job.getId());
+        if (steps.isEmpty()) {
             return null;
         }
 
-        List<Step> stepsNewestFirst = job.getStep().stream()
+        List<Step> stepsNewestFirst = steps.stream()
                 .sorted(Comparator.comparingInt(Step::getStepNumber).reversed())
                 .collect(Collectors.toList());
 

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookDeliveryMetrics.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookDeliveryMetrics.java
@@ -1,0 +1,45 @@
+package io.terrakube.api.plugin.vcs;
+
+import java.util.Date;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+
+import io.terrakube.api.repository.RepoWebhookDeliveryRepository;
+import io.terrakube.api.rs.webhook.RepoWebhookDeliveryStatus;
+
+@Component
+public class RepoWebhookDeliveryMetrics {
+
+    private final RepoWebhookDeliveryRepository repoWebhookDeliveryRepository;
+    private final MeterRegistry meterRegistry;
+
+    public RepoWebhookDeliveryMetrics(RepoWebhookDeliveryRepository repoWebhookDeliveryRepository,
+            MeterRegistry meterRegistry) {
+        this.repoWebhookDeliveryRepository = repoWebhookDeliveryRepository;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @PostConstruct
+    public void registerGauges() {
+        Gauge.builder("webhook.delivery.queue.depth", repoWebhookDeliveryRepository,
+                        repo -> repo.countByStatus(RepoWebhookDeliveryStatus.PENDING))
+                .description("Number of repo_webhook_delivery rows currently PENDING")
+                .register(meterRegistry);
+
+        Gauge.builder("webhook.delivery.queue.oldest.age.seconds", repoWebhookDeliveryRepository,
+                        RepoWebhookDeliveryMetrics::oldestPendingAgeSeconds)
+                .description("Age in seconds of the oldest PENDING repo_webhook_delivery row, 0 if none")
+                .register(meterRegistry);
+    }
+
+    static double oldestPendingAgeSeconds(RepoWebhookDeliveryRepository repo) {
+        Date oldest = repo.findOldestCreatedDateByStatus(RepoWebhookDeliveryStatus.PENDING);
+        if (oldest == null) {
+            return 0;
+        }
+        return Math.max(0, (System.currentTimeMillis() - oldest.getTime()) / 1000.0);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookDeliveryTransactions.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookDeliveryTransactions.java
@@ -1,0 +1,125 @@
+package io.terrakube.api.plugin.vcs;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.Hibernate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.terrakube.api.repository.RepoWebhookDeliveryRepository;
+import io.terrakube.api.rs.webhook.RepoWebhook;
+import io.terrakube.api.rs.webhook.RepoWebhookDelivery;
+import io.terrakube.api.rs.webhook.RepoWebhookDeliveryStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+// A separate bean (not extra methods on RepoWebhookService/RepoWebhookDispatchService/the poller
+// job) for the same reason as NotificationOutboxTransactions: every DB-mutating call here needs to
+// go through THIS bean's own Spring transactional proxy. RepoWebhookDispatchService calling
+// claim()/recordResult() "this."-style would be a self-invocation with no transactional effect,
+// and RepoWebhookDeliveryPollerJob is a Quartz Job - Spring's SchedulerFactoryBean instantiates and
+// field-autowires Job instances directly rather than looking them up from the ApplicationContext,
+// so a Job class never gets an AOP proxy of its own and @Transactional declared directly on it
+// would silently never apply.
+@Slf4j
+@Service
+public class RepoWebhookDeliveryTransactions {
+
+    private final RepoWebhookDeliveryRepository repoWebhookDeliveryRepository;
+
+    RepoWebhookDeliveryTransactions(RepoWebhookDeliveryRepository repoWebhookDeliveryRepository) {
+        this.repoWebhookDeliveryRepository = repoWebhookDeliveryRepository;
+    }
+
+    // Commits in its own transaction before returning, so the caller (RepoWebhookService.acceptV2Webhook)
+    // can safely trigger the immediate-dispatch path right after this returns without racing the
+    // insert's own commit - see acceptV2Webhook for why it deliberately has no @Transactional of
+    // its own wrapping this call.
+    @Transactional
+    public UUID enqueue(RepoWebhook repoWebhook, String payload, String headers) {
+        RepoWebhookDelivery delivery = new RepoWebhookDelivery();
+        delivery.setId(UUID.randomUUID());
+        delivery.setRepoWebhook(repoWebhook);
+        delivery.setPayload(payload);
+        delivery.setHeaders(headers);
+        delivery.setStatus(RepoWebhookDeliveryStatus.PENDING);
+        repoWebhookDeliveryRepository.save(delivery);
+        return delivery.getId();
+    }
+
+    // Atomic conditional UPDATE, not a pessimistic-lock read: only one concurrent caller's UPDATE
+    // can match "id = :deliveryId AND status = PENDING", so only one ever sees rows == 1 and
+    // proceeds past this method. The other sees 0 and returns immediately - no blocking, no lock
+    // held while the winner goes on to fan out to every workspace outside any transaction.
+    @Transactional
+    public ClaimedDelivery claim(UUID deliveryId) {
+        Date now = new Date();
+        int rows = repoWebhookDeliveryRepository.claimForDelivery(deliveryId, RepoWebhookDeliveryStatus.PENDING,
+                RepoWebhookDeliveryStatus.PROCESSING, now);
+        if (rows == 0) {
+            return null;
+        }
+        RepoWebhookDelivery delivery = repoWebhookDeliveryRepository.findById(deliveryId).orElse(null);
+        if (delivery == null) {
+            return null;
+        }
+        // The fan-out happens after this transaction (and its Hibernate session) has closed, so a
+        // still-lazy repoWebhook (and its vcs) proxy would blow up with a
+        // LazyInitializationException the moment RepoWebhookService reads a field off it. Force
+        // both to load now, while the session is still open.
+        Hibernate.initialize(delivery.getRepoWebhook());
+        if (delivery.getRepoWebhook().getVcs() != null) {
+            Hibernate.initialize(delivery.getRepoWebhook().getVcs());
+        }
+        return new ClaimedDelivery(delivery.getRepoWebhook(), delivery.getPayload(), delivery.getHeaders(),
+                delivery.getAttemptCount(), delivery.getLastAttemptAt());
+    }
+
+    // Keyed on the exact lastAttemptAt observed at claim time, not just id+PROCESSING: if this row
+    // was reclaimed by the stuck-row sweep (this attempt outlived the sweep's threshold) and
+    // re-dispatched by someone else in the meantime, lastAttemptAt will have moved on and this
+    // update becomes a no-op instead of clobbering the newer attempt's result.
+    @Transactional
+    public void recordResult(UUID deliveryId, Date expectedLastAttemptAt, RepoWebhookDeliveryStatus newStatus,
+            String lastError, Date nextAttemptAt) {
+        int updated = repoWebhookDeliveryRepository.recordDeliveryResult(deliveryId, RepoWebhookDeliveryStatus.PROCESSING,
+                expectedLastAttemptAt, newStatus, lastError, nextAttemptAt, new Date());
+        if (updated == 0) {
+            log.warn("Discarding stale delivery result for repo webhook delivery {} - the row was reclaimed "
+                    + "(stuck-row sweep) before this attempt finished; a duplicate fan-out attempt may have run",
+                    deliveryId);
+        }
+    }
+
+    // A row can only be stuck in PROCESSING if whatever claimed it (the immediate-dispatch path,
+    // another instance) died mid-fan-out without ever reaching recordResult - normal completion
+    // always transitions it to PROCESSED/PENDING/FAILED. Called by RepoWebhookDeliveryPollerJob
+    // every tick so a crashed instance never permanently strands a delivery.
+    @Transactional
+    public void sweepStuckProcessingRows(Date cutoff, int maxAttempts) {
+        int reclaimed = repoWebhookDeliveryRepository.reclaimStuckProcessingRows(RepoWebhookDeliveryStatus.PROCESSING,
+                RepoWebhookDeliveryStatus.PENDING, cutoff, maxAttempts, new Date());
+        int failed = repoWebhookDeliveryRepository.failStuckProcessingRowsAtMaxAttempts(RepoWebhookDeliveryStatus.PROCESSING,
+                RepoWebhookDeliveryStatus.FAILED, cutoff, maxAttempts,
+                "Delivery fan-out did not complete within the stuck-row threshold; the claiming instance likely crashed",
+                new Date());
+        if (reclaimed > 0 || failed > 0) {
+            log.warn("Repo webhook delivery sweep reclaimed {} stuck PROCESSING row(s) for retry and permanently "
+                    + "failed {} that had already exhausted their attempts", reclaimed, failed);
+        }
+    }
+
+    // Housekeeping: without this, repo_webhook_delivery grows forever - every PROCESSED/FAILED row
+    // from every push/PR event on every shared webhook sits around indefinitely.
+    @Transactional
+    public int pruneTerminalRowsOlderThan(Date cutoff) {
+        int deleted = repoWebhookDeliveryRepository.deleteTerminalRowsCreatedBefore(
+                List.of(RepoWebhookDeliveryStatus.PROCESSED, RepoWebhookDeliveryStatus.FAILED), cutoff);
+        if (deleted > 0) {
+            log.info("Repo webhook delivery retention sweep deleted {} row(s) older than {}", deleted, cutoff);
+        }
+        return deleted;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookDispatchExecutorConfig.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookDispatchExecutorConfig.java
@@ -1,0 +1,33 @@
+package io.terrakube.api.plugin.vcs;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class RepoWebhookDispatchExecutorConfig {
+
+    // Bounded, dedicated pool for the immediate-dispatch path (RepoWebhookService.acceptV2Webhook
+    // calling RepoWebhookDispatchService.dispatchAsync right after the HTTP response to GitHub
+    // would otherwise be blocked on). Without a named executor here, Spring's @Async falls back to
+    // the unbounded SimpleAsyncTaskExecutor (a new thread per call, no queue, no cap) - a burst of
+    // webhook deliveries (e.g. a force-push touching many shared-webhook repos at once) could spawn
+    // unbounded concurrent fan-outs all competing for the same DB connection pool and the same
+    // GitHub API rate limit. A full queue rejects rather than blocks the caller: the row stays
+    // PENDING and RepoWebhookDeliveryPollerJob picks it up on its next tick, so a rejection is safe,
+    // not lossy.
+    @Bean("repoWebhookDispatchExecutor")
+    public ThreadPoolTaskExecutor repoWebhookDispatchExecutor(
+            @Value("${io.terrakube.webhook.dispatch.executor.corePoolSize:10}") int corePoolSize,
+            @Value("${io.terrakube.webhook.dispatch.executor.maxPoolSize:20}") int maxPoolSize,
+            @Value("${io.terrakube.webhook.dispatch.executor.queueCapacity:200}") int queueCapacity) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(queueCapacity);
+        executor.setThreadNamePrefix("webhook-dispatch-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookDispatchService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookDispatchService.java
@@ -1,0 +1,94 @@
+package io.terrakube.api.plugin.vcs;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.terrakube.api.rs.webhook.RepoWebhookDeliveryStatus;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class RepoWebhookDispatchService {
+
+    static final int MAX_ATTEMPTS = 3;
+    private static final long ONE_MINUTE_MILLIS = 60_000L;
+    private static final long FIVE_MINUTES_MILLIS = 5 * ONE_MINUTE_MILLIS;
+
+    private final RepoWebhookDeliveryTransactions repoWebhookDeliveryTransactions;
+    private final RepoWebhookService repoWebhookService;
+    private final ObjectMapper objectMapper;
+
+    public RepoWebhookDispatchService(RepoWebhookDeliveryTransactions repoWebhookDeliveryTransactions,
+            RepoWebhookService repoWebhookService, ObjectMapper objectMapper) {
+        this.repoWebhookDeliveryTransactions = repoWebhookDeliveryTransactions;
+        this.repoWebhookService = repoWebhookService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Async("repoWebhookDispatchExecutor")
+    public void dispatchAsync(UUID deliveryId) {
+        attemptDelivery(deliveryId);
+    }
+
+    // claim() and recordResult() each open their own short transaction on a separate bean
+    // (RepoWebhookDeliveryTransactions) - the workspace fan-out in between (parsing, matching
+    // templates, calling out to GitHub/GitLab/Azure DevOps for PR files and commit statuses,
+    // scheduling Quartz job triggers) runs with no transaction held for its duration. This is the
+    // fix for the original bug: the old synchronous processV2Webhook held one open transaction
+    // (and one pooled DB connection) across the entire loop of up to dozens of workspaces and their
+    // external API calls, which is also what made a 30-workspace shared webhook exceed GitHub's
+    // 10-second delivery timeout.
+    public void attemptDelivery(UUID deliveryId) {
+        ClaimedDelivery claimed = repoWebhookDeliveryTransactions.claim(deliveryId);
+        if (claimed == null) {
+            return;
+        }
+
+        RepoWebhookDeliveryStatus newStatus;
+        Date nextAttemptAt = null;
+        String lastError = null;
+        try {
+            Map<String, String> headers = deserializeHeaders(claimed.headers());
+            repoWebhookService.processClaimedDelivery(claimed.repoWebhook(), claimed.payload(), headers);
+            newStatus = RepoWebhookDeliveryStatus.PROCESSED;
+        } catch (Exception e) {
+            // Anything that reaches here failed BEFORE (or while establishing) the per-workspace
+            // fan-out - e.g. an unparseable payload, or a transient DB error listing workspaces.
+            // Once the fan-out loop itself starts, RepoWebhookService.processClaimedDelivery catches
+            // and logs every per-workspace failure individually and never lets one propagate here,
+            // specifically so a retry of the whole delivery can never re-create a Job for a
+            // workspace whose job was already created and scheduled on an earlier attempt.
+            lastError = e.getMessage();
+            if (claimed.attemptCount() >= MAX_ATTEMPTS) {
+                newStatus = RepoWebhookDeliveryStatus.FAILED;
+                log.warn("Repo webhook delivery {} permanently failed after {} attempts: {}", deliveryId,
+                        claimed.attemptCount(), lastError, e);
+            } else {
+                newStatus = RepoWebhookDeliveryStatus.PENDING;
+                nextAttemptAt = new Date(System.currentTimeMillis() + backoffMillis(claimed.attemptCount()));
+                log.warn("Repo webhook delivery {} attempt {} failed, will retry: {}", deliveryId,
+                        claimed.attemptCount(), lastError, e);
+            }
+        }
+
+        repoWebhookDeliveryTransactions.recordResult(deliveryId, claimed.lastAttemptAt(), newStatus, lastError,
+                nextAttemptAt);
+    }
+
+    private Map<String, String> deserializeHeaders(String headersJson) throws Exception {
+        return objectMapper.readValue(headersJson, new TypeReference<Map<String, String>>() {
+        });
+    }
+
+    private long backoffMillis(int attemptCount) {
+        return attemptCount <= 1 ? ONE_MINUTE_MILLIS : FIVE_MINUTES_MILLIS;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
@@ -164,6 +164,15 @@ public class RepoWebhookService {
         }
     }
 
+    // @Transactional so repoWebhook.getVcs() (lazily loaded, accessed below by isGitLab/isAzureDevOps
+    // for every provider) has an open session to load through - without it, findById()'s own
+    // implicit per-call transaction closes before this method body runs, leaving vcs an
+    // uninitialized proxy and throwing LazyInitializationException on every delivery. This is safe
+    // for the immediate-dispatch ordering: a Spring transactional proxy commits the transaction
+    // (including repoWebhookDeliveryTransactions.enqueue()'s nested, REQUIRED-propagation insert)
+    // before returning control to the caller, so by the time WebHookController receives the
+    // deliveryId and calls dispatchAsync, the enqueue is already committed and visible.
+    @Transactional
     public UUID acceptV2Webhook(String repoWebhookId, String jsonPayload, Map<String, String> headers) {
         RepoWebhook repoWebhook = repoWebhookRepository.findById(UUID.fromString(repoWebhookId))
                 .orElseThrow(() -> new IllegalArgumentException("Repo webhook not found: " + repoWebhookId));

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -58,6 +60,7 @@ public class RepoWebhookService {
     PrCommentService prCommentService;
     RepoWebhookDeliveryTransactions repoWebhookDeliveryTransactions;
     ObjectMapper objectMapper;
+    Executor workspaceFanoutExecutor;
 
     private boolean isGitLab(RepoWebhook repoWebhook) {
         return repoWebhook.getVcs() != null && repoWebhook.getVcs().getVcsType() == VcsType.GITLAB;
@@ -252,13 +255,24 @@ public class RepoWebhookService {
 
         log.info("Processing v2 webhook for {} workspaces on repo {}", workspaces.size(), normalizedUrl);
 
-        for (Workspace workspace : workspaces) {
-            try {
-                processWorkspaceWebhook(workspace, webhookResult);
-            } catch (Exception e) {
-                log.error("Error processing v2 webhook for workspace {}: {}", workspace.getName(), e.getMessage(), e);
-            }
-        }
+        // Bounded concurrency (workspaceFanoutExecutor, default 4 - see WorkspaceFanoutExecutorConfig)
+        // instead of a fully serial loop: a shared webhook with 35+ workspaces no longer processes
+        // them one at a time, but also can't open unbounded concurrent DB/VCS/executor connections.
+        // join() blocks until every workspace has been attempted (successfully or not - each
+        // failure is caught and logged individually below, same as before), so the caller
+        // (RepoWebhookDispatchService.attemptDelivery) only records this delivery PROCESSED once
+        // every workspace item has actually been accepted.
+        List<CompletableFuture<Void>> tasks = workspaces.stream()
+                .map(workspace -> CompletableFuture.runAsync(() -> {
+                    try {
+                        processWorkspaceWebhook(workspace, webhookResult);
+                    } catch (Exception e) {
+                        log.error("Error processing v2 webhook for workspace {}: {}", workspace.getName(),
+                                e.getMessage(), e);
+                    }
+                }, workspaceFanoutExecutor))
+                .toList();
+        CompletableFuture.allOf(tasks.toArray(new CompletableFuture[0])).join();
     }
 
     private void processWorkspaceWebhook(Workspace workspace, WebhookResult webhookResult) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
@@ -36,6 +36,9 @@ import io.terrakube.api.rs.webhook.WebhookEvent;
 import io.terrakube.api.rs.webhook.WebhookEventType;
 import io.terrakube.api.rs.workspace.Workspace;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -53,6 +56,8 @@ public class RepoWebhookService {
     JobRepository jobRepository;
     ScheduleJobService scheduleJobService;
     PrCommentService prCommentService;
+    RepoWebhookDeliveryTransactions repoWebhookDeliveryTransactions;
+    ObjectMapper objectMapper;
 
     private boolean isGitLab(RepoWebhook repoWebhook) {
         return repoWebhook.getVcs() != null && repoWebhook.getVcs().getVcsType() == VcsType.GITLAB;
@@ -159,8 +164,7 @@ public class RepoWebhookService {
         }
     }
 
-    @Transactional
-    public void processV2Webhook(String repoWebhookId, String jsonPayload, Map<String, String> headers) {
+    public UUID acceptV2Webhook(String repoWebhookId, String jsonPayload, Map<String, String> headers) {
         RepoWebhook repoWebhook = repoWebhookRepository.findById(UUID.fromString(repoWebhookId))
                 .orElseThrow(() -> new IllegalArgumentException("Repo webhook not found: " + repoWebhookId));
 
@@ -181,6 +185,19 @@ public class RepoWebhookService {
             throw new SecurityException("HMAC signature verification failed");
         }
 
+        String headersJson;
+        try {
+            headersJson = objectMapper.writeValueAsString(headers);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize webhook headers", e);
+        }
+        return repoWebhookDeliveryTransactions.enqueue(repoWebhook, jsonPayload, headersJson);
+    }
+
+    public void processClaimedDelivery(RepoWebhook repoWebhook, String jsonPayload, Map<String, String> headers) {
+        boolean azureDevOps = isAzureDevOps(repoWebhook);
+        boolean gitlab = isGitLab(repoWebhook);
+
         WebhookResult webhookResult;
         if (azureDevOps) {
             webhookResult = azDevOpsWebhookService.parseAzDevOpsPayload(jsonPayload, headers);
@@ -191,12 +208,12 @@ public class RepoWebhookService {
         }
 
         if (webhookResult.getEvent() != null && webhookResult.getEvent().equals("ping")) {
-            log.info("Received ping for repo webhook {}", repoWebhookId);
+            log.info("Received ping for repo webhook {}", repoWebhook.getId());
             return;
         }
 
         if (!webhookResult.isValid()) {
-            log.warn("Invalid webhook result for repo webhook {}", repoWebhookId);
+            log.warn("Invalid webhook result for repo webhook {}", repoWebhook.getId());
             return;
         }
 

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
@@ -227,6 +227,26 @@ public class RepoWebhookService {
         }
 
         String normalizedUrl = repoWebhook.getRepositoryUrl();
+
+        // GitHub/GitLab PR file changes are a repo-level fact (which files a PR touched doesn't
+        // depend on whose credentials asked), but processWorkspaceWebhook used to fetch them fresh
+        // per workspace - on a shared webhook with N workspaces, that's N redundant paginated API
+        // calls for the exact same answer. Fetch once here with the repo webhook's own Vcs and let
+        // every workspace below reuse it; processWorkspaceWebhook still fetches per-workspace as a
+        // fallback if this didn't populate anything (no repo-level Vcs, or the fetch came back
+        // empty - which also covers a repo-level credential that can't read this PR, so a workspace
+        // with its own working credentials still gets a chance). Azure DevOps is deliberately
+        // excluded: per-workspace credentials there aren't just a fallback, see the comment in
+        // processWorkspaceWebhook.
+        if (!azureDevOps && webhookResult.getPrFilesUrl() != null && repoWebhook.getVcs() != null) {
+            List<String> prFiles = gitlab
+                    ? gitLabWebhookService.fetchPrFileChanges(repoWebhook.getVcs(), normalizedUrl,
+                            webhookResult.getPrFilesUrl())
+                    : gitHubWebhookService.fetchPrFileChanges(repoWebhook.getVcs(), normalizedUrl,
+                            webhookResult.getPrFilesUrl());
+            webhookResult.setFileChanges(prFiles);
+        }
+
         List<Workspace> workspaces = workspaceRepository
                 .findByNormalizedSourceWithMigratedWebhook(normalizedUrl);
 
@@ -273,7 +293,13 @@ public class RepoWebhookService {
                         azDevOpsWebhookService.fetchPrFileChanges(
                                 workspace.getVcs(), workspace.getSource(), webhookResult.getPrNumber().intValue()));
             }
-        } else if (webhookResult.getPrFilesUrl() != null) {
+        } else if (webhookResult.getPrFilesUrl() != null
+                && (webhookResult.getFileChanges() == null || webhookResult.getFileChanges().isEmpty())) {
+            // Fallback only: processClaimedDelivery already tried this once, repo-wide, with the
+            // repo webhook's own Vcs. Reaching here means that either didn't run (no repo-level
+            // Vcs) or came back empty - which could genuinely be a zero-file-change PR, or could be
+            // the repo-level credential lacking access while this workspace's own credential works,
+            // so it's still worth this workspace trying with its own Vcs.
             if (workspace.getVcs() != null) {
                 List<String> prFiles = isGitLab(workspace)
                         ? gitLabWebhookService.fetchPrFileChanges(

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookHttpClientConfig.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookHttpClientConfig.java
@@ -1,0 +1,65 @@
+package io.terrakube.api.plugin.vcs;
+
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.util.Timeout;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Configuration
+public class WebhookHttpClientConfig {
+
+    // A fresh RestTemplate(new HttpComponentsClientHttpRequestFactory()) per call (the previous
+    // behavior of WebhookServiceBase.makeApiRequest) opens a brand-new TCP+TLS connection for every
+    // GitHub/GitLab/Azure DevOps API call, with no cap on how many can be open at once. This pools
+    // and reuses connections instead, and caps concurrent connections per target host
+    // (setDefaultMaxPerRoute) at the workspace-fanout concurrency (Task 3's
+    // io.terrakube.webhook.workspace-fanout.concurrency) - that's the actual ceiling on how many of
+    // these calls run at once for a single delivery, so the connection pool shouldn't allow more
+    // concurrency than the caller can ever produce. setMaxTotal is looser (5x) to allow for
+    // multiple different target hosts (self-hosted GitHub Enterprise, GitLab, Azure DevOps, and any
+    // number of distinct repos) without being unbounded.
+    @Bean("webhookRestTemplate")
+    public RestTemplate webhookRestTemplate(
+            @Value("${io.terrakube.webhook.dispatch.http.connectTimeoutSeconds:5}") long connectTimeoutSeconds,
+            @Value("${io.terrakube.webhook.dispatch.http.responseTimeoutSeconds:30}") long responseTimeoutSeconds,
+            @Value("${io.terrakube.webhook.dispatch.http.connectionRequestTimeoutSeconds:2}") long connectionRequestTimeoutSeconds,
+            @Value("${io.terrakube.webhook.workspace-fanout.concurrency:4}") int maxConnectionsPerRoute) {
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(maxConnectionsPerRoute * 5);
+        connectionManager.setDefaultMaxPerRoute(maxConnectionsPerRoute);
+        connectionManager.setDefaultConnectionConfig(ConnectionConfig.custom()
+                .setConnectTimeout(Timeout.ofSeconds(connectTimeoutSeconds))
+                .build());
+
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setResponseTimeout(Timeout.ofSeconds(responseTimeoutSeconds))
+                .setConnectionRequestTimeout(Timeout.ofSeconds(connectionRequestTimeoutSeconds))
+                .build();
+
+        CloseableHttpClient httpClient = HttpClients.custom()
+                .setConnectionManager(connectionManager)
+                .setDefaultRequestConfig(requestConfig)
+                .build();
+
+        return new RestTemplate(new HttpComponentsClientHttpRequestFactory(httpClient));
+    }
+
+    @Bean
+    public Counter webhookTimeoutCounter(MeterRegistry meterRegistry) {
+        return Counter.builder("webhook.http.timeout.count")
+                .description("GitHub/GitLab/Azure DevOps API calls that failed with a connection, response, or "
+                        + "connection-pool-acquisition timeout (or any other low-level I/O failure Spring wraps "
+                        + "the same way)")
+                .register(meterRegistry);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookServiceBase.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookServiceBase.java
@@ -15,21 +15,39 @@ import javax.crypto.spec.SecretKeySpec;
 import io.terrakube.api.rs.job.JobStatus;
 
 import org.apache.commons.lang3.function.TriFunction;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-import lombok.AllArgsConstructor;
+import io.micrometer.core.instrument.Counter;
+
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
-@AllArgsConstructor
 @Slf4j
 @Service
 public class WebhookServiceBase {
+
+    // Field injection, not the constructor injection used elsewhere in this codebase: every
+    // GitHub/GitLab/Azure DevOps/Bitbucket webhook service subclasses this with its own
+    // constructor that doesn't call super(...) explicitly, relying on the implicit no-arg
+    // constructor - adding a constructor parameter here would force updating all four subclasses'
+    // constructors (and every caller that builds them) just to thread through a dependency none of
+    // them otherwise need direct access to. @Setter (public) exists purely so
+    // GitHubWebhookServiceTest can inject a WireMock-backed RestTemplate in a plain unit test,
+    // outside of Spring.
+    @Autowired
+    @Qualifier("webhookRestTemplate")
+    @Setter
+    private RestTemplate webhookRestTemplate;
+
+    @Autowired
+    private Counter webhookTimeoutCounter;
 
     protected String[] extractOwnerAndRepo(String repoUrl) {
         try {
@@ -105,9 +123,19 @@ public class WebhookServiceBase {
     }
 
     protected ResponseEntity<String> makeApiRequest(HttpHeaders headers, String body, String apiUrl, HttpMethod method) {
-        RestTemplate restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
         HttpEntity<String> entity = new HttpEntity<>(body, headers);
-        return restTemplate.exchange(apiUrl, method, entity, String.class);
+        try {
+            return webhookRestTemplate.exchange(apiUrl, method, entity, String.class);
+        } catch (org.springframework.web.client.ResourceAccessException e) {
+            // RestTemplate wraps every low-level I/O failure from the underlying HTTP client
+            // (connect timeout, response timeout, connection-pool-acquisition timeout, DNS
+            // failure, connection reset) in this one exception type - counted together as
+            // "timeout" per the spec's wording, re-thrown unchanged so every existing caller's
+            // error handling (e.g. GitHubWebhookService.sendCommitStatus is already called from
+            // inside ScheduleJob.updateJobStatusOnVcs's catch-all) is unaffected.
+            webhookTimeoutCounter.increment();
+            throw e;
+        }
     }
 
     protected String parseTerrakubeCommand(String commentBody) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WorkspaceFanoutExecutorConfig.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WorkspaceFanoutExecutorConfig.java
@@ -1,0 +1,30 @@
+package io.terrakube.api.plugin.vcs;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class WorkspaceFanoutExecutorConfig {
+
+    // Bounds how many workspaces on one shared webhook are processed concurrently. Without this,
+    // a repo with 35+ workspaces either processes them fully serially (slow, and each workspace
+    // still opens its own DB connections and outbound VCS/executor calls one at a time) or, if
+    // naively parallelized without a cap, could open dozens of concurrent connections at once. A
+    // full queue rejects rather than blocks the caller (RepoWebhookService.processClaimedDelivery):
+    // a rejected workspace task is caught and logged like any other per-workspace failure - see
+    // the comment there.
+    @Bean("workspaceFanoutExecutor")
+    public ThreadPoolTaskExecutor workspaceFanoutExecutor(
+            @Value("${io.terrakube.webhook.workspace-fanout.concurrency:4}") int concurrency,
+            @Value("${io.terrakube.webhook.workspace-fanout.queue-capacity:200}") int queueCapacity) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(concurrency);
+        executor.setMaxPoolSize(concurrency);
+        executor.setQueueCapacity(queueCapacity);
+        executor.setThreadNamePrefix("workspace-fanout-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WorkspaceFanoutMetrics.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WorkspaceFanoutMetrics.java
@@ -1,0 +1,33 @@
+package io.terrakube.api.plugin.vcs;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+// Explicit constructor (not @AllArgsConstructor): there are two ThreadPoolTaskExecutor beans in
+// this context (this one and repoWebhookDispatchExecutor), so the injection point needs a
+// @Qualifier on the constructor parameter itself - relying on Lombok to copy that annotation onto
+// a generated constructor isn't something to depend on.
+@Component
+public class WorkspaceFanoutMetrics {
+
+    private final ThreadPoolTaskExecutor workspaceFanoutExecutor;
+    private final MeterRegistry meterRegistry;
+
+    public WorkspaceFanoutMetrics(@Qualifier("workspaceFanoutExecutor") ThreadPoolTaskExecutor workspaceFanoutExecutor,
+            MeterRegistry meterRegistry) {
+        this.workspaceFanoutExecutor = workspaceFanoutExecutor;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @PostConstruct
+    public void registerGauge() {
+        Gauge.builder("webhook.workspace.fanout.queue.depth", workspaceFanoutExecutor,
+                        executor -> executor.getThreadPoolExecutor().getQueue().size())
+                .description("Number of workspace-fanout tasks queued waiting for a free thread")
+                .register(meterRegistry);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/controller/WebHookController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/controller/WebHookController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
+import io.terrakube.api.plugin.vcs.RepoWebhookDispatchService;
 import io.terrakube.api.plugin.vcs.RepoWebhookService;
 import io.terrakube.api.plugin.vcs.WebhookService;
 
@@ -15,6 +16,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.regex.Pattern;
 
 @Slf4j
@@ -29,6 +32,9 @@ public class WebHookController {
 
     @Autowired
     RepoWebhookService repoWebhookService;
+
+    @Autowired
+    RepoWebhookDispatchService repoWebhookDispatchService;
 
     @Autowired
     ObjectMapper objectMapper;
@@ -53,15 +59,24 @@ public class WebHookController {
             return ResponseEntity.status(401).build();
         }
         log.info("Processing v2 webhook");
+        UUID deliveryId;
         try {
             String jsonPayload = objectMapper.writeValueAsString(payload);
-            repoWebhookService.processV2Webhook(repoWebhookId, jsonPayload, headers);
+            deliveryId = repoWebhookService.acceptV2Webhook(repoWebhookId, jsonPayload, headers);
         } catch (IllegalArgumentException | SecurityException e) {
             log.warn("V2 webhook request rejected");
             return ResponseEntity.status(401).build();
         } catch (Exception e) {
             log.error("Error processing v2 webhook", e);
             return ResponseEntity.internalServerError().build();
+        }
+        try {
+            repoWebhookDispatchService.dispatchAsync(deliveryId);
+        } catch (RejectedExecutionException e) {
+            // The dispatch executor's queue is full - the row is still PENDING (this submission
+            // never claimed it), so RepoWebhookDeliveryPollerJob picks it up on its next tick.
+            log.warn("Repo webhook dispatch executor rejected delivery {}, will be picked up by the poller",
+                    deliveryId);
         }
         return ResponseEntity.ok().build();
     }

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriUtils;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -56,6 +57,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AzDevOpsWebhookService extends WebhookServiceBase {
 
     private static final String API_VERSION = "7.0";
+    private static final int MAX_PR_FILE_PAGES = 100;
     private static final String HOOKS_API_VERSION = "7.1";
     private static final String TOKEN_HEADER = "x-terrakube-token";
     /**
@@ -675,24 +677,56 @@ public class AzDevOpsWebhookService extends WebhookServiceBase {
             return changedFiles;
         }
 
-        String changesUrl = String.format(
-                "%s/%s/_apis/git/repositories/%s/pullRequests/%s/iterations/%s/changes?api-version=%s",
-                repo.orgBaseUrl, encodedProject, repositoryId, prNumber, latestIteration, API_VERSION);
+        // GitPullRequestIterationChanges paginates via $top/$skip (default $top=100, max 2000) and
+        // echoes the next page's values back as nextTop/nextSkip in the response body itself (not
+        // a header) - both are 0 once there are no more changes. A single unpaginated request
+        // silently truncates the file list for any PR touching more than 100 files, which is
+        // common for monorepo PRs. MAX_PR_FILE_PAGES is a defensive cap (100 pages), not a real
+        // Azure DevOps limit.
+        int top = 100;
+        int skip = 0;
+        for (int page = 0; page < MAX_PR_FILE_PAGES; page++) {
+            String changesUrl = String.format(
+                    "%s/%s/_apis/git/repositories/%s/pullRequests/%s/iterations/%s/changes?$top=%s&$skip=%s&api-version=%s",
+                    repo.orgBaseUrl, encodedProject, repositoryId, prNumber, latestIteration, top, skip, API_VERSION);
 
-        ResponseEntity<String> changesResponse = callAzureApi(vcs, "", changesUrl, HttpMethod.GET);
-        if (changesResponse == null || !changesResponse.getStatusCode().is2xxSuccessful()) {
-            log.error("Failed to fetch Azure DevOps changes for pull request {}", prNumber);
-            return changedFiles;
-        }
-        try {
-            JsonNode rootNode = objectMapper.readTree(changesResponse.getBody());
-            for (JsonNode change : rootNode.path("changeEntries")) {
-                addChangedFile(changedFiles, change);
+            ResponseEntity<String> changesResponse = callAzureApi(vcs, "", changesUrl, HttpMethod.GET);
+            if (changesResponse == null || !changesResponse.getStatusCode().is2xxSuccessful()) {
+                log.error("Failed to fetch Azure DevOps changes for pull request {}", prNumber);
+                break;
             }
-        } catch (Exception e) {
-            log.error("Error parsing Azure DevOps pull request changes", e);
+            ChangesPage changesPage;
+            try {
+                changesPage = parseChangesPage(changesResponse.getBody());
+            } catch (Exception e) {
+                log.error("Error parsing Azure DevOps pull request changes", e);
+                break;
+            }
+            changedFiles.addAll(changesPage.files());
+            if (changesPage.nextTop() == 0 && changesPage.nextSkip() == 0) {
+                break;
+            }
+            top = changesPage.nextTop();
+            skip = changesPage.nextSkip();
         }
         return changedFiles;
+    }
+
+    // A page of GitPullRequestIterationChanges: nextTop/nextSkip are both 0 once there are no more
+    // pages (see getPullRequestChanges).
+    record ChangesPage(List<String> files, int nextTop, int nextSkip) {
+    }
+
+    // Package-private (not private) so AzDevOpsWebhookServiceTest can exercise the pagination
+    // decision - including the nextTop/nextSkip "no more pages" sentinel - directly against a JSON
+    // fixture, without standing up an HTTP stack for what's really just a JSON-shape question.
+    ChangesPage parseChangesPage(String responseBody) throws JsonProcessingException {
+        List<String> files = new ArrayList<>();
+        JsonNode rootNode = objectMapper.readTree(responseBody);
+        for (JsonNode change : rootNode.path("changeEntries")) {
+            addChangedFile(files, change);
+        }
+        return new ChangesPage(files, rootNode.path("nextTop").asInt(0), rootNode.path("nextSkip").asInt(0));
     }
 
     private void addChangedFile(List<String> changedFiles, JsonNode change) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -328,24 +328,83 @@ public class GitHubWebhookService extends WebhookServiceBase {
         return prNumbers;
     }
 
+    // GitHub paginates /pulls/{number}/files at 30 entries per page by default (100 max per page,
+    // up to 3000 files total across pages) - a single unpaginated request silently truncates the
+    // file list for any PR touching more files than fit on one page, which is common for monorepo
+    // PRs. MAX_PR_FILE_PAGES is a defensive cap (100 pages * 100/page = 10000 files), not a real
+    // GitHub limit, so a malformed or malicious Link header can't spin this into an infinite loop.
+    private static final int MAX_PR_FILE_PAGES = 100;
+
     private List<String> getPrFileChanges(Vcs vcs, String[] ownerAndRepo, String apiUrl) {
         List<String> changedFiles = new ArrayList<>();
+        String nextUrl = withPerPage(apiUrl);
 
-        ResponseEntity<String> response = callGitHubApi(vcs, ownerAndRepo, "", apiUrl, HttpMethod.GET);
-        if(response == null || response.getStatusCode().value() != 200) {
-            log.error("Failed to fetch PR file changes from GitHub, response: {}", response != null ? response.getBody() : "No response");
-            return changedFiles;
-        }
-        
-        try {
-            JsonNode rootNode = objectMapper.readTree(response.getBody());
-            for (JsonNode file : rootNode) {
-                changedFiles.add(file.path("filename").asText());
+        for (int page = 0; nextUrl != null && page < MAX_PR_FILE_PAGES; page++) {
+            ResponseEntity<String> response = callGitHubApi(vcs, ownerAndRepo, "", nextUrl, HttpMethod.GET);
+            if (response == null || response.getStatusCode().value() != 200) {
+                log.error("Failed to fetch PR file changes from GitHub, response: {}", response != null ? response.getBody() : "No response");
+                break;
             }
-        } catch (Exception e) {
-            log.error("Error parsing JSON response", e);
+
+            try {
+                changedFiles.addAll(parseChangedFilesFromPage(response.getBody()));
+            } catch (Exception e) {
+                log.error("Error parsing JSON response", e);
+                break;
+            }
+
+            nextUrl = extractNextPageUrl(response.getHeaders().getFirst(HttpHeaders.LINK));
         }
         return changedFiles;
+    }
+
+    // Package-private (not private) so GitHubWebhookServiceTest can exercise the parsing logic -
+    // including the previous_filename/rename handling - directly, without standing up an HTTP
+    // stack for what's really just a JSON-shape question.
+    List<String> parseChangedFilesFromPage(String responseBody) throws JsonProcessingException {
+        List<String> files = new ArrayList<>();
+        JsonNode rootNode = objectMapper.readTree(responseBody);
+        for (JsonNode file : rootNode) {
+            files.add(file.path("filename").asText());
+            // Renames need the old path too, or a workspace whose path filter only matches the
+            // pre-rename location never sees the change that moved it out.
+            String previousFilename = file.path("previous_filename").asText(null);
+            if (previousFilename != null && !previousFilename.isEmpty()) {
+                files.add(previousFilename);
+            }
+        }
+        return files;
+    }
+
+    String withPerPage(String apiUrl) {
+        return apiUrl + (apiUrl.contains("?") ? "&" : "?") + "per_page=100";
+    }
+
+    // Parses a GitHub RFC 5988 Link header, e.g.:
+    // <https://api.github.com/.../files?page=2>; rel="next", <...>; rel="last"
+    // Returns the rel="next" URL, or null once there isn't one (the last page).
+    String extractNextPageUrl(String linkHeader) {
+        if (linkHeader == null || linkHeader.isBlank()) {
+            return null;
+        }
+        for (String link : linkHeader.split(",")) {
+            String[] segments = link.split(";");
+            if (segments.length < 2) {
+                continue;
+            }
+            boolean isNext = false;
+            for (int i = 1; i < segments.length; i++) {
+                if (segments[i].trim().equals("rel=\"next\"")) {
+                    isNext = true;
+                    break;
+                }
+            }
+            String urlSegment = segments[0].trim();
+            if (isNext && urlSegment.startsWith("<") && urlSegment.endsWith(">")) {
+                return urlSegment.substring(1, urlSegment.length() - 1);
+            }
+        }
+        return null;
     }
 
     public String createOrUpdateWebhook(Workspace workspace, Webhook webhook) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookService.java
@@ -266,66 +266,12 @@ public class GitHubWebhookService extends WebhookServiceBase {
         } else {
             log.error(String.format("Failed to send job status to GitHub, message %s", response.getBody()));
         }
-
-        // Optional: Check if the commit is part of a PR and send status to the PR as
-        // well
-        try {
-            List<Integer> prNumbers = getPullRequestNumbersForCommit(workspace, job.getCommitId());
-            for (Integer prNumber : prNumbers) {
-                String prApiUrl = workspace.getVcs().getApiUrl() + "/repos/" + String.join("/", ownerAndRepos)
-                        + "/pulls/" + prNumber + "/statuses";
-
-                // Send the status to the pull request
-                ResponseEntity<String> prResponse = callGitHubApi(workspace.getVcs(), ownerAndRepos, body, prApiUrl,
-                        HttpMethod.POST);
-                if (prResponse == null) {
-                    log.error("Failed to send job status on PR #{} in workspace {} to GitHub", prNumber,
-                            workspace.getName());
-                    continue;
-                }
-
-                if (prResponse.getStatusCode().value() == 201) {
-                    log.info("Job status sent successfully to PR #{} on GitHub", prNumber);
-                } else {
-                    log.error(String.format("Failed to send job status to PR #%, message %s", prNumber,
-                            prResponse.getBody()));
-                }
-            }
-        } catch (Exception e) {
-            log.error("Error occurred while checking PRs for commit {}: {}", job.getCommitId(), e.getMessage());
-        }
     }
 
     // GitHub's commit-status description has a hard 140-character API limit.
     public static String buildCommitStatusDescription(JobStatus jobStatus, String runSummary) {
         String description = WebhookServiceBase.buildCommitStatusDescription(jobStatus, runSummary);
         return description.length() > 140 ? description.substring(0, 140) : description;
-    }
-
-    private List<Integer> getPullRequestNumbersForCommit(Workspace workspace, String commitId) {
-        List<Integer> prNumbers = new ArrayList<>();
-        String[] ownerAndRepo = extractOwnerAndRepo(workspace.getSource());
-        String apiUrl = workspace.getVcs().getApiUrl() + "/repos/" + String.join("/", ownerAndRepo)
-                + "/commits/" + commitId + "/pulls";
-
-        ResponseEntity<String> response = callGitHubApi(workspace.getVcs(), ownerAndRepo, null, apiUrl,
-                HttpMethod.GET);
-
-        if (response != null && response.getStatusCode().value() == 200) {
-            try {
-                JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
-                for (JsonNode pr : jsonNode) {
-                    prNumbers.add(pr.path("number").asInt());
-                }
-            } catch (Exception e) {
-                log.error("Failed to parse PR data for commit {}: {}", commitId, e.getMessage());
-            }
-        } else {
-            log.error("Failed to fetch PRs for commit {}: {}", commitId,
-                    response != null ? response.getBody() : "No response");
-        }
-
-        return prNumbers;
     }
 
     // GitHub paginates /pulls/{number}/files at 30 entries per page by default (100 max per page,

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -343,6 +343,15 @@ public class GitLabWebhookService extends WebhookServiceBase {
                                                                 log.debug("Added new path: {}", diffModel.getNewPath());
                                                             }
                                                         }
+                                                        // Renamed files need the old path too, or a workspace whose path
+                                                        // filter only matches the pre-rename location never sees the
+                                                        // change that moved it out.
+                                                        if (diffModel.isRenamedFile() && diffModel.getOldPath() != null
+                                                                && !diffModel.getOldPath().equals(diffModel.getNewPath())
+                                                                && !fileChanges.contains(diffModel.getOldPath())) {
+                                                            fileChanges.add(diffModel.getOldPath());
+                                                            log.debug("Added old path for rename: {}", diffModel.getOldPath());
+                                                        }
 
                                                         log.debug("Processing diff - Old: {}, New: {}, NewFile: {}, DeletedFile: {}, RenamedFile: {}",
                                                                 diffModel.getOldPath(),

--- a/api/src/main/java/io/terrakube/api/repository/AddressRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/AddressRepository.java
@@ -1,9 +1,18 @@
 package io.terrakube.api.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.address.Address;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface AddressRepository extends JpaRepository<Address, UUID> {
+
+    // ExecutorService.validateJobAddress reads this after ScheduleJob has deliberately released
+    // its transaction before making external calls (see ScheduleJob's class comment) - Job.address
+    // is a lazy @OneToMany with no fetch override, so job.getAddress() has no session left to
+    // initialize through by the time it's read there. A plain repository query has no such problem
+    // (each Spring Data repository call is its own short, already-committed transaction).
+    List<Address> findByJob(Job job);
 }

--- a/api/src/main/java/io/terrakube/api/repository/ItemRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/ItemRepository.java
@@ -1,0 +1,9 @@
+package io.terrakube.api.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import io.terrakube.api.rs.collection.item.Item;
+
+import java.util.UUID;
+
+public interface ItemRepository extends JpaRepository<Item, UUID> {
+}

--- a/api/src/main/java/io/terrakube/api/repository/ReferenceRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/ReferenceRepository.java
@@ -1,6 +1,8 @@
 package io.terrakube.api.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import io.terrakube.api.rs.collection.Collection;
 import io.terrakube.api.rs.collection.Reference;
 import io.terrakube.api.rs.workspace.Workspace;
@@ -14,4 +16,17 @@ public interface ReferenceRepository extends JpaRepository<Reference, UUID> {
     Optional<List<Reference>> findByWorkspace(Workspace workspace);
 
     boolean existsByWorkspaceAndCollection(Workspace workspace, Collection collection);
+
+    // ExecutorService.loadDefault runs after ScheduleJob has deliberately released its transaction
+    // before making external calls (see ScheduleJob's class comment) - Collection.item is a lazy
+    // @OneToMany with no session left open by the time loadDefault reads collection.getItem(), so a
+    // plain findByWorkspace() throws LazyInitializationException. LEFT JOIN FETCH (not an inner
+    // join) so a Collection with zero items doesn't silently drop its Reference from the result;
+    // DISTINCT because the *-to-many fetch produces one row per item, which would otherwise return
+    // duplicate Reference objects for any collection with more than one item.
+    @Query("SELECT DISTINCT r FROM reference r "
+            + "JOIN FETCH r.collection c "
+            + "LEFT JOIN FETCH c.item "
+            + "WHERE r.workspace = :workspace")
+    List<Reference> findByWorkspaceWithCollectionItems(@Param("workspace") Workspace workspace);
 }

--- a/api/src/main/java/io/terrakube/api/repository/RepoWebhookDeliveryRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/RepoWebhookDeliveryRepository.java
@@ -1,0 +1,77 @@
+package io.terrakube.api.repository;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import io.terrakube.api.rs.webhook.RepoWebhookDelivery;
+import io.terrakube.api.rs.webhook.RepoWebhookDeliveryStatus;
+
+// Every bulk UPDATE below uses @Modifying(clearAutomatically = true): a bulk UPDATE bypasses
+// Hibernate's first-level cache, so without clearing, an entity already loaded in the caller's
+// persistence context would keep showing its pre-update values on a subsequent find/query.
+public interface RepoWebhookDeliveryRepository extends JpaRepository<RepoWebhookDelivery, UUID> {
+
+    // Atomic claim: flips PENDING -> PROCESSING and bumps bookkeeping in one statement, so two
+    // concurrent callers on the same row (the immediate post-accept dispatch racing the poller)
+    // can't both pass a check-then-act race - only one UPDATE can match the WHERE status =
+    // :expectedStatus predicate.
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE repo_webhook_delivery d SET d.status = :newStatus, d.attemptCount = d.attemptCount + 1, "
+            + "d.lastAttemptAt = :now, d.updatedDate = :now "
+            + "WHERE d.id = :id AND d.status = :expectedStatus")
+    int claimForDelivery(@Param("id") UUID id, @Param("expectedStatus") RepoWebhookDeliveryStatus expectedStatus,
+            @Param("newStatus") RepoWebhookDeliveryStatus newStatus, @Param("now") Date now);
+
+    // Keyed on the exact lastAttemptAt observed at claim time so a result from an attempt that
+    // outlived the stuck-row sweep's reclaim window is discarded instead of clobbering whatever a
+    // later claimant already recorded for this row.
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE repo_webhook_delivery d SET d.status = :newStatus, d.lastError = :lastError, "
+            + "d.nextAttemptAt = :nextAttemptAt, d.updatedDate = :now "
+            + "WHERE d.id = :id AND d.status = :expectedStatus AND d.lastAttemptAt = :expectedLastAttemptAt")
+    int recordDeliveryResult(@Param("id") UUID id, @Param("expectedStatus") RepoWebhookDeliveryStatus expectedStatus,
+            @Param("expectedLastAttemptAt") Date expectedLastAttemptAt,
+            @Param("newStatus") RepoWebhookDeliveryStatus newStatus, @Param("lastError") String lastError,
+            @Param("nextAttemptAt") Date nextAttemptAt, @Param("now") Date now);
+
+    // Bounded, fairness-ordered (oldest first) so one repo with a burst of deliveries can't starve
+    // every other repo's deliveries out of a poll cycle. nextAttemptAt is null for a row that has
+    // never failed; such a row is due as soon as it's PENDING.
+    @Query("SELECT d FROM repo_webhook_delivery d WHERE d.status = :status "
+            + "AND (d.nextAttemptAt IS NULL OR d.nextAttemptAt <= :now) ORDER BY d.createdDate ASC")
+    List<RepoWebhookDelivery> findDueForDispatch(@Param("status") RepoWebhookDeliveryStatus status,
+            @Param("now") Date now, Pageable pageable);
+
+    // Crash recovery: an instance that claimed a row (PENDING -> PROCESSING) and died mid-fan-out
+    // leaves it stuck in PROCESSING forever without this. attemptCount is NOT bumped again here -
+    // the attempt was already counted at claim time.
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE repo_webhook_delivery d SET d.status = :pending, d.updatedDate = :cutoffQueriedAt "
+            + "WHERE d.status = :processing AND d.lastAttemptAt < :cutoff AND d.attemptCount < :maxAttempts")
+    int reclaimStuckProcessingRows(@Param("processing") RepoWebhookDeliveryStatus processing,
+            @Param("pending") RepoWebhookDeliveryStatus pending, @Param("cutoff") Date cutoff,
+            @Param("maxAttempts") int maxAttempts, @Param("cutoffQueriedAt") Date cutoffQueriedAt);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE repo_webhook_delivery d SET d.status = :failed, d.lastError = :note, d.updatedDate = :cutoffQueriedAt "
+            + "WHERE d.status = :processing AND d.lastAttemptAt < :cutoff AND d.attemptCount >= :maxAttempts")
+    int failStuckProcessingRowsAtMaxAttempts(@Param("processing") RepoWebhookDeliveryStatus processing,
+            @Param("failed") RepoWebhookDeliveryStatus failed, @Param("cutoff") Date cutoff,
+            @Param("maxAttempts") int maxAttempts, @Param("note") String note,
+            @Param("cutoffQueriedAt") Date cutoffQueriedAt);
+
+    // Retention sweep: only ever targets rows in a terminal state (PROCESSED/FAILED) older than
+    // the cutoff - a row still PENDING/PROCESSING is mid-flight regardless of age and must never
+    // be deleted out from under the dispatch pipeline.
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM repo_webhook_delivery d WHERE d.status IN :terminalStatuses AND d.createdDate < :cutoff")
+    int deleteTerminalRowsCreatedBefore(@Param("terminalStatuses") List<RepoWebhookDeliveryStatus> terminalStatuses,
+            @Param("cutoff") Date cutoff);
+}

--- a/api/src/main/java/io/terrakube/api/repository/RepoWebhookDeliveryRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/RepoWebhookDeliveryRepository.java
@@ -74,4 +74,11 @@ public interface RepoWebhookDeliveryRepository extends JpaRepository<RepoWebhook
     @Query("DELETE FROM repo_webhook_delivery d WHERE d.status IN :terminalStatuses AND d.createdDate < :cutoff")
     int deleteTerminalRowsCreatedBefore(@Param("terminalStatuses") List<RepoWebhookDeliveryStatus> terminalStatuses,
             @Param("cutoff") Date cutoff);
+
+    // Backs the webhook.delivery.queue.depth/oldest.age.seconds Micrometer gauges (see
+    // RepoWebhookDeliveryMetrics).
+    long countByStatus(RepoWebhookDeliveryStatus status);
+
+    @Query("SELECT MIN(d.createdDate) FROM repo_webhook_delivery d WHERE d.status = :status")
+    Date findOldestCreatedDateByStatus(@Param("status") RepoWebhookDeliveryStatus status);
 }

--- a/api/src/main/java/io/terrakube/api/rs/webhook/RepoWebhookDelivery.java
+++ b/api/src/main/java/io/terrakube/api/rs/webhook/RepoWebhookDelivery.java
@@ -8,6 +8,8 @@ import org.hibernate.annotations.JdbcTypeCode;
 import io.terrakube.api.plugin.security.audit.GenericAuditFields;
 import io.terrakube.api.rs.IdConverter;
 
+import com.yahoo.elide.annotation.Exclude;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
@@ -22,6 +24,10 @@ import jakarta.persistence.TemporalType;
 import lombok.Getter;
 import lombok.Setter;
 
+// Not an Elide resource: this table is an internal dispatch/retry ledger (debugging aid), not
+// API-consumer data, and it carries raw request payloads/headers from VCS providers that
+// shouldn't be exposed - even to admins - through the JSON-API/GraphQL endpoints.
+@Exclude
 @Getter
 @Setter
 @Entity(name = "repo_webhook_delivery")

--- a/api/src/main/java/io/terrakube/api/rs/webhook/RepoWebhookDelivery.java
+++ b/api/src/main/java/io/terrakube/api/rs/webhook/RepoWebhookDelivery.java
@@ -1,0 +1,66 @@
+package io.terrakube.api.rs.webhook;
+
+import java.sql.Types;
+import java.util.Date;
+import java.util.UUID;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import io.terrakube.api.plugin.security.audit.GenericAuditFields;
+import io.terrakube.api.rs.IdConverter;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity(name = "repo_webhook_delivery")
+public class RepoWebhookDelivery extends GenericAuditFields {
+
+    @Id
+    @JdbcTypeCode(Types.VARCHAR)
+    @Convert(converter = IdConverter.class)
+    private UUID id;
+
+    // Explicit @JoinColumn: this project's Hibernate physical naming strategy
+    // (PhysicalNamingStrategyStandardImpl) does not snake_case implicit names, so a camelCase
+    // field like "repoWebhook" would otherwise generate a literal "repoWebhook_id" column instead
+    // of matching the changelog's "repo_webhook_id".
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "repo_webhook_id")
+    private RepoWebhook repoWebhook;
+
+    // Plain @Column, not @Lob: see RepoWebhookDeliveryRepository.findDueForDispatch, which runs
+    // with no surrounding transaction from a Quartz job - a clob/Large Object column requires one
+    // on every read (see notification_outbox for the identical fix and its full rationale).
+    private String payload;
+
+    private String headers;
+
+    @Enumerated(EnumType.STRING)
+    private RepoWebhookDeliveryStatus status = RepoWebhookDeliveryStatus.PENDING;
+
+    @Column(name = "attempt_count")
+    private int attemptCount = 0;
+
+    @Column(name = "last_attempt_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date lastAttemptAt;
+
+    @Column(name = "next_attempt_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date nextAttemptAt;
+
+    @Column(name = "last_error")
+    private String lastError;
+}

--- a/api/src/main/java/io/terrakube/api/rs/webhook/RepoWebhookDeliveryStatus.java
+++ b/api/src/main/java/io/terrakube/api/rs/webhook/RepoWebhookDeliveryStatus.java
@@ -1,0 +1,8 @@
+package io.terrakube.api.rs.webhook;
+
+public enum RepoWebhookDeliveryStatus {
+    PENDING,
+    PROCESSING,
+    PROCESSED,
+    FAILED
+}

--- a/api/src/main/resources/application-demo.properties
+++ b/api/src/main/resources/application-demo.properties
@@ -100,6 +100,34 @@ spring.quartz.jdbc.initialize-schema=never
 ####################
 io.terrakube.notification.ssrf.blockPrivateNetworks=true
 
+##################
+#WEBHOOK DELIVERY#
+##################
+# Dispatch pool is bounded so a burst of shared-webhook deliveries (e.g. a force-push touching a
+# repo with many workspaces) can't spawn unbounded threads competing for the app's DB connection
+# pool or the VCS provider's API rate limit. The poller is the durability backstop for the
+# immediate-dispatch path - crash recovery, executor-queue-full rejections, and retries whose
+# backoff has elapsed - see RepoWebhookDeliveryPollerJob.
+io.terrakube.webhook.dispatch.executor.corePoolSize=${WebhookDispatchExecutorCorePoolSize:10}
+io.terrakube.webhook.dispatch.executor.maxPoolSize=${WebhookDispatchExecutorMaxPoolSize:20}
+io.terrakube.webhook.dispatch.executor.queueCapacity=${WebhookDispatchExecutorQueueCapacity:200}
+io.terrakube.webhook.poller.batchSize=${WebhookPollerBatchSize:200}
+io.terrakube.webhook.poller.stuckProcessingThresholdMinutes=${WebhookPollerStuckProcessingThresholdMinutes:5}
+io.terrakube.webhook.delivery.retentionDays=${WebhookDeliveryRetentionDays:30}
+# Bounds how many workspaces on one shared webhook are processed concurrently - see
+# WorkspaceFanoutExecutorConfig. Deliberately small: each workspace's processing itself makes
+# outbound VCS/executor HTTP calls, so this is the real ceiling on how many of those run at once
+# for a single delivery, not just a thread-pool size.
+io.terrakube.webhook.workspace-fanout.concurrency=${WebhookWorkspaceFanoutConcurrency:4}
+io.terrakube.webhook.workspace-fanout.queue-capacity=${WebhookWorkspaceFanoutQueueCapacity:200}
+# Pooled HTTP client for GitHub/GitLab/Azure DevOps API calls (WebhookHttpClientConfig) - replaces
+# a fresh RestTemplate + TCP/TLS handshake per call. connectionRequestTimeoutSeconds is how long a
+# caller waits for a pooled connection to free up before failing, separate from the connect/response
+# timeouts against the remote host itself.
+io.terrakube.webhook.dispatch.http.connectTimeoutSeconds=${WebhookDispatchConnectTimeoutSeconds:5}
+io.terrakube.webhook.dispatch.http.responseTimeoutSeconds=${WebhookDispatchResponseTimeoutSeconds:30}
+io.terrakube.webhook.dispatch.http.connectionRequestTimeoutSeconds=${WebhookDispatchConnectionRequestTimeoutSeconds:2}
+
 ##############
 #EXECUTOR URL#
 ##############

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -102,6 +102,10 @@ spring.quartz.jdbc.initialize-schema=never
 spring.quartz.properties.org.quartz.jobStore.isClustered=true
 spring.quartz.properties.org.quartz.scheduler.instanceId=AUTO
 spring.quartz.properties.org.quartz.jobStore.clusterCheckinInterval=20000
+# Default (8) intentionally leaves headroom under the default Hikari pool (10, see
+# io.terrakube.api.plugin.datasource.poolSize) for webhook ingestion and other DB consumers -
+# SchedulerThreadPoolValidation fails startup if this is ever raised to or above the pool size.
+spring.quartz.properties.org.quartz.threadPool.threadCount=${io.terrakube.scheduler.thread-count:8}
 
 ####################
 #NOTIFICATION SETUP#
@@ -131,6 +135,19 @@ io.terrakube.webhook.dispatch.executor.queueCapacity=200
 io.terrakube.webhook.poller.batchSize=200
 io.terrakube.webhook.poller.stuckProcessingThresholdMinutes=5
 io.terrakube.webhook.delivery.retentionDays=30
+# Bounds how many workspaces on one shared webhook are processed concurrently - see
+# WorkspaceFanoutExecutorConfig. Deliberately small: each workspace's processing itself makes
+# outbound VCS/executor HTTP calls, so this is the real ceiling on how many of those run at once
+# for a single delivery, not just a thread-pool size.
+io.terrakube.webhook.workspace-fanout.concurrency=4
+io.terrakube.webhook.workspace-fanout.queue-capacity=200
+# Pooled HTTP client for GitHub/GitLab/Azure DevOps API calls (WebhookHttpClientConfig) - replaces
+# a fresh RestTemplate + TCP/TLS handshake per call. connectionRequestTimeoutSeconds is how long a
+# caller waits for a pooled connection to free up before failing, separate from the connect/response
+# timeouts against the remote host itself.
+io.terrakube.webhook.dispatch.http.connectTimeoutSeconds=5
+io.terrakube.webhook.dispatch.http.responseTimeoutSeconds=30
+io.terrakube.webhook.dispatch.http.connectionRequestTimeoutSeconds=2
 
 ##############
 #EXECUTOR URL#
@@ -203,7 +220,10 @@ io.terrakube.tools.branch=${TerrakubeToolsBranch}
 ##########
 # HEALTH #
 ##########
-management.endpoints.web.exposure.include=health
+# Restrict access to /actuator/prometheus at the network/ingress level (e.g. only scrapeable from
+# inside the cluster) - this doesn't add auth of its own, matching how /actuator/health is already
+# exposed unauthenticated for k8s probes.
+management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.enabled=true
 management.endpoints.enabled-by-default=false
 management.endpoint.health.probes.enabled=true

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -117,6 +117,21 @@ io.terrakube.notification.poller.stuckSendingThresholdMinutes=5
 io.terrakube.notification.ssrf.blockPrivateNetworks=true
 io.terrakube.notification.outbox.retentionDays=90
 
+##################
+#WEBHOOK DELIVERY#
+##################
+# Dispatch pool is bounded so a burst of shared-webhook deliveries (e.g. a force-push touching a
+# repo with many workspaces) can't spawn unbounded threads competing for the app's DB connection
+# pool or the VCS provider's API rate limit. The poller is the durability backstop for the
+# immediate-dispatch path - crash recovery, executor-queue-full rejections, and retries whose
+# backoff has elapsed - see RepoWebhookDeliveryPollerJob.
+io.terrakube.webhook.dispatch.executor.corePoolSize=10
+io.terrakube.webhook.dispatch.executor.maxPoolSize=20
+io.terrakube.webhook.dispatch.executor.queueCapacity=200
+io.terrakube.webhook.poller.batchSize=200
+io.terrakube.webhook.poller.stuckProcessingThresholdMinutes=5
+io.terrakube.webhook.delivery.retentionDays=30
+
 ##############
 #EXECUTOR URL#
 ##############

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -129,25 +129,25 @@ io.terrakube.notification.outbox.retentionDays=90
 # pool or the VCS provider's API rate limit. The poller is the durability backstop for the
 # immediate-dispatch path - crash recovery, executor-queue-full rejections, and retries whose
 # backoff has elapsed - see RepoWebhookDeliveryPollerJob.
-io.terrakube.webhook.dispatch.executor.corePoolSize=10
-io.terrakube.webhook.dispatch.executor.maxPoolSize=20
-io.terrakube.webhook.dispatch.executor.queueCapacity=200
-io.terrakube.webhook.poller.batchSize=200
-io.terrakube.webhook.poller.stuckProcessingThresholdMinutes=5
-io.terrakube.webhook.delivery.retentionDays=30
+io.terrakube.webhook.dispatch.executor.corePoolSize=${WebhookDispatchExecutorCorePoolSize:10}
+io.terrakube.webhook.dispatch.executor.maxPoolSize=${WebhookDispatchExecutorMaxPoolSize:20}
+io.terrakube.webhook.dispatch.executor.queueCapacity=${WebhookDispatchExecutorQueueCapacity:200}
+io.terrakube.webhook.poller.batchSize=${WebhookPollerBatchSize:200}
+io.terrakube.webhook.poller.stuckProcessingThresholdMinutes=${WebhookPollerStuckProcessingThresholdMinutes:5}
+io.terrakube.webhook.delivery.retentionDays=${WebhookDeliveryRetentionDays:30}
 # Bounds how many workspaces on one shared webhook are processed concurrently - see
 # WorkspaceFanoutExecutorConfig. Deliberately small: each workspace's processing itself makes
 # outbound VCS/executor HTTP calls, so this is the real ceiling on how many of those run at once
 # for a single delivery, not just a thread-pool size.
-io.terrakube.webhook.workspace-fanout.concurrency=4
-io.terrakube.webhook.workspace-fanout.queue-capacity=200
+io.terrakube.webhook.workspace-fanout.concurrency=${WebhookWorkspaceFanoutConcurrency:4}
+io.terrakube.webhook.workspace-fanout.queue-capacity=${WebhookWorkspaceFanoutQueueCapacity:200}
 # Pooled HTTP client for GitHub/GitLab/Azure DevOps API calls (WebhookHttpClientConfig) - replaces
 # a fresh RestTemplate + TCP/TLS handshake per call. connectionRequestTimeoutSeconds is how long a
 # caller waits for a pooled connection to free up before failing, separate from the connect/response
 # timeouts against the remote host itself.
-io.terrakube.webhook.dispatch.http.connectTimeoutSeconds=5
-io.terrakube.webhook.dispatch.http.responseTimeoutSeconds=30
-io.terrakube.webhook.dispatch.http.connectionRequestTimeoutSeconds=2
+io.terrakube.webhook.dispatch.http.connectTimeoutSeconds=${WebhookDispatchConnectTimeoutSeconds:5}
+io.terrakube.webhook.dispatch.http.responseTimeoutSeconds=${WebhookDispatchResponseTimeoutSeconds:30}
+io.terrakube.webhook.dispatch.http.connectionRequestTimeoutSeconds=${WebhookDispatchConnectionRequestTimeoutSeconds:2}
 
 ##############
 #EXECUTOR URL#

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -121,4 +121,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-notification.xml" />
     <include file="/db/changelog/local/changelog-2.33.0-job-target-replace-addrs.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-provider-trust-signature.xml"/>
+    <include file="/db/changelog/local/changelog-2.33.0-repo-webhook-delivery.xml" />
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.0-repo-webhook-delivery.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.0-repo-webhook-delivery.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <changeSet id="2-33-0-repo-webhook-delivery" author="jake">
+        <!-- payload/headers/last_error are "text", not "clob": clob maps to PostgreSQL's
+             oid-backed Large Object storage, which requires every read to happen inside a real
+             (non-autocommit) transaction - the delivery poller's findDueForDispatch() query runs
+             on a plain repository call from a Quartz job with no surrounding transaction, so a
+             clob column here would crash every poll tick with "Large Objects may not be used in
+             auto-commit mode." (see notification_outbox for the same fix). -->
+        <createTable tableName="repo_webhook_delivery">
+            <column name="id" type="varchar(36)">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="repo_webhook_id" type="varchar(36)">
+                <constraints nullable="false" />
+            </column>
+            <column name="payload" type="text" />
+            <column name="headers" type="text" />
+            <column name="status" type="varchar(20)" defaultValue="PENDING">
+                <constraints nullable="false" />
+            </column>
+            <column name="attempt_count" type="int" defaultValueNumeric="0">
+                <constraints nullable="false" />
+            </column>
+            <column name="last_attempt_at" type="datetime" />
+            <column name="next_attempt_at" type="datetime" />
+            <column name="last_error" type="text" />
+            <column name="created_date" type="datetime" />
+            <column name="updated_date" type="datetime" />
+            <column name="created_by" type="varchar(128)" />
+            <column name="updated_by" type="varchar(128)" />
+        </createTable>
+        <addForeignKeyConstraint baseTableName="repo_webhook_delivery" baseColumnNames="repo_webhook_id"
+            constraintName="fk_repo_webhook_delivery_repo_webhook_id" referencedTableName="repo_webhook"
+            referencedColumnNames="id" onDelete="CASCADE" />
+        <createIndex tableName="repo_webhook_delivery" indexName="idx_repo_webhook_delivery_status">
+            <column name="status" />
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/AddressRepositoryTest.java
+++ b/api/src/test/java/io/terrakube/api/AddressRepositoryTest.java
@@ -1,0 +1,66 @@
+package io.terrakube.api;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.terrakube.api.repository.AddressRepository;
+import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.address.Address;
+import io.terrakube.api.rs.job.address.AddressType;
+import io.terrakube.api.rs.workspace.Workspace;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// Deliberately NOT @Transactional at the class level: ExecutorService.validateJobAddress calls
+// addressRepository.findByJob() after ScheduleJob has already released its transaction before
+// making external calls (see ScheduleJob's class comment) - this test reproduces that exact
+// condition by giving the repository call no ambient transaction of its own either. A plain
+// job.getAddress() would throw LazyInitializationException here (Job.address is a lazy @OneToMany
+// with no fetch override).
+class AddressRepositoryTest extends ServerApplicationTests {
+
+    @Autowired
+    AddressRepository addressRepository;
+
+    @Autowired
+    JobRepository jobRepository;
+
+    @Autowired
+    WorkspaceRepository workspaceRepository;
+
+    @Autowired
+    OrganizationRepository organizationRepository;
+
+    @Test
+    void findByJobDoesNotThrowLazyInitializationException() {
+        Organization organization = organizationRepository
+                .findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).orElseThrow();
+        Workspace workspace = workspaceRepository
+                .findById(UUID.fromString("5ed411ca-7ab8-4d2f-b591-02d0d5788afc")).orElseThrow();
+
+        Job job = new Job();
+        job.setStatus(JobStatus.pending);
+        job.setOrganization(organization);
+        job.setWorkspace(workspace);
+        job = jobRepository.saveAndFlush(job);
+
+        Address target = new Address();
+        target.setName("module.network.aws_instance.example");
+        target.setType(AddressType.TARGET);
+        target.setJob(job);
+        addressRepository.saveAndFlush(target);
+
+        List<Address> found = addressRepository.findByJob(job);
+
+        assertThat(found).extracting(Address::getName).contains("module.network.aws_instance.example");
+        assertThat(found).extracting(Address::getType).contains(AddressType.TARGET);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/ReferenceRepositoryTest.java
+++ b/api/src/test/java/io/terrakube/api/ReferenceRepositoryTest.java
@@ -1,0 +1,83 @@
+package io.terrakube.api;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.terrakube.api.repository.CollectionRepository;
+import io.terrakube.api.repository.ItemRepository;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.repository.ReferenceRepository;
+import io.terrakube.api.repository.WorkspaceRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.collection.Collection;
+import io.terrakube.api.rs.collection.Reference;
+import io.terrakube.api.rs.collection.item.Item;
+import io.terrakube.api.rs.workspace.Workspace;
+import io.terrakube.api.rs.workspace.parameters.Category;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// Deliberately NOT @Transactional at the class level: ExecutorService.loadDefault calls
+// referenceRepository.findByWorkspaceWithCollectionItems() after ScheduleJob has already released
+// its transaction before making external calls (see ScheduleJob's class comment) - this test
+// reproduces that exact condition by giving the repository call no ambient transaction of its own
+// either. A plain findByWorkspace() followed by collection.getItem() would throw
+// LazyInitializationException here exactly as it did in production (Collection.item is a lazy
+// @OneToMany with no fetch override).
+class ReferenceRepositoryTest extends ServerApplicationTests {
+
+    @Autowired
+    ReferenceRepository referenceRepository;
+
+    @Autowired
+    CollectionRepository collectionRepository;
+
+    @Autowired
+    ItemRepository itemRepository;
+
+    @Autowired
+    WorkspaceRepository workspaceRepository;
+
+    @Autowired
+    OrganizationRepository organizationRepository;
+
+    @Test
+    void findByWorkspaceWithCollectionItemsDoesNotThrowLazyInitializationException() {
+        Organization organization = organizationRepository
+                .findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).orElseThrow();
+        Workspace workspace = workspaceRepository
+                .findById(UUID.fromString("5ed411ca-7ab8-4d2f-b591-02d0d5788afc")).orElseThrow();
+
+        Collection collection = new Collection();
+        collection.setName("regression-test-collection-" + UUID.randomUUID());
+        collection.setDescription("Regression test collection");
+        collection.setPriority(1);
+        collection.setOrganization(organization);
+        collection = collectionRepository.saveAndFlush(collection);
+
+        Item item = new Item();
+        item.setKey("TEST_KEY");
+        item.setValue("test-value");
+        item.setCategory(Category.ENV);
+        item.setCollection(collection);
+        itemRepository.saveAndFlush(item);
+
+        Reference reference = new Reference();
+        reference.setWorkspace(workspace);
+        reference.setCollection(collection);
+        referenceRepository.saveAndFlush(reference);
+
+        List<Reference> results = referenceRepository.findByWorkspaceWithCollectionItems(workspace);
+
+        Collection finalCollection = collection;
+        Reference found = results.stream()
+                .filter(r -> r.getCollection().getId().equals(finalCollection.getId()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(found.getCollection().getItem()).extracting(Item::getKey).contains("TEST_KEY");
+    }
+}

--- a/api/src/test/java/io/terrakube/api/RepoWebhookAcceptV2WebhookIntegrationTest.java
+++ b/api/src/test/java/io/terrakube/api/RepoWebhookAcceptV2WebhookIntegrationTest.java
@@ -1,0 +1,96 @@
+package io.terrakube.api;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.terrakube.api.plugin.vcs.RepoWebhookService;
+import io.terrakube.api.repository.OrganizationRepository;
+import io.terrakube.api.repository.RepoWebhookRepository;
+import io.terrakube.api.repository.VcsRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.vcs.VcsType;
+import io.terrakube.api.rs.webhook.RepoWebhook;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// Deliberately NOT @Transactional at the class level: WebHookController calls
+// RepoWebhookService.acceptV2Webhook() with no ambient transaction of its own, and that method's
+// own @Transactional is what's under test here. Wrapping this test in @Transactional would keep
+// one Hibernate session open across the whole test method and mask exactly the
+// LazyInitializationException this test exists to catch - repoWebhook.getVcs() is a proxy loaded
+// by a repository call (findById) whose own implicit per-call transaction closes before
+// acceptV2Webhook's method body reads it, unless acceptV2Webhook has its own @Transactional.
+class RepoWebhookAcceptV2WebhookIntegrationTest extends ServerApplicationTests {
+
+    @Autowired
+    RepoWebhookService repoWebhookService;
+
+    @Autowired
+    RepoWebhookRepository repoWebhookRepository;
+
+    @Autowired
+    VcsRepository vcsRepository;
+
+    @Autowired
+    OrganizationRepository organizationRepository;
+
+    @Test
+    void acceptV2WebhookDoesNotThrowLazyInitializationExceptionLoadingVcs() throws Exception {
+        Organization organization = organizationRepository
+                .findById(UUID.fromString("d9b58bd3-f3fc-4056-a026-1163297e80a8")).orElseThrow();
+
+        Vcs vcs = new Vcs();
+        vcs.setName("regression-test-vcs");
+        vcs.setDescription("Regression test VCS connection");
+        vcs.setVcsType(VcsType.GITHUB);
+        vcs.setOrganization(organization);
+        vcs = vcsRepository.saveAndFlush(vcs);
+
+        String secret = "regression-test-secret";
+        RepoWebhook repoWebhook = new RepoWebhook();
+        repoWebhook.setRepositoryUrl("https://github.com/owner/lazy-init-regression-" + UUID.randomUUID());
+        repoWebhook.setWebhookSecret(secret);
+        repoWebhook.setVcs(vcs);
+        repoWebhook = repoWebhookRepository.saveAndFlush(repoWebhook);
+
+        String payload = "{\"zen\":\"test\"}";
+        Map<String, String> headers = Map.of(
+                "x-hub-signature-256", computeHmac(secret, payload),
+                "x-github-event", "ping");
+
+        // Regression test for the bug that broke every v2 webhook delivery in production:
+        // acceptV2Webhook loads repoWebhook via a fresh repository call (this test has no ambient
+        // transaction, matching WebHookController), then immediately reads
+        // repoWebhook.getVcs().getVcsType() to pick a provider (isGitLab/isAzureDevOps) before it
+        // even gets to signature verification - if acceptV2Webhook isn't itself @Transactional,
+        // that lazy proxy has no session left to load through and throws
+        // org.hibernate.LazyInitializationException.
+        UUID deliveryId = repoWebhookService.acceptV2Webhook(repoWebhook.getId().toString(), payload, headers);
+
+        assertThat(deliveryId).isNotNull();
+    }
+
+    private String computeHmac(String secret, String payload) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        SecretKeySpec keySpec = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        mac.init(keySpec);
+        byte[] hash = mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+        StringBuilder hex = new StringBuilder(2 * hash.length);
+        for (byte b : hash) {
+            String h = Integer.toHexString(0xff & b);
+            if (h.length() == 1) {
+                hex.append('0');
+            }
+            hex.append(h);
+        }
+        return "sha256=" + hex;
+    }
+}

--- a/api/src/test/java/io/terrakube/api/RepoWebhookDeliveryRepositoryTest.java
+++ b/api/src/test/java/io/terrakube/api/RepoWebhookDeliveryRepositoryTest.java
@@ -1,0 +1,187 @@
+package io.terrakube.api;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.terrakube.api.repository.RepoWebhookDeliveryRepository;
+import io.terrakube.api.repository.RepoWebhookRepository;
+import io.terrakube.api.rs.webhook.RepoWebhook;
+import io.terrakube.api.rs.webhook.RepoWebhookDelivery;
+import io.terrakube.api.rs.webhook.RepoWebhookDeliveryStatus;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// @Modifying bulk-update queries (claimForDelivery, recordDeliveryResult, the stuck-row sweep)
+// require an active transaction to execute at all - unlike save()/findById(), they don't get one
+// implicitly from the repository proxy. This also gives each test method rollback-based isolation.
+@Transactional
+class RepoWebhookDeliveryRepositoryTest extends ServerApplicationTests {
+
+    @Autowired
+    RepoWebhookDeliveryRepository repoWebhookDeliveryRepository;
+
+    @Autowired
+    RepoWebhookRepository repoWebhookRepository;
+
+    @PersistenceContext
+    EntityManager entityManager;
+
+    // GenericAuditFields.createdDate is @CreationTimestamp (Hibernate sets it on insert,
+    // overriding any value passed to setCreatedDate) and updatable = false - a raw UPDATE is the
+    // only way to backdate a row for a retention-cutoff test.
+    private void backdate(UUID id, Date date) {
+        entityManager.createNativeQuery("UPDATE repo_webhook_delivery SET created_date = ?1 WHERE id = ?2")
+                .setParameter(1, date)
+                .setParameter(2, id.toString())
+                .executeUpdate();
+        entityManager.clear();
+    }
+
+    private RepoWebhook savedRepoWebhook(String repositoryUrl) {
+        RepoWebhook repoWebhook = new RepoWebhook();
+        repoWebhook.setRepositoryUrl(repositoryUrl);
+        repoWebhook.setWebhookSecret(UUID.randomUUID().toString());
+        return repoWebhookRepository.saveAndFlush(repoWebhook);
+    }
+
+    private RepoWebhookDelivery newDelivery(RepoWebhook repoWebhook) {
+        RepoWebhookDelivery delivery = new RepoWebhookDelivery();
+        delivery.setId(UUID.randomUUID());
+        delivery.setRepoWebhook(repoWebhook);
+        delivery.setPayload("{}");
+        delivery.setHeaders("{}");
+        delivery.setStatus(RepoWebhookDeliveryStatus.PENDING);
+        return delivery;
+    }
+
+    @Test
+    void findDueForDispatchReturnsPendingRowsWhoseNextAttemptHasArrivedOrIsUnset() {
+        RepoWebhook repoWebhook = savedRepoWebhook("https://github.com/org/repo-" + UUID.randomUUID() + ".git");
+
+        RepoWebhookDelivery due = newDelivery(repoWebhook);
+        due.setAttemptCount(1);
+        due.setLastAttemptAt(new Date(System.currentTimeMillis() - 120_000));
+        due.setNextAttemptAt(new Date(System.currentTimeMillis() - 60_000));
+        repoWebhookDeliveryRepository.saveAndFlush(due);
+
+        RepoWebhookDelivery notYetDue = newDelivery(repoWebhook);
+        notYetDue.setAttemptCount(1);
+        notYetDue.setNextAttemptAt(new Date(System.currentTimeMillis() + 300_000));
+        repoWebhookDeliveryRepository.saveAndFlush(notYetDue);
+
+        List<RepoWebhookDelivery> result = repoWebhookDeliveryRepository
+                .findDueForDispatch(RepoWebhookDeliveryStatus.PENDING, new Date(), PageRequest.of(0, 200));
+
+        assertThat(result).extracting(RepoWebhookDelivery::getId).contains(due.getId())
+                .doesNotContain(notYetDue.getId());
+    }
+
+    @Test
+    void claimForDeliveryOnlySucceedsOnceForTheSameRow() {
+        RepoWebhook repoWebhook = savedRepoWebhook("https://github.com/org/repo-" + UUID.randomUUID() + ".git");
+        RepoWebhookDelivery delivery = repoWebhookDeliveryRepository.saveAndFlush(newDelivery(repoWebhook));
+
+        Date now = new Date();
+        int firstClaim = repoWebhookDeliveryRepository.claimForDelivery(delivery.getId(), RepoWebhookDeliveryStatus.PENDING,
+                RepoWebhookDeliveryStatus.PROCESSING, now);
+        int secondClaim = repoWebhookDeliveryRepository.claimForDelivery(delivery.getId(), RepoWebhookDeliveryStatus.PENDING,
+                RepoWebhookDeliveryStatus.PROCESSING, now);
+
+        assertThat(firstClaim).isEqualTo(1);
+        assertThat(secondClaim).isEqualTo(0);
+
+        RepoWebhookDelivery reloaded = repoWebhookDeliveryRepository.findById(delivery.getId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(RepoWebhookDeliveryStatus.PROCESSING);
+        assertThat(reloaded.getAttemptCount()).isEqualTo(1);
+    }
+
+    @Test
+    void recordDeliveryResultIsANoOpWhenTheRowWasReclaimedInTheMeantime() {
+        RepoWebhook repoWebhook = savedRepoWebhook("https://github.com/org/repo-" + UUID.randomUUID() + ".git");
+        RepoWebhookDelivery delivery = repoWebhookDeliveryRepository.saveAndFlush(newDelivery(repoWebhook));
+
+        Date firstClaimAt = new Date();
+        repoWebhookDeliveryRepository.claimForDelivery(delivery.getId(), RepoWebhookDeliveryStatus.PENDING,
+                RepoWebhookDeliveryStatus.PROCESSING, firstClaimAt);
+
+        repoWebhookDeliveryRepository.reclaimStuckProcessingRows(RepoWebhookDeliveryStatus.PROCESSING,
+                RepoWebhookDeliveryStatus.PENDING, new Date(System.currentTimeMillis() + 1), 3, new Date());
+        Date secondClaimAt = new Date(firstClaimAt.getTime() + 1000);
+        repoWebhookDeliveryRepository.claimForDelivery(delivery.getId(), RepoWebhookDeliveryStatus.PENDING,
+                RepoWebhookDeliveryStatus.PROCESSING, secondClaimAt);
+
+        int updated = repoWebhookDeliveryRepository.recordDeliveryResult(delivery.getId(), RepoWebhookDeliveryStatus.PROCESSING,
+                firstClaimAt, RepoWebhookDeliveryStatus.PROCESSED, null, null, new Date());
+
+        assertThat(updated).isZero();
+        RepoWebhookDelivery reloaded = repoWebhookDeliveryRepository.findById(delivery.getId()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(RepoWebhookDeliveryStatus.PROCESSING);
+    }
+
+    @Test
+    void stuckRowSweepReclaimsBelowMaxAttemptsAndFailsAtMaxAttempts() {
+        RepoWebhook repoWebhook = savedRepoWebhook("https://github.com/org/repo-" + UUID.randomUUID() + ".git");
+        Date staleAttemptAt = new Date(System.currentTimeMillis() - 600_000);
+
+        RepoWebhookDelivery belowMax = newDelivery(repoWebhook);
+        belowMax.setStatus(RepoWebhookDeliveryStatus.PROCESSING);
+        belowMax.setAttemptCount(1);
+        belowMax.setLastAttemptAt(staleAttemptAt);
+        repoWebhookDeliveryRepository.saveAndFlush(belowMax);
+
+        RepoWebhookDelivery atMax = newDelivery(repoWebhook);
+        atMax.setStatus(RepoWebhookDeliveryStatus.PROCESSING);
+        atMax.setAttemptCount(3);
+        atMax.setLastAttemptAt(staleAttemptAt);
+        repoWebhookDeliveryRepository.saveAndFlush(atMax);
+
+        Date cutoff = new Date(System.currentTimeMillis() - 300_000);
+        repoWebhookDeliveryRepository.reclaimStuckProcessingRows(RepoWebhookDeliveryStatus.PROCESSING,
+                RepoWebhookDeliveryStatus.PENDING, cutoff, 3, new Date());
+        repoWebhookDeliveryRepository.failStuckProcessingRowsAtMaxAttempts(RepoWebhookDeliveryStatus.PROCESSING,
+                RepoWebhookDeliveryStatus.FAILED, cutoff, 3, "stuck", new Date());
+
+        assertThat(repoWebhookDeliveryRepository.findById(belowMax.getId()).orElseThrow().getStatus())
+                .isEqualTo(RepoWebhookDeliveryStatus.PENDING);
+        assertThat(repoWebhookDeliveryRepository.findById(atMax.getId()).orElseThrow().getStatus())
+                .isEqualTo(RepoWebhookDeliveryStatus.FAILED);
+    }
+
+    @Test
+    void deleteTerminalRowsCreatedBeforeOnlyRemovesOldTerminalRows() {
+        RepoWebhook repoWebhook = savedRepoWebhook("https://github.com/org/repo-" + UUID.randomUUID() + ".git");
+        Date cutoff = new Date();
+        Date old = new Date(cutoff.getTime() - 1000);
+        Date recent = new Date(cutoff.getTime() + 1000);
+
+        RepoWebhookDelivery oldProcessed = newDelivery(repoWebhook);
+        oldProcessed.setStatus(RepoWebhookDeliveryStatus.PROCESSED);
+        repoWebhookDeliveryRepository.saveAndFlush(oldProcessed);
+        backdate(oldProcessed.getId(), old);
+
+        RepoWebhookDelivery recentProcessed = newDelivery(repoWebhook);
+        recentProcessed.setStatus(RepoWebhookDeliveryStatus.PROCESSED);
+        repoWebhookDeliveryRepository.saveAndFlush(recentProcessed);
+        backdate(recentProcessed.getId(), recent);
+
+        RepoWebhookDelivery oldPending = newDelivery(repoWebhook);
+        repoWebhookDeliveryRepository.saveAndFlush(oldPending);
+        backdate(oldPending.getId(), old);
+
+        repoWebhookDeliveryRepository.deleteTerminalRowsCreatedBefore(
+                List.of(RepoWebhookDeliveryStatus.PROCESSED, RepoWebhookDeliveryStatus.FAILED), cutoff);
+
+        assertThat(repoWebhookDeliveryRepository.findById(oldProcessed.getId())).isEmpty();
+        assertThat(repoWebhookDeliveryRepository.findById(recentProcessed.getId())).isPresent();
+        assertThat(repoWebhookDeliveryRepository.findById(oldPending.getId())).isPresent();
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ExecutorAvailabilityListenerTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ExecutorAvailabilityListenerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.terrakube.api.repository.JobRepository;
 import io.terrakube.api.rs.job.Job;
 
@@ -21,7 +22,8 @@ class ExecutorAvailabilityListenerTest {
     private final ScheduleJobService scheduleJobService = mock(ScheduleJobService.class);
 
     private ExecutorAvailabilityListener subject() {
-        return new ExecutorAvailabilityListener(container, jobRepository, scheduleJobService);
+        return new ExecutorAvailabilityListener(container, jobRepository, scheduleJobService,
+                new SimpleMeterRegistry());
     }
 
     @Test

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/QuartzMetricsTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/QuartzMetricsTest.java
@@ -1,0 +1,29 @@
+package io.terrakube.api.plugin.scheduler;
+
+import org.junit.jupiter.api.Test;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class QuartzMetricsTest {
+
+    @Test
+    void returnsTheCurrentlyExecutingJobCount() throws Exception {
+        Scheduler scheduler = mock(Scheduler.class);
+        when(scheduler.getCurrentlyExecutingJobs()).thenReturn(java.util.List.of(
+                mock(org.quartz.JobExecutionContext.class), mock(org.quartz.JobExecutionContext.class)));
+
+        assertThat(QuartzMetrics.currentlyExecutingCount(scheduler)).isEqualTo(2);
+    }
+
+    @Test
+    void returnsNegativeOneWhenSchedulerThrows() throws Exception {
+        Scheduler scheduler = mock(Scheduler.class);
+        when(scheduler.getCurrentlyExecutingJobs()).thenThrow(new SchedulerException("down"));
+
+        assertThat(QuartzMetrics.currentlyExecutingCount(scheduler)).isEqualTo(-1);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
@@ -34,8 +34,6 @@ import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.Scheduler;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionStatus;
 
 import graphql.Assert;
 import io.terrakube.api.helpers.FailUnkownMethod;
@@ -101,7 +99,6 @@ public class ScheduleJobTest {
     WorkspaceVariableValidationService workspaceVariableValidationService;
     RedisTemplate<String, Object> redisTemplate;
     ValueOperations<String, Object> valueOperations;
-    PlatformTransactionManager transactionManager;
     JobNotificationTrigger jobNotificationTrigger;
 
     UUID stepId = UUID.randomUUID();
@@ -130,11 +127,6 @@ public class ScheduleJobTest {
 
         redisTemplate = mock(RedisTemplate.class, new FailUnkownMethod<RedisTemplate>());
         valueOperations = mock(ValueOperations.class, new FailUnkownMethod<ValueOperations>());
-        // Only execute() (the production entry point) uses this, to wrap doRunExecution in a real
-        // transaction - these tests all go through runExecution directly (see subject()'s javadoc
-        // reference in ScheduleJob), which has no persistence context to commit, so it's never called.
-        transactionManager = mock(PlatformTransactionManager.class,
-                new FailUnkownMethod<PlatformTransactionManager>());
         // Plain mock (not FailUnkownMethod): almost every status-transition path under test now
         // calls notifyStatusChanged(), and its outcome is irrelevant to what these tests assert.
         jobNotificationTrigger = mock(JobNotificationTrigger.class);
@@ -167,7 +159,6 @@ public class ScheduleJobTest {
                 globalVarRepository,
                 variableRepository,
                 workspaceVariableValidationService,
-                transactionManager,
                 jobNotificationTrigger);
     }
 
@@ -997,13 +988,19 @@ public class ScheduleJobTest {
     }
 
     @Test
-    public void executeCommitsTheTransactionBeforeReleasingTheExecutionLock() throws Exception {
-        // Reproduces a race a live run exposed: two overlapping firings for the same job both
-        // read it as "pending" and both ran completeJob(). Root cause was the execution lock
-        // releasing (inside execute()) before the surrounding @Transactional commit (which only
-        // happened once execute() itself returned) - a second firing could acquire the freed lock
-        // and read pre-commit (stale) state. Proves the fix: lock release now waits for the
-        // explicit TransactionTemplate commit to actually finish first.
+    public void executeReleasesTheExecutionLockOnlyAfterProcessingCompletes() throws Exception {
+        // Reproduces (and now guards against a different way of reintroducing) a race a live run
+        // once exposed: two overlapping firings for the same job both read it as "pending" and
+        // both ran completeJob(). The original root cause was the execution lock releasing (inside
+        // execute()) before a single surrounding @Transactional commit had actually finished, so a
+        // second firing could acquire the freed lock and read pre-commit (stale) state. execute()
+        // no longer wraps doRunExecution in one transaction at all (see the class comment on
+        // ScheduleJob) - every write it makes (jobRepository.save, workspaceRepository.save, etc.)
+        // is its own already-committed call by the time it returns, via Spring Data's own
+        // per-repository-method transaction. What this test proves instead: the lock is still held
+        // across the entire operation - acquired before job loading, released only after every
+        // write doRunExecution makes has already happened - so there's no window for a second
+        // firing to see a state this firing hasn't finished writing yet.
         Job job = job(JobStatus.completed);
         doReturn(false).when(tclService).isTemplatePlanOnly(any());
         doReturn(Collections.emptyList()).when(globalVarRepository).findByOrganization(any());
@@ -1015,13 +1012,8 @@ public class ScheduleJobTest {
         doReturn(job.getStep()).when(stepRepository).findByJobId(anyInt());
         doReturn(null).when(stepRepository).save(any());
         doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
-        doReturn(job).when(jobRepository).getReferenceById(job.getId());
+        doReturn(Optional.of(job)).when(jobRepository).findById(job.getId());
         lenient().doReturn(true).when(redisTemplate).delete(anyString());
-
-        TransactionStatus transactionStatus = mock(TransactionStatus.class, new FailUnkownMethod<TransactionStatus>());
-        doReturn(transactionStatus).when(transactionManager).getTransaction(any());
-        doNothing().when(transactionManager).commit(transactionStatus);
-        lenient().doNothing().when(transactionManager).rollback(transactionStatus);
 
         JobDataMap jobDataMap = new JobDataMap();
         jobDataMap.put(ScheduleJob.JOB_ID, job.getId());
@@ -1035,14 +1027,14 @@ public class ScheduleJobTest {
         doReturn(quartzScheduler).when(jobExecutionContext).getScheduler();
         doReturn("InstanceId").when(jobExecutionContext).getFireInstanceId();
 
-        InOrder inOrder = inOrder(valueOperations, transactionManager, redisTemplate);
+        InOrder inOrder = inOrder(valueOperations, jobRepository, workspaceRepository, redisTemplate);
 
         subject().execute(jobExecutionContext);
 
         inOrder.verify(valueOperations).setIfAbsent(any(), any(), any(Duration.class)); // lock acquired
-        inOrder.verify(transactionManager).getTransaction(any());                        // tx begins
-        inOrder.verify(transactionManager).commit(transactionStatus);                    // tx commits
-        inOrder.verify(redisTemplate).delete("job-execution-lock:" + job.getId());       // lock released last
+        inOrder.verify(jobRepository).findById(job.getId());                            // job loaded
+        inOrder.verify(workspaceRepository).save(job.getWorkspace());                   // a write happens
+        inOrder.verify(redisTemplate).delete("job-execution-lock:" + job.getId());      // lock released last
     }
 
     @Test

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/SchedulerThreadPoolValidationTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/SchedulerThreadPoolValidationTest.java
@@ -1,0 +1,36 @@
+package io.terrakube.api.plugin.scheduler;
+
+import org.junit.jupiter.api.Test;
+
+import io.terrakube.api.plugin.datasource.DataSourceConfigurationProperties;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SchedulerThreadPoolValidationTest {
+
+    private DataSourceConfigurationProperties propertiesWithPoolSize(int poolSize) {
+        DataSourceConfigurationProperties properties = new DataSourceConfigurationProperties();
+        properties.setPoolSize(poolSize);
+        return properties;
+    }
+
+    @Test
+    void acceptsAThreadCountBelowThePoolSize() {
+        assertThatCode(() -> new SchedulerThreadPoolValidation(8, propertiesWithPoolSize(10)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsAThreadCountEqualToThePoolSize() {
+        assertThatThrownBy(() -> new SchedulerThreadPoolValidation(10, propertiesWithPoolSize(10)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("must be less than");
+    }
+
+    @Test
+    void rejectsAThreadCountAboveThePoolSize() {
+        assertThatThrownBy(() -> new SchedulerThreadPoolValidation(20, propertiesWithPoolSize(10)))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/TclServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/TclServiceTest.java
@@ -70,7 +70,7 @@ public class TclServiceTest {
         UUID templateId = UUID.randomUUID();
         Template template = templateWithTcl(encodeYaml(yaml));
 
-        doReturn(template).when(templateRepository).getReferenceById(templateId);
+        doReturn(java.util.Optional.of(template)).when(templateRepository).findById(templateId);
 
         Assertions.assertTrue(subject().isTemplatePlanOnly(templateId.toString()));
     }
@@ -85,7 +85,7 @@ public class TclServiceTest {
         UUID templateId = UUID.randomUUID();
         Template template = templateWithTcl(encodeYaml(yaml));
 
-        doReturn(template).when(templateRepository).getReferenceById(templateId);
+        doReturn(java.util.Optional.of(template)).when(templateRepository).findById(templateId);
 
         Assertions.assertTrue(subject().isTemplatePlanOnly(templateId.toString()));
     }
@@ -102,7 +102,7 @@ public class TclServiceTest {
         UUID templateId = UUID.randomUUID();
         Template template = templateWithTcl(encodeYaml(yaml));
 
-        doReturn(template).when(templateRepository).getReferenceById(templateId);
+        doReturn(java.util.Optional.of(template)).when(templateRepository).findById(templateId);
 
         Assertions.assertTrue(subject().isTemplatePlanOnly(templateId.toString()));
     }
@@ -119,7 +119,7 @@ public class TclServiceTest {
         UUID templateId = UUID.randomUUID();
         Template template = templateWithTcl(encodeYaml(yaml));
 
-        doReturn(template).when(templateRepository).getReferenceById(templateId);
+        doReturn(java.util.Optional.of(template)).when(templateRepository).findById(templateId);
 
         Assertions.assertFalse(subject().isTemplatePlanOnly(templateId.toString()));
     }
@@ -137,7 +137,7 @@ public class TclServiceTest {
         UUID templateId = UUID.randomUUID();
         Template template = templateWithTcl(encodeYaml(yaml));
 
-        doReturn(template).when(templateRepository).getReferenceById(templateId);
+        doReturn(java.util.Optional.of(template)).when(templateRepository).findById(templateId);
 
         Assertions.assertFalse(subject().isTemplatePlanOnly(templateId.toString()));
     }
@@ -152,7 +152,7 @@ public class TclServiceTest {
         UUID templateId = UUID.randomUUID();
         Template template = templateWithTcl(encodeYaml(yaml));
 
-        doReturn(template).when(templateRepository).getReferenceById(templateId);
+        doReturn(java.util.Optional.of(template)).when(templateRepository).findById(templateId);
 
         Assertions.assertFalse(subject().isTemplatePlanOnly(templateId.toString()));
     }
@@ -167,7 +167,7 @@ public class TclServiceTest {
         UUID templateId = UUID.randomUUID();
         Template template = templateWithTcl(encodeYaml(yaml));
 
-        doReturn(template).when(templateRepository).getReferenceById(templateId);
+        doReturn(java.util.Optional.of(template)).when(templateRepository).findById(templateId);
 
         Assertions.assertFalse(subject().isTemplatePlanOnly(templateId.toString()));
     }
@@ -286,7 +286,7 @@ public class TclServiceTest {
         job.setId(42);
         job.setTemplateReference(templateId.toString());
 
-        doReturn(template).when(templateRepository).getReferenceById(templateId);
+        doReturn(java.util.Optional.of(template)).when(templateRepository).findById(templateId);
         doReturn(job).when(jobRepository).lockForUpdate(42);
         doReturn(Collections.emptyList()).when(stepRepository).findByJobId(42);
         doReturn(job).when(jobRepository).getReferenceById(42);
@@ -317,6 +317,6 @@ public class TclServiceTest {
 
         Assertions.assertSame(job, result);
         Mockito.verify(stepRepository, Mockito.never()).save(org.mockito.ArgumentMatchers.any(Step.class));
-        Mockito.verify(templateRepository, Mockito.never()).getReferenceById(org.mockito.ArgumentMatchers.any(UUID.class));
+        Mockito.verify(templateRepository, Mockito.never()).findById(org.mockito.ArgumentMatchers.any(UUID.class));
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import io.terrakube.api.plugin.scheduler.job.tcl.model.Flow;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.FlowType;
+import io.terrakube.api.repository.AddressRepository;
 import io.terrakube.api.repository.VariableRepository;
 import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.rs.job.Job;
@@ -36,6 +37,9 @@ class ExecutorServiceTest {
 
     @Mock
     private WorkspaceRepository workspaceRepository;
+
+    @Mock
+    private AddressRepository addressRepository;
 
     @InjectMocks
     private ExecutorService executorService;
@@ -203,7 +207,7 @@ class ExecutorServiceTest {
 
     @Test
     void shouldNotSetTfCliArgsWhenAddressListIsEmpty() {
-        job.setAddress(List.of());
+        when(addressRepository.findByJob(job)).thenReturn(List.of());
         ExecutorContext context = createContext();
 
         ExecutorContext result = executorService.validateJobAddress(context, job);
@@ -216,7 +220,7 @@ class ExecutorServiceTest {
         Address address = new Address();
         address.setName("aws_s3_bucket.bucket");
         address.setType(AddressType.TARGET);
-        job.setAddress(List.of(address));
+        when(addressRepository.findByJob(job)).thenReturn(List.of(address));
 
         ExecutorContext context = createContext();
         ExecutorContext result = executorService.validateJobAddress(context, job);
@@ -230,7 +234,7 @@ class ExecutorServiceTest {
         Address address = new Address();
         address.setName("aws_identitystore_user.users[\"name.surname\"]");
         address.setType(AddressType.TARGET);
-        job.setAddress(List.of(address));
+        when(addressRepository.findByJob(job)).thenReturn(List.of(address));
 
         ExecutorContext context = createContext();
         ExecutorContext result = executorService.validateJobAddress(context, job);
@@ -244,7 +248,7 @@ class ExecutorServiceTest {
         Address address = new Address();
         address.setName("aws_identitystore_user.users[\"name.surname\"]");
         address.setType(AddressType.REPLACE);
-        job.setAddress(List.of(address));
+        when(addressRepository.findByJob(job)).thenReturn(List.of(address));
 
         ExecutorContext context = createContext();
         ExecutorContext result = executorService.validateJobAddress(context, job);
@@ -267,7 +271,7 @@ class ExecutorServiceTest {
         replace.setName("aws_instance.server[\"web-prod\"]");
         replace.setType(AddressType.REPLACE);
 
-        job.setAddress(List.of(target1, target2, replace));
+        when(addressRepository.findByJob(job)).thenReturn(List.of(target1, target2, replace));
 
         ExecutorContext context = createContext();
         ExecutorContext result = executorService.validateJobAddress(context, job);
@@ -284,7 +288,7 @@ class ExecutorServiceTest {
         Address address = new Address();
         address.setName("aws_s3_bucket.bucket");
         address.setType(AddressType.TARGET);
-        job.setAddress(List.of(address));
+        when(addressRepository.findByJob(job)).thenReturn(List.of(address));
 
         ExecutorContext context = createContext();
         context.getEnvironmentVariables().put("TF_CLI_ARGS_plan", "-existing-flag");

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/webhook/RepoWebhookDeliveryPollerJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/webhook/RepoWebhookDeliveryPollerJobTest.java
@@ -1,0 +1,90 @@
+package io.terrakube.api.plugin.scheduler.webhook;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.RejectedExecutionException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobExecutionContext;
+import org.springframework.data.domain.Pageable;
+
+import io.terrakube.api.plugin.vcs.RepoWebhookDeliveryTransactions;
+import io.terrakube.api.plugin.vcs.RepoWebhookDispatchService;
+import io.terrakube.api.repository.RepoWebhookDeliveryRepository;
+import io.terrakube.api.rs.webhook.RepoWebhookDelivery;
+import io.terrakube.api.rs.webhook.RepoWebhookDeliveryStatus;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RepoWebhookDeliveryPollerJobTest {
+
+    @Mock
+    RepoWebhookDeliveryRepository repoWebhookDeliveryRepository;
+    @Mock
+    RepoWebhookDispatchService repoWebhookDispatchService;
+    @Mock
+    RepoWebhookDeliveryTransactions repoWebhookDeliveryTransactions;
+    @Mock
+    JobExecutionContext jobExecutionContext;
+
+    RepoWebhookDeliveryPollerJob subject;
+
+    @BeforeEach
+    void setUp() {
+        // Constructed directly rather than via @InjectMocks: the constructor takes plain int/long
+        // tuning values (batchSize, stuckProcessingThresholdMinutes) that @Value only resolves in
+        // a real Spring context - @InjectMocks would silently default them to 0.
+        subject = new RepoWebhookDeliveryPollerJob(repoWebhookDeliveryRepository, repoWebhookDispatchService,
+                repoWebhookDeliveryTransactions, 200, 5);
+    }
+
+    private RepoWebhookDelivery row() {
+        RepoWebhookDelivery delivery = new RepoWebhookDelivery();
+        delivery.setId(UUID.randomUUID());
+        delivery.setStatus(RepoWebhookDeliveryStatus.PENDING);
+        return delivery;
+    }
+
+    @Test
+    void dispatchesEveryRowReturnedAsDue() throws Exception {
+        RepoWebhookDelivery first = row();
+        RepoWebhookDelivery second = row();
+        when(repoWebhookDeliveryRepository.findDueForDispatch(eq(RepoWebhookDeliveryStatus.PENDING), any(),
+                any(Pageable.class))).thenReturn(List.of(first, second));
+
+        subject.execute(jobExecutionContext);
+
+        verify(repoWebhookDispatchService).dispatchAsync(first.getId());
+        verify(repoWebhookDispatchService).dispatchAsync(second.getId());
+    }
+
+    @Test
+    void sweepsStuckProcessingRowsEveryTickViaTheTransactionalBean() throws Exception {
+        when(repoWebhookDeliveryRepository.findDueForDispatch(any(), any(), any(Pageable.class))).thenReturn(List.of());
+
+        subject.execute(jobExecutionContext);
+
+        verify(repoWebhookDeliveryTransactions).sweepStuckProcessingRows(any(), eq(3));
+    }
+
+    @Test
+    void aRejectedDispatchDoesNotStopTheRestOfTheBatch() throws Exception {
+        RepoWebhookDelivery first = row();
+        RepoWebhookDelivery second = row();
+        when(repoWebhookDeliveryRepository.findDueForDispatch(any(), any(), any(Pageable.class)))
+                .thenReturn(List.of(first, second));
+        doThrow(new RejectedExecutionException("pool full")).when(repoWebhookDispatchService)
+                .dispatchAsync(first.getId());
+
+        subject.execute(jobExecutionContext);
+
+        verify(repoWebhookDispatchService).dispatchAsync(second.getId());
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/webhook/RepoWebhookDeliveryRetentionJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/webhook/RepoWebhookDeliveryRetentionJobTest.java
@@ -1,0 +1,39 @@
+package io.terrakube.api.plugin.scheduler.webhook;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobExecutionContext;
+
+import io.terrakube.api.plugin.vcs.RepoWebhookDeliveryTransactions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RepoWebhookDeliveryRetentionJobTest {
+
+    @Mock
+    RepoWebhookDeliveryTransactions repoWebhookDeliveryTransactions;
+
+    @Test
+    void pruneCutoffIsRetentionDaysBeforeNow() throws Exception {
+        RepoWebhookDeliveryRetentionJob subject = new RepoWebhookDeliveryRetentionJob(repoWebhookDeliveryTransactions, 30);
+
+        long before = System.currentTimeMillis();
+        subject.execute(Mockito.mock(JobExecutionContext.class));
+        long after = System.currentTimeMillis();
+
+        ArgumentCaptor<Date> cutoffCaptor = ArgumentCaptor.forClass(Date.class);
+        verify(repoWebhookDeliveryTransactions).pruneTerminalRowsOlderThan(cutoffCaptor.capture());
+
+        long expectedMin = before - (30L * 24 * 60 * 60 * 1000);
+        long expectedMax = after - (30L * 24 * 60 * 60 * 1000);
+        assertThat(cutoffCaptor.getValue().getTime()).isBetween(expectedMin, expectedMax);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -33,6 +34,7 @@ import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
 import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
 import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.repository.StepRepository;
 import io.terrakube.api.rs.Organization;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
@@ -50,6 +52,7 @@ public class PrCommentServiceTest {
     GitLabWebhookService gitLabWebhookService;
     BitBucketWebhookService bitBucketWebhookService;
     JobRepository jobRepository;
+    StepRepository stepRepository;
     StorageTypeService storageTypeService;
     StreamingService streamingService;
     ObjectMapper objectMapper;
@@ -62,6 +65,7 @@ public class PrCommentServiceTest {
         gitLabWebhookService = mock(GitLabWebhookService.class);
         bitBucketWebhookService = mock(BitBucketWebhookService.class);
         jobRepository = mock(JobRepository.class);
+        stepRepository = mock(StepRepository.class);
         storageTypeService = mock(StorageTypeService.class);
         streamingService = mock(StreamingService.class);
         objectMapper = new ObjectMapper();
@@ -71,9 +75,23 @@ public class PrCommentServiceTest {
                 gitLabWebhookService,
                 bitBucketWebhookService,
                 jobRepository,
+                stepRepository,
                 storageTypeService,
                 streamingService,
                 objectMapper);
+    }
+
+    /**
+     * The real code now reads steps via StepRepository.findByJobId (not the job's lazy
+     * job.getStep() collection - see PrCommentService.fetchStepOutputText), so tests must keep
+     * the mock in sync with whatever steps a job is set up with.
+     */
+    private void setSteps(Job job, List<Step> steps) {
+        job.setStep(steps);
+        // lenient: plenty of tests build a job via createJob() but never exercise the
+        // fetchStepOutputText path (e.g. short-circuit on missing PR number), which would
+        // otherwise trip Mockito's strict-stubbing check.
+        lenient().doReturn(steps).when(stepRepository).findByJobId(job.getId());
     }
 
     private Job createJob(VcsType vcsType, Integer prNumber, JobStatus status) {
@@ -100,7 +118,7 @@ public class PrCommentServiceTest {
         Step step = new Step();
         step.setId(UUID.randomUUID());
         step.setStepNumber(1);
-        job.setStep(List.of(step));
+        setSteps(job, List.of(step));
 
         return job;
     }
@@ -521,7 +539,7 @@ public class PrCommentServiceTest {
         notifyStep.setId(UUID.randomUUID());
         notifyStep.setStepNumber(2);
 
-        job.setStep(List.of(planStep, notifyStep));
+        setSteps(job, List.of(planStep, notifyStep));
 
         doReturn("").when(streamingService).getCurrentLogs(any(), any());
         doReturn("Plan: 2 to add, 0 to change, 0 to destroy.".getBytes(StandardCharsets.UTF_8))
@@ -554,7 +572,7 @@ public class PrCommentServiceTest {
         erroredStep.setId(UUID.randomUUID());
         erroredStep.setStepNumber(2);
 
-        job.setStep(List.of(initStep, erroredStep));
+        setSteps(job, List.of(initStep, erroredStep));
 
         doReturn("").when(streamingService).getCurrentLogs(any(), any());
         doReturn("Initializing the backend...".getBytes(StandardCharsets.UTF_8))
@@ -661,7 +679,7 @@ public class PrCommentServiceTest {
     @Test
     public void postPlanResultHandlesJobWithNoSteps() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
-        job.setStep(List.of());
+        setSteps(job, List.of());
 
         doReturn("12345").when(gitHubWebhookService).postPrComment(any(), any());
         doReturn(job).when(jobRepository).save(any());
@@ -752,6 +770,7 @@ public class PrCommentServiceTest {
     public void postPlanResultUpdatesExistingThreadCommentWhenPriorPlanJobExists() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
         job.setId(99);
+        setSteps(job, job.getStep());
         stubStepOutput("Plan: 1 to add, 0 to change, 0 to destroy.");
 
         Job priorJob = createJob(VcsType.GITHUB, 5, JobStatus.completed);
@@ -775,6 +794,7 @@ public class PrCommentServiceTest {
     public void postPlanResultFallsBackToNewCommentWhenUpdateFails() {
         Job job = createJob(VcsType.GITHUB, 5, JobStatus.completed);
         job.setId(99);
+        setSteps(job, job.getStep());
         stubStepOutput("Plan: 1 to add, 0 to change, 0 to destroy.");
 
         Job priorJob = createJob(VcsType.GITHUB, 5, JobStatus.completed);

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookDeliveryMetricsTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookDeliveryMetricsTest.java
@@ -1,0 +1,34 @@
+package io.terrakube.api.plugin.vcs;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+
+import io.terrakube.api.repository.RepoWebhookDeliveryRepository;
+import io.terrakube.api.rs.webhook.RepoWebhookDeliveryStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RepoWebhookDeliveryMetricsTest {
+
+    @Test
+    void ageIsZeroWhenNoPendingRowsExist() {
+        RepoWebhookDeliveryRepository repository = mock(RepoWebhookDeliveryRepository.class);
+        when(repository.findOldestCreatedDateByStatus(RepoWebhookDeliveryStatus.PENDING)).thenReturn(null);
+
+        assertThat(RepoWebhookDeliveryMetrics.oldestPendingAgeSeconds(repository)).isZero();
+    }
+
+    @Test
+    void ageReflectsHowLongTheOldestPendingRowHasWaited() {
+        RepoWebhookDeliveryRepository repository = mock(RepoWebhookDeliveryRepository.class);
+        when(repository.findOldestCreatedDateByStatus(RepoWebhookDeliveryStatus.PENDING))
+                .thenReturn(new Date(System.currentTimeMillis() - 90_000));
+
+        double age = RepoWebhookDeliveryMetrics.oldestPendingAgeSeconds(repository);
+
+        assertThat(age).isBetween(89.0, 95.0);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookDeliveryTransactionsTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookDeliveryTransactionsTest.java
@@ -1,0 +1,124 @@
+package io.terrakube.api.plugin.vcs;
+
+import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.terrakube.api.repository.RepoWebhookDeliveryRepository;
+import io.terrakube.api.rs.webhook.RepoWebhook;
+import io.terrakube.api.rs.webhook.RepoWebhookDelivery;
+import io.terrakube.api.rs.webhook.RepoWebhookDeliveryStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RepoWebhookDeliveryTransactionsTest {
+
+    @Mock
+    RepoWebhookDeliveryRepository repoWebhookDeliveryRepository;
+
+    RepoWebhookDeliveryTransactions subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new RepoWebhookDeliveryTransactions(repoWebhookDeliveryRepository);
+    }
+
+    @Test
+    void enqueueSavesAPendingRowAndReturnsItsId() {
+        RepoWebhook repoWebhook = new RepoWebhook();
+        repoWebhook.setId(UUID.randomUUID());
+
+        UUID id = subject.enqueue(repoWebhook, "{\"a\":1}", "{\"x-github-event\":\"push\"}");
+
+        assertThat(id).isNotNull();
+        verify(repoWebhookDeliveryRepository).save(argThat(delivery ->
+                delivery.getId().equals(id)
+                        && delivery.getRepoWebhook() == repoWebhook
+                        && delivery.getPayload().equals("{\"a\":1}")
+                        && delivery.getHeaders().equals("{\"x-github-event\":\"push\"}")
+                        && delivery.getStatus() == RepoWebhookDeliveryStatus.PENDING));
+    }
+
+    @Test
+    void claimReturnsNullWhenTheRowWasNotClaimable() {
+        UUID id = UUID.randomUUID();
+        when(repoWebhookDeliveryRepository.claimForDelivery(eq(id), eq(RepoWebhookDeliveryStatus.PENDING),
+                eq(RepoWebhookDeliveryStatus.PROCESSING), any())).thenReturn(0);
+
+        assertThat(subject.claim(id)).isNull();
+        verify(repoWebhookDeliveryRepository, never()).findById(any());
+    }
+
+    @Test
+    void claimReturnsTheClaimedRowsDataWhenSuccessful() {
+        UUID id = UUID.randomUUID();
+        Date lastAttemptAt = new Date();
+        RepoWebhook repoWebhook = new RepoWebhook();
+        repoWebhook.setId(UUID.randomUUID());
+        RepoWebhookDelivery row = new RepoWebhookDelivery();
+        row.setId(id);
+        row.setRepoWebhook(repoWebhook);
+        row.setPayload("{}");
+        row.setHeaders("{}");
+        row.setAttemptCount(1);
+        row.setLastAttemptAt(lastAttemptAt);
+        when(repoWebhookDeliveryRepository.claimForDelivery(eq(id), eq(RepoWebhookDeliveryStatus.PENDING),
+                eq(RepoWebhookDeliveryStatus.PROCESSING), any())).thenReturn(1);
+        when(repoWebhookDeliveryRepository.findById(id)).thenReturn(Optional.of(row));
+
+        ClaimedDelivery claimed = subject.claim(id);
+
+        assertThat(claimed).isNotNull();
+        assertThat(claimed.repoWebhook()).isSameAs(repoWebhook);
+        assertThat(claimed.payload()).isEqualTo("{}");
+        assertThat(claimed.attemptCount()).isEqualTo(1);
+        assertThat(claimed.lastAttemptAt()).isEqualTo(lastAttemptAt);
+    }
+
+    @Test
+    void recordResultDelegatesToTheConditionalUpdate() {
+        UUID id = UUID.randomUUID();
+        Date lastAttemptAt = new Date();
+        Date nextAttemptAt = new Date(lastAttemptAt.getTime() + 60_000);
+
+        subject.recordResult(id, lastAttemptAt, RepoWebhookDeliveryStatus.PENDING, "boom", nextAttemptAt);
+
+        verify(repoWebhookDeliveryRepository).recordDeliveryResult(eq(id), eq(RepoWebhookDeliveryStatus.PROCESSING),
+                eq(lastAttemptAt), eq(RepoWebhookDeliveryStatus.PENDING), eq("boom"), eq(nextAttemptAt), any());
+    }
+
+    @Test
+    void sweepStuckProcessingRowsReclaimsAndFailsInOneCall() {
+        Date cutoff = new Date();
+
+        subject.sweepStuckProcessingRows(cutoff, 3);
+
+        verify(repoWebhookDeliveryRepository).reclaimStuckProcessingRows(eq(RepoWebhookDeliveryStatus.PROCESSING),
+                eq(RepoWebhookDeliveryStatus.PENDING), eq(cutoff), eq(3), any());
+        verify(repoWebhookDeliveryRepository).failStuckProcessingRowsAtMaxAttempts(eq(RepoWebhookDeliveryStatus.PROCESSING),
+                eq(RepoWebhookDeliveryStatus.FAILED), eq(cutoff), eq(3), any(), any());
+    }
+
+    @Test
+    void pruneTerminalRowsOlderThanDelegatesToTheDeleteQuery() {
+        Date cutoff = new Date();
+        when(repoWebhookDeliveryRepository.deleteTerminalRowsCreatedBefore(
+                eq(java.util.List.of(RepoWebhookDeliveryStatus.PROCESSED, RepoWebhookDeliveryStatus.FAILED)), eq(cutoff)))
+                .thenReturn(5);
+
+        int deleted = subject.pruneTerminalRowsOlderThan(cutoff);
+
+        assertThat(deleted).isEqualTo(5);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookDispatchServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookDispatchServiceTest.java
@@ -1,0 +1,102 @@
+package io.terrakube.api.plugin.vcs;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.terrakube.api.rs.webhook.RepoWebhook;
+import io.terrakube.api.rs.webhook.RepoWebhookDeliveryStatus;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RepoWebhookDispatchServiceTest {
+
+    @Mock
+    RepoWebhookDeliveryTransactions repoWebhookDeliveryTransactions;
+
+    @Mock
+    RepoWebhookService repoWebhookService;
+
+    RepoWebhookDispatchService subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new RepoWebhookDispatchService(repoWebhookDeliveryTransactions, repoWebhookService, new ObjectMapper());
+    }
+
+    private ClaimedDelivery claimedDelivery(RepoWebhook repoWebhook, int attemptCount) {
+        return new ClaimedDelivery(repoWebhook, "{}", "{\"x-github-event\":\"push\"}", attemptCount, new Date());
+    }
+
+    @Test
+    void doesNothingWhenTheRowCannotBeClaimed() {
+        UUID deliveryId = UUID.randomUUID();
+        when(repoWebhookDeliveryTransactions.claim(deliveryId)).thenReturn(null);
+
+        subject.attemptDelivery(deliveryId);
+
+        verifyNoInteractions(repoWebhookService);
+        verify(repoWebhookDeliveryTransactions, never()).recordResult(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void marksProcessedAndPassesDeserializedHeadersWhenFanOutSucceeds() throws Exception {
+        UUID deliveryId = UUID.randomUUID();
+        RepoWebhook repoWebhook = new RepoWebhook();
+        repoWebhook.setId(UUID.randomUUID());
+        ClaimedDelivery claimed = claimedDelivery(repoWebhook, 1);
+        when(repoWebhookDeliveryTransactions.claim(deliveryId)).thenReturn(claimed);
+
+        subject.attemptDelivery(deliveryId);
+
+        ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(repoWebhookService).processClaimedDelivery(eq(repoWebhook), eq("{}"), headersCaptor.capture());
+        org.assertj.core.api.Assertions.assertThat(headersCaptor.getValue()).containsEntry("x-github-event", "push");
+        verify(repoWebhookDeliveryTransactions).recordResult(eq(deliveryId), eq(claimed.lastAttemptAt()),
+                eq(RepoWebhookDeliveryStatus.PROCESSED), isNull(), isNull());
+    }
+
+    @Test
+    void schedulesARetryWithBackoffWhenFanOutSetupFailsBelowMaxAttempts() throws Exception {
+        UUID deliveryId = UUID.randomUUID();
+        RepoWebhook repoWebhook = new RepoWebhook();
+        ClaimedDelivery claimed = claimedDelivery(repoWebhook, 1);
+        when(repoWebhookDeliveryTransactions.claim(deliveryId)).thenReturn(claimed);
+        doThrow(new RuntimeException("boom")).when(repoWebhookService)
+                .processClaimedDelivery(eq(repoWebhook), any(), anyMap());
+
+        subject.attemptDelivery(deliveryId);
+
+        verify(repoWebhookDeliveryTransactions).recordResult(eq(deliveryId), eq(claimed.lastAttemptAt()),
+                eq(RepoWebhookDeliveryStatus.PENDING), eq("boom"), any(Date.class));
+    }
+
+    @Test
+    void permanentlyFailsAfterMaxAttempts() throws Exception {
+        UUID deliveryId = UUID.randomUUID();
+        RepoWebhook repoWebhook = new RepoWebhook();
+        ClaimedDelivery claimed = claimedDelivery(repoWebhook, RepoWebhookDispatchService.MAX_ATTEMPTS);
+        when(repoWebhookDeliveryTransactions.claim(deliveryId)).thenReturn(claimed);
+        doThrow(new RuntimeException("boom")).when(repoWebhookService)
+                .processClaimedDelivery(eq(repoWebhook), any(), anyMap());
+
+        subject.attemptDelivery(deliveryId);
+
+        verify(repoWebhookDeliveryTransactions).recordResult(eq(deliveryId), eq(claimed.lastAttemptAt()),
+                eq(RepoWebhookDeliveryStatus.FAILED), eq("boom"), isNull());
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
@@ -95,7 +95,8 @@ class RepoWebhookServiceTest {
                 scheduleJobService,
                 prCommentService,
                 repoWebhookDeliveryTransactions,
-                objectMapper);
+                objectMapper,
+                Runnable::run);
     }
 
     private Workspace workspaceWithSource(String source) {

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
@@ -31,6 +31,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.terrakube.api.plugin.scheduler.ScheduleJobService;
 import io.terrakube.api.plugin.vcs.provider.azdevops.AzDevOpsWebhookService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
@@ -63,6 +65,8 @@ class RepoWebhookServiceTest {
     JobRepository jobRepository;
     ScheduleJobService scheduleJobService;
     PrCommentService prCommentService;
+    RepoWebhookDeliveryTransactions repoWebhookDeliveryTransactions;
+    ObjectMapper objectMapper;
 
     RepoWebhookService subject;
 
@@ -77,6 +81,8 @@ class RepoWebhookServiceTest {
         jobRepository = mock(JobRepository.class);
         scheduleJobService = mock(ScheduleJobService.class);
         prCommentService = mock(PrCommentService.class);
+        repoWebhookDeliveryTransactions = mock(RepoWebhookDeliveryTransactions.class);
+        objectMapper = new ObjectMapper();
 
         subject = new RepoWebhookService(
                 repoWebhookRepository,
@@ -87,7 +93,9 @@ class RepoWebhookServiceTest {
                 azDevOpsWebhookService,
                 jobRepository,
                 scheduleJobService,
-                prCommentService);
+                prCommentService,
+                repoWebhookDeliveryTransactions,
+                objectMapper);
     }
 
     private Workspace workspaceWithSource(String source) {
@@ -341,16 +349,126 @@ class RepoWebhookServiceTest {
     }
 
     @Nested
-    class ProcessV2Webhook {
+    class AcceptV2Webhook {
+
+        @Test
+        void v2WebhookMigrationRemovalScenario() throws Exception {
+            String repoUrl = "https://github.com/owner/repo";
+
+            // 1. Create a workspace using webhook version 1
+            Workspace workspace = workspaceWithSource(repoUrl);
+            workspace.setName("workspace-v1");
+            Vcs vcs = new Vcs();
+            vcs.setVcsType(VcsType.GITHUB);
+            workspace.setVcs(vcs);
+
+            Webhook webhook = new Webhook();
+            webhook.setWorkspace(workspace);
+            webhook.setMigratedV2(false);
+            webhook.setRemoteHookId("old-v1-hook-id");
+            workspace.setWebhook(webhook);
+
+            // 2. Migrate to version 2
+            webhook.setMigratedV2(true);
+
+            // 3. Validate the version 1 webhook is removed correctly
+            // We simulate the logic from WebhookManageHook here to validate it works with RepoWebhookService
+            RepoWebhook repoWebhook = repoWebhookWith(repoUrl, "new-secret");
+            when(repoWebhookRepository.findByRepositoryUrl(anyString())).thenReturn(Optional.of(repoWebhook));
+
+            // This is the logic we are validating (from WebhookManageHook)
+            if (webhook.isMigratedV2() && workspace.getVcs() != null && workspace.getVcs().getVcsType() == VcsType.GITHUB) {
+                subject.getOrCreateRepoWebhook(workspace);
+                subject.createOrUpdateSharedWebhook(repoWebhook);
+
+                if (webhook.getRemoteHookId() != null && !webhook.getRemoteHookId().isEmpty()) {
+                    gitHubWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
+                    webhook.setRemoteHookId(null);
+                }
+            }
+
+            // Verify
+            verify(gitHubWebhookService).deleteWebhook(workspace, "old-v1-hook-id");
+            assertThat(webhook.getRemoteHookId()).isNull();
+
+            // Cleanup
+            workspaceRepository.delete(workspace);
+            verify(workspaceRepository).delete(workspace);
+        }
+
+        @Test
+        void throwsOnInvalidUuid() {
+            assertThatThrownBy(() -> subject.acceptV2Webhook("not-a-uuid", "{}", Map.of()))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void throwsOnNotFound() {
+            UUID id = UUID.randomUUID();
+            when(repoWebhookRepository.findById(id)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> subject.acceptV2Webhook(id.toString(), "{}", Map.of()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Repo webhook not found");
+        }
+
+        @Test
+        void throwsSecurityExceptionOnHmacFailure() {
+            String secret = "test-secret";
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            Map<String, String> headers = Map.of("x-hub-signature-256", "sha256=invalid");
+
+            assertThatThrownBy(() -> subject.acceptV2Webhook(rw.getId().toString(), "{}", headers))
+                    .isInstanceOf(SecurityException.class)
+                    .hasMessageContaining("HMAC signature verification failed");
+
+            verify(repoWebhookDeliveryTransactions, never()).enqueue(any(), any(), any());
+        }
+
+        @Test
+        void throwsWhenSignatureHeaderMissing() {
+            String secret = "test-secret";
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            assertThatThrownBy(() -> subject.acceptV2Webhook(rw.getId().toString(), "{}", Map.of()))
+                    .isInstanceOf(SecurityException.class);
+        }
+
+        @Test
+        void enqueuesAndReturnsDeliveryIdOnValidSignature() throws Exception {
+            String secret = "test-secret";
+            String payload = "{\"ref\":\"refs/heads/main\"}";
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            UUID deliveryId = UUID.randomUUID();
+            when(repoWebhookDeliveryTransactions.enqueue(eq(rw), eq(payload), any())).thenReturn(deliveryId);
+
+            String sig = computeHmac(secret, payload);
+            Map<String, String> headers = Map.of(
+                    "x-hub-signature-256", sig,
+                    "x-github-event", "push");
+
+            UUID result = subject.acceptV2Webhook(rw.getId().toString(), payload, headers);
+
+            assertThat(result).isEqualTo(deliveryId);
+            ArgumentCaptor<String> headersJsonCaptor = ArgumentCaptor.forClass(String.class);
+            verify(repoWebhookDeliveryTransactions).enqueue(eq(rw), eq(payload), headersJsonCaptor.capture());
+            assertThat(headersJsonCaptor.getValue()).contains("x-github-event").contains("push");
+        }
+    }
+
+    @Nested
+    class ProcessClaimedDelivery {
 
         @Test
         void v2WebhookMigrationScenario() throws Exception {
             String repoUrl = "https://github.com/owner/repo";
-            String secret = "migration-test-secret";
             String payload = "{\"ref\":\"refs/heads/main\", \"commits\": [{\"id\": \"abc123\"}]}";
-            
-            RepoWebhook rw = repoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            RepoWebhook rw = repoWebhookWith(repoUrl, "migration-test-secret");
 
             // 1. Create two dummy workspaces
             Workspace ws1 = workspaceWithSource(repoUrl);
@@ -371,10 +489,7 @@ class RepoWebhookServiceTest {
             when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(repoUrl))
                     .thenReturn(Collections.emptyList());
 
-            String sig = computeHmac(secret, payload);
-            Map<String, String> headers = Map.of(
-                    "x-hub-signature-256", sig,
-                    "x-github-event", "push");
+            Map<String, String> headers = Map.of("x-github-event", "push");
 
             WebhookResult pushResult = new WebhookResult();
             pushResult.setEvent("push");
@@ -385,7 +500,7 @@ class RepoWebhookServiceTest {
             when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(pushResult);
 
             // Process webhook (V1 state) - should create 0 jobs
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
             verify(jobRepository, never()).save(any(Job.class));
 
             // 3. Migrate the configuration to version 2
@@ -425,14 +540,14 @@ class RepoWebhookServiceTest {
             });
 
             // 4. Create a webhook request using version 2 and validate jobs are created
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             // Verify a job was created for each workspace
             verify(jobRepository, times(2)).save(any(Job.class));
-            
+
             ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
             verify(jobRepository, times(2)).save(jobCaptor.capture());
-            
+
             List<Job> savedJobs = jobCaptor.getAllValues();
             assertThat(savedJobs).extracting(Job::getTemplateReference)
                     .containsExactlyInAnyOrder("template-1", "template-2");
@@ -447,11 +562,9 @@ class RepoWebhookServiceTest {
         @Test
         void v2WebhookPullRequestScenario() throws Exception {
             String repoUrl = "https://github.com/owner/repo";
-            String secret = "pr-migration-test-secret";
             String payload = "{\"action\":\"opened\", \"pull_request\": {\"number\": 42, \"head\": {\"sha\": \"def456\"}}}";
-            
-            RepoWebhook rw = repoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            RepoWebhook rw = repoWebhookWith(repoUrl, "pr-migration-test-secret");
 
             // 1. Create two dummy workspaces
             Workspace ws1 = workspaceWithSource(repoUrl);
@@ -471,10 +584,7 @@ class RepoWebhookServiceTest {
             when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(repoUrl))
                     .thenReturn(Collections.emptyList());
 
-            String sig = computeHmac(secret, payload);
-            Map<String, String> headers = Map.of(
-                    "x-hub-signature-256", sig,
-                    "x-github-event", "pull_request");
+            Map<String, String> headers = Map.of("x-github-event", "pull_request");
 
             WebhookResult prResult = new WebhookResult();
             prResult.setEvent("pull_request");
@@ -484,13 +594,13 @@ class RepoWebhookServiceTest {
             prResult.setPrNumber(42);
             prResult.setPrFilesUrl("https://api.github.com/repos/owner/repo/pulls/42/files");
             when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(prResult);
-            
+
             // Mock file changes for PR
             when(gitHubWebhookService.fetchPrFileChanges(any(), eq(repoUrl), eq(prResult.getPrFilesUrl())))
                     .thenReturn(List.of("variables.tf"));
 
             // Process webhook (V1 state) - should create 0 jobs
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
             verify(jobRepository, never()).save(any(Job.class));
 
             // 3. Migrate the configuration to version 2
@@ -528,18 +638,18 @@ class RepoWebhookServiceTest {
             });
 
             // 4. Create a webhook request using version 2 and validate jobs are created
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             // Verify a job was created for each workspace
             verify(jobRepository, times(2)).save(any(Job.class));
-            
+
             ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
             verify(jobRepository, times(2)).save(jobCaptor.capture());
-            
+
             List<Job> savedJobs = jobCaptor.getAllValues();
             assertThat(savedJobs).extracting(Job::getTemplateReference)
                     .containsExactlyInAnyOrder("pr-template-1", "pr-template-2");
-            
+
             assertThat(savedJobs).allSatisfy(job -> {
                 assertThat(job.getCommitId()).isEqualTo("def456");
                 assertThat(job.getOverrideBranch()).isEqualTo("feature-branch");
@@ -560,11 +670,9 @@ class RepoWebhookServiceTest {
             // bails out immediately when job.getPrNumber() is null/0, so no PR comment was ever
             // posted for a repo on the shared (v2) webhook - only the commit status check showed up.
             String repoUrl = "https://github.com/owner/repo";
-            String secret = "pr-workflow-test-secret";
             String payload = "{\"action\":\"opened\", \"pull_request\": {\"number\": 7, \"head\": {\"sha\": \"cafe123\"}}}";
 
-            RepoWebhook rw = repoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = repoWebhookWith(repoUrl, "pr-workflow-test-secret");
 
             Workspace ws = workspaceWithSource(repoUrl);
             ws.setName("ws-pr-workflow");
@@ -587,10 +695,7 @@ class RepoWebhookServiceTest {
             when(webhookEventRepository.findByWebhookAndEventOrderByPriorityAsc(wh, WebhookEventType.PULL_REQUEST))
                     .thenReturn(List.of(event));
 
-            String sig = computeHmac(secret, payload);
-            Map<String, String> headers = Map.of(
-                    "x-hub-signature-256", sig,
-                    "x-github-event", "pull_request");
+            Map<String, String> headers = Map.of("x-github-event", "pull_request");
 
             WebhookResult prResult = new WebhookResult();
             prResult.setEvent("pull_request");
@@ -607,7 +712,7 @@ class RepoWebhookServiceTest {
                 return j;
             });
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
             verify(jobRepository).save(jobCaptor.capture());
@@ -627,11 +732,9 @@ class RepoWebhookServiceTest {
             // PR for a repo using the shared webhook. WebhookResult.prDetailsUrl now defers that fetch
             // to processWorkspaceWebhook, once workspace.getVcs() is known.
             String repoUrl = "https://github.com/owner/repo";
-            String secret = "issue-comment-test-secret";
             String payload = "{\"action\":\"created\", \"comment\": {\"body\": \"terrakube plan\"}}";
 
-            RepoWebhook rw = repoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = repoWebhookWith(repoUrl, "issue-comment-test-secret");
 
             Workspace ws = workspaceWithSource(repoUrl);
             ws.setName("ws-issue-comment");
@@ -653,10 +756,7 @@ class RepoWebhookServiceTest {
             when(webhookEventRepository.findByWebhookAndEventOrderByPriorityAsc(wh, WebhookEventType.PULL_REQUEST))
                     .thenReturn(List.of(event));
 
-            String sig = computeHmac(secret, payload);
-            Map<String, String> headers = Map.of(
-                    "x-hub-signature-256", sig,
-                    "x-github-event", "issue_comment");
+            Map<String, String> headers = Map.of("x-github-event", "issue_comment");
 
             // parseGitHubPayload was called with vcs=null (the v2-safe overload), so it couldn't
             // resolve commit/branch itself - it left them unset and recorded prDetailsUrl instead,
@@ -689,7 +789,7 @@ class RepoWebhookServiceTest {
                 return j;
             });
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             verify(gitHubWebhookService).resolvePrDetails(eq(ws.getVcs()), eq(repoUrl),
                     eq("https://api.github.com/repos/owner/repo/pulls/9"), eq(commentResult));
@@ -706,11 +806,9 @@ class RepoWebhookServiceTest {
         @Test
         void v2WebhookIssueCommentSkipsWorkspaceWithNoVcsInsteadOfNpe() throws Exception {
             String repoUrl = "https://github.com/owner/repo";
-            String secret = "issue-comment-no-vcs-secret";
             String payload = "{\"action\":\"created\", \"comment\": {\"body\": \"terrakube plan\"}}";
 
-            RepoWebhook rw = repoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = repoWebhookWith(repoUrl, "issue-comment-no-vcs-secret");
 
             Workspace ws = workspaceWithSource(repoUrl);
             ws.setName("ws-no-vcs");
@@ -722,10 +820,7 @@ class RepoWebhookServiceTest {
             when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(repoUrl))
                     .thenReturn(List.of(ws));
 
-            String sig = computeHmac(secret, payload);
-            Map<String, String> headers = Map.of(
-                    "x-hub-signature-256", sig,
-                    "x-github-event", "issue_comment");
+            Map<String, String> headers = Map.of("x-github-event", "issue_comment");
 
             WebhookResult commentResult = new WebhookResult();
             commentResult.setEvent("issue_comment");
@@ -737,7 +832,7 @@ class RepoWebhookServiceTest {
             commentResult.setPrDetailsUrl("https://api.github.com/repos/owner/repo/pulls/11");
             when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(commentResult);
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             verify(gitHubWebhookService, never()).resolvePrDetails(any(), any(), any(), any());
             verify(jobRepository, never()).save(any(Job.class));
@@ -783,11 +878,9 @@ class RepoWebhookServiceTest {
         @Test
         void v2WebhookIssueCommentAcknowledgesReceiptWithEyesReaction() throws Exception {
             String repoUrl = "https://github.com/owner/repo";
-            String secret = "issue-comment-ack-secret";
             String payload = "{\"action\":\"created\", \"comment\": {\"body\": \"terrakube plan\"}}";
 
-            RepoWebhook rw = repoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = repoWebhookWith(repoUrl, "issue-comment-ack-secret");
 
             Workspace ws = prCommentWorkspace(repoUrl, "ws-ack", "plan", 9, true, false);
             when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(repoUrl)).thenReturn(List.of(ws));
@@ -796,10 +889,9 @@ class RepoWebhookServiceTest {
             when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(commentResult);
             when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
 
-            String sig = computeHmac(secret, payload);
-            Map<String, String> headers = Map.of("x-hub-signature-256", sig, "x-github-event", "issue_comment");
+            Map<String, String> headers = Map.of("x-github-event", "issue_comment");
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             verify(prCommentService).acknowledgeReceipt(ws, "comment-1", 9);
         }
@@ -807,11 +899,9 @@ class RepoWebhookServiceTest {
         @Test
         void v2WebhookIssueCommentApplyCreatesAutoApplyJobWhenEnabled() throws Exception {
             String repoUrl = "https://github.com/owner/repo";
-            String secret = "issue-comment-apply-secret";
             String payload = "{\"action\":\"created\", \"comment\": {\"body\": \"terrakube apply\"}}";
 
-            RepoWebhook rw = repoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = repoWebhookWith(repoUrl, "issue-comment-apply-secret");
 
             Workspace ws = prCommentWorkspace(repoUrl, "ws-apply-enabled", "apply", 12, true, true);
             ws.setDefaultTemplate("default-template-id");
@@ -825,10 +915,9 @@ class RepoWebhookServiceTest {
                 return j;
             });
 
-            String sig = computeHmac(secret, payload);
-            Map<String, String> headers = Map.of("x-hub-signature-256", sig, "x-github-event", "issue_comment");
+            Map<String, String> headers = Map.of("x-github-event", "issue_comment");
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             assertThat(ws.isLocked()).isTrue();
             verify(workspaceRepository).save(ws);
@@ -848,11 +937,9 @@ class RepoWebhookServiceTest {
         @Test
         void v2WebhookIssueCommentApplyPostsDisabledNoticeWhenNotEnabled() throws Exception {
             String repoUrl = "https://github.com/owner/repo";
-            String secret = "issue-comment-apply-disabled-secret";
             String payload = "{\"action\":\"created\", \"comment\": {\"body\": \"terrakube apply\"}}";
 
-            RepoWebhook rw = repoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = repoWebhookWith(repoUrl, "issue-comment-apply-disabled-secret");
 
             Workspace ws = prCommentWorkspace(repoUrl, "ws-apply-disabled", "apply", 13, true, false);
             when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(repoUrl)).thenReturn(List.of(ws));
@@ -860,10 +947,9 @@ class RepoWebhookServiceTest {
             WebhookResult commentResult = resolvedCommentResult("apply", 13, "comment-apply-2");
             when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(commentResult);
 
-            String sig = computeHmac(secret, payload);
-            Map<String, String> headers = Map.of("x-hub-signature-256", sig, "x-github-event", "issue_comment");
+            Map<String, String> headers = Map.of("x-github-event", "issue_comment");
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             assertThat(ws.isLocked()).isFalse();
             verify(prCommentService).postApplyDisabledNotice(ws, 13);
@@ -873,11 +959,9 @@ class RepoWebhookServiceTest {
         @Test
         void v2WebhookReleaseScenario() throws Exception {
             String repoUrl = "https://github.com/owner/repo";
-            String secret = "release-test-secret";
             String payload = "{\"action\":\"published\", \"release\": {\"tag_name\": \"v1.0.0\", \"target_commitish\": \"main\"}}";
-            
-            RepoWebhook rw = repoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+
+            RepoWebhook rw = repoWebhookWith(repoUrl, "release-test-secret");
 
             // 1. Create two dummy workspaces
             Workspace ws1 = workspaceWithSource(repoUrl);
@@ -897,10 +981,7 @@ class RepoWebhookServiceTest {
             when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(repoUrl))
                     .thenReturn(Collections.emptyList());
 
-            String sig = computeHmac(secret, payload);
-            Map<String, String> headers = Map.of(
-                    "x-hub-signature-256", sig,
-                    "x-github-event", "release");
+            Map<String, String> headers = Map.of("x-github-event", "release");
 
             WebhookResult releaseResult = new WebhookResult();
             releaseResult.setEvent("release");
@@ -911,7 +992,7 @@ class RepoWebhookServiceTest {
             when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(releaseResult);
 
             // Process webhook (V1 state) - should create 0 jobs
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
             verify(jobRepository, never()).save(any(Job.class));
 
             // 3. Migrate the configuration to version 2
@@ -945,18 +1026,18 @@ class RepoWebhookServiceTest {
             });
 
             // 4. Create a webhook request using version 2 and validate jobs are created
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             // Verify a job was created for each workspace
             verify(jobRepository, times(2)).save(any(Job.class));
-            
+
             ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
             verify(jobRepository, times(2)).save(jobCaptor.capture());
-            
+
             List<Job> savedJobs = jobCaptor.getAllValues();
             assertThat(savedJobs).extracting(Job::getTemplateReference)
                     .containsExactlyInAnyOrder("release-template-1", "release-template-2");
-            
+
             assertThat(savedJobs).allSatisfy(job -> {
                 assertThat(job.getCommitId()).isEqualTo("tag-sha-123");
                 assertThat(job.getOverrideBranch()).isEqualTo("refs/tags/v1.0.0");
@@ -970,109 +1051,18 @@ class RepoWebhookServiceTest {
         }
 
         @Test
-        void v2WebhookMigrationRemovalScenario() throws Exception {
-            String repoUrl = "https://github.com/owner/repo";
-            
-            // 1. Create a workspace using webhook version 1
-            Workspace workspace = workspaceWithSource(repoUrl);
-            workspace.setName("workspace-v1");
-            Vcs vcs = new Vcs();
-            vcs.setVcsType(VcsType.GITHUB);
-            workspace.setVcs(vcs);
-
-            Webhook webhook = new Webhook();
-            webhook.setWorkspace(workspace);
-            webhook.setMigratedV2(false);
-            webhook.setRemoteHookId("old-v1-hook-id");
-            workspace.setWebhook(webhook);
-
-            // 2. Migrate to version 2
-            webhook.setMigratedV2(true);
-
-            // 3. Validate the version 1 webhook is removed correctly
-            // We simulate the logic from WebhookManageHook here to validate it works with RepoWebhookService
-            RepoWebhook repoWebhook = repoWebhookWith(repoUrl, "new-secret");
-            when(repoWebhookRepository.findByRepositoryUrl(anyString())).thenReturn(Optional.of(repoWebhook));
-            
-            // This is the logic we are validating (from WebhookManageHook)
-            if (webhook.isMigratedV2() && workspace.getVcs() != null && workspace.getVcs().getVcsType() == VcsType.GITHUB) {
-                subject.getOrCreateRepoWebhook(workspace);
-                subject.createOrUpdateSharedWebhook(repoWebhook);
-                
-                if (webhook.getRemoteHookId() != null && !webhook.getRemoteHookId().isEmpty()) {
-                    gitHubWebhookService.deleteWebhook(workspace, webhook.getRemoteHookId());
-                    webhook.setRemoteHookId(null);
-                }
-            }
-
-            // Verify
-            verify(gitHubWebhookService).deleteWebhook(workspace, "old-v1-hook-id");
-            assertThat(webhook.getRemoteHookId()).isNull();
-            
-            // Cleanup
-            workspaceRepository.delete(workspace);
-            verify(workspaceRepository).delete(workspace);
-        }
-
-        @Test
-        void throwsOnInvalidUuid() {
-            assertThatThrownBy(() -> subject.processV2Webhook("not-a-uuid", "{}", Map.of()))
-                    .isInstanceOf(IllegalArgumentException.class);
-        }
-
-        @Test
-        void throwsOnNotFound() {
-            UUID id = UUID.randomUUID();
-            when(repoWebhookRepository.findById(id)).thenReturn(Optional.empty());
-
-            assertThatThrownBy(() -> subject.processV2Webhook(id.toString(), "{}", Map.of()))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("Repo webhook not found");
-        }
-
-        @Test
-        void throwsSecurityExceptionOnHmacFailure() {
-            String secret = "test-secret";
-            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
-
-            Map<String, String> headers = Map.of("x-hub-signature-256", "sha256=invalid");
-
-            assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), "{}", headers))
-                    .isInstanceOf(SecurityException.class)
-                    .hasMessageContaining("HMAC signature verification failed");
-
-            verify(jobRepository, never()).save(any());
-        }
-
-        @Test
-        void throwsWhenSignatureHeaderMissing() {
-            String secret = "test-secret";
-            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
-
-            assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), "{}", Map.of()))
-                    .isInstanceOf(SecurityException.class);
-        }
-
-        @Test
         void handlesValidPingEvent() throws Exception {
-            String secret = "test-secret";
             String payload = "{\"zen\":\"test\"}";
-            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", "test-secret");
 
-            String sig = computeHmac(secret, payload);
-            Map<String, String> headers = Map.of(
-                    "x-hub-signature-256", sig,
-                    "x-github-event", "ping");
+            Map<String, String> headers = Map.of("x-github-event", "ping");
 
             WebhookResult pingResult = new WebhookResult();
             pingResult.setEvent("ping");
             pingResult.setValid(true);
             when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(pingResult);
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             verify(jobRepository, never()).save(any());
             verify(workspaceRepository, never()).findByNormalizedSourceWithMigratedWebhook(any());
@@ -1080,15 +1070,10 @@ class RepoWebhookServiceTest {
 
         @Test
         void fansOutToMultipleWorkspaces() throws Exception {
-            String secret = "test-secret";
             String payload = "{\"ref\":\"refs/heads/main\"}";
-            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", "test-secret");
 
-            String sig = computeHmac(secret, payload);
-            Map<String, String> headers = Map.of(
-                    "x-hub-signature-256", sig,
-                    "x-github-event", "push");
+            Map<String, String> headers = Map.of("x-github-event", "push");
 
             WebhookResult pushResult = new WebhookResult();
             pushResult.setEvent("push");
@@ -1133,22 +1118,17 @@ class RepoWebhookServiceTest {
                     .thenReturn(List.of(event2));
             when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             verify(jobRepository, times(2)).save(any(Job.class));
         }
 
         @Test
         void continuesProcessingWhenOneWorkspaceFails() throws Exception {
-            String secret = "test-secret";
             String payload = "{\"ref\":\"refs/heads/main\"}";
-            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", "test-secret");
 
-            String sig = computeHmac(secret, payload);
-            Map<String, String> headers = Map.of(
-                    "x-hub-signature-256", sig,
-                    "x-github-event", "push");
+            Map<String, String> headers = Map.of("x-github-event", "push");
 
             WebhookResult pushResult = new WebhookResult();
             pushResult.setEvent("push");
@@ -1183,7 +1163,7 @@ class RepoWebhookServiceTest {
                     .thenReturn(List.of(event2));
             when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             // ws1 skipped, ws2 should still create a job
             verify(jobRepository, times(1)).save(any(Job.class));
@@ -1191,22 +1171,17 @@ class RepoWebhookServiceTest {
 
         @Test
         void skipsInvalidWebhookResult() throws Exception {
-            String secret = "test-secret";
             String payload = "{}";
-            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", "test-secret");
 
-            String sig = computeHmac(secret, payload);
-            Map<String, String> headers = Map.of(
-                    "x-hub-signature-256", sig,
-                    "x-github-event", "unknown");
+            Map<String, String> headers = Map.of("x-github-event", "unknown");
 
             WebhookResult invalidResult = new WebhookResult();
             invalidResult.setEvent("unknown");
             invalidResult.setValid(false);
             when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(invalidResult);
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             verify(workspaceRepository, never()).findByNormalizedSourceWithMigratedWebhook(any());
             verify(jobRepository, never()).save(any());
@@ -1222,19 +1197,15 @@ class RepoWebhookServiceTest {
             String payload = "{\"action\":\"push\"}";
             RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
             when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            when(repoWebhookDeliveryTransactions.enqueue(eq(rw), eq(payload), any())).thenReturn(UUID.randomUUID());
 
             String sig = computeHmac(secret, payload);
             Map<String, String> headers = Map.of(
                     "x-hub-signature-256", sig,
                     "x-github-event", "ping");
 
-            WebhookResult pingResult = new WebhookResult();
-            pingResult.setEvent("ping");
-            pingResult.setValid(true);
-            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(pingResult);
-
-            // Should not throw — valid signature
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            // Should not throw - valid signature
+            subject.acceptV2Webhook(rw.getId().toString(), payload, headers);
         }
 
         @Test
@@ -1248,7 +1219,7 @@ class RepoWebhookServiceTest {
             String sig = computeHmac(secret, "{\"action\":\"different\"}");
             Map<String, String> headers = Map.of("x-hub-signature-256", sig);
 
-            assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), payload, headers))
+            assertThatThrownBy(() -> subject.acceptV2Webhook(rw.getId().toString(), payload, headers))
                     .isInstanceOf(SecurityException.class);
         }
 
@@ -1262,7 +1233,7 @@ class RepoWebhookServiceTest {
             String sig = computeHmac("wrong-secret", payload);
             Map<String, String> headers = Map.of("x-hub-signature-256", sig);
 
-            assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), payload, headers))
+            assertThatThrownBy(() -> subject.acceptV2Webhook(rw.getId().toString(), payload, headers))
                     .isInstanceOf(SecurityException.class);
         }
     }
@@ -1318,14 +1289,12 @@ class RepoWebhookServiceTest {
         }
 
         @Test
-        void processV2WebhookGitLabPushFansOutAndVerifiesToken() {
+        void gitLabPushFansOutToWorkspace() {
             String repoUrl = "https://gitlab.com/owner/repo";
-            String secret = "gitlab-token-secret";
             String payload = "{\"object_kind\":\"push\"}";
-            RepoWebhook rw = gitlabRepoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = gitlabRepoWebhookWith(repoUrl, "gitlab-token-secret");
 
-            Map<String, String> headers = Map.of("x-gitlab-token", secret);
+            Map<String, String> headers = Map.of();
 
             WebhookResult pushResult = new WebhookResult();
             pushResult.setEvent("push");
@@ -1353,7 +1322,7 @@ class RepoWebhookServiceTest {
                     .thenReturn(List.of(event));
             when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
             verify(jobRepository).save(jobCaptor.capture());
@@ -1365,14 +1334,12 @@ class RepoWebhookServiceTest {
         }
 
         @Test
-        void processV2WebhookGitLabMergeRequestFetchesFileChanges() {
+        void gitLabMergeRequestFetchesFileChanges() {
             String repoUrl = "https://gitlab.com/owner/repo";
-            String secret = "mr-token-secret";
             String payload = "{\"object_kind\":\"merge_request\"}";
-            RepoWebhook rw = gitlabRepoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = gitlabRepoWebhookWith(repoUrl, "mr-token-secret");
 
-            Map<String, String> headers = Map.of("x-gitlab-token", secret);
+            Map<String, String> headers = Map.of();
 
             WebhookResult mrResult = new WebhookResult();
             mrResult.setEvent("merge_request");
@@ -1404,7 +1371,7 @@ class RepoWebhookServiceTest {
                     .thenReturn(List.of(event));
             when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             verify(gitLabWebhookService).fetchPrFileChanges(any(), eq(repoUrl), eq("42"));
             verify(gitHubWebhookService, never()).fetchPrFileChanges(any(), any(), any());
@@ -1416,14 +1383,12 @@ class RepoWebhookServiceTest {
         }
 
         @Test
-        void processV2WebhookGitLabReleaseCreatesJobs() {
+        void gitLabReleaseCreatesJobs() {
             String repoUrl = "https://gitlab.com/owner/repo";
-            String secret = "release-token-secret";
             String payload = "{\"object_kind\":\"release\"}";
-            RepoWebhook rw = gitlabRepoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = gitlabRepoWebhookWith(repoUrl, "release-token-secret");
 
-            Map<String, String> headers = Map.of("x-gitlab-token", secret);
+            Map<String, String> headers = Map.of();
 
             WebhookResult releaseResult = new WebhookResult();
             releaseResult.setEvent("release");
@@ -1449,7 +1414,7 @@ class RepoWebhookServiceTest {
                     .thenReturn(List.of(event));
             when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
             verify(jobRepository).save(jobCaptor.capture());
@@ -1467,11 +1432,11 @@ class RepoWebhookServiceTest {
 
             Map<String, String> headers = Map.of("x-gitlab-token", "wrong-token");
 
-            assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), "{}", headers))
+            assertThatThrownBy(() -> subject.acceptV2Webhook(rw.getId().toString(), "{}", headers))
                     .isInstanceOf(SecurityException.class)
                     .hasMessageContaining("GitLab token verification failed");
 
-            verify(jobRepository, never()).save(any());
+            verify(repoWebhookDeliveryTransactions, never()).enqueue(any(), any(), any());
         }
 
         @Test
@@ -1479,10 +1444,10 @@ class RepoWebhookServiceTest {
             RepoWebhook rw = gitlabRepoWebhookWith("https://gitlab.com/owner/repo", "secret");
             when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
 
-            assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), "{}", Map.of()))
+            assertThatThrownBy(() -> subject.acceptV2Webhook(rw.getId().toString(), "{}", Map.of()))
                     .isInstanceOf(SecurityException.class);
 
-            verify(jobRepository, never()).save(any());
+            verify(repoWebhookDeliveryTransactions, never()).enqueue(any(), any(), any());
         }
 
         @Test
@@ -1591,11 +1556,25 @@ class RepoWebhookServiceTest {
         void processV2WebhookAzDevOpsTokenVerificationSucceeds() {
             String repoUrl = "https://dev.azure.com/org/proj/repo";
             String secret = "az-test-secret";
-            String payload = "{\"eventType\":\"git.push\"}";
             RepoWebhook rw = azDevOpsRepoWebhookWith(repoUrl, secret);
             when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            when(repoWebhookDeliveryTransactions.enqueue(eq(rw), any(), any())).thenReturn(UUID.randomUUID());
 
             Map<String, String> headers = Map.of("x-terrakube-token", secret);
+
+            // Should not throw
+            subject.acceptV2Webhook(rw.getId().toString(), "{\"eventType\":\"git.push\"}", headers);
+
+            verify(repoWebhookDeliveryTransactions).enqueue(eq(rw), any(), any());
+        }
+
+        @Test
+        void azDevOpsPushWithNoMatchingWorkspacesParsesAndNoOps() {
+            String repoUrl = "https://dev.azure.com/org/proj/repo";
+            String payload = "{\"eventType\":\"git.push\"}";
+            RepoWebhook rw = azDevOpsRepoWebhookWith(repoUrl, "az-test-secret");
+
+            Map<String, String> headers = Map.of();
 
             WebhookResult pushResult = new WebhookResult();
             pushResult.setEvent("push");
@@ -1609,8 +1588,7 @@ class RepoWebhookServiceTest {
             when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(repoUrl))
                     .thenReturn(Collections.emptyList());
 
-            // Should not throw
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             verify(azDevOpsWebhookService).parseAzDevOpsPayload(eq(payload), any());
             verify(gitHubWebhookService, never()).parseGitHubPayload(any(), any());
@@ -1625,11 +1603,11 @@ class RepoWebhookServiceTest {
 
             Map<String, String> headers = Map.of("x-terrakube-token", "wrong-token");
 
-            assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), "{}", headers))
+            assertThatThrownBy(() -> subject.acceptV2Webhook(rw.getId().toString(), "{}", headers))
                     .isInstanceOf(SecurityException.class)
                     .hasMessageContaining("Azure DevOps token verification failed");
 
-            verify(jobRepository, never()).save(any());
+            verify(repoWebhookDeliveryTransactions, never()).enqueue(any(), any(), any());
         }
 
         @Test
@@ -1637,21 +1615,19 @@ class RepoWebhookServiceTest {
             RepoWebhook rw = azDevOpsRepoWebhookWith("https://dev.azure.com/org/proj/repo", "secret");
             when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
 
-            assertThatThrownBy(() -> subject.processV2Webhook(rw.getId().toString(), "{}", Map.of()))
+            assertThatThrownBy(() -> subject.acceptV2Webhook(rw.getId().toString(), "{}", Map.of()))
                     .isInstanceOf(SecurityException.class);
 
-            verify(jobRepository, never()).save(any());
+            verify(repoWebhookDeliveryTransactions, never()).enqueue(any(), any(), any());
         }
 
         @Test
         void processV2WebhookAzDevOpsPushFansOutWithFileChanges() {
             String repoUrl = "https://dev.azure.com/org/proj/repo";
-            String secret = "az-push-secret";
             String payload = "{\"eventType\":\"git.push\",\"resource\":{\"refUpdates\":[{\"name\":\"refs/heads/main\",\"newObjectId\":\"abc123\"}]}}";
-            RepoWebhook rw = azDevOpsRepoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = azDevOpsRepoWebhookWith(repoUrl, "az-push-secret");
 
-            Map<String, String> headers = Map.of("x-terrakube-token", secret);
+            Map<String, String> headers = Map.of();
 
             WebhookResult pushResult = new WebhookResult();
             pushResult.setEvent("push");
@@ -1700,7 +1676,7 @@ class RepoWebhookServiceTest {
                     .thenReturn(List.of(event2));
             when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             verify(jobRepository, times(2)).save(any(Job.class));
             verify(azDevOpsWebhookService, times(2)).fetchPushFileChanges(any(), eq(repoUrl), eq(payload));
@@ -1713,12 +1689,10 @@ class RepoWebhookServiceTest {
         @Test
         void processV2WebhookAzDevOpsPullRequestFetchesFileChanges() {
             String repoUrl = "https://dev.azure.com/org/proj/repo";
-            String secret = "az-pr-secret";
             String payload = "{\"eventType\":\"git.pullrequest.created\"}";
-            RepoWebhook rw = azDevOpsRepoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = azDevOpsRepoWebhookWith(repoUrl, "az-pr-secret");
 
-            Map<String, String> headers = Map.of("x-terrakube-token", secret);
+            Map<String, String> headers = Map.of();
 
             WebhookResult prResult = new WebhookResult();
             prResult.setEvent("pull_request");
@@ -1751,7 +1725,7 @@ class RepoWebhookServiceTest {
                     .thenReturn(List.of(event));
             when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             verify(azDevOpsWebhookService).fetchPrFileChanges(any(), eq(repoUrl), eq(42));
             ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
@@ -1764,12 +1738,10 @@ class RepoWebhookServiceTest {
         @Test
         void processV2WebhookAzDevOpsReleaseCreatesJobs() {
             String repoUrl = "https://dev.azure.com/org/proj/repo";
-            String secret = "az-release-secret";
             String payload = "{\"eventType\":\"git.push\"}";
-            RepoWebhook rw = azDevOpsRepoWebhookWith(repoUrl, secret);
-            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            RepoWebhook rw = azDevOpsRepoWebhookWith(repoUrl, "az-release-secret");
 
-            Map<String, String> headers = Map.of("x-terrakube-token", secret);
+            Map<String, String> headers = Map.of();
 
             WebhookResult releaseResult = new WebhookResult();
             releaseResult.setEvent("release");
@@ -1796,7 +1768,7 @@ class RepoWebhookServiceTest {
                     .thenReturn(List.of(event));
             when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
 
-            subject.processV2Webhook(rw.getId().toString(), payload, headers);
+            subject.processClaimedDelivery(rw, payload, headers);
 
             ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
             verify(jobRepository).save(jobCaptor.capture());

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
@@ -779,7 +779,11 @@ class RepoWebhookServiceTest {
                         commentResult.setBranch("feature-branch");
                         return true;
                     });
-            when(gitHubWebhookService.fetchPrFileChanges(eq(ws.getVcs()), eq(repoUrl),
+            // any(), not eq(ws.getVcs()): processClaimedDelivery now tries this once repo-wide with
+            // the repo webhook's own Vcs before any workspace loop iteration is reached (see
+            // RepoWebhookService.processClaimedDelivery) - the workspace-scoped fallback in
+            // processWorkspaceWebhook only runs if that didn't populate anything.
+            when(gitHubWebhookService.fetchPrFileChanges(any(), eq(repoUrl),
                     eq("https://api.github.com/repos/owner/repo/pulls/9/files")))
                     .thenReturn(List.of("main.tf"));
 
@@ -1185,6 +1189,70 @@ class RepoWebhookServiceTest {
 
             verify(workspaceRepository, never()).findByNormalizedSourceWithMigratedWebhook(any());
             verify(jobRepository, never()).save(any());
+        }
+
+        @Test
+        void fetchesPrFileChangesOnceForTheWholeDeliveryNotOncePerWorkspace() throws Exception {
+            // Regression test: fetchPrFileChanges used to run inside the per-workspace loop, so a
+            // shared webhook with N workspaces made N redundant (and, post-pagination-fix,
+            // potentially multi-page) calls for the exact same PR's file list. It should now be
+            // fetched once, repo-wide, using the repo webhook's own Vcs, and reused by every
+            // workspace.
+            String repoUrl = "https://github.com/owner/repo";
+            String payload = "{\"action\":\"opened\", \"pull_request\": {\"number\": 42, \"head\": {\"sha\": \"def456\"}}}";
+
+            RepoWebhook rw = repoWebhookWith(repoUrl, "dedupe-test-secret");
+            Map<String, String> headers = Map.of("x-github-event", "pull_request");
+
+            WebhookResult prResult = new WebhookResult();
+            prResult.setEvent("pull_request");
+            prResult.setValid(true);
+            prResult.setBranch("feature-branch");
+            prResult.setCommit("def456");
+            prResult.setPrNumber(42);
+            prResult.setPrFilesUrl("https://api.github.com/repos/owner/repo/pulls/42/files");
+            when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(prResult);
+            when(gitHubWebhookService.fetchPrFileChanges(eq(rw.getVcs()), eq(repoUrl), eq(prResult.getPrFilesUrl())))
+                    .thenReturn(List.of("modules/network/main.tf"));
+
+            Workspace ws1 = workspaceWithSource(repoUrl);
+            ws1.setName("dedupe-ws1");
+            Webhook wh1 = new Webhook();
+            WebhookEvent event1 = new WebhookEvent();
+            event1.setEvent(WebhookEventType.PULL_REQUEST);
+            event1.setBranch("feature-branch");
+            event1.setPath("**");
+            event1.setPathType(WebhookEventPathType.PATTERN);
+            event1.setTemplateId("template-1");
+            wh1.setEvents(List.of(event1));
+            ws1.setWebhook(wh1);
+
+            Workspace ws2 = workspaceWithSource(repoUrl);
+            ws2.setName("dedupe-ws2");
+            Webhook wh2 = new Webhook();
+            WebhookEvent event2 = new WebhookEvent();
+            event2.setEvent(WebhookEventType.PULL_REQUEST);
+            event2.setBranch("feature-branch");
+            event2.setPath("**");
+            event2.setPathType(WebhookEventPathType.PATTERN);
+            event2.setTemplateId("template-2");
+            wh2.setEvents(List.of(event2));
+            ws2.setWebhook(wh2);
+
+            when(workspaceRepository.findByNormalizedSourceWithMigratedWebhook(repoUrl))
+                    .thenReturn(List.of(ws1, ws2));
+            when(webhookEventRepository.findByWebhookAndEventOrderByPriorityAsc(wh1, WebhookEventType.PULL_REQUEST))
+                    .thenReturn(List.of(event1));
+            when(webhookEventRepository.findByWebhookAndEventOrderByPriorityAsc(wh2, WebhookEventType.PULL_REQUEST))
+                    .thenReturn(List.of(event2));
+            when(jobRepository.save(any(Job.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            subject.processClaimedDelivery(rw, payload, headers);
+
+            verify(gitHubWebhookService, times(1)).fetchPrFileChanges(any(), any(), any());
+            verify(gitHubWebhookService, never()).fetchPrFileChanges(eq(ws1.getVcs()), any(), any());
+            verify(gitHubWebhookService, never()).fetchPrFileChanges(eq(ws2.getVcs()), any(), any());
+            verify(jobRepository, times(2)).save(any(Job.class));
         }
     }
 

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/provider/azdevops/AzDevOpsWebhookServiceTest.java
@@ -1,12 +1,19 @@
 package io.terrakube.api.plugin.vcs.provider.azdevops;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.terrakube.api.plugin.vcs.provider.azdevops.AzDevOpsWebhookService.ChangesPage;
 import io.terrakube.api.rs.job.JobStatus;
 
 public class AzDevOpsWebhookServiceTest {
+
+    private final AzDevOpsWebhookService subject = new AzDevOpsWebhookService(new ObjectMapper(), null);
 
     @Test
     public void buildCommitStatusDescriptionAppendsRunSummaryOnSuccess() {
@@ -52,5 +59,55 @@ public class AzDevOpsWebhookServiceTest {
         String description = AzDevOpsWebhookService.buildCommitStatusDescription(JobStatus.queue, null);
 
         assertEquals("Your task is in Terrakube queue.", description);
+    }
+
+    @Nested
+    class ParseChangesPage {
+
+        @Test
+        void collectsFilePathsAndStripsTheLeadingSlash() throws Exception {
+            String body = "{\"changeEntries\":["
+                    + "{\"item\":{\"path\":\"/modules/network/main.tf\",\"gitObjectType\":\"blob\"},\"changeType\":\"edit\"},"
+                    + "{\"item\":{\"path\":\"/modules/database/main.tf\",\"gitObjectType\":\"blob\"},\"changeType\":\"add\"}"
+                    + "]}";
+
+            ChangesPage page = subject.parseChangesPage(body);
+
+            assertThat(page.files()).containsExactly("modules/network/main.tf", "modules/database/main.tf");
+            assertThat(page.nextTop()).isZero();
+            assertThat(page.nextSkip()).isZero();
+        }
+
+        @Test
+        void skipsFolderEntries() throws Exception {
+            String body = "{\"changeEntries\":["
+                    + "{\"item\":{\"path\":\"/modules\",\"isFolder\":true,\"gitObjectType\":\"tree\"},\"changeType\":\"edit\"},"
+                    + "{\"item\":{\"path\":\"/modules/network/main.tf\",\"gitObjectType\":\"blob\"},\"changeType\":\"edit\"}"
+                    + "]}";
+
+            ChangesPage page = subject.parseChangesPage(body);
+
+            assertThat(page.files()).containsExactly("modules/network/main.tf");
+        }
+
+        @Test
+        void reportsNextTopAndNextSkipWhenAnotherPageIsAvailable() throws Exception {
+            String body = "{\"changeEntries\":[],\"nextTop\":100,\"nextSkip\":100}";
+
+            ChangesPage page = subject.parseChangesPage(body);
+
+            assertThat(page.nextTop()).isEqualTo(100);
+            assertThat(page.nextSkip()).isEqualTo(100);
+        }
+
+        @Test
+        void nextTopAndNextSkipAreBothZeroWhenAbsent() throws Exception {
+            String body = "{\"changeEntries\":[]}";
+
+            ChangesPage page = subject.parseChangesPage(body);
+
+            assertThat(page.nextTop()).isZero();
+            assertThat(page.nextSkip()).isZero();
+        }
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookServiceTest.java
@@ -1,18 +1,35 @@
 package io.terrakube.api.plugin.vcs.provider.github;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
 
+import io.terrakube.api.plugin.vcs.TokenService;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.vcs.Vcs;
+import io.terrakube.api.rs.workspace.Workspace;
 
 public class GitHubWebhookServiceTest {
 
@@ -156,6 +173,54 @@ public class GitHubWebhookServiceTest {
         @Test
         void returnsNullForBlankHeader() {
             assertNull(subject.extractNextPageUrl("   "));
+        }
+    }
+
+    @Nested
+    class SendCommitStatus {
+
+        WireMockServer wireMockServer;
+        TokenService tokenService;
+        GitHubWebhookService subjectWithRestTemplate;
+
+        @BeforeEach
+        void setUp() throws Exception {
+            wireMockServer = new WireMockServer(options().dynamicPort());
+            wireMockServer.start();
+            tokenService = mock(TokenService.class);
+            when(tokenService.getAccessToken(any(String[].class), any())).thenReturn("test-token");
+            subjectWithRestTemplate = new GitHubWebhookService(new ObjectMapper(), tokenService);
+            subjectWithRestTemplate.setWebhookRestTemplate(new RestTemplate());
+
+            wireMockServer.stubFor(post(urlPathMatching("/repos/owner/repo/statuses/.*"))
+                    .willReturn(aResponse().withStatus(201)));
+        }
+
+        @AfterEach
+        void tearDown() {
+            wireMockServer.stop();
+        }
+
+        @Test
+        void neverCallsThePullsStatusesEndpoint() {
+            Vcs vcs = new Vcs();
+            vcs.setApiUrl("http://localhost:" + wireMockServer.port());
+            Organization organization = new Organization();
+            organization.setName("test-org");
+            Workspace workspace = new Workspace();
+            workspace.setSource("https://github.com/owner/repo");
+            workspace.setVcs(vcs);
+            workspace.setOrganization(organization);
+            workspace.setName("test-ws");
+            Job job = new Job();
+            job.setWorkspace(workspace);
+            job.setCommitId("abc123");
+            job.setStatus(JobStatus.completed);
+
+            subjectWithRestTemplate.sendCommitStatus(job, JobStatus.completed, null);
+
+            wireMockServer.verify(1, postRequestedFor(urlPathMatching("/repos/owner/repo/statuses/.*")));
+            wireMockServer.verify(0, postRequestedFor(urlPathMatching(".*/pulls/.*/statuses.*")));
         }
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/provider/github/GitHubWebhookServiceTest.java
@@ -1,13 +1,22 @@
 package io.terrakube.api.plugin.vcs.provider.github;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.terrakube.api.rs.job.JobStatus;
 
 public class GitHubWebhookServiceTest {
+
+    private final GitHubWebhookService subject = new GitHubWebhookService(new ObjectMapper(), null);
 
     @Test
     public void buildCommitStatusDescriptionAppendsRunSummaryOnSuccess() {
@@ -63,5 +72,90 @@ public class GitHubWebhookServiceTest {
 
         assertEquals(140, description.length());
         assertTrue(description.startsWith("Your task has been completed successfully. Plan:"));
+    }
+
+    @Nested
+    class ParseChangedFilesFromPage {
+
+        @Test
+        void collectsFilenamesFromEveryEntry() throws Exception {
+            String body = "["
+                    + "{\"filename\":\"modules/network/main.tf\"},"
+                    + "{\"filename\":\"modules/database/main.tf\"}"
+                    + "]";
+
+            List<String> files = subject.parseChangedFilesFromPage(body);
+
+            assertThat(files).containsExactly("modules/network/main.tf", "modules/database/main.tf");
+        }
+
+        @Test
+        void includesPreviousFilenameForRenamedEntries() throws Exception {
+            String body = "[{\"filename\":\"modules/network-v2/main.tf\","
+                    + "\"status\":\"renamed\",\"previous_filename\":\"modules/network/main.tf\"}]";
+
+            List<String> files = subject.parseChangedFilesFromPage(body);
+
+            assertThat(files).containsExactlyInAnyOrder("modules/network-v2/main.tf", "modules/network/main.tf");
+        }
+
+        @Test
+        void doesNotAddAPreviousFilenameEntryWhenAbsent() throws Exception {
+            String body = "[{\"filename\":\"modules/network/main.tf\"}]";
+
+            List<String> files = subject.parseChangedFilesFromPage(body);
+
+            assertThat(files).containsExactly("modules/network/main.tf");
+        }
+    }
+
+    @Nested
+    class WithPerPage {
+
+        @Test
+        void appendsAsFirstQueryParamWhenUrlHasNone() {
+            String url = subject.withPerPage("https://api.github.com/repos/owner/repo/pulls/42/files");
+
+            assertThat(url).isEqualTo("https://api.github.com/repos/owner/repo/pulls/42/files?per_page=100");
+        }
+
+        @Test
+        void appendsAsAdditionalQueryParamWhenUrlAlreadyHasOne() {
+            String url = subject.withPerPage("https://api.github.com/repos/owner/repo/pulls/42/files?page=2");
+
+            assertThat(url).isEqualTo("https://api.github.com/repos/owner/repo/pulls/42/files?page=2&per_page=100");
+        }
+    }
+
+    @Nested
+    class ExtractNextPageUrl {
+
+        @Test
+        void returnsTheRelNextUrlWhenPresentAmongMultipleLinks() {
+            String linkHeader = "<https://api.github.com/repos/owner/repo/pulls/42/files?page=2>; rel=\"next\", "
+                    + "<https://api.github.com/repos/owner/repo/pulls/42/files?page=5>; rel=\"last\"";
+
+            String next = subject.extractNextPageUrl(linkHeader);
+
+            assertThat(next).isEqualTo("https://api.github.com/repos/owner/repo/pulls/42/files?page=2");
+        }
+
+        @Test
+        void returnsNullWhenOnlyRelLastIsPresent() {
+            String linkHeader = "<https://api.github.com/repos/owner/repo/pulls/42/files?page=1>; rel=\"first\", "
+                    + "<https://api.github.com/repos/owner/repo/pulls/42/files?page=1>; rel=\"prev\"";
+
+            assertNull(subject.extractNextPageUrl(linkHeader));
+        }
+
+        @Test
+        void returnsNullForMissingHeader() {
+            assertNull(subject.extractNextPageUrl(null));
+        }
+
+        @Test
+        void returnsNullForBlankHeader() {
+            assertNull(subject.extractNextPageUrl("   "));
+        }
     }
 }


### PR DESCRIPTION
## Why

Repos with a GitHub webhook shared across many workspaces (~30 in the reported case) hit a chain of related scaling failures, filed together as one bug report since they're all instances of the same root problem: webhook/scheduler processing scales with workspace count and PR size, but nothing in the chain is bounded or async.

- Webhook delivery timed out because the entire per-workspace fan-out ran synchronously inside the HTTP request GitHub was waiting on — a scaling ceiling, not something fixable by optimizing the existing code.
- Fixing that required looking closely at what the fan-out does per workspace, which surfaced a real correctness bug (PR file-changes pagination missing files past page one) and a real efficiency bug (every workspace independently re-fetching identical PR data) that were live regardless of the timeout.
- The scheduler has the identical structural problem one layer downstream: each dispatched job holds a DB connection for its entire run, so a large fan-out can hold enough connections simultaneously to exhaust the pool. Fixing webhook delivery without this would just move the scaling ceiling, not remove it.
- Narrowing that transaction boundary is a real behavior change — code that used to run safely inside one long transaction (any lazy Hibernate association was fine to touch anywhere) no longer does. Shipping it with unclosed lazy-loading gaps would trade one production incident for another, so those had to be found and closed as part of this work, not after.

## What

- **Async webhook delivery.** Webhook ingest now validates and persists the delivery (new `RepoWebhookDelivery` entity, `PENDING` status) in a fast transaction and returns immediately; a poller job claims deliveries and does the workspace fan-out out-of-band, with retry/attempt tracking and retention cleanup. Mirrors the existing `notification_outbox` pattern already in the codebase.
- **PR file-changes pagination fixed.** GitHub and Azure DevOps only fetched the first page of PR-changed-files, so large/monorepo PRs could silently miss files past page one and fail to trigger workspaces that should have matched. GitLab was already correct. Also fixed rename handling (`previous_filename`/`oldPath`) so renamed files match on both old and new paths.
- **Redundant per-workspace fetch removed.** PR file-changes are now fetched once per delivery and reused across all matching workspaces, instead of every workspace re-fetching the same data independently.
- **Scheduler scale-hardening.** `ScheduleJob`'s transaction boundary is narrowed so a job's DB connection isn't held for the full terraform run; workspace fan-out runs on a dedicated bounded executor instead of unbounded parallelism; VCS HTTP calls go through a pooled `RestTemplate` with explicit connect/read timeouts; the Quartz thread pool is sized and validated at startup; Micrometer/Prometheus metrics were added for delivery queue depth/age, fan-out, Quartz, and HikariCP so these failure modes are visible going forward.
- **Dead GitHub endpoint removed.** `GitHubWebhookService` called a commit-status endpoint (`/pulls/{n}/statuses`) that isn't a valid GitHub API endpoint and 404'd on every call (with a broken format string besides) — deleted rather than fixed, since it wasn't doing anything useful.
- **Two `LazyInitializationException` gaps closed.** Narrowing the transaction boundary above exposed lazy Hibernate accesses that used to be implicitly safe: `Collection.item` (caught via a production log) and `Job.address` (found by auditing the executor for the same access pattern, since it's read to build terraform `-target`/`-replace` flags). Both fixed by loading through an explicit repository query/`JOIN FETCH` instead of the lazy relationship. `ScheduleJob.execute()` also gained a safety-net catch so any similar gap fails the job cleanly and retries instead of crashing the worker.

## How

- **Outbox/poller:** `RepoWebhookDelivery` table + repository (`claimForDelivery`, `findDueForDispatch`, `reclaimStuckProcessingRows`, `failStuckProcessingRowsAtMaxAttempts`) backing `RepoWebhookDeliveryPollerJob` and a `RepoWebhookDeliveryRetentionJob`; `RepoWebhookService.processV2Webhook` split into `acceptV2Webhook` (fast, `@Transactional`, enqueues) and `processClaimedDelivery` (fan-out).
- **Pagination:** GitHub follows `Link: rel="next"` with `per_page=100`; Azure DevOps loops `$top`/`$skip` using `nextTop`/`nextSkip` from the response body (verified against Microsoft's REST docs), capped at `MAX_PR_FILE_PAGES`.
- **Redundant fetch:** `processClaimedDelivery` fetches PR file changes once via `repoWebhook.getVcs()` before the workspace loop; per-workspace fetch in `processWorkspaceWebhook` becomes a fallback, only used if the pre-fetched result is empty (Azure DevOps excluded, per an existing code comment about per-workspace credentials).
- **Transaction boundary:** `ScheduleJob.execute()` loads the job via `findById()` outside any wrapping transaction rather than running the whole execution inside one long transaction. The Redis per-job execution lock (`EXECUTION_LOCK_PREFIX`) still guards single-worker processing and is unaffected, since Spring Data JPA commits each repository call's own short transaction regardless of the removed wrapping transaction.
- **Bounded fan-out:** workspace fan-out runs via `CompletableFuture.runAsync(...)` on a dedicated `WorkspaceFanoutExecutorConfig` executor instead of the caller's thread/unbounded parallelism.
- **Pooled HTTP client:** VCS calls go through a shared `PoolingHttpClientConnectionManager`-backed `RestTemplate` (`WebhookHttpClientConfig`) with explicit timeouts; `WebhookServiceBase.makeApiRequest` catches `ResourceAccessException` so a slow/hanging call fails fast instead of hanging a thread.
- **Lazy-loading fixes:** `ReferenceRepository.findByWorkspaceWithCollectionItems` (explicit `JOIN FETCH` on `Collection.item`) and `AddressRepository.findByJob` added to replace the two lazy accesses that broke; `ExecutorService` updated to read through both instead of the entity's lazy relationships.

## Testing

- `mvn -pl api -am test` — 889 tests, `BUILD SUCCESS`. New integration tests run against a real Postgres instance (deliberately not `@Transactional`) specifically for the lazy-loading fixes, since that bug class only reproduces without Spring's test-transaction rollback masking it: `RepoWebhookAcceptV2WebhookIntegrationTest`, `ReferenceRepositoryTest`, `AddressRepositoryTest`.
- tested manually against a private monorepo with 35 workspaces

Closes #3438 