### PR TITLE
fix(ui): don't show "no changes needed" while a plan is still running

### DIFF
--- a/ui/src/domain/Jobs/Details.tsx
+++ b/ui/src/domain/Jobs/Details.tsx
@@ -290,6 +290,8 @@ export const DetailsJob = ({ jobId }: Props) => {
       return renderConsoleOutput(item);
     }
 
+    const isStepRunning = !isTerminalJobStatus(item.status);
+
     const structuredContent = structuredApplyChanges ? (
       <StructuredPlanOutput
         changes={structuredApplyChanges}
@@ -297,9 +299,15 @@ export const DetailsJob = ({ jobId }: Props) => {
         applyMode
         outputs={stepOutputs}
         jobDiagnostics={stepJobDiagnostics}
+        isStepRunning={isStepRunning}
       />
     ) : structuredChanges ? (
-      <StructuredPlanOutput changes={structuredChanges} outputLog={item.outputLog} jobDiagnostics={stepJobDiagnostics} />
+      <StructuredPlanOutput
+        changes={structuredChanges}
+        outputLog={item.outputLog}
+        jobDiagnostics={stepJobDiagnostics}
+        isStepRunning={isStepRunning}
+      />
     ) : (
       <div>{parse(template ?? "")}</div>
     );

--- a/ui/src/domain/Jobs/StructuredPlanOutput.css
+++ b/ui/src/domain/Jobs/StructuredPlanOutput.css
@@ -1012,6 +1012,14 @@
   color: #3fb950;
 }
 
+.structured-plan-inProgress {
+  color: rgba(0, 0, 0, 0.65);
+}
+
+[data-theme="dark"] .structured-plan-inProgress {
+  color: rgba(255, 255, 255, 0.65);
+}
+
 @media (max-width: 960px) {
   .structured-plan-toolbar {
     align-items: stretch;

--- a/ui/src/domain/Jobs/StructuredPlanOutput.tsx
+++ b/ui/src/domain/Jobs/StructuredPlanOutput.tsx
@@ -42,6 +42,11 @@ type Props = {
   applyMode?: boolean;
   outputs?: TerraformOutputValue[];
   jobDiagnostics?: Diagnostic[];
+  // Whether the owning step is still executing. An empty `changes` array is indistinguishable
+  // from "plan finished, nothing differs" while the step is running - the backend just hasn't
+  // streamed any resource changes yet. Defaults to false (finished) so existing call sites that
+  // only ever render this component once a step's output is final keep their current behavior.
+  isStepRunning?: boolean;
 };
 
 type ActionName = "create" | "update" | "replace" | "delete" | "read" | "import" | "unknown" | "no-op" | "ephemeral";
@@ -1313,7 +1318,14 @@ const matchesAddressFilter = (row: PreparedChangeRow, filterValue: string) => {
   });
 };
 
-export const StructuredPlanOutput = ({ changes, outputLog, applyMode = false, outputs, jobDiagnostics }: Props) => {
+export const StructuredPlanOutput = ({
+  changes,
+  outputLog,
+  applyMode = false,
+  outputs,
+  jobDiagnostics,
+  isStepRunning = false,
+}: Props) => {
   const [expandedRowKeys, setExpandedRowKeys] = useState<string[]>([]);
   const [expandedAttributeKeys, setExpandedAttributeKeys] = useState<string[]>([]);
   const [addressFilter, setAddressFilter] = useState("");
@@ -1449,10 +1461,20 @@ export const StructuredPlanOutput = ({ changes, outputLog, applyMode = false, ou
 
   // An empty changes list normally means "we compared and nothing differs" - but it's also what
   // a failed plan looks like before any resource address was ever seen (see
-  // TerraformExecutorServiceImpl.plan()'s final flush). Job-level diagnostics are how that
-  // failure reaches this component, so their presence means "we don't actually know", not
-  // "nothing changed" - fall through to the diagnostics panel below instead of claiming success.
+  // TerraformExecutorServiceImpl.plan()'s final flush), and what a plan that's still running
+  // looks like before the backend has streamed any resource changes at all. Job-level
+  // diagnostics or a still-running step are both ways of saying "we don't actually know", not
+  // "nothing changed" - fall through instead of claiming success.
   if (!changes?.length && !hasJobDiagnostics) {
+    if (isStepRunning) {
+      return (
+        <div className="structured-plan-noChanges structured-plan-inProgress">
+          <LoadingOutlined className="structured-plan-noChangesIcon" />
+          <span>Plan is running — waiting for results…</span>
+        </div>
+      );
+    }
+
     return (
       <div className="structured-plan-noChanges">
         <CheckCircleOutlined className="structured-plan-noChangesIcon" />

--- a/ui/src/domain/Jobs/__tests__/Details.test.tsx
+++ b/ui/src/domain/Jobs/__tests__/Details.test.tsx
@@ -120,6 +120,46 @@ describe("DetailsJob apply structured output", () => {
       expect(screen.getByRole("button", { name: /aws_instance\.example/i })).toBeInTheDocument();
     });
   });
+
+  it("does not claim 'no changes needed' while a plan step is still running with no changes streamed yet", async () => {
+    getMock.mockImplementation((url: string) => {
+      if (url.includes("/context/v1/")) {
+        return Promise.resolve({ data: {} });
+      }
+
+      return Promise.resolve({
+        data: {
+          data: {
+            id: "1",
+            attributes: { status: "running" },
+          },
+          included: [
+            {
+              id: "step-1",
+              type: "step",
+              attributes: { name: "Plan", status: "running", stepNumber: "1" },
+            },
+          ],
+        },
+      });
+    });
+
+    useStructuredOutputStreamMock.mockReturnValue({
+      phase: "plan",
+      changes: { "step-1": [] },
+      jobDiagnostics: {},
+    });
+
+    render(<DetailsJob jobId="1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/plan is running/i)).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText("Your infrastructure matches the configuration — no changes needed.")
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("DetailsJob SSE reconnect behavior", () => {

--- a/ui/src/domain/Jobs/__tests__/StructuredPlanOutput.test.tsx
+++ b/ui/src/domain/Jobs/__tests__/StructuredPlanOutput.test.tsx
@@ -11,6 +11,15 @@ describe("StructuredPlanOutput", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows an in-progress state instead of a false success state while the step is still running", () => {
+    render(<StructuredPlanOutput changes={[]} isStepRunning />);
+
+    expect(
+      screen.queryByText("Your infrastructure matches the configuration — no changes needed.")
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/plan is running/i)).toBeInTheDocument();
+  });
+
   it("surfaces diagnostics instead of a false success state when a failed plan produced no changes", () => {
     render(
       <StructuredPlanOutput


### PR DESCRIPTION
## Summary

Fixes a misleading message in the structured plan output: while a plan is still **running**, the UI showed *"Your infrastructure matches the configuration — no changes needed."* even though the plan hadn't finished and no changes had actually been evaluated yet.

## Root cause

`StructuredPlanOutput` inferred "no changes" purely from an empty `changes` array. But `changes` is legitimately empty for two very different reasons:
1. The plan finished and truly found no diffs.
2. The plan is still streaming and the backend hasn't emitted any resource changes yet.

The component had no way to tell these apart, so case (2) rendered a false success state mid-run.

## Fix

- Added an `isStepRunning` prop to `StructuredPlanOutput`. When `changes` is empty **and** the step is still running, it now renders a distinct "Plan is running — waiting for results…" state instead of the success message.
- `Details.tsx` derives `isStepRunning` from the step's status (via the existing `isTerminalJobStatus` check) and passes it to both the plan and apply structured-output views.
- Added a CSS variant (`structured-plan-inProgress`) so the in-progress message doesn't render with the same green "success" styling.

## Test plan

- [x] Added a `StructuredPlanOutput` unit test asserting the in-progress state renders (and the success message does not) when `isStepRunning` is true with empty changes.
- [x] Added a `Details` integration test simulating a running plan step with an empty live-streamed `changes` array, asserting the "no changes needed" message is never shown while running.
- [x] Full `ui/src/domain/Jobs` test suite passes (89/89).