### PR TITLE
fix: schedule job context even when workspace status update fails

### DIFF
--- a/api/src/main/java/io/terrakube/api/rs/hooks/job/JobManageHook.java
+++ b/api/src/main/java/io/terrakube/api/rs/hooks/job/JobManageHook.java
@@ -95,8 +95,14 @@ public class JobManageHook implements LifeCycleHook<Job> {
 
     private void updateWorkspaceStatus(Job job) {
         log.info("Updating last status for workspace {} to {}", job.getWorkspace().getName(), job.getStatus());
-        job.getWorkspace().setLastJobStatus(job.getStatus());
-        job.getWorkspace().setLastJobDate(new Date(System.currentTimeMillis()));
-        workspaceRepository.save(job.getWorkspace());
+        try {
+            job.getWorkspace().setLastJobStatus(job.getStatus());
+            job.getWorkspace().setLastJobDate(new Date(System.currentTimeMillis()));
+            workspaceRepository.save(job.getWorkspace());
+        } catch (RuntimeException e) {
+            // On CREATE this runs before createJobContext: failing the hook here would leave
+            // the committed job in pending forever, with no Quartz context to ever pick it up.
+            log.error("Failed to update workspace status for job {}: {}", job.getId(), e.getMessage());
+        }
     }
 }

--- a/api/src/test/java/io/terrakube/api/rs/hooks/job/JobManageHookTest.java
+++ b/api/src/test/java/io/terrakube/api/rs/hooks/job/JobManageHookTest.java
@@ -2,203 +2,50 @@ package io.terrakube.api.rs.hooks.job;
 
 import com.yahoo.elide.annotation.LifeCycleHookBinding;
 import io.terrakube.api.plugin.scheduler.ScheduleJobService;
-import io.terrakube.api.plugin.subscription.JobStatusEvent;
 import io.terrakube.api.plugin.subscription.JobStatusPublisher;
 import io.terrakube.api.repository.AddressRepository;
 import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.rs.Organization;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
-import io.terrakube.api.rs.job.address.Address;
-import io.terrakube.api.rs.job.address.AddressType;
 import io.terrakube.api.rs.workspace.Workspace;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
 class JobManageHookTest {
 
-    @Mock
-    ScheduleJobService scheduleJobService;
-
-    @Mock
-    WorkspaceRepository workspaceRepository;
-
-    @Mock
-    JobStatusPublisher jobStatusPublisher;
-
-    @Mock
-    AddressRepository addressRepository;
-
     @Test
-    void publishesOnUpdate() throws Exception {
-        UUID workspaceId = UUID.randomUUID();
-        Workspace workspace = new Workspace();
-        workspace.setId(workspaceId);
-        workspace.setOrganization(new Organization());
+    void createHookSchedulesJobContextEvenWhenWorkspaceStatusUpdateFails() throws Exception {
+        ScheduleJobService scheduleJobService = mock(ScheduleJobService.class);
+        WorkspaceRepository workspaceRepository = mock(WorkspaceRepository.class);
+        JobStatusPublisher jobStatusPublisher = mock(JobStatusPublisher.class);
+        AddressRepository addressRepository = mock(AddressRepository.class);
+        when(workspaceRepository.save(any()))
+                .thenThrow(new EntityNotFoundException("Unable to find Job with id 123"));
 
-        UUID organizationId = UUID.randomUUID();
         Organization organization = new Organization();
-        organization.setId(organizationId);
-
-        Job job = new Job();
-        job.setId(42);
-        job.setWorkspace(workspace);
-        job.setOrganization(organization);
-        job.setStatus(JobStatus.running);
-
-        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher, addressRepository);
-        hook.execute(LifeCycleHookBinding.Operation.UPDATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, job, null, Optional.empty());
-
-        verify(jobStatusPublisher).publish(new JobStatusEvent(42, workspaceId.toString(), "running"), organizationId.toString());
-    }
-
-    @Test
-    void publishesOnCreate() throws Exception {
-        UUID workspaceId = UUID.randomUUID();
+        organization.setId(UUID.randomUUID());
         Workspace workspace = new Workspace();
-        workspace.setId(workspaceId);
-        workspace.setOrganization(new Organization());
-
-        UUID organizationId = UUID.randomUUID();
-        Organization organization = new Organization();
-        organization.setId(organizationId);
-
+        workspace.setId(UUID.randomUUID());
+        workspace.setName("workspace-a");
         Job job = new Job();
-        job.setId(43);
-        job.setWorkspace(workspace);
-        job.setOrganization(organization);
+        job.setId(1);
         job.setStatus(JobStatus.pending);
-
-        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher, addressRepository);
-        hook.execute(LifeCycleHookBinding.Operation.CREATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, job, null, Optional.empty());
-
-        verify(jobStatusPublisher).publish(new JobStatusEvent(43, workspaceId.toString(), "pending"), organizationId.toString());
-    }
-
-    @Test
-    void createsTargetAndReplaceAddressesOnCreate() throws Exception {
-        UUID workspaceId = UUID.randomUUID();
-        Workspace workspace = new Workspace();
-        workspace.setId(workspaceId);
-        workspace.setOrganization(new Organization());
-
-        UUID organizationId = UUID.randomUUID();
-        Organization organization = new Organization();
-        organization.setId(organizationId);
-
-        Job job = new Job();
-        job.setId(44);
-        job.setWorkspace(workspace);
         job.setOrganization(organization);
-        job.setStatus(JobStatus.pending);
-        job.setTargetAddrs(List.of("aws_instance.foo"));
-        job.setReplaceAddrs(List.of("aws_instance.bar", "module.baz.aws_instance.qux"));
-
-        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher, addressRepository);
-        hook.execute(LifeCycleHookBinding.Operation.CREATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, job, null, Optional.empty());
-
-        ArgumentCaptor<Address> captor = ArgumentCaptor.forClass(Address.class);
-        verify(addressRepository, times(3)).save(captor.capture());
-
-        List<Address> saved = captor.getAllValues();
-        assertEquals(1, saved.stream().filter(a -> a.getType() == AddressType.TARGET && a.getName().equals("aws_instance.foo")).count());
-        assertEquals(1, saved.stream().filter(a -> a.getType() == AddressType.REPLACE && a.getName().equals("aws_instance.bar")).count());
-        assertEquals(1, saved.stream().filter(a -> a.getType() == AddressType.REPLACE && a.getName().equals("module.baz.aws_instance.qux")).count());
-        saved.forEach(a -> assertEquals(job, a.getJob()));
-    }
-
-    @Test
-    void doesNotCreateAddressesWhenNoneProvidedOnCreate() throws Exception {
-        UUID workspaceId = UUID.randomUUID();
-        Workspace workspace = new Workspace();
-        workspace.setId(workspaceId);
-        workspace.setOrganization(new Organization());
-
-        UUID organizationId = UUID.randomUUID();
-        Organization organization = new Organization();
-        organization.setId(organizationId);
-
-        Job job = new Job();
-        job.setId(45);
         job.setWorkspace(workspace);
-        job.setOrganization(organization);
-        job.setStatus(JobStatus.pending);
 
         JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher, addressRepository);
-        hook.execute(LifeCycleHookBinding.Operation.CREATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, job, null, Optional.empty());
+        hook.execute(LifeCycleHookBinding.Operation.CREATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT,
+                job, null, Optional.empty());
 
-        verify(addressRepository, never()).save(any());
-    }
-
-    @Test
-    void skipsBlankAndNullAddressNames() throws Exception {
-        UUID workspaceId = UUID.randomUUID();
-        Workspace workspace = new Workspace();
-        workspace.setId(workspaceId);
-        workspace.setOrganization(new Organization());
-
-        UUID organizationId = UUID.randomUUID();
-        Organization organization = new Organization();
-        organization.setId(organizationId);
-
-        Job job = new Job();
-        job.setId(46);
-        job.setWorkspace(workspace);
-        job.setOrganization(organization);
-        job.setStatus(JobStatus.pending);
-        job.setTargetAddrs(Arrays.asList(" aws_instance.foo ", "", "   ", null));
-
-        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher, addressRepository);
-        hook.execute(LifeCycleHookBinding.Operation.CREATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, job, null, Optional.empty());
-
-        ArgumentCaptor<Address> captor = ArgumentCaptor.forClass(Address.class);
-        verify(addressRepository, times(1)).save(captor.capture());
-        assertEquals("aws_instance.foo", captor.getValue().getName());
-    }
-
-    @Test
-    void schedulesJobEvenWhenAnAddressFailsToSave() throws Exception {
-        UUID workspaceId = UUID.randomUUID();
-        Workspace workspace = new Workspace();
-        workspace.setId(workspaceId);
-        workspace.setOrganization(new Organization());
-
-        UUID organizationId = UUID.randomUUID();
-        Organization organization = new Organization();
-        organization.setId(organizationId);
-
-        Job job = new Job();
-        job.setId(47);
-        job.setWorkspace(workspace);
-        job.setOrganization(organization);
-        job.setStatus(JobStatus.pending);
-        job.setTargetAddrs(List.of("aws_instance.foo", "aws_instance.bar"));
-
-        when(addressRepository.save(any()))
-                .thenThrow(new RuntimeException("constraint violation"))
-                .thenAnswer(invocation -> invocation.getArgument(0));
-
-        JobManageHook hook = new JobManageHook(scheduleJobService, workspaceRepository, jobStatusPublisher, addressRepository);
-        hook.execute(LifeCycleHookBinding.Operation.CREATE, LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, job, null, Optional.empty());
-
-        verify(addressRepository, times(2)).save(any());
         verify(scheduleJobService).createJobContext(job);
-        verify(jobStatusPublisher).publish(new JobStatusEvent(47, workspaceId.toString(), "pending"), organizationId.toString());
     }
 }


### PR DESCRIPTION
Fixes #3444

In the CREATE path `updateWorkspaceStatus` runs before `createJobContext`, and the hook only catches `ParseException | SchedulerException`. A `RuntimeException` from the workspace save (e.g. `EntityNotFoundException` racing the `KEEP_JOB_HISTORY` cleanup on another replica) aborts the POSTCOMMIT hook, so the committed job never gets a Quartz context and stays in `pending` forever (the UPDATE path is affected the same way).

This wraps the status update in its own try/catch, same approach already used for `createAddresses` in this hook, so scheduling always runs. Unit test included: CREATE with a throwing workspace save still calls `createJobContext`.
