### PR TITLE
fix(ui): unify workspace/job status badge rendering

### DIFF
--- a/ui/src/domain/Jobs/Details.tsx
+++ b/ui/src/domain/Jobs/Details.tsx
@@ -1,23 +1,16 @@
-import {
-  CheckCircleOutlined,
-  CheckOutlined,
-  ClockCircleOutlined,
-  CloseCircleOutlined,
-  CloseOutlined,
-  CommentOutlined,
-  ExclamationCircleOutlined,
-  StopOutlined,
-  SyncOutlined,
-  UserOutlined,
-} from "@ant-design/icons";
+import { CheckOutlined, CloseOutlined, CommentOutlined, StopOutlined, UserOutlined } from "@ant-design/icons";
 import { Alert, Avatar, Button, Card, Collapse, message, Radio, RadioChangeEvent, Space, Spin, Tag, Typography } from "antd";
 import { AxiosResponse } from "axios";
 import parse from "html-react-parser";
 import { DateTime } from "luxon";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { cloneElement, useCallback, useEffect, useRef, useState } from "react";
 import { ORGANIZATION_ARCHIVE } from "../../config/actionTypes";
 import axiosInstance, { axiosClient } from "../../config/axiosConfig";
 import { useAbortController, usePolling, useStructuredOutputStream } from "../../hooks";
+import WorkspaceStatusTag from "../../modules/workspaces/components/WorkspaceStatusTag";
+import { statusColors } from "../../modules/workspaces/utils/workspaceStatusColors";
+import { getWorkspaceStatusIcon } from "../../modules/workspaces/utils/workspaceStatusIcon";
+import { getWorkspaceStatusText } from "../../modules/workspaces/utils/workspaceStatusText";
 import { IncludedItem, Job, JobStep, Workspace } from "../types";
 import { LiveTerminalOutput } from "./LiveTerminalOutput";
 import { getJobOutputRequestUrl, getPublicApiOrigin, isTerrakubeApiUrl } from "./outputUrl";
@@ -38,7 +31,6 @@ import {
 type Props = {
   jobId: string;
 };
-
 
 const TERMINAL_JOB_STATUSES = new Set(["completed", "noChanges", "failed", "cancelled", "rejected", "notExecuted"]);
 const INCOMPLETE_VARIABLE_GUARD_STEP_NAME = "Incomplete sensitive variables";
@@ -264,7 +256,6 @@ export const DetailsJob = ({ jobId }: Props) => {
       return null;
     }
 
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- purely a propagation
     // guard so a click inside this toggle never reaches the Collapse header's own click-to-toggle handler.
     return (
       <div onClick={(event) => event.stopPropagation()}>
@@ -321,7 +312,7 @@ export const DetailsJob = ({ jobId }: Props) => {
       <span>
         {getIconStatus(item)}
         <h3 style={{ display: "inline" }}>
-          &nbsp; {item.name} {item.status}
+          &nbsp; {item.name} {getWorkspaceStatusText(item.status)}
         </h3>
       </span>
     );
@@ -353,23 +344,12 @@ export const DetailsJob = ({ jobId }: Props) => {
       });
   };
 
+  // Delegates to the same status -> icon/color map WorkspaceStatusTag uses, so a step's icon
+  // always matches the color/shape used everywhere else status is shown for the same status value.
   const getIconStatus = (item: JobStep) => {
-    switch (item.status) {
-      case "completed":
-        return <CheckCircleOutlined style={{ fontSize: "20px", color: "#52c41a" }} />;
-      case "noChanges":
-        return <CheckCircleOutlined style={{ fontSize: "20px", color: "#52c41a" }} />;
-      case "notExecuted":
-        return <CheckCircleOutlined style={{ fontSize: "20px", color: "#fa8f37" }} />;
-      case "running":
-        return <SyncOutlined spin style={{ color: "#108ee9", fontSize: "20px" }} />;
-      case "failed":
-        return <CloseCircleOutlined style={{ fontSize: "20px", color: "#FB0136" }} />;
-      case "cancelled":
-        return <CloseCircleOutlined style={{ fontSize: "20px", color: "#FB0136" }} />;
-      default:
-        return <ClockCircleOutlined style={{ fontSize: "20px" }} />;
-    }
+    return cloneElement(getWorkspaceStatusIcon(item.status), {
+      style: { fontSize: "20px", color: statusColors[item.status] },
+    });
   };
 
   const handleApprove = () => {
@@ -626,42 +606,7 @@ export const DetailsJob = ({ jobId }: Props) => {
             ? renderPrCommentErrorAlert(job.data.attributes.prCommentError, job.data.attributes.prNumber)
             : null}
           <div>
-            <Tag
-              icon={
-                job.data.attributes.status === "completed" ? (
-                  <CheckCircleOutlined />
-                ) : job.data.attributes.status === "running" ? (
-                  <SyncOutlined spin />
-                ) : job.data.attributes.status === "waitingApproval" ? (
-                  <ExclamationCircleOutlined />
-                ) : job.data.attributes.status === "cancelled" ? (
-                  <StopOutlined />
-                ) : job.data.attributes.status === "failed" ? (
-                  <StopOutlined />
-                ) : (
-                  <ClockCircleOutlined />
-                )
-              }
-              color={
-                job.data.attributes.status === "completed"
-                  ? "#2eb039"
-                  : job.data.attributes.status === "noChanges"
-                    ? "#2eb039"
-                    : job.data.attributes.status === "notExecuted"
-                      ? "#fa8f37"
-                      : job.data.attributes.status === "running"
-                        ? "#108ee9"
-                        : job.data.attributes.status == "waitingApproval"
-                          ? "#fa8f37"
-                          : job.data.attributes.status == "rejected"
-                            ? "#FB0136"
-                            : job.data.attributes.status == "failed"
-                              ? "#FB0136"
-                              : ""
-              }
-            >
-              {job.data.attributes.status}
-            </Tag>{" "}
+            <WorkspaceStatusTag status={job.data.attributes.status} />{" "}
             <h2 style={{ display: "inline" }}>Triggered via UI</h2>
           </div>
 
@@ -730,20 +675,17 @@ export const DetailsJob = ({ jobId }: Props) => {
           {steps.length > 0 ? (
             steps.map((item) => {
               const stepLabel = renderStepLabel(item);
-
-              if (!shouldStepBeCollapsible(item)) {
-                return (
-                  <Card key={item.id} size="small" style={{ width: "100%" }}>
-                    {stepLabel}
-                  </Card>
-                );
-              }
+              // Steps with nothing to show yet (e.g. a pending approval step) still render through
+              // Collapse rather than a bare Card - a disabled panel keeps the same arrow/label/extra
+              // grid as every expandable step, so rows stay in one aligned column instead of the
+              // Card variant's text sitting flush left of the others.
+              const isCollapsible = shouldStepBeCollapsible(item);
 
               return (
                 <Collapse
                   key={item.id}
                   style={{ width: "100%" }}
-                  activeKey={activeStepKeys[item.id] ?? []}
+                  activeKey={isCollapsible ? (activeStepKeys[item.id] ?? []) : []}
                   onChange={(keys) => {
                     userToggledStepIds.current.add(item.id);
                     setActiveStepKeys((previous) => ({
@@ -755,8 +697,9 @@ export const DetailsJob = ({ jobId }: Props) => {
                     {
                       key: "2",
                       label: stepLabel,
-                      extra: renderStepExtra(item),
-                      children: renderStepContent(item),
+                      collapsible: isCollapsible ? undefined : "disabled",
+                      extra: isCollapsible ? renderStepExtra(item) : undefined,
+                      children: isCollapsible ? renderStepContent(item) : undefined,
                     },
                   ]}
                 />
@@ -771,8 +714,14 @@ export const DetailsJob = ({ jobId }: Props) => {
               <Card
                 title={
                   <span style={{ fontSize: "14px" }}>
-                    <b>Needs Confirmation:</b> Someone from <b>{job.data.attributes.approvalTeam}</b> must confirm to
-                    continue.
+                    <b>Needs Confirmation:</b>{" "}
+                    {job.data.attributes.approvalTeam ? (
+                      <>
+                        Someone from <b>{job.data.attributes.approvalTeam}</b> must confirm to continue.
+                      </>
+                    ) : (
+                      "Someone must confirm to continue."
+                    )}
                   </span>
                 }
               >

--- a/ui/src/domain/Jobs/StructuredPlanOutput.tsx
+++ b/ui/src/domain/Jobs/StructuredPlanOutput.tsx
@@ -1569,7 +1569,6 @@ export const StructuredPlanOutput = ({ changes, outputLog, applyMode = false, ou
                   <div
                     key={segment.key}
                     className={`structured-plan-summarySegment structured-plan-summarySegment--${segment.key}`}
-                    style={{ flexGrow: segment.count }}
                   >
                     <span className="structured-plan-summarySymbol">{segment.symbol}</span>
                     <span>{segment.label}</span>

--- a/ui/src/domain/Jobs/__tests__/Details.test.tsx
+++ b/ui/src/domain/Jobs/__tests__/Details.test.tsx
@@ -200,7 +200,7 @@ describe("DetailsJob SSE reconnect behavior", () => {
       // for the transition to actually happen.
       await waitFor(
         () => {
-          expect(screen.getByText("completed")).toBeInTheDocument();
+          expect(screen.getByText("Completed")).toBeInTheDocument();
         },
         { timeout: 8000 }
       );

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -1,13 +1,9 @@
 import {
-  CheckCircleOutlined,
   ClockCircleOutlined,
-  ExclamationCircleOutlined,
   FolderOutlined,
   LockOutlined,
   PlayCircleOutlined,
   ProfileOutlined,
-  StopOutlined,
-  SyncOutlined,
   ThunderboltOutlined,
   UnlockOutlined,
   UserOutlined,
@@ -28,7 +24,6 @@ import {
   Spin,
   Table,
   Tabs,
-  Tag,
   Typography,
   Card,
   Segmented,
@@ -73,6 +68,7 @@ import { getIaCIconById, getIaCNameById, renderVCSLogo } from "./Workspaces";
 import "./Workspaces.css";
 import LoadingFallback from "@/components/LoadingFallback";
 import RunList from "@/modules/workspaces/components/RunList";
+import WorkspaceStatusTag from "@/modules/workspaces/components/WorkspaceStatusTag";
 
 import { setupWorkspaceIncludes, isValidUrl, fixSshURL, StateOutputVariableWithName } from "./workspaceDataUtils";
 const DetailsJob = lazy(() => import("../Jobs/Details").then((m) => ({ default: m.DetailsJob })));
@@ -616,28 +612,7 @@ export const WorkspaceDetails = ({
                                   <Col>
                                     {
                                       <div className="textLeft">
-                                        <Tag
-                                          icon={
-                                            item.status == "completed" ? (
-                                              <CheckCircleOutlined />
-                                            ) : item.status == "running" ? (
-                                              <SyncOutlined spin />
-                                            ) : item.status === "waitingApproval" ? (
-                                              <ExclamationCircleOutlined />
-                                            ) : item.status === "cancelled" ? (
-                                              <StopOutlined />
-                                            ) : item.status === "failed" ? (
-                                              <StopOutlined />
-                                            ) : item.status === "notExecuted" ? (
-                                              <CheckCircleOutlined />
-                                            ) : (
-                                              <ClockCircleOutlined />
-                                            )
-                                          }
-                                          color={item.statusColor}
-                                        >
-                                          {item.status}
-                                        </Tag>{" "}
+                                        <WorkspaceStatusTag status={item.status} />{" "}
                                       </div>
                                     }
                                   </Col>

--- a/ui/src/domain/Workspaces/workspaceDataUtils.ts
+++ b/ui/src/domain/Workspaces/workspaceDataUtils.ts
@@ -114,34 +114,9 @@ export async function setupWorkspaceIncludes(
         );
         break;
       case include.JOB:
-        let finalColor = "";
-        switch (element.attributes.status) {
-          case "completed":
-            finalColor = "#2eb039";
-            break;
-          case "noChanges":
-            finalColor = "#9f37fa";
-            break;
-          case "rejected":
-            finalColor = "#FB0136";
-            break;
-          case "failed":
-            finalColor = "#FB0136";
-            break;
-          case "running":
-            finalColor = "#108ee9";
-            break;
-          case "waitingApproval":
-            finalColor = "#fa8f37";
-            break;
-          default:
-            finalColor = "";
-            break;
-        }
         jobs.push({
           id: element.id,
           title: "Queue manually using " + getIaCNameById(data?.data?.attributes?.iacType),
-          statusColor: finalColor,
           commitId: element.attributes.commitId,
           stepNumber: element.attributes.stepNumber,
           latestChange: DateTime.fromISO(element.attributes.createdDate).toRelative(),

--- a/ui/src/domain/types.ts
+++ b/ui/src/domain/types.ts
@@ -151,7 +151,6 @@ export type FlatJob = {
   id: string;
   title: string;
   status: JobStatus;
-  statusColor: string;
   latestChange: string;
   commitId?: string;
   createdBy: string;

--- a/ui/src/modules/workspaces/components/RunFilter.tsx
+++ b/ui/src/modules/workspaces/components/RunFilter.tsx
@@ -1,15 +1,15 @@
-import {
-  BarsOutlined,
-  ExclamationCircleOutlined,
-  StopOutlined,
-  SyncOutlined,
-  CheckCircleOutlined,
-  ClockCircleOutlined,
-  PauseCircleOutlined,
-} from "@ant-design/icons";
+import { BarsOutlined } from "@ant-design/icons";
 import { Card, Row, Col, Segmented, theme, Select, Flex } from "antd";
 import { FlatJob, JobStatus } from "../../../domain/types";
-import { useEffect, useState, useMemo, ReactNode } from "react";
+import { cloneElement, useEffect, useState, useMemo } from "react";
+import { statusColors } from "../utils/workspaceStatusColors";
+import { getWorkspaceStatusIcon } from "../utils/workspaceStatusIcon";
+import { getWorkspaceStatusText } from "../utils/workspaceStatusText";
+
+// getWorkspaceStatusIcon returns a bare icon (colored via its parent Tag elsewhere) - here the
+// icon sits directly in a Segmented option with no colored wrapper, so it needs its own color.
+const getColoredStatusIcon = (status: string) =>
+  cloneElement(getWorkspaceStatusIcon(status), { style: { color: statusColors[status] } });
 
 type Props = {
   jobs: FlatJob[];
@@ -22,35 +22,9 @@ type StatusCount = {
   [key: string]: number;
 };
 
-type StatusIconMap = {
-  [key in JobStatus | "All"]: ReactNode;
-};
-
 // Storage keys for persisting filter state
 const RUNS_FILTER_KEY = "runsFilterValue";
 const RUNS_TEMPLATE_FILTER_KEY = "runsTemplateFilter";
-
-// Map status to their icons and colors
-const statusIcons: StatusIconMap = {
-  [JobStatus.Completed]: <CheckCircleOutlined style={{ color: "#2eb039" }} />,
-  [JobStatus.NoChanges]: <CheckCircleOutlined style={{ color: "#2eb039" }} />,
-  [JobStatus.Running]: <SyncOutlined style={{ color: "#108ee9" }} />,
-  [JobStatus.WaitingApproval]: <ExclamationCircleOutlined style={{ color: "#fa8f37" }} />,
-  [JobStatus.Pending]: <PauseCircleOutlined style={{ color: "#808080" }} />,
-  [JobStatus.Cancelled]: <StopOutlined style={{ color: "#FB0136" }} />,
-  [JobStatus.Failed]: <StopOutlined style={{ color: "#FB0136" }} />,
-  [JobStatus.Approved]: <CheckCircleOutlined style={{ color: "#2eb039" }} />,
-  [JobStatus.Queue]: <ClockCircleOutlined style={{ color: "#808080" }} />,
-  [JobStatus.Rejected]: <StopOutlined style={{ color: "#FB0136" }} />,
-  [JobStatus.Unknown]: <ExclamationCircleOutlined style={{ color: "#808080" }} />,
-  [JobStatus.NotExecuted]: <ClockCircleOutlined style={{ color: "#808080" }} />,
-  All: <BarsOutlined />,
-};
-
-// Helper function to capitalize first letter
-const capitalize = (str: string): string => {
-  return str.charAt(0).toUpperCase() + str.slice(1);
-};
 
 // Safely parse JSON with a fallback value
 const safeJsonParse = (jsonString: string | null, fallback: any): any => {
@@ -139,22 +113,22 @@ export default function RunFilter({ jobs, onFiltered, applyFilter, templateNames
 
     // Add the statuses we always want to show first, in the specified order
     for (const status of alwaysShowStatuses) {
-      const displayText = status === "All" ? "All" : capitalize(status);
+      const displayText = status === "All" ? "All" : getWorkspaceStatusText(status);
       options.push({
         label: `${displayText} ${statusCounts[status] || 0}`,
         value: status,
-        icon: statusIcons[status as JobStatus],
+        icon: status === "All" ? <BarsOutlined /> : getColoredStatusIcon(status),
       });
     }
 
     // Add any additional statuses that exist in the data and aren't already added
     Object.keys(statusCounts).forEach((status) => {
       if (!alwaysShowStatuses.includes(status as JobStatus | "All") && statusCounts[status] > 0) {
-        const displayText = status === "All" ? "All" : capitalize(status);
+        const displayText = status === "All" ? "All" : getWorkspaceStatusText(status);
         options.push({
           label: `${displayText} ${statusCounts[status]}`,
           value: status,
-          icon: statusIcons[status as JobStatus],
+          icon: status === "All" ? <BarsOutlined /> : getColoredStatusIcon(status),
         });
       }
     });

--- a/ui/src/modules/workspaces/components/RunList.tsx
+++ b/ui/src/modules/workspaces/components/RunList.tsx
@@ -1,18 +1,11 @@
 import { List, Avatar, Tag, Pagination, Tooltip, Button } from "antd";
-import {
-  UserOutlined,
-  CheckCircleOutlined,
-  ClockCircleOutlined,
-  CloseSquareOutlined,
-  StopOutlined,
-  SyncOutlined,
-  WarningOutlined,
-} from "@ant-design/icons";
-import { FlatJob, JobStatus } from "../../../domain/types";
+import { UserOutlined, WarningOutlined } from "@ant-design/icons";
+import { FlatJob } from "../../../domain/types";
 import { useState, useEffect, useCallback } from "react";
 import axiosInstance from "../../../config/axiosConfig";
 import { ORGANIZATION_ARCHIVE } from "../../../config/actionTypes";
 import RunFilter from "./RunFilter";
+import WorkspaceStatusTag from "./WorkspaceStatusTag";
 
 // Storage key for persisting pagination state
 const RUNS_PAGE_KEY = "runsCurrentPage";
@@ -116,54 +109,6 @@ export default function RunList({ jobs, onRunClick }: Props) {
     return "Terraform";
   };
 
-  const getStatusTagColor = (status: JobStatus): string => {
-    switch (status) {
-      case JobStatus.Completed:
-        return "success";
-      case JobStatus.NoChanges:
-        return "purple";
-      case JobStatus.Running:
-        return "processing";
-      case JobStatus.WaitingApproval:
-        return "warning";
-      case JobStatus.Failed:
-        return "error";
-      case JobStatus.Cancelled:
-        return "error";
-      case JobStatus.Rejected:
-        return "error";
-      default:
-        return "default";
-    }
-  };
-
-  const renderStatusTag = (status: JobStatus) => (
-    <Tag
-      icon={
-        status === JobStatus.Completed ? (
-          <CheckCircleOutlined />
-        ) : status === JobStatus.NoChanges ? (
-          <CheckCircleOutlined />
-        ) : status === JobStatus.Running ? (
-          <SyncOutlined spin />
-        ) : status === JobStatus.WaitingApproval ? (
-          <WarningOutlined />
-        ) : status === JobStatus.Failed ? (
-          <CloseSquareOutlined />
-        ) : status === JobStatus.Cancelled ? (
-          <StopOutlined />
-        ) : status === JobStatus.Rejected ? (
-          <CloseSquareOutlined />
-        ) : (
-          <ClockCircleOutlined />
-        )
-      }
-      color={getStatusTagColor(status)}
-    >
-      {status.toLowerCase()}
-    </Tag>
-  );
-
   const sortedJobs = filteredJobs.sort((a, b) => parseInt(a.id) - parseInt(b.id)).reverse();
   const paginatedJobs = sortedJobs.slice((currentPage - 1) * pageSize, currentPage * pageSize);
 
@@ -194,7 +139,7 @@ export default function RunList({ jobs, onRunClick }: Props) {
           <List.Item
             actions={[
               <div key="status" style={{ textAlign: "right" }}>
-                {renderStatusTag(item.status)}
+                <WorkspaceStatusTag status={item.status} />
                 {item.prCommentError && (
                   <Tooltip title={item.prCommentError}>
                     <WarningOutlined style={{ color: "#fa8f37", marginLeft: 6 }} />

--- a/ui/src/modules/workspaces/components/WorkspaceStatusTag.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceStatusTag.tsx
@@ -1,43 +1,16 @@
 import { Tag } from "antd";
-import { JobStatus } from "../../../domain/types";
 import { statusColors } from "../utils/workspaceStatusColors";
 import { getWorkspaceStatusIcon } from "../utils/workspaceStatusIcon";
+import { getWorkspaceStatusText } from "../utils/workspaceStatusText";
 
 type Props = {
   status?: string;
 };
 
 export default function WorkspaceStatusTag({ status }: Props) {
-  const getStatusText = () => {
-    switch (status) {
-      case JobStatus.Completed:
-        return JobStatus.Completed;
-      case JobStatus.NoChanges:
-        return "No Changes";
-      case JobStatus.Running:
-        return JobStatus.Running;
-      case JobStatus.Queue:
-        return "Queued";
-      case JobStatus.Pending:
-        return "Pending";
-      case JobStatus.WaitingApproval:
-        return "Waiting Approval";
-      case "NeverExecuted":
-        return "Never Executed";
-      case JobStatus.Rejected:
-        return JobStatus.Rejected;
-      case JobStatus.Cancelled:
-        return JobStatus.Cancelled;
-      case JobStatus.Failed:
-        return JobStatus.Failed;
-      default:
-        return status;
-    }
-  };
-
   return (
     <Tag icon={getWorkspaceStatusIcon(status)} color={status && statusColors[status]}>
-      {getStatusText()}
+      {getWorkspaceStatusText(status)}
     </Tag>
   );
 }

--- a/ui/src/modules/workspaces/utils/workspaceStatusColors.ts
+++ b/ui/src/modules/workspaces/utils/workspaceStatusColors.ts
@@ -6,7 +6,11 @@ export const statusColors: Record<string, string> = {
   [JobStatus.Queue]: "#8c8c8c",
   [JobStatus.Pending]: "#8c8c8c",
   [JobStatus.WaitingApproval]: "#fa8f37",
+  [JobStatus.NotExecuted]: "#fa8f37",
   [JobStatus.Rejected]: "#FB0136",
   [JobStatus.Failed]: "#FB0136",
+  [JobStatus.Cancelled]: "#FB0136",
   [JobStatus.NoChanges]: "#e037fa",
+  [JobStatus.Approved]: "#2eb039",
+  [JobStatus.Unknown]: "#8c8c8c",
 };

--- a/ui/src/modules/workspaces/utils/workspaceStatusIcon.tsx
+++ b/ui/src/modules/workspaces/utils/workspaceStatusIcon.tsx
@@ -18,6 +18,8 @@ export function getWorkspaceStatusIcon(status?: string) {
       return <SyncOutlined spin />;
     case JobStatus.WaitingApproval:
       return <ExclamationCircleOutlined />;
+    case JobStatus.NotExecuted:
+      return <CheckCircleOutlined />;
     case "NeverExecuted":
       return <InfoCircleOutlined />;
     case JobStatus.Rejected:
@@ -28,6 +30,10 @@ export function getWorkspaceStatusIcon(status?: string) {
     case JobStatus.Queue:
     case JobStatus.Pending:
       return <ClockCircleOutlined />;
+    case JobStatus.Approved:
+      return <CheckCircleOutlined />;
+    case JobStatus.Unknown:
+      return <ExclamationCircleOutlined />;
     default:
       return <ClockCircleOutlined />;
   }

--- a/ui/src/modules/workspaces/utils/workspaceStatusPalette.tsx
+++ b/ui/src/modules/workspaces/utils/workspaceStatusPalette.tsx
@@ -23,7 +23,7 @@ export const WORKSPACE_STATUS_PALETTE: WorkspaceStatusPaletteEntry[] = [
   { value: WorkspaceStatusFilter.All, label: "All", icon: <BarsOutlined /> },
   {
     value: JobStatus.WaitingApproval,
-    label: "Awaiting approval",
+    label: "Waiting Approval",
     icon: <ExclamationCircleOutlined />,
     color: "#fa8f37",
   },

--- a/ui/src/modules/workspaces/utils/workspaceStatusText.ts
+++ b/ui/src/modules/workspaces/utils/workspaceStatusText.ts
@@ -1,0 +1,34 @@
+import { JobStatus } from "../../../domain/types";
+
+export function getWorkspaceStatusText(status?: string): string | undefined {
+  switch (status) {
+    case JobStatus.Completed:
+      return "Completed";
+    case JobStatus.NoChanges:
+      return "No Changes";
+    case JobStatus.Running:
+      return "Running";
+    case JobStatus.Queue:
+      return "Queued";
+    case JobStatus.Pending:
+      return "Pending";
+    case JobStatus.WaitingApproval:
+      return "Waiting Approval";
+    case JobStatus.NotExecuted:
+      return "Not Executed";
+    case "NeverExecuted":
+      return "Never Executed";
+    case JobStatus.Rejected:
+      return "Rejected";
+    case JobStatus.Cancelled:
+      return "Cancelled";
+    case JobStatus.Failed:
+      return "Failed";
+    case JobStatus.Approved:
+      return "Approved";
+    case JobStatus.Unknown:
+      return "Unknown";
+    default:
+      return status;
+  }
+}


### PR DESCRIPTION
## What

Unifies status badge rendering (color, icon, text) across the workspace/job UI, and fixes several related layout and copy bugs that came out of the same investigation:

- Job Details page: top-level job status tag, and the per-step status list
- Workspace overview page: "Latest Run" panel and the Runs tab list (`RunList`)
- Runs page filter (`RunFilter`) and the compact workspace status filter pills
- Job step list column alignment (pending/approval steps sat flush-left of expandable ones)
- Terraform plan output summary badges (create/change/destroy pills sized proportional to resource count instead of evenly)
- "Needs Confirmation" approval text when no approval team is assigned

## Why

Status badges had drifted into five separate, hand-rolled implementations across the codebase, each with its own switch/ternary for color, icon, and label text. The result was visibly inconsistent: some badges showed raw enum values (`waitingApproval`, `completed`) while others showed humanized text (`Waiting Approval`), colors didn't match between pages for the same status, and the Runs filter mangled camelCase values into run-on labels (`WaitingApproval`, `NoChanges`). One of those hardcoded maps was also missing a real enum member, causing a live TypeScript compile error.

## How

- Consolidated all badge rendering onto the existing `WorkspaceStatusTag` component and its `statusColors` / `getWorkspaceStatusIcon` / `getWorkspaceStatusText` (new) helpers, removing four duplicate implementations
- Fixed `getWorkspaceStatusText` returning raw lowercase enum values for `completed`/`running`/`failed`/`rejected`/`cancelled` instead of Title Case, and filled in missing `NotExecuted`/`Cancelled`/`Approved`/`Unknown` entries in the canonical color/icon maps
- Replaced the job step list's `Card`/`Collapse` branching with a single `Collapse`-based layout (using a disabled panel for steps with nothing to show) so every row shares the same arrow/label/extra grid
- Removed the `flexGrow: count` inline style driving the plan output summary badges, letting them size uniformly via existing CSS
- Made the approval-team confirmation text conditional so it reads "Someone must confirm to continue." instead of leaving an empty `<b>` tag when no team is set
- Replaced `RunFilter`'s naive `capitalize()` and hardcoded icon map with the canonical helpers, fixing both the mangled labels and the missing-enum compile error; restored per-status icon color lost in that swap (the shared icon helper returns bare icons meant for a colored `Tag`, not a standalone filter chip)
- Deleted the now-dead `statusColor` field/plumbing (`FlatJob` type, `workspaceDataUtils.ts`) once nothing computed or consumed it anymore
