### PR TITLE
fix: misc ui fixes

### DIFF
--- a/ui/src/components/HelpMenu/HelpMenu.tsx
+++ b/ui/src/components/HelpMenu/HelpMenu.tsx
@@ -1,12 +1,11 @@
 import { ApiOutlined, DownOutlined, QuestionCircleOutlined } from "@ant-design/icons";
 import { Dropdown } from "antd";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import "./HelpMenu.css";
 
 export const HelpMenu = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const navigate = useNavigate();
 
   const helpItems = [
     {
@@ -26,11 +25,6 @@ export const HelpMenu = () => {
     },
   ];
 
-  const handleApiDocs = () => {
-    setIsOpen(false);
-    navigate("/api-docs");
-  };
-
   return (
     <Dropdown
       trigger={["click"]}
@@ -40,10 +34,10 @@ export const HelpMenu = () => {
       popupRender={() => (
         <div className="help-menu-dropdown">
           <div className="help-menu-header">Help & Support</div>
-          <div className="help-menu-item" onClick={handleApiDocs}>
+          <Link to="/api-docs" className="help-menu-item" onClick={() => setIsOpen(false)}>
             <ApiOutlined className="help-menu-item-icon" />
             <span>API Docs</span>
-          </div>
+          </Link>
           {helpItems.map((item) => (
             <a
               key={item.key}

--- a/ui/src/components/HelpMenu/__tests__/HelpMenu.test.tsx
+++ b/ui/src/components/HelpMenu/__tests__/HelpMenu.test.tsx
@@ -2,12 +2,6 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { HelpMenu } from "../HelpMenu";
 
-const mockNavigate = jest.fn();
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
-  useNavigate: () => mockNavigate,
-}));
-
 function renderHelpMenu() {
   return render(
     <MemoryRouter>
@@ -17,17 +11,14 @@ function renderHelpMenu() {
 }
 
 describe("HelpMenu", () => {
-  beforeEach(() => {
-    mockNavigate.mockClear();
-  });
-
-  it("navigates to /api-docs in-app when API Docs is clicked, instead of opening a new tab", async () => {
+  it("links API Docs to /api-docs in-app, instead of opening a new tab", async () => {
     renderHelpMenu();
 
     fireEvent.click(screen.getByLabelText("help menu"));
-    fireEvent.click(await screen.findByText("API Docs"));
 
-    expect(mockNavigate).toHaveBeenCalledWith("/api-docs");
+    const apiDocsLink = (await screen.findByText("API Docs")).closest("a");
+    expect(apiDocsLink).toHaveAttribute("href", "/api-docs");
+    expect(apiDocsLink).not.toHaveAttribute("target", "_blank");
   });
 
   it("still opens Documentation as an external link in a new tab", async () => {

--- a/ui/src/components/OrganizationSelector/OrganizationSelector.css
+++ b/ui/src/components/OrganizationSelector/OrganizationSelector.css
@@ -1,5 +1,5 @@
 .org-selector-button {
-  background-color: #1563ff !important;
+  background-color: var(--ant-color-primary) !important;
   color: white !important;
   border: none !important;
   border-radius: 8px !important;
@@ -18,11 +18,11 @@
 }
 
 .org-selector-button:hover {
-  background-color: #004ce6 !important;
+  background-color: var(--ant-color-primary-hover) !important;
 }
 
 .org-selector-button:focus {
-  outline: 2px solid rgba(21, 99, 255, 0.4);
+  outline: 2px solid color-mix(in srgb, var(--ant-color-primary) 40%, transparent);
   outline-offset: 2px;
 }
 
@@ -87,7 +87,7 @@
 }
 
 .org-selector-item.selected {
-  background-color: #e6f0ff !important;
+  background-color: var(--ant-color-primary-bg) !important;
   color: #1a1a1a !important;
 }
 
@@ -97,7 +97,7 @@
 }
 
 .org-selector-check {
-  color: #1563ff !important;
+  color: var(--ant-color-primary) !important;
   font-size: 14px !important;
   position: absolute !important;
   right: 12px !important;
@@ -167,7 +167,7 @@
 }
 
 [data-theme="dark"] .org-selector-item.selected {
-  background-color: #21262d !important;
+  background-color: var(--ant-color-primary-bg) !important;
   color: #e6edf3 !important;
 }
 
@@ -181,31 +181,6 @@
 
 [data-theme="dark"] .org-selector-manage-icon {
   color: #8b949e !important;
-}
-
-/* Color scheme: terrakube (purple) */
-[data-color-scheme="terrakube"] .org-selector-button {
-  background-color: #722ed1 !important;
-}
-
-[data-color-scheme="terrakube"] .org-selector-button:hover {
-  background-color: #5b21b6 !important;
-}
-
-[data-color-scheme="terrakube"] .org-selector-button:focus {
-  outline: 2px solid rgba(114, 46, 209, 0.4);
-}
-
-[data-color-scheme="terrakube"] .org-selector-check {
-  color: #722ed1 !important;
-}
-
-[data-color-scheme="terrakube"] .org-selector-item.selected {
-  background-color: #f3e8ff !important;
-}
-
-[data-color-scheme="terrakube"][data-theme="dark"] .org-selector-item.selected {
-  background-color: #2d1548 !important;
 }
 
 .org-selector-dropdown--top {

--- a/ui/src/components/OrganizationSelector/OrganizationSelector.tsx
+++ b/ui/src/components/OrganizationSelector/OrganizationSelector.tsx
@@ -1,13 +1,12 @@
 import React from "react";
 import { BankOutlined, DownOutlined, CheckOutlined, SearchOutlined, UnorderedListOutlined } from "@ant-design/icons";
 import { Button, Dropdown, Input } from "antd";
+import { Link } from "react-router-dom";
 import { FlatOrganization } from "@/domain/types";
 import "./OrganizationSelector.css";
 
 // Below this count, a search box just adds clutter for no benefit.
 const SEARCH_THRESHOLD = 8;
-
-let initialOnOrgChange: ((orgId: string) => void) | null = null;
 
 /**
  * Props for the OrganizationSelector component
@@ -19,8 +18,6 @@ export interface OrganizationSelectorProps {
   organizations: FlatOrganization[];
   /** Callback when user selects a different organization */
   onOrgChange: (orgId: string) => void;
-  /** Callback when user clicks "Manage Organizations" */
-  onManageOrgs: () => void;
   /** Which side the dropdown opens toward. Defaults to "bottom". Use "top" when the button sits near the bottom of the viewport (e.g. pinned to a sidebar footer). */
   placement?: "top" | "bottom";
 }
@@ -41,7 +38,6 @@ export interface OrganizationSelectorProps {
  *   organizationName="My Org"
  *   organizations={orgs}
  *   onOrgChange={(orgId) => handleOrgChange(orgId)}
- *   onManageOrgs={() => navigate('/')}
  * />
  * ```
  */
@@ -49,7 +45,6 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
   organizationName,
   organizations,
   onOrgChange,
-  onManageOrgs,
   placement = "bottom",
 }) => {
   const [open, setOpen] = React.useState(false);
@@ -62,12 +57,6 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
   );
 
   const displayName = organizationName?.trim() ? organizationName : "Choose an organization";
-
-  if (initialOnOrgChange === null) {
-    initialOnOrgChange = onOrgChange;
-  }
-
-  const shouldShowCurrentOrgOption = onOrgChange !== initialOnOrgChange;
 
   React.useEffect(() => {
     if (!open) {
@@ -89,23 +78,17 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
   }, [open]);
 
   const handleOrganizationClick = (orgId: string) => {
-    if (orgId === selectedOrgId) {
-      return;
-    }
     onOrgChange(orgId);
     setOpen(false);
     setSearchTerm("");
   };
 
   const handleManageOrganizationsClick = () => {
-    onManageOrgs();
     setOpen(false);
     setSearchTerm("");
   };
 
-  const visibleOrganizations = organizations
-    .filter((org) => shouldShowCurrentOrgOption || org.id !== selectedOrgId)
-    .filter((org) => org.name.toLowerCase().includes(searchTerm.toLowerCase()));
+  const visibleOrganizations = organizations.filter((org) => org.name.toLowerCase().includes(searchTerm.toLowerCase()));
 
   return (
     <div className="org-selector-container" ref={containerRef}>
@@ -139,40 +122,22 @@ export const OrganizationSelector: React.FC<OrganizationSelectorProps> = ({
               <div className="org-selector-empty">No organizations match your search.</div>
             ) : (
               visibleOrganizations.map((org) => (
-                <div
+                <Link
                   key={org.id}
+                  to={`/organizations/${org.id}/workspaces`}
                   className={org.id === selectedOrgId ? "org-selector-item selected" : "org-selector-item"}
                   onClick={() => handleOrganizationClick(org.id)}
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                      event.preventDefault();
-                      handleOrganizationClick(org.id);
-                    }
-                  }}
                 >
                   <span className="org-selector-item-name">{org.name}</span>
                   {org.id === selectedOrgId && <CheckOutlined className="org-selector-check" />}
-                </div>
+                </Link>
               ))
             )}
           </div>
-          <div
-            className="org-selector-manage-link"
-            onClick={handleManageOrganizationsClick}
-            role="button"
-            tabIndex={0}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" || event.key === " ") {
-                event.preventDefault();
-                handleManageOrganizationsClick();
-              }
-            }}
-          >
+          <Link to="/organizations" className="org-selector-manage-link" onClick={handleManageOrganizationsClick}>
             <UnorderedListOutlined className="org-selector-manage-icon" />
             <span>Manage Organizations</span>
-          </div>
+          </Link>
         </div>
       )}
     </div>

--- a/ui/src/components/OrganizationSelector/__tests__/OrganizationSelector.test.tsx
+++ b/ui/src/components/OrganizationSelector/__tests__/OrganizationSelector.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import { OrganizationSelector } from "../OrganizationSelector";
+import { MemoryRouter } from "react-router-dom";
+import { OrganizationSelector, OrganizationSelectorProps } from "../OrganizationSelector";
 import { FlatOrganization } from "@/domain/types";
 
 const mockOrganizations: FlatOrganization[] = [
@@ -24,8 +25,15 @@ const defaultProps = {
   organizationName: "Acme Corp",
   organizations: mockOrganizations,
   onOrgChange: jest.fn(),
-  onManageOrgs: jest.fn(),
 };
+
+function renderSelector(props: Partial<OrganizationSelectorProps> = {}) {
+  return render(
+    <MemoryRouter>
+      <OrganizationSelector {...defaultProps} {...props} />
+    </MemoryRouter>
+  );
+}
 
 describe("OrganizationSelector", () => {
   beforeEach(() => {
@@ -34,59 +42,69 @@ describe("OrganizationSelector", () => {
 
   describe("Rendering", () => {
     it("renders button with current organization name", () => {
-      render(<OrganizationSelector {...defaultProps} />);
+      renderSelector();
       expect(screen.getByText("Acme Corp")).toBeInTheDocument();
     });
 
     it("renders 'Choose an organization' when organizationName is empty", () => {
-      render(<OrganizationSelector {...defaultProps} organizationName="" />);
+      renderSelector({ organizationName: "" });
       expect(screen.getByText("Choose an organization")).toBeInTheDocument();
     });
 
     it("renders 'Choose an organization' when organizationName is not provided", () => {
-      render(<OrganizationSelector {...defaultProps} organizationName="" />);
+      renderSelector({ organizationName: "" });
       expect(screen.getByText("Choose an organization")).toBeInTheDocument();
     });
   });
 
   describe("Dropdown Interaction", () => {
     it("opens dropdown when button is clicked", () => {
-      render(<OrganizationSelector {...defaultProps} />);
+      renderSelector();
       const button = screen.getByRole("button", { name: /Acme Corp/i });
 
       fireEvent.click(button);
 
-      // After clicking, dropdown should be visible with organization list
-      expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+      expect(screen.getAllByText("Acme Corp").length).toBeGreaterThan(1);
       expect(screen.getByText("Dev Team")).toBeInTheDocument();
       expect(screen.getByText("QA Team")).toBeInTheDocument();
     });
 
-    it("displays all organizations in dropdown list", () => {
-      render(<OrganizationSelector {...defaultProps} />);
+    it("displays all organizations in dropdown list, including the current one", () => {
+      renderSelector();
       const button = screen.getByRole("button", { name: /Acme Corp/i });
 
       fireEvent.click(button);
 
       mockOrganizations.forEach((org) => {
-        expect(screen.getByText(org.name)).toBeInTheDocument();
+        expect(screen.getAllByText(org.name).length).toBeGreaterThan(0);
       });
     });
 
-    it("shows 'Manage Organizations' link in dropdown", () => {
-      render(<OrganizationSelector {...defaultProps} />);
+    it("links each organization to its workspaces page", () => {
+      renderSelector();
       const button = screen.getByRole("button", { name: /Acme Corp/i });
 
       fireEvent.click(button);
 
-      expect(screen.getByText("Manage Organizations")).toBeInTheDocument();
+      const devTeamLink = screen.getByText("Dev Team").closest("a");
+      expect(devTeamLink).toHaveAttribute("href", "/organizations/org-2/workspaces");
+    });
+
+    it("shows 'Manage Organizations' link in dropdown", () => {
+      renderSelector();
+      const button = screen.getByRole("button", { name: /Acme Corp/i });
+
+      fireEvent.click(button);
+
+      const manageLink = screen.getByText("Manage Organizations").closest("a");
+      expect(manageLink).toHaveAttribute("href", "/organizations");
     });
   });
 
   describe("Callbacks", () => {
     it("calls onOrgChange with correct orgId when organization is selected", () => {
       const onOrgChange = jest.fn();
-      render(<OrganizationSelector {...defaultProps} onOrgChange={onOrgChange} />);
+      renderSelector({ onOrgChange });
 
       const button = screen.getByRole("button", { name: /Acme Corp/i });
       fireEvent.click(button);
@@ -97,75 +115,56 @@ describe("OrganizationSelector", () => {
       expect(onOrgChange).toHaveBeenCalledWith("org-2");
     });
 
-    it("calls onManageOrgs when 'Manage Organizations' link is clicked", () => {
-      const onManageOrgs = jest.fn();
-      render(<OrganizationSelector {...defaultProps} onManageOrgs={onManageOrgs} />);
-
-      const button = screen.getByRole("button", { name: /Acme Corp/i });
-      fireEvent.click(button);
-
-      const manageLink = screen.getByText("Manage Organizations");
-      fireEvent.click(manageLink);
-
-      expect(onManageOrgs).toHaveBeenCalled();
-    });
-
-    it("does not call onOrgChange when selecting the current organization", () => {
+    it("calls onOrgChange when selecting the current organization", () => {
       const onOrgChange = jest.fn();
-      render(<OrganizationSelector {...defaultProps} onOrgChange={onOrgChange} />);
+      renderSelector({ onOrgChange });
 
       const button = screen.getByRole("button", { name: /Acme Corp/i });
       fireEvent.click(button);
 
-      const acmeOption = screen.getAllByText("Acme Corp")[1]; // Get the dropdown option, not the button
+      const acmeOption = screen.getAllByText("Acme Corp")[1];
       fireEvent.click(acmeOption);
 
-      expect(onOrgChange).not.toHaveBeenCalled();
+      expect(onOrgChange).toHaveBeenCalledWith("org-1");
     });
   });
 
   describe("Edge Cases", () => {
     it("handles empty organizations list gracefully", () => {
-      render(<OrganizationSelector {...defaultProps} organizations={[]} />);
+      renderSelector({ organizations: [] });
 
       const button = screen.getByRole("button", { name: /Acme Corp/i });
       fireEvent.click(button);
 
-      // Should still show "Manage Organizations" link
       expect(screen.getByText("Manage Organizations")).toBeInTheDocument();
     });
 
     it("handles single organization in list", () => {
       const singleOrg = [mockOrganizations[0]];
-      render(<OrganizationSelector {...defaultProps} organizations={singleOrg} />);
+      renderSelector({ organizations: singleOrg });
 
       const button = screen.getByRole("button", { name: /Acme Corp/i });
       fireEvent.click(button);
 
-      expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+      expect(screen.getAllByText("Acme Corp").length).toBeGreaterThan(1);
       expect(screen.getByText("Manage Organizations")).toBeInTheDocument();
     });
 
     it("closes dropdown when clicking outside", () => {
-      const { container } = render(<OrganizationSelector {...defaultProps} />);
+      const { container } = renderSelector();
 
       const button = screen.getByRole("button", { name: /Acme Corp/i });
       fireEvent.click(button);
 
-      // Verify dropdown is open
       expect(screen.getByText("Dev Team")).toBeInTheDocument();
 
-      // Click outside
       fireEvent.click(container);
-
-      // Dropdown should be closed (Dev Team should not be visible as a separate element)
-      // This test may need adjustment based on actual implementation
     });
   });
 
   describe("Placement", () => {
     it("opens the dropdown upward when placement is 'top'", () => {
-      render(<OrganizationSelector {...defaultProps} placement="top" />);
+      renderSelector({ placement: "top" });
       const button = screen.getByRole("button", { name: /Acme Corp/i });
 
       fireEvent.click(button);
@@ -174,7 +173,7 @@ describe("OrganizationSelector", () => {
     });
 
     it("opens the dropdown downward by default", () => {
-      render(<OrganizationSelector {...defaultProps} />);
+      renderSelector();
       const button = screen.getByRole("button", { name: /Acme Corp/i });
 
       fireEvent.click(button);

--- a/ui/src/components/UserMenu/UserMenu.css
+++ b/ui/src/components/UserMenu/UserMenu.css
@@ -65,6 +65,12 @@
 }
 
 .user-menu-item {
+  width: 100%;
+  background: none;
+  border: none;
+  font: inherit;
+  text-align: left;
+  text-decoration: none;
   padding: 8px 16px !important;
   margin: 0 !important;
   cursor: pointer;

--- a/ui/src/components/UserMenu/UserMenu.tsx
+++ b/ui/src/components/UserMenu/UserMenu.tsx
@@ -1,7 +1,7 @@
 import { DownOutlined, PoweroffOutlined, SettingOutlined, UserOutlined } from "@ant-design/icons";
 import { Avatar, Dropdown } from "antd";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
 import { useAuth } from "../../config/authConfig";
 import getUserFromStorage from "../../config/authUser";
@@ -13,7 +13,6 @@ export const UserMenu = () => {
   const [username, setUsername] = useState<string>();
   const [avatarUrl, setAvatarUrl] = useState<string>();
   const auth = useAuth();
-  const navigate = useNavigate();
 
   useEffect(() => {
     const user = getUserFromStorage();
@@ -24,11 +23,6 @@ export const UserMenu = () => {
       getGravatarUrl(user.profile.email).then(setAvatarUrl);
     }
   }, []);
-
-  const handleUserSettings = () => {
-    setIsOpen(false);
-    navigate(`/settings/tokens`);
-  };
 
   const signOutClickHandler = () => {
     setIsOpen(false);
@@ -49,14 +43,14 @@ export const UserMenu = () => {
             <span className="user-menu-signed-in">Signed in as</span>
             <span className="user-menu-username">{username}</span>
           </div>
-          <div className="user-menu-item" onClick={handleUserSettings}>
+          <Link to="/settings/tokens" className="user-menu-item" onClick={() => setIsOpen(false)}>
             <SettingOutlined className="user-menu-item-icon" />
             <span>Account settings</span>
-          </div>
-          <div className="user-menu-item" onClick={signOutClickHandler}>
+          </Link>
+          <button type="button" className="user-menu-item" onClick={signOutClickHandler}>
             <PoweroffOutlined className="user-menu-item-icon" />
             <span>Sign out</span>
-          </div>
+          </button>
         </div>
       )}
     >

--- a/ui/src/config/orgId.ts
+++ b/ui/src/config/orgId.ts
@@ -1,0 +1,12 @@
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isOrgId(value: string | null | undefined): value is string {
+  return !!value && UUID_PATTERN.test(value);
+}
+
+export function getOrgIdFromPathname(pathname: string): string | null {
+  const segments = pathname.split("/").filter(Boolean);
+  const index = segments.indexOf("organizations");
+  const candidate = index >= 0 ? segments[index + 1] : null;
+  return isOrgId(candidate) ? candidate : null;
+}

--- a/ui/src/config/validation.ts
+++ b/ui/src/config/validation.ts
@@ -1,0 +1,6 @@
+import type { Rule } from "antd/es/form";
+
+export const organizationNameRules: Rule[] = [
+  { required: true, message: "This field is required!" },
+  { pattern: /^[a-zA-Z0-9]*$/, message: "Only letters and numbers are allowed!" },
+];

--- a/ui/src/domain/Home/App.tsx
+++ b/ui/src/domain/Home/App.tsx
@@ -19,6 +19,7 @@ import "./Home.css";
 import AppSidebar from "@/modules/layout/AppSidebar/AppSidebar";
 import LoadingFallback from "@/components/LoadingFallback";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
+import { getOrgIdFromPathname } from "../../config/orgId";
 import organizationService from "@/modules/organizations/organizationService";
 import { FlatOrganization } from "../types";
 const { Footer } = Layout;
@@ -148,32 +149,27 @@ const AppLayout = () => {
   const { colorScheme, themeMode } = useTheme();
 
   useEffect(() => {
-    const pathname = window.location.pathname;
-    const paths = pathname.split("/");
-    const orgIdIndex = paths.indexOf("organizations") + 1;
+    const orgId = getOrgIdFromPathname(window.location.pathname);
 
-    if (orgIdIndex > 0 && orgIdIndex < paths.length) {
-      const orgId = paths[orgIdIndex];
-      if (orgId) {
-        const storedOrgName = sessionStorage.getItem(ORGANIZATION_NAME);
-        const storedOrgId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
+    if (orgId) {
+      const storedOrgName = sessionStorage.getItem(ORGANIZATION_NAME);
+      const storedOrgId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
 
-        if (storedOrgName && storedOrgId === orgId) {
-          setOrganizationName(storedOrgName);
-        } else {
-          organizationService
-            .getOrganizationNameGraphQL(orgId)
-            .then((orgName) => {
-              if (orgName) {
-                sessionStorage.setItem(ORGANIZATION_ARCHIVE, orgId);
-                sessionStorage.setItem(ORGANIZATION_NAME, orgName);
-                setOrganizationName(orgName);
-              }
-            })
-            .catch((err) => {
-              console.error("Failed to load organization:", err);
-            });
-        }
+      if (storedOrgName && storedOrgId === orgId) {
+        setOrganizationName(storedOrgName);
+      } else {
+        organizationService
+          .getOrganizationNameGraphQL(orgId)
+          .then((orgName) => {
+            if (orgName) {
+              sessionStorage.setItem(ORGANIZATION_ARCHIVE, orgId);
+              sessionStorage.setItem(ORGANIZATION_NAME, orgName);
+              setOrganizationName(orgName);
+            }
+          })
+          .catch((err) => {
+            console.error("Failed to load organization:", err);
+          });
       }
     } else {
       const storedOrgName = sessionStorage.getItem(ORGANIZATION_NAME);

--- a/ui/src/domain/Home/App.tsx
+++ b/ui/src/domain/Home/App.tsx
@@ -147,6 +147,19 @@ const AppLayout = () => {
   const [orgs, setOrgs] = useState<FlatOrganization[]>([]);
   const [workspaceManageState, setWorkspaceManageState] = useState(false);
   const { colorScheme, themeMode } = useTheme();
+  const segments = location.pathname.split("/").filter(Boolean);
+  const noOrgContext =
+    segments.length === 0 ||
+    segments[0] === "settings" ||
+    (segments[0] === "organizations" && (segments.length === 1 || segments[1] === "create"));
+
+  useEffect(() => {
+    if (noOrgContext) {
+      sessionStorage.removeItem(ORGANIZATION_NAME);
+      sessionStorage.removeItem(ORGANIZATION_ARCHIVE);
+      setOrganizationName("");
+    }
+  }, [location.pathname, noOrgContext]);
 
   useEffect(() => {
     const orgId = getOrgIdFromPathname(window.location.pathname);

--- a/ui/src/domain/Home/App.tsx
+++ b/ui/src/domain/Home/App.tsx
@@ -250,9 +250,276 @@ const AppLayout = () => {
   );
 };
 
+const router = createBrowserRouter(
+  [
+    {
+      path: "/",
+      element: <AppLayout />,
+      children: [
+        {
+          path: "/",
+          element: <OrganizationsPickerPage />,
+        },
+        {
+          path: "/organizations",
+          element: <OrganizationsPickerPage />,
+        },
+        {
+          path: "/organizations/create",
+          element: <CreateOrganizationRoute />,
+        },
+        {
+          path: "/organizations/:id/workspaces",
+          element: <OrganizationsDetailRoute />,
+        },
+        {
+          path: "/organizations/:id/projects",
+          element: <OrganizationsProjectsRoute />,
+        },
+        {
+          path: "/organizations/:orgid/projects/:id",
+          element: <OrganizationsProjectDetailRoute />,
+        },
+        {
+          path: "/workspaces/create",
+          element: <CreateWorkspace />,
+        },
+        {
+          path: "/workspaces/import",
+          element: <ImportWorkspace />,
+        },
+        {
+          path: "/workspaces/:id",
+          element: <WorkspaceDetailsRoute />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id",
+          element: <WorkspaceDetailsRoute />,
+        },
+        {
+          path: "/workspaces/:id/runs",
+          element: <WorkspaceDetailsRoute selectedTab="2" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/runs",
+          element: <WorkspaceDetailsRoute selectedTab="2" />,
+        },
+        {
+          path: "/workspaces/:id/runs/:runid",
+          element: <WorkspaceDetailsRoute selectedTab="2" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/runs/:runid",
+          element: <WorkspaceDetailsRoute selectedTab="2" />,
+        },
+        {
+          path: "/workspaces/:id/states",
+          element: <WorkspaceDetailsRoute selectedTab="3" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/states",
+          element: <WorkspaceDetailsRoute selectedTab="3" />,
+        },
+        {
+          path: "/workspaces/:id/variables",
+          element: <WorkspaceDetailsRoute selectedTab="4" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/variables",
+          element: <WorkspaceDetailsRoute selectedTab="4" />,
+        },
+        {
+          path: "/workspaces/:id/schedules",
+          element: <WorkspaceDetailsRoute selectedTab="5" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/schedules",
+          element: <WorkspaceDetailsRoute selectedTab="5" />,
+        },
+        {
+          path: "/workspaces/:id/settings",
+          element: <WorkspaceDetailsRoute selectedTab="6" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/settings",
+          element: <WorkspaceDetailsRoute selectedTab="6" />,
+        },
+        {
+          path: "/workspaces/:id/settings/general",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="general" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/settings/general",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="general" />,
+        },
+        {
+          path: "/workspaces/:id/settings/locking",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="locking" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/settings/locking",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="locking" />,
+        },
+        {
+          path: "/workspaces/:id/settings/sshkey",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="sshkey" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/settings/sshkey",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="sshkey" />,
+        },
+        {
+          path: "/workspaces/:id/settings/webhook",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="webhook" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/settings/webhook",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="webhook" />,
+        },
+        {
+          path: "/workspaces/:id/settings/notifications",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="notifications" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/settings/notifications",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="notifications" />,
+        },
+        {
+          path: "/workspaces/:id/settings/state-shared",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="state-shared" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/settings/state-shared",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="state-shared" />,
+        },
+        {
+          path: "/workspaces/:id/settings/team-access",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="team-access" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/settings/team-access",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="team-access" />,
+        },
+        {
+          path: "/workspaces/:id/settings/advanced",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="advanced" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/settings/advanced",
+          element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="advanced" />,
+        },
+        {
+          path: "/organizations/:orgid/registry",
+          element: <RegistryRoute />,
+        },
+        {
+          path: "/organizations/:orgid/registry/search",
+          element: <PublicRegistrySearchRoute />,
+        },
+        {
+          path: "/organizations/:orgid/registry/create",
+          element: <CreateModule />,
+        },
+        {
+          path: "/organizations/:orgid/registry/providers/:providerid",
+          element: <ProviderDetailsRoute />,
+        },
+        {
+          path: "/organizations/:orgid/registry/:id",
+          element: <ModuleDetailsRoute />,
+        },
+        {
+          path: "/organizations/:orgid/settings",
+          element: <OrganizationSettings />,
+        },
+        {
+          path: "/organizations/:orgid/settings/general",
+          element: <OrganizationSettings selectedTab="1" />,
+        },
+        {
+          path: "/organizations/:orgid/settings/teams",
+          element: <OrganizationSettings selectedTab="2" />,
+        },
+        {
+          path: "/organizations/:orgid/settings/variables",
+          element: <OrganizationSettings selectedTab="3" />,
+        },
+        {
+          path: "/organizations/:orgid/settings/vcs",
+          element: <OrganizationSettings selectedTab="4" />,
+        },
+        {
+          path: "/organizations/:orgid/settings/vcs/new/:vcsName",
+          element: <OrganizationSettings selectedTab="4" vcsMode="new" />,
+        },
+        {
+          path: "/settings/tokens",
+          element: <UserSettingsPage />,
+        },
+        {
+          path: "/settings/theme",
+          element: <UserSettingsPage />,
+        },
+        {
+          path: "/organizations/:orgid/settings/ssh",
+          element: <OrganizationSettings selectedTab="6" />,
+        },
+        {
+          path: "/organizations/:orgid/settings/tags",
+          element: <OrganizationSettings selectedTab="7" />,
+        },
+        {
+          path: "/organizations/:orgid/settings/agents",
+          element: <OrganizationSettings selectedTab="8" />,
+        },
+        {
+          path: "/organizations/:orgid/settings/federated-credentials",
+          element: <OrganizationSettings selectedTab="11" />,
+        },
+        {
+          path: "/organizations/:orgid/settings/templates",
+          element: <OrganizationSettings selectedTab="5" />,
+        },
+        {
+          path: "/organizations/:orgid/settings/actions",
+          element: <OrganizationSettings selectedTab="10" />,
+        },
+        {
+          path: "/organizations/:orgid/settings/notifications",
+          element: <OrganizationSettings selectedTab="12" />,
+        },
+        {
+          path: "/organizations/:orgid/settings/collection",
+          element: <OrganizationSettings selectedTab="9" />,
+        },
+        {
+          path: "/organizations/:orgid/settings/collection/new",
+          element: <OrganizationSettings selectedTab="9" collectionMode="new" />,
+        },
+        {
+          path: "/organizations/:orgid/settings/collection/edit/:collectionid",
+          element: <CollectionSettingsWrapper mode="edit" />,
+        },
+        {
+          path: "/organizations/:orgid/settings/collection/:collectionid",
+          element: <CollectionSettingsWrapper mode="detail" />,
+        },
+      ],
+    },
+    {
+      // Full-bleed: Scalar renders its own sidebar/nav, so this route skips
+      // AppLayout entirely rather than duplicating it alongside ours.
+      path: "/api-docs",
+      element: <ApiDocsPage />,
+    },
+  ],
+  {
+    basename: getBasePath(),
+  }
+);
+
 const App = () => {
   const auth = useAuth();
-  const basePath = getBasePath();
 
   useEffect(() => {
     const removeExpired = auth.events.addAccessTokenExpired(() => {
@@ -274,274 +541,6 @@ const App = () => {
   if (!auth.isAuthenticated) {
     return <Login />;
   }
-
-  const router = createBrowserRouter(
-    [
-      {
-        path: "/",
-        element: <AppLayout />,
-        children: [
-          {
-            path: "/",
-            element: <OrganizationsPickerPage />,
-          },
-          {
-            path: "/organizations",
-            element: <OrganizationsPickerPage />,
-          },
-          {
-            path: "/organizations/create",
-            element: <CreateOrganizationRoute />,
-          },
-          {
-            path: "/organizations/:id/workspaces",
-            element: <OrganizationsDetailRoute />,
-          },
-          {
-            path: "/organizations/:id/projects",
-            element: <OrganizationsProjectsRoute />,
-          },
-          {
-            path: "/organizations/:orgid/projects/:id",
-            element: <OrganizationsProjectDetailRoute />,
-          },
-          {
-            path: "/workspaces/create",
-            element: <CreateWorkspace />,
-          },
-          {
-            path: "/workspaces/import",
-            element: <ImportWorkspace />,
-          },
-          {
-            path: "/workspaces/:id",
-            element: <WorkspaceDetailsRoute />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id",
-            element: <WorkspaceDetailsRoute />,
-          },
-          {
-            path: "/workspaces/:id/runs",
-            element: <WorkspaceDetailsRoute selectedTab="2" />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id/runs",
-            element: <WorkspaceDetailsRoute selectedTab="2" />,
-          },
-          {
-            path: "/workspaces/:id/runs/:runid",
-            element: <WorkspaceDetailsRoute selectedTab="2" />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id/runs/:runid",
-            element: <WorkspaceDetailsRoute selectedTab="2" />,
-          },
-          {
-            path: "/workspaces/:id/states",
-            element: <WorkspaceDetailsRoute selectedTab="3" />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id/states",
-            element: <WorkspaceDetailsRoute selectedTab="3" />,
-          },
-          {
-            path: "/workspaces/:id/variables",
-            element: <WorkspaceDetailsRoute selectedTab="4" />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id/variables",
-            element: <WorkspaceDetailsRoute selectedTab="4" />,
-          },
-          {
-            path: "/workspaces/:id/schedules",
-            element: <WorkspaceDetailsRoute selectedTab="5" />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id/schedules",
-            element: <WorkspaceDetailsRoute selectedTab="5" />,
-          },
-          {
-            path: "/workspaces/:id/settings",
-            element: <WorkspaceDetailsRoute selectedTab="6" />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id/settings",
-            element: <WorkspaceDetailsRoute selectedTab="6" />,
-          },
-          {
-            path: "/workspaces/:id/settings/general",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="general" />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id/settings/general",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="general" />,
-          },
-          {
-            path: "/workspaces/:id/settings/locking",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="locking" />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id/settings/locking",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="locking" />,
-          },
-          {
-            path: "/workspaces/:id/settings/sshkey",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="sshkey" />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id/settings/sshkey",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="sshkey" />,
-          },
-          {
-            path: "/workspaces/:id/settings/webhook",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="webhook" />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id/settings/webhook",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="webhook" />,
-          },
-          {
-            path: "/workspaces/:id/settings/notifications",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="notifications" />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id/settings/notifications",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="notifications" />,
-          },
-          {
-            path: "/workspaces/:id/settings/state-shared",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="state-shared" />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id/settings/state-shared",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="state-shared" />,
-          },
-          {
-            path: "/workspaces/:id/settings/team-access",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="team-access" />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id/settings/team-access",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="team-access" />,
-          },
-          {
-            path: "/workspaces/:id/settings/advanced",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="advanced" />,
-          },
-          {
-            path: "/organizations/:orgid/workspaces/:id/settings/advanced",
-            element: <WorkspaceDetailsRoute selectedTab="6" settingsSection="advanced" />,
-          },
-          {
-            path: "/organizations/:orgid/registry",
-            element: <RegistryRoute />,
-          },
-          {
-            path: "/organizations/:orgid/registry/search",
-            element: <PublicRegistrySearchRoute />,
-          },
-          {
-            path: "/organizations/:orgid/registry/create",
-            element: <CreateModule />,
-          },
-          {
-            path: "/organizations/:orgid/registry/providers/:providerid",
-            element: <ProviderDetailsRoute />,
-          },
-          {
-            path: "/organizations/:orgid/registry/:id",
-            element: <ModuleDetailsRoute />,
-          },
-          {
-            path: "/organizations/:orgid/settings",
-            element: <OrganizationSettings />,
-          },
-          {
-            path: "/organizations/:orgid/settings/general",
-            element: <OrganizationSettings selectedTab="1" />,
-          },
-          {
-            path: "/organizations/:orgid/settings/teams",
-            element: <OrganizationSettings selectedTab="2" />,
-          },
-          {
-            path: "/organizations/:orgid/settings/variables",
-            element: <OrganizationSettings selectedTab="3" />,
-          },
-          {
-            path: "/organizations/:orgid/settings/vcs",
-            element: <OrganizationSettings selectedTab="4" />,
-          },
-          {
-            path: "/organizations/:orgid/settings/vcs/new/:vcsName",
-            element: <OrganizationSettings selectedTab="4" vcsMode="new" />,
-          },
-          {
-            path: "/settings/tokens",
-            element: <UserSettingsPage />,
-          },
-          {
-            path: "/settings/theme",
-            element: <UserSettingsPage />,
-          },
-          {
-            path: "/organizations/:orgid/settings/ssh",
-            element: <OrganizationSettings selectedTab="6" />,
-          },
-          {
-            path: "/organizations/:orgid/settings/tags",
-            element: <OrganizationSettings selectedTab="7" />,
-          },
-          {
-            path: "/organizations/:orgid/settings/agents",
-            element: <OrganizationSettings selectedTab="8" />,
-          },
-          {
-            path: "/organizations/:orgid/settings/federated-credentials",
-            element: <OrganizationSettings selectedTab="11" />,
-          },
-          {
-            path: "/organizations/:orgid/settings/templates",
-            element: <OrganizationSettings selectedTab="5" />,
-          },
-          {
-            path: "/organizations/:orgid/settings/actions",
-            element: <OrganizationSettings selectedTab="10" />,
-          },
-          {
-            path: "/organizations/:orgid/settings/notifications",
-            element: <OrganizationSettings selectedTab="12" />,
-          },
-          {
-            path: "/organizations/:orgid/settings/collection",
-            element: <OrganizationSettings selectedTab="9" />,
-          },
-          {
-            path: "/organizations/:orgid/settings/collection/new",
-            element: <OrganizationSettings selectedTab="9" collectionMode="new" />,
-          },
-          {
-            path: "/organizations/:orgid/settings/collection/edit/:collectionid",
-            element: <CollectionSettingsWrapper mode="edit" />,
-          },
-          {
-            path: "/organizations/:orgid/settings/collection/:collectionid",
-            element: <CollectionSettingsWrapper mode="detail" />,
-          },
-        ],
-      },
-      {
-        // Full-bleed: Scalar renders its own sidebar/nav, so this route skips
-        // AppLayout entirely rather than duplicating it alongside ours.
-        path: "/api-docs",
-        element: <ApiDocsPage />,
-      },
-    ],
-    {
-      basename: basePath,
-    }
-  );
 
   return (
     <ThemeProvider>

--- a/ui/src/domain/Home/App.tsx
+++ b/ui/src/domain/Home/App.tsx
@@ -234,7 +234,6 @@ const AppLayout = () => {
           setOrganizationName={setOrganizationName}
           organizations={orgs}
           onOrgChange={handleOrgChange}
-          onManageOrgs={() => navigate("/organizations")}
           workspaceManageState={workspaceManageState}
         />
         <Layout className="app-content-shell">

--- a/ui/src/domain/Home/App.tsx
+++ b/ui/src/domain/Home/App.tsx
@@ -288,6 +288,14 @@ const router = createBrowserRouter(
           element: <ImportWorkspace />,
         },
         {
+          path: "/organizations/:orgid/workspaces/create",
+          element: <CreateWorkspace />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/import",
+          element: <ImportWorkspace />,
+        },
+        {
           path: "/workspaces/:id",
           element: <WorkspaceDetailsRoute />,
         },

--- a/ui/src/domain/Home/App.tsx
+++ b/ui/src/domain/Home/App.tsx
@@ -243,13 +243,20 @@ const AppLayout = () => {
 
 const App = () => {
   const auth = useAuth();
-  const expiry = auth?.user?.expires_at;
   const basePath = getBasePath();
 
-  // Checking with the expiry time in the localstorage and when it has crossed the access has been revoked so It will clear the local storage and by default with no localstorage object it will route to login page.
-  if (auth.isAuthenticated && auth?.user && expiry !== undefined && Math.floor(Date.now() / 1000) > expiry) {
-    localStorage.clear();
-  }
+  useEffect(() => {
+    const removeExpired = auth.events.addAccessTokenExpired(() => {
+      auth.removeUser();
+    });
+    const removeSignedOut = auth.events.addUserSignedOut(() => {
+      auth.removeUser();
+    });
+    return () => {
+      removeExpired();
+      removeSignedOut();
+    };
+  }, [auth.events, auth.removeUser]);
 
   if (auth.isLoading) {
     return null;

--- a/ui/src/domain/Home/ProfilePicture.tsx
+++ b/ui/src/domain/Home/ProfilePicture.tsx
@@ -2,7 +2,7 @@ import { PoweroffOutlined, QuestionCircleOutlined, UserOutlined } from "@ant-des
 import { Avatar, Dropdown, message } from "antd";
 import { ItemType } from "antd/es/menu/interface";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
 import { useAuth } from "../../config/authConfig";
 import getUserFromStorage from "../../config/authUser";
@@ -11,11 +11,6 @@ import "./Home.css";
 export const ProfilePicture = () => {
   const [username, setUsername] = useState<string>();
   const auth = useAuth();
-  const navigate = useNavigate();
-
-  const handleUserSettings = () => {
-    navigate(`/settings/tokens`);
-  };
 
   const signOutClickHandler = () => {
     auth.removeUser();
@@ -47,8 +42,7 @@ export const ProfilePicture = () => {
     {
       key: "user-settings",
       icon: <UserOutlined />,
-      label: "User Settings",
-      onClick: handleUserSettings,
+      label: <Link to="/settings/tokens">User Settings</Link>,
     },
     {
       key: "help",

--- a/ui/src/domain/Jobs/Details.tsx
+++ b/ui/src/domain/Jobs/Details.tsx
@@ -33,6 +33,7 @@ type Props = {
 };
 
 const TERMINAL_JOB_STATUSES = new Set(["completed", "noChanges", "failed", "cancelled", "rejected", "notExecuted"]);
+const TERMINAL_STEP_STATUSES = TERMINAL_JOB_STATUSES;
 const INCOMPLETE_VARIABLE_GUARD_STEP_NAME = "Incomplete sensitive variables";
 
 const UI_TYPE_STORAGE_KEY = "terrakube.jobDetails.uiType";
@@ -106,6 +107,7 @@ export const DetailsJob = ({ jobId }: Props) => {
   const { getSignal: getJobSignal, abort: abortJobRequests } = useAbortController();
   const { getSignal: getContextSignal, abort: abortContextRequests } = useAbortController();
   const jobRequestRef = useRef(0);
+  const cachedStepLogs = useRef<Map<string, any>>(new Map());
   const contextRequestRef = useRef(0);
   const pollRequestRef = useRef(0);
 
@@ -438,6 +440,16 @@ export const DetailsJob = ({ jobId }: Props) => {
       );
       const incompleteVariableGuard = parseIncompleteVariableGuard(response.data.data.attributes.output);
 
+      const fetchStepLog = async (stepItem: any) => {
+        const cached = cachedStepLogs.current.get(stepItem.id);
+        if (cached !== undefined) return cached;
+        const log = await outputLog(stepItem.attributes.output, stepItem.attributes.status, signal);
+        if (TERMINAL_STEP_STATUSES.has(stepItem.attributes.status) && !signal.aborted && log !== "No logs available") {
+          cachedStepLogs.current.set(stepItem.id, log);
+        }
+        return log;
+      };
+
       const stepsPromise = Promise.all(
         stepEntries.map(async (stepItem: any) => ({
           id: stepItem.id,
@@ -450,7 +462,7 @@ export const DetailsJob = ({ jobId }: Props) => {
               ? incompleteVariableGuard.rawMessage
               : stepItem.attributes.status === "running"
               ? ""
-              : await outputLog(stepItem.attributes.output, stepItem.attributes.status, signal),
+              : await fetchStepLog(stepItem),
         }))
       );
 
@@ -541,6 +553,7 @@ export const DetailsJob = ({ jobId }: Props) => {
 
   useEffect(() => {
     setLoading(true);
+    cachedStepLogs.current.clear();
     abortJobRequests();
     abortContextRequests();
 

--- a/ui/src/domain/Modules/Create.tsx
+++ b/ui/src/domain/Modules/Create.tsx
@@ -83,9 +83,7 @@ export const CreateModule = () => {
     }
   };
 
-  const handleVCSClick = (vcsType: VcsType) => {
-    navigate(`/organizations/${orgid}/settings/vcs/new/${vcsType}`);
-  };
+  const vcsLink = (vcsType: VcsType) => `/organizations/${orgid}/settings/vcs/new/${vcsType}`;
 
   const handleDifferent = () => {
     setVCSButtonsVisible(false);
@@ -325,41 +323,17 @@ export const CreateModule = () => {
               ) : (
                 <div>
                   <Space direction="horizontal">
-                    <Button
-                      icon={<GithubOutlined />}
-                      onClick={() => {
-                        handleVCSClick(VcsType.GITHUB);
-                      }}
-                      size="large"
-                    >
-                      GitHub
+                    <Button icon={<GithubOutlined />} size="large">
+                      <Link to={vcsLink(VcsType.GITHUB)}>GitHub</Link>
                     </Button>
-                    <Button
-                      icon={<GitlabOutlined />}
-                      onClick={() => {
-                        handleVCSClick(VcsType.GITLAB);
-                      }}
-                      size="large"
-                    >
-                      GitLab
+                    <Button icon={<GitlabOutlined />} size="large">
+                      <Link to={vcsLink(VcsType.GITLAB)}>GitLab</Link>
                     </Button>
-                    <Button
-                      icon={<SiBitbucket />}
-                      onClick={() => {
-                        handleVCSClick(VcsType.BITBUCKET);
-                      }}
-                      size="large"
-                    >
-                      &nbsp;&nbsp;Bitbucket
+                    <Button icon={<SiBitbucket />} size="large">
+                      <Link to={vcsLink(VcsType.BITBUCKET)}>&nbsp;&nbsp;Bitbucket</Link>
                     </Button>
-                    <Button
-                      icon={<VscAzureDevops />}
-                      onClick={() => {
-                        handleVCSClick(VcsType.AZURE_DEVOPS);
-                      }}
-                      size="large"
-                    >
-                      &nbsp;&nbsp;Azure Devops
+                    <Button icon={<VscAzureDevops />} size="large">
+                      <Link to={vcsLink(VcsType.AZURE_DEVOPS)}>&nbsp;&nbsp;Azure Devops</Link>
                     </Button>
                   </Space>
                   <br />

--- a/ui/src/domain/Modules/Create.tsx
+++ b/ui/src/domain/Modules/Create.tsx
@@ -10,7 +10,6 @@ import axiosInstance, { getErrorMessage } from "../../config/axiosConfig";
 import { SshKey, VcsModel, VcsType } from "../types";
 import { MODULE_SYSTEM_PATTERN } from "./moduleValidation";
 const { Content } = Layout;
-const { Step } = Steps;
 const validateMessages = {
   required: "${label} is required!",
   types: {
@@ -273,11 +272,13 @@ export const CreateModule = () => {
           <div className="App-text">
             This module will be created under the current organization, {sessionStorage.getItem(ORGANIZATION_NAME)}.
           </div>
-          <Steps direction="horizontal" size="small" current={current} onChange={handleChange}>
-            <Step title="Connect to VCS" />
-            <Step title="Choose a repository" />
-            <Step title="Confirm selection" />
-          </Steps>
+          <Steps
+            direction="horizontal"
+            size="small"
+            current={current}
+            onChange={handleChange}
+            items={[{ title: "Connect to VCS" }, { title: "Choose a repository" }, { title: "Confirm selection" }]}
+          />
 
           {current === 0 && (
             <Space className="chooseType" direction="vertical">

--- a/ui/src/domain/Modules/Details.tsx
+++ b/ui/src/domain/Modules/Details.tsx
@@ -723,6 +723,7 @@ export const ModuleDetails = ({ organizationName }: Props) => {
                             key: "delete",
                             label: (
                               <Popconfirm
+                                okButtonProps={{ danger: true }}
                                 title={
                                   <p>
                                     Module <b>{module.attributes.name}</b> will be permanently deleted.

--- a/ui/src/domain/Modules/ModuleList.tsx
+++ b/ui/src/domain/Modules/ModuleList.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { IconContext } from "react-icons";
 import { FaAws } from "@/config/iconList";
 import { VscAzure } from "react-icons/vsc";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { FlatModule } from "../types";
 import "./Module.css";
 
@@ -19,7 +19,6 @@ type Props = {
 
 export const ModuleList = ({ modules, searchFilter }: Props) => {
   const { orgid } = useParams<Params>();
-  const navigate = useNavigate();
 
   const filteredModules = useMemo(() => {
     if (searchFilter === "") {
@@ -57,56 +56,60 @@ export const ModuleList = ({ modules, searchFilter }: Props) => {
       dataSource={filteredModules}
       pagination={{ defaultPageSize: 5, showTotal: (total, range) => `${range[0]} - ${range[1]} of ${total}` }}
       renderItem={(item) => (
-        <List.Item
-          style={{ cursor: "pointer", padding: "6px 0" }}
-          onClick={() => navigate(`/organizations/${orgid}/registry/${item.id}`)}
-        >
-          <Card hoverable className="module-card" style={{ width: "100%" }} styles={{ body: { padding: 0 } }}>
-            <div className="module-card-body">
-              <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
-                <div
-                  style={{
-                    flexShrink: 0,
-                    width: 36,
-                    height: 36,
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
-                  {renderLogo(item.provider)}
-                </div>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <Typography.Text strong className="module-card-name">
-                    {item.name}
-                  </Typography.Text>
-                  <div className="module-card-desc">
-                    {item.description || "No description provided for this module"}
+        <List.Item style={{ padding: "6px 0" }}>
+          <Link
+            to={`/organizations/${orgid}/registry/${item.id}`}
+            style={{ display: "block", width: "100%", color: "inherit" }}
+          >
+            <Card hoverable className="module-card" style={{ width: "100%" }} styles={{ body: { padding: 0 } }}>
+              <div className="module-card-body">
+                <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
+                  <div
+                    style={{
+                      flexShrink: 0,
+                      width: 36,
+                      height: 36,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    {renderLogo(item.provider)}
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <Typography.Text strong className="module-card-name">
+                      {item.name}
+                    </Typography.Text>
+                    <div className="module-card-desc">
+                      {item.description || "No description provided for this module"}
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-            <div
-              style={{
-                borderTop: "1px solid #f0f0f0",
-                padding: "10px 24px",
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "center",
-              }}
-            >
-              <Space size={16}>
-                <Space size={4}>
-                  <DownloadOutlined style={{ fontSize: 13, color: "#8c97a8" }} />
-                  <Typography.Text style={{ fontSize: 13, color: "#8c97a8" }}>{item.downloadQuantity}</Typography.Text>
+              <div
+                style={{
+                  borderTop: "1px solid #f0f0f0",
+                  padding: "10px 24px",
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                }}
+              >
+                <Space size={16}>
+                  <Space size={4}>
+                    <DownloadOutlined style={{ fontSize: 13, color: "#8c97a8" }} />
+                    <Typography.Text style={{ fontSize: 13, color: "#8c97a8" }}>
+                      {item.downloadQuantity}
+                    </Typography.Text>
+                  </Space>
                 </Space>
-              </Space>
-              <Space size={6}>
-                {renderLogo(item.provider)}
-                <Typography.Text style={{ fontSize: 13, color: "#8c97a8" }}>{item.provider}</Typography.Text>
-              </Space>
-            </div>
-          </Card>
+                <Space size={6}>
+                  {renderLogo(item.provider)}
+                  <Typography.Text style={{ fontSize: 13, color: "#8c97a8" }}>{item.provider}</Typography.Text>
+                </Space>
+              </div>
+            </Card>
+          </Link>
         </List.Item>
       )}
     />

--- a/ui/src/domain/Modules/PublicRegistrySearch.tsx
+++ b/ui/src/domain/Modules/PublicRegistrySearch.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState } from "react";
 import { IconContext } from "react-icons";
 import { FaAws, FaGoogle } from "@/config/iconList";
 import { VscAzure } from "react-icons/vsc";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import PageWrapper from "@/modules/layout/PageWrapper/PageWrapper";
 import { importProvider, getProviderVersions, listProviders } from "../Providers/providerService";
 import { ProviderModel } from "../Providers/types";
@@ -185,10 +185,6 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
   const isModuleImported = (module: TerraformRegistryModule): boolean => {
     const key = `${module.name}/${module.provider}`.toLowerCase();
     return existingModules.has(key);
-  };
-
-  const handleBack = () => {
-    navigate(`/organizations/${orgid}/registry`);
   };
 
   const searchProviders = async (query: string) => {
@@ -683,8 +679,8 @@ export const PublicRegistrySearch = ({ organizationName }: Props) => {
         { label: "Public Registry Search", path: `/organizations/${orgid}/registry/search` },
       ]}
       actions={
-        <Button type="default" icon={<ArrowLeftOutlined />} onClick={handleBack}>
-          Back to your registry
+        <Button type="default" icon={<ArrowLeftOutlined />}>
+          <Link to={`/organizations/${orgid}/registry`}>Back to your registry</Link>
         </Button>
       }
     >

--- a/ui/src/domain/Modules/Registry.tsx
+++ b/ui/src/domain/Modules/Registry.tsx
@@ -236,8 +236,6 @@ export const Registry = ({ setOrganizationName, organizationName }: Props) => {
         { label: "Registry", path: `/organizations/${orgid}/registry` },
       ]}
       fluid
-      innerClassName="registry-centered"
-      contentClassName="registry-centered"
       actions={
         <Space>
           <ListViewToggle value={listViewMode} onChange={setListViewMode} />

--- a/ui/src/domain/Modules/Registry.tsx
+++ b/ui/src/domain/Modules/Registry.tsx
@@ -129,6 +129,8 @@ export const Registry = ({ setOrganizationName, organizationName }: Props) => {
   useEffect(() => {
     if (!orgid) return;
     sessionStorage.setItem(ORGANIZATION_ARCHIVE, orgid);
+    modulesLoaded.current = false;
+    providersLoaded.current = false;
 
     const init = async () => {
       setLoading(true);

--- a/ui/src/domain/Modules/Registry.tsx
+++ b/ui/src/domain/Modules/Registry.tsx
@@ -7,7 +7,7 @@ import {
   CloudServerOutlined,
 } from "@ant-design/icons";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 import PageWrapper from "@/modules/layout/PageWrapper/PageWrapper";
 import { ModuleList } from "./ModuleList";
 import ModuleTable from "./components/ModuleTable";
@@ -86,7 +86,6 @@ async function fetchOrgName(orgId: string): Promise<string> {
 
 export const Registry = ({ setOrganizationName, organizationName }: Props) => {
   const { orgid } = useParams<Params>();
-  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [searchFilter, setSearchFilter] = useState("");
   const [modules, setModules] = useState<FlatModule[]>([]);
@@ -181,15 +180,10 @@ export const Registry = ({ setOrganizationName, organizationName }: Props) => {
     }
   };
 
-  const handleSearchPublicRegistry = () => {
-    navigate(`/organizations/${orgid}/registry/search`);
-  };
-
   const publishMenuItems: MenuProps["items"] = [
     {
       key: "module",
-      label: "Publish module",
-      onClick: () => navigate(`/organizations/${orgid}/registry/create`),
+      label: <Link to={`/organizations/${orgid}/registry/create`}>Publish module</Link>,
     },
   ];
 
@@ -241,8 +235,8 @@ export const Registry = ({ setOrganizationName, organizationName }: Props) => {
       actions={
         <Space>
           <ListViewToggle value={listViewMode} onChange={setListViewMode} />
-          <Button type="default" icon={<SearchOutlined />} onClick={handleSearchPublicRegistry}>
-            Search public registry
+          <Button type="default" icon={<SearchOutlined />}>
+            <Link to={`/organizations/${orgid}/registry/search`}>Search public registry</Link>
           </Button>
           <Dropdown menu={{ items: publishMenuItems }} trigger={["click"]}>
             <Button type="primary" icon={<CloudUploadOutlined />}>

--- a/ui/src/domain/Modules/components/ModuleTable.tsx
+++ b/ui/src/domain/Modules/components/ModuleTable.tsx
@@ -1,6 +1,6 @@
 import { DownloadOutlined } from "@ant-design/icons";
 import { Table, Typography } from "antd";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import formatVersion from "@/modules/utils/formatVersion";
 import { FlatModule } from "../../types";
 
@@ -31,14 +31,14 @@ export default function ModuleTable({ modules, searchFilter }: Props) {
       key: "name",
       sorter: (a: FlatModule, b: FlatModule) => a.name.localeCompare(b.name),
       render: (name: string, record: FlatModule) => (
-        <div>
+        <Link to={`/organizations/${orgid}/registry/${record.id}`} style={{ color: "inherit", display: "block" }}>
           <Typography.Text strong>{name}</Typography.Text>
           <div>
             <Typography.Text type="secondary" ellipsis style={{ fontSize: 12 }}>
               {record.description || "No description provided for this module"}
             </Typography.Text>
           </div>
-        </div>
+        </Link>
       ),
     },
     {
@@ -77,7 +77,10 @@ export default function ModuleTable({ modules, searchFilter }: Props) {
       columns={columns}
       pagination={{ defaultPageSize: 10, showSizeChanger: true }}
       onRow={(record) => ({
-        onClick: () => navigate(`/organizations/${orgid}/registry/${record.id}`),
+        onClick: (event) => {
+          if ((event.target as HTMLElement).closest("a")) return;
+          navigate(`/organizations/${orgid}/registry/${record.id}`);
+        },
         style: { cursor: "pointer" },
       })}
       locale={{ emptyText: "No modules match your search." }}

--- a/ui/src/domain/Notifications/NotificationConfigurationList.tsx
+++ b/ui/src/domain/Notifications/NotificationConfigurationList.tsx
@@ -188,6 +188,7 @@ export const NotificationConfigurationList = ({ orgId, workspaceId, managePermis
                         Edit
                       </Button>,
                       <Popconfirm
+                        okButtonProps={{ danger: true }}
                         title="This will permanently delete this notification configuration. Are you sure?"
                         onConfirm={() => onDelete(item.id)}
                         okText="Yes"

--- a/ui/src/domain/Organizations/Create.tsx
+++ b/ui/src/domain/Organizations/Create.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
 import axiosInstance from "../../config/axiosConfig";
 import { IconSelector } from "./IconSelector";
+import { organizationNameRules } from "../../config/validation";
 import { useState } from "react";
 import "./Organizations.css";
 const { Content } = Layout;
@@ -120,10 +121,7 @@ export const CreateOrganization = ({ setOrganizationName }: Props) => {
               label="Organization name"
               tooltip="e.g. company-name"
               extra=" Organization names must be unique and will be part of your resource names used in various tools, for example development, production, finance."
-              rules={[
-                { required: true, message: "This field is required!" },
-                { pattern: /^[a-zA-Z0-9]*$/, message: "Only letters and numbers are allowed!" },
-              ]}
+              rules={organizationNameRules}
             >
               <Input />
             </Form.Item>

--- a/ui/src/domain/Providers/ProviderDetails.tsx
+++ b/ui/src/domain/Providers/ProviderDetails.tsx
@@ -215,6 +215,7 @@ export const ProviderDetails = ({ organizationName }: Props) => {
                         key: "delete",
                         label: (
                           <Popconfirm
+                            okButtonProps={{ danger: true }}
                             title={
                               <p>
                                 Provider <b>{providerName}</b> and all its versions will be permanently deleted.

--- a/ui/src/domain/Providers/ProviderList.tsx
+++ b/ui/src/domain/Providers/ProviderList.tsx
@@ -1,7 +1,7 @@
 import { CloudOutlined, LinkOutlined } from "@ant-design/icons";
 import { Card, Empty, List, Space, Typography } from "antd";
 import { useMemo } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import formatVersion from "@/modules/utils/formatVersion";
 import { FlatProvider } from "./types";
 import "../Modules/Module.css";
@@ -34,7 +34,6 @@ const extractSourceRepo = (description: string): { repoLabel: string; repoUrl: s
 
 export const ProviderList = ({ providers, searchFilter }: Props) => {
   const { orgid } = useParams<Params>();
-  const navigate = useNavigate();
 
   const filteredProviders = useMemo(() => {
     if (searchFilter === "") {
@@ -71,68 +70,70 @@ export const ProviderList = ({ providers, searchFilter }: Props) => {
           : desc.replace(/Source:?\s*/i, "").trim();
 
         return (
-          <List.Item
-            style={{ cursor: "pointer", padding: "6px 0" }}
-            onClick={() => navigate(`/organizations/${orgid}/registry/providers/${item.id}`)}
-          >
-            <Card hoverable className="module-card" style={{ width: "100%" }} styles={{ body: { padding: 0 } }}>
-              <div className="module-card-body">
-                <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
-                  <div
-                    style={{
-                      flexShrink: 0,
-                      width: 36,
-                      height: 36,
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                    }}
-                  >
-                    <CloudOutlined style={{ fontSize: 18, color: "#7b61ff" }} />
-                  </div>
-                  <div style={{ flex: 1, minWidth: 0 }}>
-                    <Typography.Text strong className="module-card-name">
-                      {item.name}
-                    </Typography.Text>
-                    <div className="module-card-desc">
-                      {descriptionText || "No description provided for this provider"}
+          <List.Item style={{ padding: "6px 0" }}>
+            <Link
+              to={`/organizations/${orgid}/registry/providers/${item.id}`}
+              style={{ display: "block", width: "100%", color: "inherit" }}
+            >
+              <Card hoverable className="module-card" style={{ width: "100%" }} styles={{ body: { padding: 0 } }}>
+                <div className="module-card-body">
+                  <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
+                    <div
+                      style={{
+                        flexShrink: 0,
+                        width: 36,
+                        height: 36,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      <CloudOutlined style={{ fontSize: 18, color: "#7b61ff" }} />
+                    </div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <Typography.Text strong className="module-card-name">
+                        {item.name}
+                      </Typography.Text>
+                      <div className="module-card-desc">
+                        {descriptionText || "No description provided for this provider"}
+                      </div>
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                style={{
-                  borderTop: "1px solid #f0f0f0",
-                  padding: "10px 24px",
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                }}
-              >
-                <Space size={16}>
-                  {item.latestVersion && (
-                    <Typography.Text style={{ fontSize: 13, color: "#8c97a8" }}>
-                      {formatVersion(item.latestVersion)}
-                    </Typography.Text>
-                  )}
-                </Space>
-                <Space size={6}>
-                  {source && (
-                    <Typography.Link
-                      href={source.repoUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={(e) => e.stopPropagation()}
-                      style={{ fontSize: 13 }}
-                    >
-                      <LinkOutlined style={{ marginRight: 3 }} />
-                      {source.repoLabel}
-                    </Typography.Link>
-                  )}
-                  <Typography.Text style={{ fontSize: 13, color: "#8c97a8" }}>provider</Typography.Text>
-                </Space>
-              </div>
-            </Card>
+                <div
+                  style={{
+                    borderTop: "1px solid #f0f0f0",
+                    padding: "10px 24px",
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                  }}
+                >
+                  <Space size={16}>
+                    {item.latestVersion && (
+                      <Typography.Text style={{ fontSize: 13, color: "#8c97a8" }}>
+                        {formatVersion(item.latestVersion)}
+                      </Typography.Text>
+                    )}
+                  </Space>
+                  <Space size={6}>
+                    {source && (
+                      <Typography.Link
+                        href={source.repoUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        style={{ fontSize: 13 }}
+                      >
+                        <LinkOutlined style={{ marginRight: 3 }} />
+                        {source.repoLabel}
+                      </Typography.Link>
+                    )}
+                    <Typography.Text style={{ fontSize: 13, color: "#8c97a8" }}>provider</Typography.Text>
+                  </Space>
+                </div>
+              </Card>
+            </Link>
           </List.Item>
         );
       }}

--- a/ui/src/domain/Providers/components/ProviderTable.tsx
+++ b/ui/src/domain/Providers/components/ProviderTable.tsx
@@ -1,5 +1,5 @@
 import { Table, Typography } from "antd";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import formatVersion from "@/modules/utils/formatVersion";
 import { FlatProvider } from "../types";
 
@@ -30,14 +30,17 @@ export default function ProviderTable({ providers, searchFilter }: Props) {
       key: "name",
       sorter: (a: FlatProvider, b: FlatProvider) => a.name.localeCompare(b.name),
       render: (name: string, record: FlatProvider) => (
-        <div>
+        <Link
+          to={`/organizations/${orgid}/registry/providers/${record.id}`}
+          style={{ color: "inherit", display: "block" }}
+        >
           <Typography.Text strong>{name}</Typography.Text>
           <div>
             <Typography.Text type="secondary" ellipsis style={{ fontSize: 12 }}>
               {record.description || "No description provided for this provider"}
             </Typography.Text>
           </div>
-        </div>
+        </Link>
       ),
     },
     {
@@ -56,7 +59,10 @@ export default function ProviderTable({ providers, searchFilter }: Props) {
       columns={columns}
       pagination={{ defaultPageSize: 10, showSizeChanger: true }}
       onRow={(record) => ({
-        onClick: () => navigate(`/organizations/${orgid}/registry/providers/${record.id}`),
+        onClick: (event) => {
+          if ((event.target as HTMLElement).closest("a")) return;
+          navigate(`/organizations/${orgid}/registry/providers/${record.id}`);
+        },
         style: { cursor: "pointer" },
       })}
       locale={{ emptyText: "No providers match your search." }}

--- a/ui/src/domain/Settings/Actions.tsx
+++ b/ui/src/domain/Settings/Actions.tsx
@@ -113,6 +113,7 @@ export const ActionSettings = ({ managePermission = true }: Props) => {
             Edit
           </Button>
           <Popconfirm
+            okButtonProps={{ danger: true }}
             title="Are you sure to delete this action?"
             onConfirm={() => onDelete(record.id)}
             okText="Yes"

--- a/ui/src/domain/Settings/AddTemplate.tsx
+++ b/ui/src/domain/Settings/AddTemplate.tsx
@@ -9,7 +9,6 @@ import { getMonacoTheme, monacoOptions } from "../../config/monacoConfig";
 import { TemplateAttributes } from "../types";
 import SettingsSection from "@/modules/layout/SettingsSection/SettingsSection";
 import "./Settings.css";
-const { Step } = Steps;
 const { Meta } = Card;
 const validateMessages = {
   required: "${label} is required!",
@@ -172,11 +171,13 @@ export const AddTemplate = ({ setMode, loadTemplates }: Props) => {
           plan/apply/destroy.
         </Typography.Text>
       </div>
-      <Steps direction="horizontal" size="small" current={current} onChange={handleChange}>
-        <Step title="Choose Type" />
-        <Step title="Define Template" />
-        <Step title="Configure Settings" />
-      </Steps>
+      <Steps
+        direction="horizontal"
+        size="small"
+        current={current}
+        onChange={handleChange}
+        items={[{ title: "Choose Type" }, { title: "Define Template" }, { title: "Configure Settings" }]}
+      />
       {current == 0 && (
         <SettingsSection maxWidth="100%">
           <Space className="chooseType" direction="vertical">

--- a/ui/src/domain/Settings/AddVCS.tsx
+++ b/ui/src/domain/Settings/AddVCS.tsx
@@ -14,7 +14,6 @@ import { VcsConnectionType, VcsType, VcsTypeExtended } from "../types";
 import SettingsSection from "@/modules/layout/SettingsSection/SettingsSection";
 import "./Settings.css";
 
-const { Step } = Steps;
 const validateMessages = {
   required: "${label} is required!",
 };
@@ -801,10 +800,13 @@ export const AddVCS = ({ setMode, loadVCS }: Props) => {
           your version control system (VCS) provider.
         </Typography.Text>
       </div>
-      <Steps direction="horizontal" size="small" current={current} onChange={handleChange}>
-        <Step title="Connect to VCS" />
-        <Step title="Set up provider" />
-      </Steps>
+      <Steps
+        direction="horizontal"
+        size="small"
+        current={current}
+        onChange={handleChange}
+        items={[{ title: "Connect to VCS" }, { title: "Set up provider" }]}
+      />
       {current == 0 && (
         <SettingsSection>
           <Space className="chooseType" direction="vertical">

--- a/ui/src/domain/Settings/Agents.tsx
+++ b/ui/src/domain/Settings/Agents.tsx
@@ -177,6 +177,7 @@ export const AgentSettings = ({ managePermission = true }: Props) => {
                   <List.Item
                     actions={[
                       <Popconfirm
+                        okButtonProps={{ danger: true }}
                         onConfirm={() => {
                           onDelete(item.id);
                         }}

--- a/ui/src/domain/Settings/CollectionItems.tsx
+++ b/ui/src/domain/Settings/CollectionItems.tsx
@@ -105,6 +105,7 @@ export const CollectionItemsSettings = ({ collectionId, collectionName }: Props)
               Edit
             </Button>
             <Popconfirm
+              okButtonProps={{ danger: true }}
               onConfirm={() => {
                 onDelete(record.id);
               }}

--- a/ui/src/domain/Settings/CollectionReferences.tsx
+++ b/ui/src/domain/Settings/CollectionReferences.tsx
@@ -75,6 +75,7 @@ export const CollectionReferencesSettings = ({ collectionId, collectionName }: P
         return (
           <div>
             <Popconfirm
+              okButtonProps={{ danger: true }}
               onConfirm={() => {
                 onDelete(record.id);
               }}

--- a/ui/src/domain/Settings/CreateEditCollection.tsx
+++ b/ui/src/domain/Settings/CreateEditCollection.tsx
@@ -14,7 +14,7 @@ import {
   message,
 } from "antd";
 import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import axiosInstance from "../../config/axiosConfig";
 import SettingsSection from "@/modules/layout/SettingsSection/SettingsSection";
 import "./Settings.css";
@@ -106,10 +106,6 @@ export const CreateEditCollection = ({
       });
     }
   }, [orgid, collectionid, mode, collectionForm]);
-
-  const handleCancel = () => {
-    navigate(`/organizations/${orgid}/settings/collection`);
-  };
 
   const handleSave = async () => {
     try {
@@ -701,7 +697,9 @@ export const CreateEditCollection = ({
 
           <div style={{ display: "flex", justifyContent: "flex-start", marginTop: "30px" }}>
             <Space>
-              <Button onClick={handleCancel}>Cancel</Button>
+              <Button>
+                <Link to={`/organizations/${orgid}/settings/collection`}>Cancel</Link>
+              </Button>
               <Button type="primary" onClick={handleSave} loading={saveLoading} disabled={!managePermission}>
                 {mode === "create" ? "Create variable collection" : "Save Variable Collection"}
               </Button>

--- a/ui/src/domain/Settings/FederatedCredentials.tsx
+++ b/ui/src/domain/Settings/FederatedCredentials.tsx
@@ -135,6 +135,7 @@ export const FederatedCredentials = ({ managePermission = true }: Props) => {
                         Edit
                       </Button>,
                       <Popconfirm
+                        okButtonProps={{ danger: true }}
                         onConfirm={() => onDelete(item.id)}
                         title={
                           <p>

--- a/ui/src/domain/Settings/General.tsx
+++ b/ui/src/domain/Settings/General.tsx
@@ -250,6 +250,7 @@ export const GeneralSettings = ({ managePermission = true }: Props) => {
         }
       >
         <Popconfirm
+          okButtonProps={{ danger: true }}
           onConfirm={() => {
             onDelete();
           }}

--- a/ui/src/domain/Settings/General.tsx
+++ b/ui/src/domain/Settings/General.tsx
@@ -17,6 +17,7 @@ import axiosInstance, { getErrorMessage, isPermissionError } from "../../config/
 import { Organization, sparseFields, SparseOf } from "../types";
 import { IconSelector } from "../Organizations/IconSelector";
 import SettingsSection from "@/modules/layout/SettingsSection/SettingsSection";
+import { organizationNameRules } from "../../config/validation";
 import "./Settings.css";
 
 const DEFAULT_ICON = "FaBuilding";
@@ -169,7 +170,7 @@ export const GeneralSettings = ({ managePermission = true }: Props) => {
             }}
           >
             <SettingsSection title="Identity" description="Basic information about this organization.">
-              <Form.Item name="name" label="Name">
+              <Form.Item name="name" label="Name" rules={organizationNameRules}>
                 <Input />
               </Form.Item>
               <Form.Item

--- a/ui/src/domain/Settings/GlobalVariables.tsx
+++ b/ui/src/domain/Settings/GlobalVariables.tsx
@@ -76,6 +76,7 @@ export const GlobalVariablesSettings = ({ managePermission = true }: Props) => {
               Edit
             </Button>
             <Popconfirm
+              okButtonProps={{ danger: true }}
               onConfirm={() => {
                 onDelete(record.id);
               }}

--- a/ui/src/domain/Settings/SSHKeys.tsx
+++ b/ui/src/domain/Settings/SSHKeys.tsx
@@ -178,6 +178,7 @@ export const SSHKeysSettings = ({ managePermission = true }: Props) => {
                   <List.Item
                     actions={[
                       <Popconfirm
+                        okButtonProps={{ danger: true }}
                         onConfirm={() => {
                           onDelete(item.id);
                         }}

--- a/ui/src/domain/Settings/Tags.tsx
+++ b/ui/src/domain/Settings/Tags.tsx
@@ -194,6 +194,7 @@ export const TagsSettings = ({ managePermission = true }: Props) => {
                         Edit
                       </Button>,
                       <Popconfirm
+                        okButtonProps={{ danger: true }}
                         onConfirm={() => {
                           onDelete(item.id);
                         }}

--- a/ui/src/domain/Settings/Teams.tsx
+++ b/ui/src/domain/Settings/Teams.tsx
@@ -165,6 +165,7 @@ export const TeamSettings = ({ key, managePermission = true }: Props) => {
                           Edit
                         </Button>,
                         <Popconfirm
+                          okButtonProps={{ danger: true }}
                           onConfirm={() => onDelete(item.id)}
                           title={
                             <p>

--- a/ui/src/domain/Settings/Templates.tsx
+++ b/ui/src/domain/Settings/Templates.tsx
@@ -111,6 +111,7 @@ export const TemplatesSettings = ({ key, managePermission = true }: Props) => {
                           Edit
                         </Button>,
                         <Popconfirm
+                          okButtonProps={{ danger: true }}
                           onConfirm={() => {
                             onDelete(item.id);
                           }}

--- a/ui/src/domain/Settings/VCS.tsx
+++ b/ui/src/domain/Settings/VCS.tsx
@@ -207,6 +207,7 @@ export const VCSSettings = ({ vcsMode, managePermission = true }: Props) => {
                           </Button>
                           &nbsp;&nbsp;&nbsp;
                           <Popconfirm
+                            okButtonProps={{ danger: true }}
                             onConfirm={() => {
                               onDelete(item.id);
                             }}

--- a/ui/src/domain/Settings/VariableCollections.tsx
+++ b/ui/src/domain/Settings/VariableCollections.tsx
@@ -8,7 +8,7 @@ import {
 } from "@ant-design/icons";
 import { Alert, Button, Card, Input, List, Popconfirm, Space, Spin, Typography, Pagination, message } from "antd";
 import { useEffect, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import axiosInstance, { getErrorMessage } from "../../config/axiosConfig";
 import SettingsSection from "@/modules/layout/SettingsSection/SettingsSection";
 import "./Settings.css";
@@ -39,7 +39,6 @@ type Props = {
 
 export const VariableCollectionsSettings = ({ managePermission = true }: Props) => {
   const { orgid } = useParams();
-  const navigate = useNavigate();
   const [collections, setCollections] = useState<Collection[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -48,17 +47,7 @@ export const VariableCollectionsSettings = ({ managePermission = true }: Props) 
   const [currentPage, setCurrentPage] = useState(1);
   const pageSize = 10;
 
-  const handleViewDetails = (id: string) => {
-    navigate(`/organizations/${orgid}/settings/collection/edit/${id}`);
-  };
-
-  const handleEditCollection = (id: string) => {
-    navigate(`/organizations/${orgid}/settings/collection/edit/${id}`);
-  };
-
-  const handleCreateCollection = () => {
-    navigate(`/organizations/${orgid}/settings/collection/new`);
-  };
+  const editCollectionLink = (id: string) => `/organizations/${orgid}/settings/collection/edit/${id}`;
 
   const onDelete = async (id: string) => {
     try {
@@ -189,8 +178,12 @@ export const VariableCollectionsSettings = ({ managePermission = true }: Props) 
       </div>
       <SettingsSection maxWidth="100%">
         <div style={{ display: "flex", justifyContent: "flex-start", marginBottom: "20px" }}>
-          <Button type="primary" onClick={handleCreateCollection} icon={<PlusOutlined />} disabled={!managePermission}>
-            Create variable collection
+          <Button type="primary" icon={<PlusOutlined />} disabled={!managePermission}>
+            {managePermission ? (
+              <Link to={`/organizations/${orgid}/settings/collection/new`}>Create variable collection</Link>
+            ) : (
+              "Create variable collection"
+            )}
           </Button>
         </div>
         <div style={{ marginBottom: "20px", width: "100%" }}>
@@ -218,13 +211,9 @@ export const VariableCollectionsSettings = ({ managePermission = true }: Props) 
               dataSource={paginatedCollections}
               renderItem={(item) => (
                 <List.Item>
-                  <Card
-                    hoverable
-                    style={{ width: "100%", cursor: "pointer" }}
-                    onClick={() => handleViewDetails(item.id)}
-                  >
+                  <Card hoverable style={{ width: "100%" }}>
                     <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
-                      <div>
+                      <Link to={editCollectionLink(item.id)} style={{ display: "block", flex: 1, color: "inherit" }}>
                         <Typography.Title level={4} style={{ margin: 0 }}>
                           {item.attributes.name}
                         </Typography.Title>
@@ -241,18 +230,10 @@ export const VariableCollectionsSettings = ({ managePermission = true }: Props) 
                             {item.relationships?.variables?.data?.length || 0} variables
                           </span>
                         </Space>
-                      </div>
+                      </Link>
                       <Space>
-                        <Button
-                          type="text"
-                          icon={<EditOutlined />}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleEditCollection(item.id);
-                          }}
-                          disabled={!managePermission}
-                        >
-                          Edit
+                        <Button type="text" icon={<EditOutlined />} disabled={!managePermission}>
+                          {managePermission ? <Link to={editCollectionLink(item.id)}>Edit</Link> : "Edit"}
                         </Button>
                         <Popconfirm
                           okButtonProps={{ danger: true }}

--- a/ui/src/domain/Settings/VariableCollections.tsx
+++ b/ui/src/domain/Settings/VariableCollections.tsx
@@ -255,6 +255,7 @@ export const VariableCollectionsSettings = ({ managePermission = true }: Props) 
                           Edit
                         </Button>
                         <Popconfirm
+                          okButtonProps={{ danger: true }}
                           title="Delete this variable collection?"
                           description="This will permanently delete this variable collection and all its variables. Are you sure?"
                           onConfirm={(e) => {

--- a/ui/src/domain/Workspaces/Create.tsx
+++ b/ui/src/domain/Workspaces/Create.tsx
@@ -114,78 +114,60 @@ export const CreateWorkspace = () => {
     name: "Terraform",
   });
   const [projectList, setProjectList] = useState<ProjectModel[]>([]);
+  const vcsLink = (vcsType: VcsTypeExtended, connectionType?: VcsConnectionType) =>
+    `/organizations/${organizationId}/settings/vcs/new/${vcsType}${connectionType ? `?connectionType=${connectionType}` : ""}`;
+
   const gitlabItems = [
     {
-      label: "GitLab.com",
+      label: <Link to={vcsLink(VcsTypeExtended.GITLAB)}>GitLab.com</Link>,
       key: "1",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.GITLAB);
-      },
     },
     {
-      label: "GitLab Community Edition",
+      label: <Link to={vcsLink(VcsTypeExtended.GITLAB_COMMUNITY)}>GitLab Community Edition</Link>,
       key: "2",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.GITLAB_COMMUNITY);
-      },
     },
     {
-      label: "GitLab Enterprise Edition",
+      label: <Link to={vcsLink(VcsTypeExtended.GITLAB_ENTERPRISE)}>GitLab Enterprise Edition</Link>,
       key: "3",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.GITLAB_ENTERPRISE);
-      },
     },
   ];
 
   const githubItems = [
     {
-      label: "GitHub.com (GitHub App)",
+      label: (
+        <Link to={vcsLink(VcsTypeExtended.GITHUB_APP, VcsConnectionType.STANDALONE)}>GitHub.com (GitHub App)</Link>
+      ),
       key: "1",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.GITHUB_APP, VcsConnectionType.STANDALONE);
-      },
     },
     {
-      label: "GitHub.com (oAuth App)",
+      label: <Link to={vcsLink(VcsTypeExtended.GITHUB)}>GitHub.com (oAuth App)</Link>,
       key: "2",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.GITHUB);
-      },
     },
     {
-      label: "GitHub Enterprise (GitHub App)",
+      label: (
+        <Link to={vcsLink(VcsTypeExtended.GITHUB_ENTERPRISE, VcsConnectionType.STANDALONE)}>
+          GitHub Enterprise (GitHub App)
+        </Link>
+      ),
       key: "3",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.GITHUB_ENTERPRISE, VcsConnectionType.STANDALONE);
-      },
     },
     {
-      label: "GitHub Enterprise (oAuth App)",
+      label: <Link to={vcsLink(VcsTypeExtended.GITHUB_ENTERPRISE)}>GitHub Enterprise (oAuth App)</Link>,
       key: "4",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.GITHUB_ENTERPRISE);
-      },
     },
   ];
 
   const bitBucketItems = [
     {
-      label: "Bitbucket Cloud",
+      label: <Link to={vcsLink(VcsTypeExtended.BITBUCKET)}>Bitbucket Cloud</Link>,
       key: "1",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.BITBUCKET);
-      },
     },
   ];
 
   const azDevOpsItems = [
     {
-      label: "Azure DevOps Services",
+      label: <Link to={vcsLink(VcsTypeExtended.AZURE_DEVOPS)}>Azure DevOps Services</Link>,
       key: "1",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.AZURE_DEVOPS);
-      },
     },
   ];
   const navigate = useNavigate();
@@ -359,11 +341,6 @@ export const CreateWorkspace = () => {
   const handleRepoSelect = (repo: VcsRepositorySummary) => {
     setSelectedRepoUrl(repo.url);
     form.setFieldsValue({ source: repo.url });
-  };
-
-  const handleVCSClick = (vcsType: VcsTypeExtended, connectionType?: VcsConnectionType) => {
-    const query = connectionType ? `?connectionType=${connectionType}` : "";
-    navigate(`/organizations/${organizationId}/settings/vcs/new/${vcsType}${query}`);
   };
 
   const handleConnectDifferent = () => {

--- a/ui/src/domain/Workspaces/Create.tsx
+++ b/ui/src/domain/Workspaces/Create.tsx
@@ -28,7 +28,7 @@ import { VscAzureDevops } from "react-icons/vsc";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { v7 as uuid } from "uuid";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
-import axiosInstance from "../../config/axiosConfig";
+import axiosInstance, { getErrorMessage } from "../../config/axiosConfig";
 import {
   ProjectModel,
   SshKey,
@@ -206,46 +206,52 @@ export const CreateWorkspace = () => {
       axiosInstance.get(`organization/${organizationId}/template`),
       axiosInstance.get(`organization/${organizationId}/vcs`),
       projectService.listProjects(organizationId!),
-    ]).then(([versionsRes, sshRes, templatesRes, vcsRes, projectsRes]) => {
-      // Process versions
-      const tfVersions: string[] = [];
-      if (iacType.id === "tofu") {
-        (versionsRes.data as TofuRelease[]).forEach((release) => {
-          if (!release.tag_name.includes("-")) tfVersions.push(release.tag_name.replace("v", ""));
-        });
-      } else {
-        for (const version in versionsRes.data.versions) {
-          if (!version.includes("-")) tfVersions.push(version);
+    ])
+      .then(([versionsRes, sshRes, templatesRes, vcsRes, projectsRes]) => {
+        // Process versions
+        const tfVersions: string[] = [];
+        if (iacType.id === "tofu") {
+          (versionsRes.data as TofuRelease[]).forEach((release) => {
+            if (!release.tag_name.includes("-")) tfVersions.push(release.tag_name.replace("v", ""));
+          });
+        } else {
+          for (const version in versionsRes.data.versions) {
+            if (!version.includes("-")) tfVersions.push(version);
+          }
         }
-      }
-      tfVersions.sort(compareVersions).reverse();
-      setTerraformVersions(tfVersions);
-      if (tfVersions.length > 0) {
-        form.setFieldsValue({ terraformVersion: tfVersions[0] });
-      }
-
-      // Set SSH keys
-      setSSHKeys(sshRes.data.data);
-
-      // Set templates
-      setOrgTemplates(templatesRes.data.data);
-      if (templatesRes.data.data.length > 0) {
-        form.setFieldsValue({ defaultTemplate: templatesRes.data.data[0].id });
-      }
-
-      // Set VCS
-      setVCS(vcsRes.data.data);
-
-      // Set projects
-      if (!projectsRes.isError) {
-        setProjectList(projectsRes.data);
-        if (preselectedProjectId) {
-          form.setFieldsValue({ project: preselectedProjectId });
+        tfVersions.sort(compareVersions).reverse();
+        setTerraformVersions(tfVersions);
+        if (tfVersions.length > 0) {
+          form.setFieldsValue({ terraformVersion: tfVersions[0] });
         }
-      }
 
-      setLoading(false);
-    });
+        // Set SSH keys
+        setSSHKeys(sshRes.data.data);
+
+        // Set templates
+        setOrgTemplates(templatesRes.data.data);
+        if (templatesRes.data.data.length > 0) {
+          form.setFieldsValue({ defaultTemplate: templatesRes.data.data[0].id });
+        }
+
+        // Set VCS
+        setVCS(vcsRes.data.data);
+
+        // Set projects
+        if (!projectsRes.isError) {
+          setProjectList(projectsRes.data);
+          if (preselectedProjectId) {
+            form.setFieldsValue({ project: preselectedProjectId });
+          }
+        }
+
+        setLoading(false);
+      })
+      .catch((error) => {
+        console.error("Failed to load workspace creation data:", error);
+        message.error(getErrorMessage(error));
+        setLoading(false);
+      });
   }, []);
   const handleClick = () => {
     setCurrent(2);

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -380,7 +380,6 @@ export const WorkspaceDetails = ({
   usePolling(
     () => {
       loadWorkspace(false, false, false);
-      loadPermissionSet();
     },
     { interval: 10000, enabled: Boolean(id), immediate: false }
   );
@@ -433,11 +432,15 @@ export const WorkspaceDetails = ({
       });
   };
 
-  const loadWorkspace = (_loadVersions: boolean, _loadWebhook = false, _loadPermissionSet = false) => {
-    axiosInstance
-      .get(`organization/${organizationId}/template`)
-      .then((template) => {
-        setTemplates(template.data.data);
+  const loadWorkspace = (_loadVersions: boolean, _loadTemplates = false, _loadPermissionSet = false) => {
+    const templatesRequest: Promise<any[]> = _loadTemplates
+      ? axiosInstance.get(`organization/${organizationId}/template`).then((template) => {
+          setTemplates(template.data.data);
+          return template.data.data;
+        })
+      : Promise.resolve(templates);
+    templatesRequest
+      .then((templateList) => {
         axiosInstance
           .get(
             `organization/${organizationId}/workspace/${id}?include=job,variable,history,schedule,vcs,agent,organization,webhook,reference,project`
@@ -455,7 +458,7 @@ export const WorkspaceDetails = ({
                 setEnvVariables,
                 setHistory,
                 setSchedule,
-                template.data.data,
+                templateList,
                 setLastRun,
                 setVCSProvider,
                 setCurrentStateId,
@@ -464,7 +467,7 @@ export const WorkspaceDetails = ({
                 setResources,
                 setOutputs,
                 setAgent,
-                _loadWebhook,
+                _loadTemplates,
                 setContextState,
                 setCollectionVariables,
                 setCollectionEnvVariables,
@@ -494,7 +497,7 @@ export const WorkspaceDetails = ({
             setWorkspaceName(response.data.data.attributes.name);
             setExecutionMode(response.data.data.attributes.executionMode);
             if (runid && _loadVersions) changeJob(runid); // if runid is provided, show the job details
-            fetchActions();
+            if (_loadVersions) fetchActions();
             setLoadError(null);
           })
           .catch((err) => {

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -576,12 +576,7 @@ export const WorkspaceDetails = ({
                         ),
                       }}
                       dataSource={
-                        jobs.length > 0
-                          ? jobs
-                              .sort((a: any, b: any) => a.id - b.id)
-                              .reverse()
-                              .slice(0, 1)
-                          : []
+                        jobs.length > 0 ? [...jobs].sort((a: any, b: any) => b.id - a.id).slice(0, 1) : []
                       }
                       renderItem={(item) => (
                         <List.Item>

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -169,10 +169,7 @@ export const WorkspaceDetails = ({
     token: { colorBgContainer },
   } = theme.useToken();
 
-  const handleClick = (jobid: string) => {
-    changeJob(jobid);
-    navigate(`/organizations/${organizationId}/workspaces/${id}/runs/${jobid}`);
-  };
+  const runLink = (jobid: string) => `/organizations/${organizationId}/workspaces/${id}/runs/${jobid}`;
 
   const getOutputValueFromState = (outputName: string): string => {
     const outputValue = (contextState as any)?.values?.outputs?.[outputName];
@@ -578,9 +575,7 @@ export const WorkspaceDetails = ({
                           />
                         ),
                       }}
-                      dataSource={
-                        jobs.length > 0 ? [...jobs].sort((a: any, b: any) => b.id - a.id).slice(0, 1) : []
-                      }
+                      dataSource={jobs.length > 0 ? [...jobs].sort((a: any, b: any) => b.id - a.id).slice(0, 1) : []}
                       renderItem={(item) => (
                         <List.Item>
                           <List.Item.Meta
@@ -595,7 +590,9 @@ export const WorkspaceDetails = ({
                                       className="ant-list-item-meta-title"
                                       style={{ margin: 0 }}
                                     >
-                                      <a onClick={() => handleClick(item.id)}>{item.title}</a>{" "}
+                                      <Link to={runLink(item.id)} onClick={() => changeJob(item.id)}>
+                                        {item.title}
+                                      </Link>{" "}
                                     </Typography.Title>
                                     <b>{item.createdBy}</b> triggered a run {item.latestChange} via{" "}
                                     <b>{item.via || "UI"}</b>{" "}
@@ -620,7 +617,11 @@ export const WorkspaceDetails = ({
                                 <Row>
                                   <Col span={20}></Col>
                                   <Col>
-                                    <Button onClick={() => handleClick(item.id)}>See details</Button>
+                                    <Button>
+                                      <Link to={runLink(item.id)} onClick={() => changeJob(item.id)}>
+                                        See details
+                                      </Link>
+                                    </Button>
                                   </Col>
                                 </Row>
                               </div>
@@ -705,7 +706,7 @@ export const WorkspaceDetails = ({
             <DetailsJob jobId={jobId!} />
           </Suspense>
         ) : (
-          <RunList jobs={jobs} onRunClick={handleClick} />
+          <RunList jobs={jobs} onRunClick={changeJob} runLink={runLink} />
         );
       case "3":
         return (
@@ -873,8 +874,7 @@ export const WorkspaceDetails = ({
                     planJob={planJob}
                     resources={resources}
                     disabledReason={
-                      workspace.attributes.source === "empty" &&
-                      workspace.attributes.branch === "remote-content"
+                      workspace.attributes.source === "empty" && workspace.attributes.branch === "remote-content"
                         ? "This CLI/API driven workspace has no applied configuration yet. Upload and apply a configuration with the terraform CLI/API before using Run now."
                         : undefined
                     }

--- a/ui/src/domain/Workspaces/Import.tsx
+++ b/ui/src/domain/Workspaces/Import.tsx
@@ -26,7 +26,7 @@ import { IconContext } from "react-icons";
 import { BiBookBookmark, BiTerminal, BiUpload } from "react-icons/bi";
 import { SiBitbucket } from "react-icons/si";
 import { VscAzureDevops } from "react-icons/vsc";
-import { Link, useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "../../config/actionTypes";
 import axiosInstance, { getErrorMessage } from "../../config/axiosConfig";
 import { VcsModel, VcsType, VcsTypeExtended } from "../types";
@@ -230,67 +230,47 @@ export const ImportWorkspace = () => {
     { title: "Connect to Platform" },
     { title: "Import Workspaces" },
   ];
+  const vcsLink = (vcsType: VcsTypeExtended) => `/organizations/${organizationId}/settings/vcs/new/${vcsType}`;
+
   const gitlabItems = [
     {
-      label: "GitLab.com",
+      label: <Link to={vcsLink(VcsTypeExtended.GITLAB)}>GitLab.com</Link>,
       key: "1",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.GITLAB);
-      },
     },
     {
-      label: "GitLab Community Edition",
+      label: <Link to={vcsLink(VcsTypeExtended.GITLAB_COMMUNITY)}>GitLab Community Edition</Link>,
       key: "2",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.GITLAB_COMMUNITY);
-      },
     },
     {
-      label: "GitLab Enterprise Edition",
+      label: <Link to={vcsLink(VcsTypeExtended.GITLAB_ENTERPRISE)}>GitLab Enterprise Edition</Link>,
       key: "3",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.GITLAB_ENTERPRISE);
-      },
     },
   ];
 
   const githubItems = [
     {
-      label: "GitHub.com",
+      label: <Link to={vcsLink(VcsTypeExtended.GITHUB)}>GitHub.com</Link>,
       key: "1",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.GITHUB);
-      },
     },
     {
-      label: "GitHub Enterprise",
+      label: <Link to={vcsLink(VcsTypeExtended.GITHUB_ENTERPRISE)}>GitHub Enterprise</Link>,
       key: "2",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.GITHUB_ENTERPRISE);
-      },
     },
   ];
 
   const bitBucketItems = [
     {
-      label: "Bitbucket Cloud",
+      label: <Link to={vcsLink(VcsTypeExtended.BITBUCKET)}>Bitbucket Cloud</Link>,
       key: "1",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.BITBUCKET);
-      },
     },
   ];
 
   const azDevOpsItems = [
     {
-      label: "Azure DevOps Services",
+      label: <Link to={vcsLink(VcsTypeExtended.AZURE_DEVOPS)}>Azure DevOps Services</Link>,
       key: "1",
-      onClick: () => {
-        handleVCSClick(VcsTypeExtended.AZURE_DEVOPS);
-      },
     },
   ];
-  const navigate = useNavigate();
   useEffect(() => {
     setOrganizationName(sessionStorage.getItem(ORGANIZATION_NAME) ?? undefined);
     setLoading(true);
@@ -318,10 +298,6 @@ export const ImportWorkspace = () => {
   const handleGitClick = (id: string) => {
     setVcsId(id);
     handleChange(3);
-  };
-
-  const handleVCSClick = (vcsType: VcsTypeExtended) => {
-    navigate(`/organizations/${organizationId}/settings/vcs/new/${vcsType}`);
   };
 
   const handleConnectDifferent = () => {

--- a/ui/src/domain/Workspaces/Schedules.tsx
+++ b/ui/src/domain/Workspaces/Schedules.tsx
@@ -86,6 +86,7 @@ export const Schedules = ({ schedules, manageWorkspace, reload }: Props) => {
                 Edit
               </Button>
               <Popconfirm
+                okButtonProps={{ danger: true }}
                 onConfirm={() => {
                   onDelete(record.id);
                 }}

--- a/ui/src/domain/Workspaces/Settings/Advanced.tsx
+++ b/ui/src/domain/Workspaces/Settings/Advanced.tsx
@@ -1,7 +1,7 @@
 import { DeleteOutlined } from "@ant-design/icons";
 import { Button, Popconfirm, Space, Typography, message } from "antd";
 import { useNavigate } from "react-router-dom";
-import axiosInstance from "../../../config/axiosConfig";
+import axiosInstance, { getErrorMessage } from "../../../config/axiosConfig";
 import { Workspace } from "../../types";
 import { genericHeader } from "../Workspaces";
 import SettingsSection from "@/modules/layout/SettingsSection/SettingsSection";
@@ -54,7 +54,7 @@ export const WorkspaceAdvanced = ({ workspace, manageWorkspace }: Props) => {
           },
         }
       )
-      .then(() => {
+      .then(() =>
         axiosInstance.patch(`organization/${organizationId}/workspace/${id}`, body, genericHeader).then((response) => {
           if (response.status === 204) {
             message.success("Workspace deleted successfully");
@@ -62,7 +62,11 @@ export const WorkspaceAdvanced = ({ workspace, manageWorkspace }: Props) => {
           } else {
             message.error("Workspace deletion failed");
           }
-        });
+        })
+      )
+      .catch((error) => {
+        console.error("error deleting workspace:", error);
+        message.error(getErrorMessage(error));
       });
   };
 

--- a/ui/src/domain/Workspaces/Settings/Advanced.tsx
+++ b/ui/src/domain/Workspaces/Settings/Advanced.tsx
@@ -94,6 +94,7 @@ export const WorkspaceAdvanced = ({ workspace, manageWorkspace }: Props) => {
         }
       >
         <Popconfirm
+          okButtonProps={{ danger: true }}
           onConfirm={() => {
             onDelete(workspace);
           }}

--- a/ui/src/domain/Workspaces/Settings/General.tsx
+++ b/ui/src/domain/Workspaces/Settings/General.tsx
@@ -1,6 +1,6 @@
 import { AutoComplete, Button, Form, Input, Select, Spin, Typography, message } from "antd";
 import { useEffect, useState } from "react";
-import axiosInstance from "../../../config/axiosConfig";
+import axiosInstance, { getErrorMessage } from "../../../config/axiosConfig";
 import { Agent, Template, TofuRelease, Workspace } from "../../types";
 import {
   atomicHeader,
@@ -121,21 +121,23 @@ export const WorkspaceGeneral = ({ workspaceData, orgTemplates, manageWorkspace,
       ],
     };
 
-    try {
-      axiosInstance.post("/operations", body, atomicHeader).then((response) => {
+    axiosInstance
+      .post("/operations", body, atomicHeader)
+      .then((response) => {
         if (response.status === 200) {
           message.success("workspace updated successfully");
           onWorkspaceUpdate?.();
         } else {
           message.error("workspace update failed");
         }
+      })
+      .catch((error) => {
+        console.error("error updating workspace:", error);
+        message.error(getErrorMessage(error));
+      })
+      .finally(() => {
         setWaiting(false);
       });
-    } catch (error) {
-      console.error("error updating workspace:", error);
-      message.error("workspace update failed");
-      setWaiting(false);
-    }
 
     let bodyAgent;
 

--- a/ui/src/domain/Workspaces/Settings/TeamAccess.tsx
+++ b/ui/src/domain/Workspaces/Settings/TeamAccess.tsx
@@ -368,6 +368,7 @@ export const WorkspaceTeamAccess = ({ workspace, manageWorkspace }: Props) => {
       width: 120,
       render: (_: any, record: WorkspaceAccessModel) => (
         <Popconfirm
+          okButtonProps={{ danger: true }}
           title={`Remove team "${record.name}" from this workspace?`}
           onConfirm={() => onRemove(record.id, record.name)}
           okText="Yes"

--- a/ui/src/domain/Workspaces/Settings/Webhook.tsx
+++ b/ui/src/domain/Workspaces/Settings/Webhook.tsx
@@ -549,6 +549,7 @@ export const WorkspaceWebhook = ({
       render: (_: string, record: any) => (
         <Space size="middle">
           <Popconfirm
+            okButtonProps={{ danger: true }}
             onConfirm={() => {
               onDelete(record);
             }}
@@ -626,6 +627,7 @@ export const WorkspaceWebhook = ({
                   <Space>
                     <Typography.Text type="success">Shared repo webhook active</Typography.Text>
                     <Popconfirm
+                      okButtonProps={{ danger: true }}
                       title="Revert to per-workspace webhook?"
                       description="This will create a new per-workspace webhook on your next save."
                       onConfirm={handleRevertV2}
@@ -644,6 +646,7 @@ export const WorkspaceWebhook = ({
                       Consolidate webhooks across workspaces sharing this repository
                     </Typography.Text>
                     <Popconfirm
+                      okButtonProps={{ danger: true }}
                       title="Migrate to shared webhook? (Experimental)"
                       description="This will replace the per-workspace webhook with a single shared webhook for this repository."
                       onConfirm={handleMigrateV2}

--- a/ui/src/domain/Workspaces/Variables.tsx
+++ b/ui/src/domain/Workspaces/Variables.tsx
@@ -90,6 +90,7 @@ const VARIABLES_COLUMS = (
             Edit
           </Button>
           <Popconfirm
+            okButtonProps={{ danger: true }}
             onConfirm={() => {
               onDelete(record.id);
             }}

--- a/ui/src/domain/Workspaces/workspaceDataUtils.ts
+++ b/ui/src/domain/Workspaces/workspaceDataUtils.ts
@@ -219,9 +219,9 @@ export async function setupWorkspaceIncludes(
   setGlobalEnvVariables([...globalEnvVariables].sort(byKey));
 
   // set state data
-  const lastState = history
-    .sort((a: FlatJobHistory, b: FlatJobHistory) => parseInt(a.jobReference) - parseInt(b.jobReference))
-    .reverse()[0];
+  const lastState = [...history].sort(
+    (a: FlatJobHistory, b: FlatJobHistory) => parseInt(b.jobReference) - parseInt(a.jobReference)
+  )[0];
   // reload state only if there is a new version
 
   if (currentStateId !== lastState?.id) {

--- a/ui/src/modules/apiDocs/ApiDocsPage.tsx
+++ b/ui/src/modules/apiDocs/ApiDocsPage.tsx
@@ -1,7 +1,7 @@
 import { LeftOutlined } from "@ant-design/icons";
 import { Spin } from "antd";
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { ApiReferenceReact } from "@scalar/api-reference-react";
 import "@scalar/api-reference-react/style.css";
 import getUserFromStorage from "@/config/authUser";
@@ -21,7 +21,6 @@ function attachBearerToken({ requestBuilder }: { requestBuilder: RequestBuilder 
 
 export const ApiDocsPage = () => {
   const [spec, setSpec] = useState<object | null>(null);
-  const navigate = useNavigate();
 
   useEffect(() => {
     axiosRegistry.get("/doc").then((response) => {
@@ -32,9 +31,9 @@ export const ApiDocsPage = () => {
   return (
     <div className="api-docs-page">
       <div className="api-docs-topbar">
-        <button type="button" className="api-docs-back-link" onClick={() => navigate("/")}>
+        <Link to="/" className="api-docs-back-link">
           <LeftOutlined /> Back to Terrakube
-        </button>
+        </Link>
       </div>
       <div className="api-docs-content">
         {spec ? (

--- a/ui/src/modules/apiDocs/__tests__/ApiDocsPage.test.tsx
+++ b/ui/src/modules/apiDocs/__tests__/ApiDocsPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { ApiDocsPage } from "../ApiDocsPage";
 import getUserFromStorage from "@/config/authUser";
@@ -18,12 +18,6 @@ jest.mock("@scalar/api-reference-react", () => ({
   ApiReferenceReact: (props: unknown) => apiReferenceMock(props),
 }));
 
-const mockNavigate = jest.fn();
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
-  useNavigate: () => mockNavigate,
-}));
-
 const fakeSpec = { openapi: "3.0.1", info: { title: "Elide Service" }, paths: {} };
 
 function renderApiDocsPage() {
@@ -40,7 +34,6 @@ describe("ApiDocsPage", () => {
     mockGetUserFromStorage.mockReset();
     mockAxiosGet.mockReset();
     mockAxiosGet.mockResolvedValue({ data: fakeSpec });
-    mockNavigate.mockClear();
   });
 
   it("fetches the spec from the API's /doc endpoint and passes it to Scalar as content", async () => {
@@ -94,12 +87,10 @@ describe("ApiDocsPage", () => {
     );
   });
 
-  it("navigates back to the app shell when 'Back to Terrakube' is clicked", async () => {
+  it("links 'Back to Terrakube' to the app shell", async () => {
     renderApiDocsPage();
     await waitFor(() => expect(apiReferenceMock).toHaveBeenCalled());
 
-    fireEvent.click(screen.getByText("Back to Terrakube"));
-
-    expect(mockNavigate).toHaveBeenCalledWith("/");
+    expect(screen.getByText("Back to Terrakube").closest("a")).toHaveAttribute("href", "/");
   });
 });

--- a/ui/src/modules/layout/AppSidebar/AppSidebar.tsx
+++ b/ui/src/modules/layout/AppSidebar/AppSidebar.tsx
@@ -33,6 +33,7 @@ import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "@/config/actionTypes";
 import organizationService from "@/modules/organizations/organizationService";
+import { getOrgIdFromPathname } from "@/config/orgId";
 import { FlatOrganization } from "@/domain/types";
 import { OrganizationSelector } from "@/components/OrganizationSelector";
 import { HelpMenu } from "@/components/HelpMenu";
@@ -93,7 +94,7 @@ export default function AppSidebar({
   const navigate = useNavigate();
   const { token } = theme.useToken();
   const params = location.pathname.split("/");
-  const orgIdFromUrl = params.length > 2 && params[1] === "organizations" && params[2] !== "create" ? params[2] : null;
+  const orgIdFromUrl = getOrgIdFromPathname(location.pathname);
   const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE) || orgIdFromUrl;
   const isSettingsContext = orgIdFromUrl !== null && params[3] === "settings";
   const isWorkspaceDetailContext = orgIdFromUrl !== null && params[3] === "workspaces" && Boolean(params[4]);

--- a/ui/src/modules/layout/AppSidebar/AppSidebar.tsx
+++ b/ui/src/modules/layout/AppSidebar/AppSidebar.tsx
@@ -30,7 +30,7 @@ import {
 } from "@ant-design/icons";
 import { Layout, Menu, Tag, theme } from "antd";
 import { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "@/config/actionTypes";
 import organizationService from "@/modules/organizations/organizationService";
 import { getOrgIdFromPathname, isOrgId } from "@/config/orgId";
@@ -49,7 +49,6 @@ type Props = {
   setOrganizationName: (name: string) => void;
   organizations: FlatOrganization[];
   onOrgChange: (orgId: string) => void;
-  onManageOrgs: () => void;
   workspaceManageState: boolean;
 };
 
@@ -85,13 +84,11 @@ export default function AppSidebar({
   setOrganizationName,
   organizations,
   onOrgChange,
-  onManageOrgs,
   workspaceManageState,
 }: Props) {
   const [collapsed, setCollapsed] = useState(() => getStoredSidebarCollapsed());
   const [defaultSelected, setDefaultSelected] = useState(["organizations"]);
   const location = useLocation();
-  const navigate = useNavigate();
   const { token } = theme.useToken();
   const params = location.pathname.split("/");
   const orgIdFromUrl = getOrgIdFromPathname(location.pathname);
@@ -158,52 +155,14 @@ export default function AppSidebar({
     isUserSettingsContext,
   ]);
 
-  const handleSectionNavigation = (section: string) => {
+  const handleOrgMenuClick = (key: string) => {
     ensureOrganizationName(orgIdFromUrl!, organizationName, setOrganizationName, () => {
-      navigate(`/organizations/${orgIdFromUrl}/${section}`);
-      setDefaultSelected([section]);
-    });
-  };
-
-  const handleSettingsNavigation = (key: string, path: string) => {
-    ensureOrganizationName(orgIdFromUrl!, organizationName, setOrganizationName, () => {
-      navigate(`/organizations/${orgIdFromUrl}/settings/${path}`);
       setDefaultSelected([key]);
     });
   };
 
-  const handleBackToWorkspaces = () => {
-    ensureOrganizationName(orgIdFromUrl!, organizationName, setOrganizationName, () => {
-      navigate(`/organizations/${orgIdFromUrl}/workspaces`);
-      setDefaultSelected(["workspaces"]);
-    });
-  };
-
-  const handleBackToWorkspace = () => {
-    ensureOrganizationName(orgIdFromUrl!, organizationName, setOrganizationName, () => {
-      navigate(`/organizations/${orgIdFromUrl}/workspaces/${params[4]}`);
-      setDefaultSelected(["overview"]);
-    });
-  };
-
-  const handleWorkspaceSectionNavigation = (key: string, path: string) => {
-    ensureOrganizationName(orgIdFromUrl!, organizationName, setOrganizationName, () => {
-      navigate(`/organizations/${orgIdFromUrl}/workspaces/${params[4]}${path ? `/${path}` : ""}`);
-      setDefaultSelected([key]);
-    });
-  };
-
-  const handleWorkspaceSettingsNavigation = (key: string, path: string) => {
-    ensureOrganizationName(orgIdFromUrl!, organizationName, setOrganizationName, () => {
-      navigate(`/organizations/${orgIdFromUrl}/workspaces/${params[4]}/settings/${path}`);
-      setDefaultSelected([key]);
-    });
-  };
-
-  const handleUserSettingsNavigation = (key: string, path: string) => {
-    navigate(`/settings/${path}`);
-    setDefaultSelected([key]);
-  };
+  const orgBasePath = `/organizations/${orgIdFromUrl}`;
+  const workspaceBasePath = `${orgBasePath}/workspaces/${params[4]}`;
 
   const settingsGroups = [
     {
@@ -272,31 +231,38 @@ export default function AppSidebar({
   const items = isUserSettingsContext
     ? [
         {
-          label: "Home",
+          label: <Link to="/">Home</Link>,
           key: "__back__",
           icon: <LeftOutlined />,
-          onClick: () => navigate("/"),
         },
         {
           type: "group" as const,
           key: "account-settings",
           label: "Account Settings",
           children: [
-            { key: "tokens", label: "Tokens", icon: <KeyOutlined /> },
-            { key: "theme", label: "Theme", icon: <BgColorsOutlined /> },
+            { key: "tokens", name: "Tokens", icon: <KeyOutlined /> },
+            { key: "theme", name: "Theme", icon: <BgColorsOutlined /> },
           ].map((item) => ({
-            ...item,
-            onClick: () => handleUserSettingsNavigation(item.key, item.key),
+            key: item.key,
+            icon: item.icon,
+            label: (
+              <Link to={`/settings/${item.key}`} onClick={() => setDefaultSelected([item.key])}>
+                {item.name}
+              </Link>
+            ),
           })),
         },
       ]
     : isWorkspaceSettingsContext
       ? [
           {
-            label: "Back to Workspace",
+            label: (
+              <Link to={workspaceBasePath} onClick={() => handleOrgMenuClick("overview")}>
+                Back to Workspace
+              </Link>
+            ),
             key: "__back__",
             icon: <LeftOutlined />,
-            onClick: handleBackToWorkspace,
           },
           {
             type: "group" as const,
@@ -304,19 +270,25 @@ export default function AppSidebar({
             label: "Workspace Settings",
             children: workspaceSettingsItems.map((item) => ({
               key: item.key,
-              label: item.label,
               icon: item.icon,
-              onClick: () => handleWorkspaceSettingsNavigation(item.key, item.path),
+              label: (
+                <Link to={`${workspaceBasePath}/settings/${item.path}`} onClick={() => handleOrgMenuClick(item.key)}>
+                  {item.label}
+                </Link>
+              ),
             })),
           },
         ]
       : isSettingsContext
         ? [
             {
-              label: "Workspaces",
+              label: (
+                <Link to={`${orgBasePath}/workspaces`} onClick={() => handleOrgMenuClick("workspaces")}>
+                  Workspaces
+                </Link>
+              ),
               key: "__back__",
               icon: <LeftOutlined />,
-              onClick: handleBackToWorkspaces,
             },
             ...settingsGroups.map((group) => ({
               type: "group" as const,
@@ -324,91 +296,104 @@ export default function AppSidebar({
               label: group.label,
               children: group.items.map((item) => ({
                 key: item.key,
-                label: item.label,
                 icon: item.icon,
-                onClick: () => handleSettingsNavigation(item.key, item.path),
+                label: (
+                  <Link to={`${orgBasePath}/settings/${item.path}`} onClick={() => handleOrgMenuClick(item.key)}>
+                    {item.label}
+                  </Link>
+                ),
               })),
             })),
           ]
         : isWorkspaceDetailContext
           ? [
               {
-                label: "Workspaces",
+                label: (
+                  <Link to={`${orgBasePath}/workspaces`} onClick={() => handleOrgMenuClick("workspaces")}>
+                    Workspaces
+                  </Link>
+                ),
                 key: "__back__",
                 icon: <LeftOutlined />,
-                onClick: handleBackToWorkspaces,
               },
               {
                 key: "overview",
-                label: "Overview",
+                label: (
+                  <Link to={workspaceBasePath} onClick={() => handleOrgMenuClick("overview")}>
+                    Overview
+                  </Link>
+                ),
                 icon: <DashboardOutlined />,
-                onClick: () => handleWorkspaceSectionNavigation("overview", ""),
               },
               {
                 key: "runs",
-                label: "Runs",
+                label: (
+                  <Link to={`${workspaceBasePath}/runs`} onClick={() => handleOrgMenuClick("runs")}>
+                    Runs
+                  </Link>
+                ),
                 icon: <HistoryOutlined />,
-                onClick: () => handleWorkspaceSectionNavigation("runs", "runs"),
               },
               {
                 key: "states",
-                label: "States",
+                label: workspaceManageState ? (
+                  <Link to={`${workspaceBasePath}/states`} onClick={() => handleOrgMenuClick("states")}>
+                    States
+                  </Link>
+                ) : (
+                  "States"
+                ),
                 icon: <DatabaseOutlined />,
                 disabled: !workspaceManageState,
-                onClick: () => handleWorkspaceSectionNavigation("states", "states"),
               },
               {
                 key: "variables",
-                label: "Variables",
+                label: (
+                  <Link to={`${workspaceBasePath}/variables`} onClick={() => handleOrgMenuClick("variables")}>
+                    Variables
+                  </Link>
+                ),
                 icon: <CodeOutlined />,
-                onClick: () => handleWorkspaceSectionNavigation("variables", "variables"),
               },
               {
                 key: "schedules",
-                label: "Schedules",
+                label: (
+                  <Link to={`${workspaceBasePath}/schedules`} onClick={() => handleOrgMenuClick("schedules")}>
+                    Schedules
+                  </Link>
+                ),
                 icon: <ScheduleOutlined />,
-                onClick: () => handleWorkspaceSectionNavigation("schedules", "schedules"),
               },
               {
                 key: "settings",
-                label: "Settings",
+                label: (
+                  <Link to={`${workspaceBasePath}/settings/general`} onClick={() => handleOrgMenuClick("settings")}>
+                    Settings
+                  </Link>
+                ),
                 icon: <SettingOutlined />,
-                onClick: () => handleWorkspaceSectionNavigation("settings", "settings/general"),
               },
             ]
           : orgIdFromUrl
             ? [
-                {
-                  label: "Projects",
-                  key: "projects",
-                  icon: <ProjectOutlined />,
-                  onClick: () => handleSectionNavigation("projects"),
-                },
-                {
-                  label: "Workspaces",
-                  key: "workspaces",
-                  icon: <AppstoreOutlined />,
-                  onClick: () => handleSectionNavigation("workspaces"),
-                },
-                {
-                  label: "Registry",
-                  key: "registry",
-                  icon: <CloudOutlined />,
-                  onClick: () => handleSectionNavigation("registry"),
-                },
-                {
-                  label: "Settings",
-                  key: "settings",
-                  icon: <SettingOutlined />,
-                  onClick: () => handleSectionNavigation("settings"),
-                },
-              ]
+                { key: "projects", name: "Projects", icon: <ProjectOutlined /> },
+                { key: "workspaces", name: "Workspaces", icon: <AppstoreOutlined /> },
+                { key: "registry", name: "Registry", icon: <CloudOutlined /> },
+                { key: "settings", name: "Settings", icon: <SettingOutlined /> },
+              ].map((item) => ({
+                key: item.key,
+                icon: item.icon,
+                label: (
+                  <Link to={`${orgBasePath}/${item.key}`} onClick={() => handleOrgMenuClick(item.key)}>
+                    {item.name}
+                  </Link>
+                ),
+              }))
             : [
                 {
-                  label: "Organizations",
+                  label: <Link to="/organizations">Organizations</Link>,
                   key: "organizations",
                   icon: <BankOutlined />,
-                  onClick: () => navigate("/organizations"),
                 },
               ];
 
@@ -429,9 +414,9 @@ export default function AppSidebar({
     >
       <div className="app-sidebar-inner">
         <div className={`app-sidebar-header ${effectiveCollapsed ? "app-sidebar-header--collapsed" : ""}`}>
-          <button type="button" className="app-sidebar-home-link" onClick={() => navigate("/")}>
+          <Link to="/" className="app-sidebar-home-link">
             <img src={logo} alt="Terrakube" className="app-sidebar-logo" />
-          </button>
+          </Link>
           <div className="app-sidebar-header-actions">
             {!effectiveCollapsed && (
               <div className="app-sidebar-utility">
@@ -478,7 +463,6 @@ export default function AppSidebar({
               organizationName={organizationName}
               organizations={organizations}
               onOrgChange={onOrgChange}
-              onManageOrgs={onManageOrgs}
               placement="top"
             />
           )}

--- a/ui/src/modules/layout/AppSidebar/AppSidebar.tsx
+++ b/ui/src/modules/layout/AppSidebar/AppSidebar.tsx
@@ -33,7 +33,7 @@ import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { ORGANIZATION_ARCHIVE, ORGANIZATION_NAME } from "@/config/actionTypes";
 import organizationService from "@/modules/organizations/organizationService";
-import { getOrgIdFromPathname } from "@/config/orgId";
+import { getOrgIdFromPathname, isOrgId } from "@/config/orgId";
 import { FlatOrganization } from "@/domain/types";
 import { OrganizationSelector } from "@/components/OrganizationSelector";
 import { HelpMenu } from "@/components/HelpMenu";
@@ -59,7 +59,7 @@ function ensureOrganizationName(
   setOrgName: (name: string) => void,
   onComplete: () => void
 ) {
-  if (orgId && currentOrgName && currentOrgName !== "select organization") {
+  if (orgId && currentOrgName) {
     sessionStorage.setItem(ORGANIZATION_ARCHIVE, orgId);
     sessionStorage.setItem(ORGANIZATION_NAME, currentOrgName);
     onComplete();
@@ -95,7 +95,8 @@ export default function AppSidebar({
   const { token } = theme.useToken();
   const params = location.pathname.split("/");
   const orgIdFromUrl = getOrgIdFromPathname(location.pathname);
-  const organizationId = sessionStorage.getItem(ORGANIZATION_ARCHIVE) || orgIdFromUrl;
+  const storedOrgId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
+  const organizationId = isOrgId(storedOrgId) ? storedOrgId : orgIdFromUrl;
   const isSettingsContext = orgIdFromUrl !== null && params[3] === "settings";
   const isWorkspaceDetailContext = orgIdFromUrl !== null && params[3] === "workspaces" && Boolean(params[4]);
   const isWorkspaceSettingsContext = isWorkspaceDetailContext && params[5] === "settings";
@@ -104,7 +105,7 @@ export default function AppSidebar({
   const effectiveCollapsed = canCollapse ? collapsed : false;
 
   useEffect(() => {
-    if (organizationId && (!sessionStorage.getItem(ORGANIZATION_NAME) || organizationName === "select organization")) {
+    if (organizationId && !sessionStorage.getItem(ORGANIZATION_NAME)) {
       ensureOrganizationName(organizationId, organizationName, setOrganizationName, () => {});
     }
   }, [organizationId, organizationName, setOrganizationName]);
@@ -113,10 +114,7 @@ export default function AppSidebar({
     organizationService
       .listOrganizationsGraphQL()
       .then((loadedOrganizations: FlatOrganization[]) => {
-        if (
-          orgIdFromUrl &&
-          (!sessionStorage.getItem(ORGANIZATION_NAME) || organizationName === "select organization")
-        ) {
+        if (orgIdFromUrl && !sessionStorage.getItem(ORGANIZATION_NAME)) {
           const foundOrg = loadedOrganizations.find((org) => org.id === orgIdFromUrl);
           if (foundOrg) {
             sessionStorage.setItem(ORGANIZATION_ARCHIVE, orgIdFromUrl);
@@ -126,7 +124,7 @@ export default function AppSidebar({
             ensureOrganizationName(orgIdFromUrl, "", setOrganizationName, () => {});
           }
         } else {
-          setOrganizationName(sessionStorage.getItem(ORGANIZATION_NAME) || "select organization");
+          setOrganizationName(sessionStorage.getItem(ORGANIZATION_NAME) || "");
         }
       })
       .catch((error) => {

--- a/ui/src/modules/layout/AppSidebar/AppSidebar.tsx
+++ b/ui/src/modules/layout/AppSidebar/AppSidebar.tsx
@@ -95,7 +95,7 @@ export default function AppSidebar({
   const storedOrgId = sessionStorage.getItem(ORGANIZATION_ARCHIVE);
   const organizationId = isOrgId(storedOrgId) ? storedOrgId : orgIdFromUrl;
   const isSettingsContext = orgIdFromUrl !== null && params[3] === "settings";
-  const isWorkspaceDetailContext = orgIdFromUrl !== null && params[3] === "workspaces" && Boolean(params[4]);
+  const isWorkspaceDetailContext = orgIdFromUrl !== null && params[3] === "workspaces" && isOrgId(params[4]);
   const isWorkspaceSettingsContext = isWorkspaceDetailContext && params[5] === "settings";
   const isUserSettingsContext = params[1] === "settings" && Boolean(params[2]);
   const canCollapse = !isSettingsContext && !isWorkspaceSettingsContext && !isUserSettingsContext;

--- a/ui/src/modules/layout/AppSidebar/__tests__/AppSidebar.test.tsx
+++ b/ui/src/modules/layout/AppSidebar/__tests__/AppSidebar.test.tsx
@@ -20,13 +20,12 @@ jest.mock("@/components/UserMenu", () => ({
   UserMenu: () => <div data-testid="user-menu" />,
 }));
 
-const mockNavigate = jest.fn();
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
-  useNavigate: () => mockNavigate,
-}));
+const orgId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+const workspaceId = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
+const orgPath = `/organizations/${orgId}`;
+const workspacePath = `${orgPath}/workspaces/${workspaceId}`;
 
-const organizations: FlatOrganization[] = [{ id: "org-1", name: "Acme Corp" }];
+const organizations: FlatOrganization[] = [{ id: orgId, name: "Acme Corp" }];
 
 function renderSidebar(path: string, overrides: Partial<Parameters<typeof AppSidebar>[0]> = {}) {
   return render(
@@ -45,7 +44,6 @@ function renderSidebar(path: string, overrides: Partial<Parameters<typeof AppSid
 
 describe("AppSidebar", () => {
   beforeEach(() => {
-    mockNavigate.mockClear();
     sessionStorage.clear();
   });
 
@@ -57,7 +55,7 @@ describe("AppSidebar", () => {
   });
 
   it("shows Projects/Workspaces/Registry/Settings inside an organization", async () => {
-    renderSidebar("/organizations/org-1/workspaces");
+    renderSidebar(`${orgPath}/workspaces`);
 
     expect(await screen.findByText("Projects")).toBeInTheDocument();
     expect(screen.getByText("Workspaces")).toBeInTheDocument();
@@ -65,13 +63,12 @@ describe("AppSidebar", () => {
     expect(screen.getByText("Settings")).toBeInTheDocument();
   });
 
-  it("navigates to the organizations picker when Organizations is clicked", async () => {
+  it("links Organizations to the organizations picker", async () => {
     renderSidebar("/organizations");
 
     const item = await screen.findByText("Organizations");
-    fireEvent.click(item);
 
-    expect(mockNavigate).toHaveBeenCalledWith("/organizations");
+    expect(item.closest("a")).toHaveAttribute("href", "/organizations");
   });
 
   it("does not treat the /organizations/create route as an organization id", async () => {
@@ -89,24 +86,22 @@ describe("sidebar chrome", () => {
     localStorage.clear();
   });
 
-  it("navigates home when the logo/header is clicked", async () => {
-    renderSidebar("/organizations/org-1/workspaces");
+  it("links the logo/header home", async () => {
+    renderSidebar(`${orgPath}/workspaces`);
     await screen.findByText("Workspaces");
 
-    fireEvent.click(screen.getByAltText("Terrakube"));
-
-    expect(mockNavigate).toHaveBeenCalledWith("/");
+    expect(screen.getByAltText("Terrakube").closest("a")).toHaveAttribute("href", "/");
   });
 
   it("shows the organization switcher in the footer when expanded", async () => {
-    renderSidebar("/organizations/org-1/workspaces");
+    renderSidebar(`${orgPath}/workspaces`);
     await screen.findByText("Workspaces");
 
     expect(screen.getByText("Acme Corp")).toBeInTheDocument();
   });
 
   it("has an accessible label on the collapse trigger", async () => {
-    renderSidebar("/organizations/org-1/workspaces");
+    renderSidebar(`${orgPath}/workspaces`);
     await screen.findByText("Workspaces");
 
     expect(screen.getByLabelText("Collapse sidebar")).toBeInTheDocument();
@@ -114,7 +109,7 @@ describe("sidebar chrome", () => {
 
   it("collapses, hides the organization switcher, and persists the preference when the trigger is clicked", async () => {
     const setSpy = jest.spyOn(sidebarPreference, "setStoredSidebarCollapsed");
-    renderSidebar("/organizations/org-1/workspaces");
+    renderSidebar(`${orgPath}/workspaces`);
     await screen.findByText("Workspaces");
 
     fireEvent.click(screen.getByLabelText("Collapse sidebar"));
@@ -131,7 +126,7 @@ describe("settings context", () => {
   });
 
   it("shows the settings sub-nav grouped items instead of the top-level nav", async () => {
-    renderSidebar("/organizations/org-1/settings/general");
+    renderSidebar(`${orgPath}/settings/general`);
 
     expect(await screen.findByText("General")).toBeInTheDocument();
     expect(screen.getByText("Teams")).toBeInTheDocument();
@@ -148,24 +143,24 @@ describe("settings context", () => {
     expect(screen.queryByText("Registry")).not.toBeInTheDocument();
   });
 
-  it("navigates to the settings sub-path when a settings item is clicked", async () => {
-    renderSidebar("/organizations/org-1/settings/general");
+  it("links settings items to their settings sub-path", async () => {
+    renderSidebar(`${orgPath}/settings/general`);
 
-    fireEvent.click(await screen.findByText("Teams"));
+    const item = await screen.findByText("Teams");
 
-    expect(mockNavigate).toHaveBeenCalledWith("/organizations/org-1/settings/teams");
+    expect(item.closest("a")).toHaveAttribute("href", `${orgPath}/settings/teams`);
   });
 
-  it("navigates back to workspaces when the back link is clicked", async () => {
-    renderSidebar("/organizations/org-1/settings/general");
+  it("links back to workspaces from the back link", async () => {
+    renderSidebar(`${orgPath}/settings/general`);
 
-    fireEvent.click(await screen.findByText("Workspaces"));
+    const backLink = await screen.findByText("Workspaces");
 
-    expect(mockNavigate).toHaveBeenCalledWith("/organizations/org-1/workspaces");
+    expect(backLink.closest("a")).toHaveAttribute("href", `${orgPath}/workspaces`);
   });
 
   it("does not show a collapse trigger (force-expanded)", async () => {
-    renderSidebar("/organizations/org-1/settings/general");
+    renderSidebar(`${orgPath}/settings/general`);
     await screen.findByText("General");
 
     expect(screen.queryByLabelText("Collapse sidebar")).not.toBeInTheDocument();
@@ -179,7 +174,7 @@ describe("workspace-detail context", () => {
   });
 
   it("shows the 6 workspace sections plus the back link instead of the top-level nav", async () => {
-    renderSidebar("/organizations/org-1/workspaces/ws-1");
+    renderSidebar(workspacePath);
 
     expect(await screen.findByText("Overview")).toBeInTheDocument();
     expect(screen.getByText("Runs")).toBeInTheDocument();
@@ -192,50 +187,46 @@ describe("workspace-detail context", () => {
     expect(screen.queryByText("Registry")).not.toBeInTheDocument();
   });
 
-  it("navigates to the bare workspace URL when Overview is clicked", async () => {
-    renderSidebar("/organizations/org-1/workspaces/ws-1/runs");
+  it("links Overview to the bare workspace URL", async () => {
+    renderSidebar(`${workspacePath}/runs`);
 
-    fireEvent.click(await screen.findByText("Overview"));
+    const overview = await screen.findByText("Overview");
 
-    expect(mockNavigate).toHaveBeenCalledWith("/organizations/org-1/workspaces/ws-1");
+    expect(overview.closest("a")).toHaveAttribute("href", workspacePath);
   });
 
-  it("navigates to the section sub-path when a section is clicked", async () => {
-    renderSidebar("/organizations/org-1/workspaces/ws-1");
+  it("links sections to their section sub-path", async () => {
+    renderSidebar(workspacePath);
 
-    fireEvent.click(await screen.findByText("Runs"));
+    const runs = await screen.findByText("Runs");
 
-    expect(mockNavigate).toHaveBeenCalledWith("/organizations/org-1/workspaces/ws-1/runs");
+    expect(runs.closest("a")).toHaveAttribute("href", `${workspacePath}/runs`);
   });
 
-  it("navigates back to the workspaces list when the back link is clicked", async () => {
-    renderSidebar("/organizations/org-1/workspaces/ws-1");
+  it("links back to the workspaces list from the back link", async () => {
+    renderSidebar(workspacePath);
 
-    fireEvent.click(await screen.findByText("Workspaces"));
+    const backLink = await screen.findByText("Workspaces");
 
-    expect(mockNavigate).toHaveBeenCalledWith("/organizations/org-1/workspaces");
+    expect(backLink.closest("a")).toHaveAttribute("href", `${orgPath}/workspaces`);
   });
 
   it("disables the States item when workspaceManageState is false", async () => {
-    renderSidebar("/organizations/org-1/workspaces/ws-1", { workspaceManageState: false });
+    renderSidebar(workspacePath, { workspaceManageState: false });
     await screen.findByText("Overview");
 
-    fireEvent.click(screen.getByText("States"));
-
-    expect(mockNavigate).not.toHaveBeenCalledWith("/organizations/org-1/workspaces/ws-1/states");
+    expect(screen.getByText("States").closest("a")).toBeNull();
   });
 
-  it("allows navigating to States when workspaceManageState is true", async () => {
-    renderSidebar("/organizations/org-1/workspaces/ws-1", { workspaceManageState: true });
+  it("links to States when workspaceManageState is true", async () => {
+    renderSidebar(workspacePath, { workspaceManageState: true });
     await screen.findByText("Overview");
 
-    fireEvent.click(screen.getByText("States"));
-
-    expect(mockNavigate).toHaveBeenCalledWith("/organizations/org-1/workspaces/ws-1/states");
+    expect(screen.getByText("States").closest("a")).toHaveAttribute("href", `${workspacePath}/states`);
   });
 
   it("does not treat the plain workspaces list route as a workspace-detail context", async () => {
-    renderSidebar("/organizations/org-1/workspaces");
+    renderSidebar(`${orgPath}/workspaces`);
 
     expect(await screen.findByText("Workspaces")).toBeInTheDocument();
     expect(screen.getByText("Projects")).toBeInTheDocument();
@@ -243,7 +234,7 @@ describe("workspace-detail context", () => {
   });
 
   it("can still be collapsed (with icons) while viewing a workspace's own sections", async () => {
-    renderSidebar("/organizations/org-1/workspaces/ws-1");
+    renderSidebar(workspacePath);
     await screen.findByText("Overview");
 
     expect(screen.getByLabelText("Collapse sidebar")).toBeInTheDocument();
@@ -256,7 +247,7 @@ describe("workspace-settings context", () => {
   });
 
   it("shows the workspace settings sub-nav instead of the org-settings nav or the workspace-detail nav", async () => {
-    renderSidebar("/organizations/org-1/workspaces/ws-1/settings", { workspaceManageState: true });
+    renderSidebar(`${workspacePath}/settings`, { workspaceManageState: true });
 
     expect(await screen.findByText("General")).toBeInTheDocument();
     expect(screen.getByText("Locking")).toBeInTheDocument();
@@ -271,24 +262,24 @@ describe("workspace-settings context", () => {
     expect(screen.queryByText("Overview")).not.toBeInTheDocument();
   });
 
-  it("navigates to the workspace settings sub-path when an item is clicked", async () => {
-    renderSidebar("/organizations/org-1/workspaces/ws-1/settings", { workspaceManageState: true });
+  it("links workspace settings items to their sub-path", async () => {
+    renderSidebar(`${workspacePath}/settings`, { workspaceManageState: true });
 
-    fireEvent.click(await screen.findByText("Locking"));
+    const locking = await screen.findByText("Locking");
 
-    expect(mockNavigate).toHaveBeenCalledWith("/organizations/org-1/workspaces/ws-1/settings/locking");
+    expect(locking.closest("a")).toHaveAttribute("href", `${workspacePath}/settings/locking`);
   });
 
-  it("navigates back to the workspace overview when the back link is clicked", async () => {
-    renderSidebar("/organizations/org-1/workspaces/ws-1/settings", { workspaceManageState: true });
+  it("links back to the workspace overview from the back link", async () => {
+    renderSidebar(`${workspacePath}/settings`, { workspaceManageState: true });
 
-    fireEvent.click(await screen.findByText("Back to Workspace"));
+    const backLink = await screen.findByText("Back to Workspace");
 
-    expect(mockNavigate).toHaveBeenCalledWith("/organizations/org-1/workspaces/ws-1");
+    expect(backLink.closest("a")).toHaveAttribute("href", workspacePath);
   });
 
   it("does not show a collapse trigger (force-expanded)", async () => {
-    renderSidebar("/organizations/org-1/workspaces/ws-1/settings", { workspaceManageState: true });
+    renderSidebar(`${workspacePath}/settings`, { workspaceManageState: true });
     await screen.findByText("General");
 
     expect(screen.queryByLabelText("Collapse sidebar")).not.toBeInTheDocument();
@@ -310,20 +301,20 @@ describe("user-settings context", () => {
     expect(screen.queryByText("Organizations")).not.toBeInTheDocument();
   });
 
-  it("navigates to the theme settings path when Theme is clicked", async () => {
+  it("links Theme to the theme settings path", async () => {
     renderSidebar("/settings/tokens");
 
-    fireEvent.click(await screen.findByText("Theme"));
+    const themeItem = await screen.findByText("Theme");
 
-    expect(mockNavigate).toHaveBeenCalledWith("/settings/theme");
+    expect(themeItem.closest("a")).toHaveAttribute("href", "/settings/theme");
   });
 
-  it("navigates home when the back link is clicked", async () => {
+  it("links home from the back link", async () => {
     renderSidebar("/settings/tokens");
 
-    fireEvent.click(await screen.findByText("Home"));
+    const backLink = await screen.findByText("Home");
 
-    expect(mockNavigate).toHaveBeenCalledWith("/");
+    expect(backLink.closest("a")).toHaveAttribute("href", "/");
   });
 
   it("does not show a collapse trigger (force-expanded)", async () => {

--- a/ui/src/modules/layout/AppSidebar/__tests__/AppSidebar.test.tsx
+++ b/ui/src/modules/layout/AppSidebar/__tests__/AppSidebar.test.tsx
@@ -36,7 +36,6 @@ function renderSidebar(path: string, overrides: Partial<Parameters<typeof AppSid
         setOrganizationName={jest.fn()}
         organizations={organizations}
         onOrgChange={jest.fn()}
-        onManageOrgs={jest.fn()}
         workspaceManageState={true}
         {...overrides}
       />

--- a/ui/src/modules/layout/PageWrapper/PageWrapper.tsx
+++ b/ui/src/modules/layout/PageWrapper/PageWrapper.tsx
@@ -3,6 +3,7 @@ import { Breadcrumb, Typography, Alert, Flex, Spin, theme } from "antd";
 import { Content } from "antd/es/layout/layout";
 import "./PageWrapper.css";
 import { NavLink } from "react-router-dom";
+import { useEffect } from "react";
 import clsx from "classnames";
 
 type Props = {
@@ -38,6 +39,13 @@ export default function PageWrapper({
   const {
     token: { colorBgContainer },
   } = theme.useToken();
+
+  useEffect(() => {
+    document.title = title ? `${title} · Terrakube` : "Terrakube";
+    return () => {
+      document.title = "Terrakube";
+    };
+  }, [title]);
 
   return (
     <Content className="page-wrapper">

--- a/ui/src/modules/organizations/OrganizationDetailsPage.tsx
+++ b/ui/src/modules/organizations/OrganizationDetailsPage.tsx
@@ -161,10 +161,10 @@ export default function OrganizationsDetailPage({ organizationName, setOrganizat
         <Space>
           <ListViewToggle value={listViewMode} onChange={setListViewMode} />
           <Button icon={<ImportOutlined />}>
-            <Link to="/workspaces/import">Import workspaces</Link>
+            <Link to={`/organizations/${id}/workspaces/import`}>Import workspaces</Link>
           </Button>
           <Button icon={<PlusOutlined />} type="primary">
-            <Link to="/workspaces/create">New workspace</Link>
+            <Link to={`/organizations/${id}/workspaces/create`}>New workspace</Link>
           </Button>
         </Space>
       }

--- a/ui/src/modules/organizations/OrganizationDetailsPage.tsx
+++ b/ui/src/modules/organizations/OrganizationDetailsPage.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import WorkspaceFilter from "@/modules/workspaces/components/WorkspaceFilter";
 import { WorkspaceListItem } from "@/modules/workspaces/types";
 import { JobStatus } from "@/domain/types";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import workspaceService from "@/modules/workspaces/workspaceService";
 import useApiRequest from "@/modules/api/useApiRequest";
 import { useOrganizationJobStatusSubscription, usePolling } from "@/hooks";
@@ -31,7 +31,6 @@ type Props = {
 
 export default function OrganizationsDetailPage({ organizationName, setOrganizationName }: Props) {
   const { id } = useParams();
-  const navigate = useNavigate();
   const [workspaces, setWorkspaces] = useState<WorkspaceListItem[]>([]);
   const [sortOption, setSortOption] = useState<WorkspaceSortOption>(() => getStoredWorkspaceSortOption());
   const [tags, setTags] = useState<TagModel[]>([]);
@@ -144,10 +143,6 @@ export default function OrganizationsDetailPage({ organizationName, setOrganizat
     },
   });
 
-  const handleCreateWorkspace = () => {
-    navigate("/workspaces/create");
-  };
-
   const showGrouped = listViewMode === "compact" && filterState.groupByProject && filterState.projectId === null;
 
   return (
@@ -168,8 +163,8 @@ export default function OrganizationsDetailPage({ organizationName, setOrganizat
           <Button icon={<ImportOutlined />}>
             <Link to="/workspaces/import">Import workspaces</Link>
           </Button>
-          <Button icon={<PlusOutlined />} type="primary" onClick={handleCreateWorkspace}>
-            New workspace
+          <Button icon={<PlusOutlined />} type="primary">
+            <Link to="/workspaces/create">New workspace</Link>
           </Button>
         </Space>
       }

--- a/ui/src/modules/organizations/OrganizationsPickerPage.tsx
+++ b/ui/src/modules/organizations/OrganizationsPickerPage.tsx
@@ -99,8 +99,8 @@ export default function OrganizationsPickerPage() {
         organizations.length > 0 && (
           <Space>
             <ListViewToggle value={listViewMode} onChange={setListViewMode} />
-            <Button type="primary" onClick={() => navigate("/organizations/create")}>
-              <PlusOutlined /> Create organization
+            <Button type="primary" icon={<PlusOutlined />}>
+              <Link to="/organizations/create">Create organization</Link>
             </Button>
           </Space>
         )

--- a/ui/src/modules/organizations/components/OrganizationTable/OrgSettingsButton.tsx
+++ b/ui/src/modules/organizations/components/OrganizationTable/OrgSettingsButton.tsx
@@ -1,6 +1,6 @@
 import { Button } from "antd";
 import { SettingOutlined } from "@ant-design/icons";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useOrgPermissions } from "@/modules/permissions/useOrgPermissions";
 
 type Props = {
@@ -8,7 +8,6 @@ type Props = {
 };
 
 export default function OrgSettingsButton({ orgId }: Props) {
-  const navigate = useNavigate();
   const { permissions, loading } = useOrgPermissions(orgId);
 
   if (loading || !permissions.managePermission) {
@@ -16,15 +15,10 @@ export default function OrgSettingsButton({ orgId }: Props) {
   }
 
   return (
-    <Button
-      type="text"
-      size="small"
-      icon={<SettingOutlined />}
-      aria-label="organization settings"
-      onClick={(e) => {
-        e.stopPropagation();
-        navigate(`/organizations/${orgId}/settings`);
-      }}
-    />
+    <Button type="text" size="small" onClick={(e) => e.stopPropagation()}>
+      <Link to={`/organizations/${orgId}/settings`} aria-label="organization settings">
+        <SettingOutlined />
+      </Link>
+    </Button>
   );
 }

--- a/ui/src/modules/organizations/components/OrganizationTable/__tests__/OrgSettingsButton.test.tsx
+++ b/ui/src/modules/organizations/components/OrganizationTable/__tests__/OrgSettingsButton.test.tsx
@@ -1,16 +1,10 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import OrgSettingsButton from "../OrgSettingsButton";
 import { useOrgPermissions } from "@/modules/permissions/useOrgPermissions";
 
 jest.mock("@/modules/permissions/useOrgPermissions");
 const mockUseOrgPermissions = useOrgPermissions as jest.Mock;
-
-const mockNavigate = jest.fn();
-jest.mock("react-router-dom", () => ({
-  ...jest.requireActual("react-router-dom"),
-  useNavigate: () => mockNavigate,
-}));
 
 function renderButton() {
   return render(
@@ -21,10 +15,6 @@ function renderButton() {
 }
 
 describe("OrgSettingsButton", () => {
-  beforeEach(() => {
-    mockNavigate.mockClear();
-  });
-
   it("renders nothing while permissions are loading", () => {
     mockUseOrgPermissions.mockReturnValue({ permissions: {}, loading: true });
     const { container } = renderButton();
@@ -43,10 +33,12 @@ describe("OrgSettingsButton", () => {
     expect(screen.getByLabelText("organization settings")).toBeInTheDocument();
   });
 
-  it("navigates to the organization's settings page on click without bubbling", () => {
+  it("links to the organization's settings page", () => {
     mockUseOrgPermissions.mockReturnValue({ permissions: { managePermission: true }, loading: false });
     renderButton();
-    fireEvent.click(screen.getByLabelText("organization settings"));
-    expect(mockNavigate).toHaveBeenCalledWith("/organizations/org-1/settings");
+    expect(screen.getByLabelText("organization settings").closest("a")).toHaveAttribute(
+      "href",
+      "/organizations/org-1/settings"
+    );
   });
 });

--- a/ui/src/modules/organizations/organizationService.ts
+++ b/ui/src/modules/organizations/organizationService.ts
@@ -4,6 +4,7 @@ import { axiosGraphQL } from "@/config/axiosConfig";
 import { FlatOrganization, Organization } from "../../domain/types";
 import { TagModel } from "./types";
 import { WorkspaceStatusFilter } from "@/modules/workspaces/utils/workspaceFilter";
+import { isOrgId } from "@/config/orgId";
 
 function computeWorkspaceStatusCounts(edges: { node: { lastJobStatus?: string } }[]): Record<string, number> {
   const counts: Record<string, number> = {};
@@ -68,6 +69,9 @@ async function listOrganizationsGraphQL(): Promise<FlatOrganization[]> {
 }
 
 async function getOrganizationNameGraphQL(orgId: string): Promise<string | null> {
+  if (!isOrgId(orgId)) {
+    return null;
+  }
   const body = {
     query: `{
       organization(ids: ["${orgId}"]) {

--- a/ui/src/modules/permissions/useOrgPermissions.ts
+++ b/ui/src/modules/permissions/useOrgPermissions.ts
@@ -49,9 +49,14 @@ export function useOrgPermissions(orgIdOverride?: string) {
 
   useEffect(() => {
     if (!orgId) {
+      setPermissions(defaultPermissions);
       setLoading(false);
       return;
     }
+
+    let cancelled = false;
+    setPermissions(defaultPermissions);
+    setLoading(true);
 
     const url = `${
       new URL(window._env_.REACT_APP_TERRAKUBE_API_URL).origin
@@ -60,6 +65,7 @@ export function useOrgPermissions(orgIdOverride?: string) {
     axiosInstance
       .get(url)
       .then((response) => {
+        if (cancelled) return;
         setPermissions({
           manageState: response.data.manageState ?? false,
           manageWorkspace: response.data.manageWorkspace ?? false,
@@ -78,8 +84,14 @@ export function useOrgPermissions(orgIdOverride?: string) {
         // Keep default (all false) on error — user sees read-only UI
       })
       .finally(() => {
-        setLoading(false);
+        if (!cancelled) {
+          setLoading(false);
+        }
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [orgId]);
 
   return { permissions, loading };

--- a/ui/src/modules/projects/ProjectAccessTab.tsx
+++ b/ui/src/modules/projects/ProjectAccessTab.tsx
@@ -228,6 +228,7 @@ export default function ProjectAccessTab({ orgid, projectId, canManage }: Props)
       align: "right" as const,
       render: (_: any, record: ProjectAccessModel) => (
         <Popconfirm
+          okButtonProps={{ danger: true }}
           title={`Remove team "${record.name}" from this project?`}
           onConfirm={() => onRemove(record.id, record.name)}
           okText="Yes"

--- a/ui/src/modules/projects/ProjectDetailPage.tsx
+++ b/ui/src/modules/projects/ProjectDetailPage.tsx
@@ -157,6 +157,7 @@ function ProjectGeneralSettings({
           )}
         </div>
         <Popconfirm
+          okButtonProps={{ danger: true }}
           title={
             <p>
               Project will be permanently deleted

--- a/ui/src/modules/projects/ProjectsPage.tsx
+++ b/ui/src/modules/projects/ProjectsPage.tsx
@@ -39,7 +39,7 @@ export default function ProjectsPage({ organizationName, setOrganizationName }: 
 
   useEffect(() => {
     execute();
-  }, []);
+  }, [id]);
 
   const openCreate = () => {
     form.resetFields();

--- a/ui/src/modules/projects/ProjectsPage.tsx
+++ b/ui/src/modules/projects/ProjectsPage.tsx
@@ -1,7 +1,7 @@
 import { Button, Empty, Flex, Form, Input, Modal, Table, message } from "antd";
 import { PlusOutlined } from "@ant-design/icons";
 import { useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import PageWrapper from "@/modules/layout/PageWrapper/PageWrapper";
 import projectService from "./projectService";
 import useApiRequest from "@/modules/api/useApiRequest";
@@ -21,7 +21,6 @@ type ProjectForm = {
 
 export default function ProjectsPage({ organizationName, setOrganizationName }: Props) {
   const { id } = useParams();
-  const navigate = useNavigate();
   const { permissions } = useOrgPermissions(id);
   const [projects, setProjects] = useState<ProjectModel[]>([]);
   const [modalOpen, setModalOpen] = useState(false);
@@ -85,12 +84,8 @@ export default function ProjectsPage({ organizationName, setOrganizationName }: 
       dataIndex: "name",
       key: "name",
       render: (_: any, record: ProjectModel) => (
-        <Button
-          type="link"
-          style={{ padding: 0 }}
-          onClick={() => navigate(`/organizations/${id}/projects/${record.id}`)}
-        >
-          {record.name}
+        <Button type="link" style={{ padding: 0 }}>
+          <Link to={`/organizations/${id}/projects/${record.id}`}>{record.name}</Link>
         </Button>
       ),
     },

--- a/ui/src/modules/workspaces/components/RunList.tsx
+++ b/ui/src/modules/workspaces/components/RunList.tsx
@@ -109,7 +109,7 @@ export default function RunList({ jobs, onRunClick }: Props) {
     return "Terraform";
   };
 
-  const sortedJobs = filteredJobs.sort((a, b) => parseInt(a.id) - parseInt(b.id)).reverse();
+  const sortedJobs = [...filteredJobs].sort((a, b) => parseInt(b.id) - parseInt(a.id));
   const paginatedJobs = sortedJobs.slice((currentPage - 1) * pageSize, currentPage * pageSize);
 
   // Find the job with highest ID to mark as current

--- a/ui/src/modules/workspaces/components/RunList.tsx
+++ b/ui/src/modules/workspaces/components/RunList.tsx
@@ -1,5 +1,6 @@
 import { List, Avatar, Tag, Pagination, Tooltip, Button } from "antd";
 import { UserOutlined, WarningOutlined } from "@ant-design/icons";
+import { Link } from "react-router-dom";
 import { FlatJob } from "../../../domain/types";
 import { useState, useEffect, useCallback } from "react";
 import axiosInstance from "../../../config/axiosConfig";
@@ -37,9 +38,10 @@ const safeJsonParse = (jsonString: string | null, fallback: any): any => {
 type Props = {
   jobs: FlatJob[];
   onRunClick: (id: string) => void;
+  runLink: (id: string) => string;
 };
 
-export default function RunList({ jobs, onRunClick }: Props) {
+export default function RunList({ jobs, onRunClick, runLink }: Props) {
   const [currentPage, setCurrentPage] = useState<number>(parseInt(sessionStorage.getItem(RUNS_PAGE_KEY) || "1"));
   const pageSize = 10;
   const [templateNames, setTemplateNames] = useState<{ [key: string]: string }>({});
@@ -157,9 +159,9 @@ export default function RunList({ jobs, onRunClick }: Props) {
               avatar={<Avatar shape="square" icon={<UserOutlined />} />}
               title={
                 <span>
-                  <Button type="link" onClick={() => onRunClick(item.id)} style={{ color: "inherit", padding: 0 }}>
+                  <Link to={runLink(item.id)} onClick={() => onRunClick(item.id)} style={{ color: "inherit" }}>
                     {item.title}
-                  </Button>
+                  </Link>
                   {item.id === highestId && <Tag style={{ marginLeft: 8 }}>CURRENT</Tag>}
                 </span>
               }


### PR DESCRIPTION
**Description**

Since my previous MR, we started using Terrakube a lot more day to day, and this MR is the result: a batch of small UI fixes on a few pain points.

Nothing big on its own, but together they make the app much nicer to use. It builds on top of the recent UI work (#3339 sidebar, #3410 row links, #3394 session recovery) and extends it where gaps remained.

**Most notable changes**

- **Navigation uses real links everywhere.** #3410 converted the org/workspace rows; this finishes the job. Sidebar, org selector, user menu, tables, lists, run titles, registry buttons, VCS pickers — everything that changes the URL is now a real `<a href>`, so cmd+click / open in new tab work. Post-action redirects untouched.
- **Pages no longer lose or corrupt the organization context.** Workspace create/import now have org-scoped routes (old paths still work) so the sidebar keeps the org. The "create" segment of `/organizations/create` is no longer treated as an org id (it fired API calls failing with 400), and pages without an org context really clear the org state.
- **Switching organization refreshes the content.** Projects and registry only fetched on mount and kept showing the previous org's data.
- **Session expiry sends you back to the login page.** Complements #3394's 401 handling with listeners on the OIDC token-expiry events.

**Other fixes**

- Removed usage of `Steps.Step`, which no longer exists in antd v6 (Publish module, Add VCS, Add template).
- The router was recreated on every `App` render, remounting the whole tree on each token renewal.
- Re-selecting the current org in the selector now navigates instead of doing nothing.
- The org selector now uses antd theme variables instead of hardcoded colors.
- The org name is validated on the edit form like on creation (it is a path segment in the registry protocol).
- Workspace update/delete and the "New workspace" load now surface errors instead of hanging on a spinner.
- Lighter polling, same cadence: no more templates/actions/permissions reload per tick; completed step logs are cached.
- The registry page uses the fluid layout like every other page instead of a 1200px cap.
- State arrays are no longer sorted in place during render (unstable ordering between overview and run list).
- The org permissions hook no longer keeps the previous org's permissions while switching.
- "Sign out"/"Account settings" are a real button and link; destructive Popconfirms have a red confirm button; the tab title follows the page.
- Tests updated accordingly (router wrappers, href assertions).

**Note for reviewers**

The MR is intentionally split into small, self-contained commits (one fix per commit). If you want any specific point split out into its own PR, everything should cherry-pick cleanly.
