### PR TITLE
feat(ui): add pending status filter to workspace list

### DIFF
--- a/ui/src/modules/organizations/OrganizationDetailsPage.tsx
+++ b/ui/src/modules/organizations/OrganizationDetailsPage.tsx
@@ -60,6 +60,7 @@ export default function OrganizationsDetailPage({ organizationName, setOrganizat
       [WorkspaceStatusFilter.NeverExecuted]: 0,
       [JobStatus.WaitingApproval]: 0,
       [JobStatus.Failed]: 0,
+      [JobStatus.Pending]: 0,
       [JobStatus.Queue]: 0,
       [JobStatus.Running]: 0,
       [JobStatus.Completed]: 0,

--- a/ui/src/modules/workspaces/components/WorkspaceStatusTag.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceStatusTag.tsx
@@ -18,6 +18,8 @@ export default function WorkspaceStatusTag({ status }: Props) {
         return JobStatus.Running;
       case JobStatus.Queue:
         return "Queued";
+      case JobStatus.Pending:
+        return "Pending";
       case JobStatus.WaitingApproval:
         return "Waiting Approval";
       case "NeverExecuted":

--- a/ui/src/modules/workspaces/utils/workspaceStatusColors.ts
+++ b/ui/src/modules/workspaces/utils/workspaceStatusColors.ts
@@ -4,6 +4,7 @@ export const statusColors: Record<string, string> = {
   [JobStatus.Completed]: "#2eb039",
   [JobStatus.Running]: "#108ee9",
   [JobStatus.Queue]: "#8c8c8c",
+  [JobStatus.Pending]: "#8c8c8c",
   [JobStatus.WaitingApproval]: "#fa8f37",
   [JobStatus.Rejected]: "#FB0136",
   [JobStatus.Failed]: "#FB0136",

--- a/ui/src/modules/workspaces/utils/workspaceStatusIcon.tsx
+++ b/ui/src/modules/workspaces/utils/workspaceStatusIcon.tsx
@@ -26,6 +26,7 @@ export function getWorkspaceStatusIcon(status?: string) {
     case JobStatus.Failed:
       return <StopOutlined />;
     case JobStatus.Queue:
+    case JobStatus.Pending:
       return <ClockCircleOutlined />;
     default:
       return <ClockCircleOutlined />;

--- a/ui/src/modules/workspaces/utils/workspaceStatusPalette.tsx
+++ b/ui/src/modules/workspaces/utils/workspaceStatusPalette.tsx
@@ -28,6 +28,7 @@ export const WORKSPACE_STATUS_PALETTE: WorkspaceStatusPaletteEntry[] = [
     color: "#fa8f37",
   },
   { value: JobStatus.Failed, label: "Failed", icon: <StopOutlined />, color: "#FB0136" },
+  { value: JobStatus.Pending, label: "Pending", icon: <ClockCircleOutlined />, color: "#8c8c8c" },
   { value: JobStatus.Queue, label: "Queued", icon: <ClockCircleOutlined />, color: "#8c8c8c" },
   { value: JobStatus.Running, label: "Running", icon: <SyncOutlined />, color: "#108ee9" },
   { value: JobStatus.Completed, label: "Completed", icon: <CheckCircleOutlined />, color: "#2eb039" },


### PR DESCRIPTION
## Summary
- Add a "Pending" status filter pill to the organization-level workspace list, alongside the existing Queued pill
- Seed `Pending` in the status counts map so pending workspaces are counted correctly instead of being silently dropped
- Add matching label/icon/color handling for `pending` in the workspace status tag so it renders consistently wherever workspace status is shown

## Why
`pending` is a valid `JobStatus` (and the default status for a new job) that workspaces can sit in, but the workspace list filter never offered it — those workspaces were invisible to every filter, including their own count. The per-workspace Run list filter already supports Pending; this brings the workspace list filter in line with it. Queued is kept as its own separate filter.

## Test plan
- [x] Rendered `WorkspaceFilter` with mocked status counts in a headless browser and confirmed the "Pending" pill appears between Failed and Queued with the correct count badge
- [x] Clicked the Pending pill and confirmed it activates (shows "Clear all") like the other filters
