### PR TITLE
fix(ui): keep workspace table pagination stable during background refresh

### DIFF
--- a/ui/src/modules/workspaces/components/WorkspaceTable/WorkspaceTable.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceTable/WorkspaceTable.tsx
@@ -188,8 +188,8 @@ export default function WorkspaceTable({
   const isGrouped = !!groups;
 
   useEffect(() => {
-    setPage(1);
-  }, [workspaces]);
+    setPage((prev) => Math.min(prev, Math.max(1, Math.ceil(workspaces.length / pageSize))));
+  }, [workspaces, pageSize]);
 
   const pagedWorkspaces = useMemo(() => {
     const start = (page - 1) * pageSize;

--- a/ui/src/modules/workspaces/components/WorkspaceTable/__tests__/WorkspaceTable.test.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceTable/__tests__/WorkspaceTable.test.tsx
@@ -133,6 +133,54 @@ describe("WorkspaceTable", () => {
     expect(container.querySelector(".ant-pagination")).toBeInTheDocument();
   });
 
+  it("stays on the current page when a background refresh supplies a new array with the same workspaces", () => {
+    const manyWorkspaces: WorkspaceListItem[] = Array.from({ length: 25 }, (_, i) => ({
+      id: `bulk-${i}`,
+      name: `bulk-workspace-${i}`,
+      iacType: "terraform",
+      source: "",
+    }));
+
+    const { container, rerender } = renderTable({ workspaces: manyWorkspaces });
+
+    fireEvent.click(screen.getByTitle("2"));
+    expect(screen.getByText("bulk-workspace-20")).toBeInTheDocument();
+
+    // Simulate a polling refresh: same workspaces, but a brand-new array reference.
+    rerender(
+      <MemoryRouter>
+        <WorkspaceTable {...defaultProps} workspaces={[...manyWorkspaces]} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("bulk-workspace-20")).toBeInTheDocument();
+    expect(container.querySelector(".ant-pagination-item-active")).toHaveTextContent("2");
+  });
+
+  it("clamps to the last valid page when a refresh shrinks the workspace list below the current page", () => {
+    const manyWorkspaces: WorkspaceListItem[] = Array.from({ length: 25 }, (_, i) => ({
+      id: `bulk-${i}`,
+      name: `bulk-workspace-${i}`,
+      iacType: "terraform",
+      source: "",
+    }));
+
+    const { rerender } = renderTable({ workspaces: manyWorkspaces });
+
+    fireEvent.click(screen.getByTitle("2"));
+    expect(screen.getByText("bulk-workspace-20")).toBeInTheDocument();
+
+    const shrunkWorkspaces = manyWorkspaces.slice(0, 5);
+    rerender(
+      <MemoryRouter>
+        <WorkspaceTable {...defaultProps} workspaces={shrunkWorkspaces} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("bulk-workspace-0")).toBeInTheDocument();
+    expect(screen.queryByText("bulk-workspace-20")).not.toBeInTheDocument();
+  });
+
   it("clicking the Name header sorts ascending when not already active", () => {
     renderTable({ sortOption: "status" });
     fireEvent.click(screen.getByText("Name"));


### PR DESCRIPTION
## Summary
- Workspace list pagination was snapping back to page 1 every ~10s while browsing, caused by an effect in `WorkspaceTable` that reset the page on *any* change to the `workspaces` array reference.
- The organization page polls every 10s (and also refreshes on websocket job-status events) and always passes a brand-new array, even when nothing meaningful changed — so the reset fired constantly.
- Fixed by clamping the current page to the valid range instead of unconditionally resetting it. Background refreshes with the same or similar data now leave the current page alone; a real shrink (e.g. filtering results down) still pulls the page back into range.

## Changes
- `ui/src/modules/workspaces/components/WorkspaceTable/WorkspaceTable.tsx`: replace unconditional `setPage(1)` on `workspaces` change with a clamp to `[1, ceil(workspaces.length / pageSize)]`.
- `ui/src/modules/workspaces/components/WorkspaceTable/__tests__/WorkspaceTable.test.tsx`: add regression tests covering (1) page stays put when a refresh supplies a new array reference with the same workspaces, and (2) page clamps to the last valid page when a refresh shrinks the list below the current page.

## Test plan
- [x] `yarn jest src/modules/workspaces/components/WorkspaceTable` — new tests pass; 2 pre-existing unrelated failures (row-click navigation) confirmed to fail identically on `main`, unaffected by this change.
- [x] Manual check: open the workspace list, page to page 2+, wait through a poll cycle, confirm you stay on that page.