### PR TITLE
fix: persist job.overrideSource for CLI/API driven Run now jobs

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorService.java
@@ -26,6 +26,7 @@ import io.terrakube.api.plugin.token.dynamic.DynamicCredentialsService;
 import io.terrakube.api.plugin.vcs.TokenService;
 import io.terrakube.api.repository.AddressRepository;
 import io.terrakube.api.repository.GlobalVarRepository;
+import io.terrakube.api.repository.JobRepository;
 import io.terrakube.api.repository.ReferenceRepository;
 import io.terrakube.api.repository.SshRepository;
 import io.terrakube.api.repository.VariableRepository;
@@ -78,6 +79,8 @@ public class ExecutorService {
     TokenService tokenService;
     @Autowired
     WorkspaceRepository workspaceRepository;
+    @Autowired
+    JobRepository jobRepository;
     @Autowired
     private VariableRepository variableRepository;
     @Autowired
@@ -173,6 +176,15 @@ public class ExecutorService {
                             + "Upload configuration via the terraform CLI or attach a VCS connection before running.");
         }
 
+        // A UI "Run now" job only sets overrideBranch, not overrideSource (see
+        // ui/src/domain/Jobs/Create.tsx) - it arrives here relying on the workspace.source
+        // fallback above. The executor's remote-content download path re-reads job.overrideSource
+        // live via the API rather than trusting the dispatch payload (the same convention it
+        // already follows for terraformPlan and job status elsewhere in that module), so without
+        // this it would see overrideSource still null and fail even though a source was resolved
+        // right here.
+        persistJobOverrideSource(job, executorContext.getBranch(), executorContext.getSource());
+
         // For CLI/API driven (remote-content) workspaces, remember the configuration version
         // being applied so a later UI "Run now" re-queues the last applied configuration.
         persistAppliedConfigurationSource(job, flow, executorContext.getSource());
@@ -255,6 +267,48 @@ public class ExecutorService {
     private boolean iacType(Job job) {
         return job.getWorkspace().getIacType() != null && job.getWorkspace().getIacType().equals("terraform") ? false
                 : true;
+    }
+
+    /**
+     * Persists the resolved source directly onto the job for CLI/API driven (remote-content) jobs
+     * whose overrideSource was not already set at creation time. A UI "Run now" job is the case
+     * that matters here: it only sets overrideBranch, so it reaches execute() with
+     * job.overrideSource still null and executorContext.getSource() resolved purely from the
+     * workspace.source fallback above. Genuine CLI-driven runs are unaffected - RemoteTfeService
+     * .createRun already sets job.overrideSource at creation, so this method is a no-op for them.
+     *
+     * Runs for every remote-content flow type (plan, apply, destroy), not just apply: whichever
+     * flow this job runs, the executor still needs a non-null job.overrideSource to download the
+     * tarball. Contrast with persistAppliedConfigurationSource below, which is deliberately
+     * apply-only because it tracks the workspace's *last applied* configuration for future runs,
+     * not what this job itself needs to run right now.
+     *
+     * VCS/SSH backed workspaces are intentionally skipped, matching persistAppliedConfigurationSource
+     * below: the "Run now" branch name field is free text, so a VCS-backed workspace could arrive
+     * here with branch resolved to the literal string "remote-content" (e.g. a mistyped/pasted
+     * value). Without this check, executorContext.getSource() would resolve to the workspace's git
+     * URL (not blank, so it would pass the checks below) and get persisted as job.overrideSource -
+     * turning today's clear "no configuration has been uploaded" failure into a confusing one where
+     * the executor tries to download a git URL as a tarball.
+     */
+    void persistJobOverrideSource(Job job, String branch, String resolvedSource) {
+        if (job.getOverrideSource() != null) {
+            return;
+        }
+        if (!"remote-content".equals(branch)) {
+            return;
+        }
+        Workspace workspace = job.getWorkspace();
+        if (workspace.getVcs() != null || workspace.getSsh() != null) {
+            return;
+        }
+        if (resolvedSource == null || resolvedSource.isBlank()) {
+            return;
+        }
+        log.info("Persisting resolved configuration source onto job {} for remote-content workspace",
+                job.getId());
+        job.setOverrideSource(resolvedSource);
+        jobRepository.save(job);
     }
 
     /**

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/ExecutorServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.Flow;
 import io.terrakube.api.plugin.scheduler.job.tcl.model.FlowType;
 import io.terrakube.api.repository.AddressRepository;
+import io.terrakube.api.repository.JobRepository;
 import io.terrakube.api.repository.VariableRepository;
 import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.rs.job.Job;
@@ -40,6 +41,9 @@ class ExecutorServiceTest {
 
     @Mock
     private AddressRepository addressRepository;
+
+    @Mock
+    private JobRepository jobRepository;
 
     @InjectMocks
     private ExecutorService executorService;
@@ -111,6 +115,72 @@ class ExecutorServiceTest {
 
         assertThat(terraformVariables).isEmpty();
         assertThat(environmentVariables).isEmpty();
+    }
+
+    @Test
+    void shouldPersistJobOverrideSourceWhenNotAlreadySet() {
+        String resolved = "https://localhost/remote/tfe/v2/configuration-versions/abc/terraformContent.tar.gz";
+
+        executorService.persistJobOverrideSource(job, "remote-content", resolved);
+
+        assertThat(job.getOverrideSource()).isEqualTo(resolved);
+        verify(jobRepository).save(job);
+    }
+
+    @Test
+    void shouldNotPersistJobOverrideSourceWhenAlreadySet() {
+        String original = "https://localhost/remote/tfe/v2/configuration-versions/original/terraformContent.tar.gz";
+        String resolved = "https://localhost/remote/tfe/v2/configuration-versions/abc/terraformContent.tar.gz";
+        job.setOverrideSource(original);
+
+        executorService.persistJobOverrideSource(job, "remote-content", resolved);
+
+        assertThat(job.getOverrideSource()).isEqualTo(original);
+        verify(jobRepository, never()).save(job);
+    }
+
+    @Test
+    void shouldNotPersistJobOverrideSourceForNonRemoteContentBranch() {
+        String resolved = "https://github.com/example/repo.git";
+
+        executorService.persistJobOverrideSource(job, "main", resolved);
+
+        assertThat(job.getOverrideSource()).isNull();
+        verify(jobRepository, never()).save(job);
+    }
+
+    @Test
+    void shouldNotPersistJobOverrideSourceWhenResolvedSourceIsBlank() {
+        executorService.persistJobOverrideSource(job, "remote-content", "  ");
+
+        assertThat(job.getOverrideSource()).isNull();
+        verify(jobRepository, never()).save(job);
+    }
+
+    @Test
+    void shouldNotPersistJobOverrideSourceForVcsWorkspace() {
+        // "Run now"'s branch name field is free text - a VCS workspace could arrive here with
+        // branch resolved to "remote-content" (e.g. mistyped/pasted), with resolvedSource actually
+        // the workspace's git URL via the executorContext.getSource() fallback. Persisting that
+        // as job.overrideSource would make the executor try to download a git URL as a tarball.
+        workspace.setVcs(new Vcs());
+        String gitUrl = "https://github.com/example/repo.git";
+
+        executorService.persistJobOverrideSource(job, "remote-content", gitUrl);
+
+        assertThat(job.getOverrideSource()).isNull();
+        verify(jobRepository, never()).save(job);
+    }
+
+    @Test
+    void shouldNotPersistJobOverrideSourceForSshWorkspace() {
+        workspace.setSsh(new Ssh());
+        String gitUrl = "git@github.com:example/repo.git";
+
+        executorService.persistJobOverrideSource(job, "remote-content", gitUrl);
+
+        assertThat(job.getOverrideSource()).isNull();
+        verify(jobRepository, never()).save(job);
     }
 
     @Test

--- a/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/workspace/SetupWorkspaceTest.java
@@ -592,6 +592,27 @@ public class SetupWorkspaceTest {
         Assertions.assertEquals(FileNotFoundException.class, e.getCause().getClass());
     }
 
+    // Reproduces the "Run now" gap: a UI-created job on a remote-content workspace whose
+    // job.overrideSource was never populated (see ExecutorService.persistJobOverrideSource on the
+    // api side, which now prevents this from happening in practice). terrakubeClient(null) mirrors
+    // that scenario without needing api-module code in this test.
+    @Test
+    public void reportsClearFailureWhenOverrideSourceIsMissing() throws Exception {
+        TerraformJob job = new TerraformJob();
+        job.setOrganizationId("ze-org");
+        job.setWorkspaceId("ze-ws");
+        job.setJobId("9041");
+        job.setBranch("remote-content");
+        job.setEnvironmentVariables(new HashMap<String, String>());
+        SetupWorkspace setup = new SetupWorkspaceImpl(new NoopWorkspaceSecurity(), false, new NoopTerraformExecutor(),
+                "https://terrakube-api.example.com", terrakubeClient(null));
+
+        WorkspaceException e = Assertions.assertThrows(WorkspaceException.class, () -> setup.prepareWorkspace(job));
+
+        Assertions.assertEquals(IOException.class, e.getCause().getClass());
+        Assertions.assertTrue(e.getCause().getMessage().contains("9041"));
+    }
+
     @Test
     public void injectsAwsCredentialsWhenAsked() throws Exception {
         TerraformJob job = successfulTarGzJob();


### PR DESCRIPTION
## Problem

Clicking **Run now** on a CLI/API-driven ("remote-content") workspace fails with:

```java
Failed to prepare work dir
java.io.IOException: No configuration tarball URL is set for job <id> (overrideSource is null).
The workspace branch is 'remote-content' but no configuration has been uploaded — upload it
via the terraform CLI or attach a VCS connection before running.
```

...even when the workspace has a successful prior apply and the "Run now" button isn't disabled.

## Root cause

`ExecutorService.execute()` correctly resolves the download source for the job via the `workspace.source` fallback (from #3402), but never writes that resolved value back onto **`job.overrideSource`** — the specific column `SetupWorkspaceImpl.downloadWorkspaceTarGz()` independently re-reads live via the API when the executor actually downloads the tarball, rather than trusting the dispatch payload (the same pattern it already follows for `terraformPlan` and job status elsewhere in that module).

The UI's "Run now" job-creation call (`ui/src/domain/Jobs/Create.tsx`) only ever sets `overrideBranch`, never `overrideSource` — so that column stays `null` for any job created this way, and the executor fails even though the API-side resolution was correct.

<details>
<summary>Why this wasn't caught by #3402's tests</summary>

#3402 added tests asserting `workspace.getSource()` resolves correctly and that the UI button disables when appropriate — both true and both passing. Neither asserted anything about `job.getOverrideSource()`, the column the *executor module* — a separate service — actually reads. The gap sits exactly at that seam, which no test on either side of the module boundary covered.
</details>

## Fix

`ExecutorService.persistJobOverrideSource()` backfills `job.overrideSource` before dispatch whenever it wasn't already set at job creation:

- **No-op for genuine CLI-driven runs** — `RemoteTfeService.createRun()` already sets `overrideSource` correctly at creation, so this never overwrites it.
- **Runs for every remote-content flow type** (plan/apply/destroy) — unlike the apply-only `persistAppliedConfigurationSource`, since *any* flow the executor runs needs a non-null source to download the tarball, not just applies.
- **Excludes VCS/SSH-backed workspaces**, mirroring `persistAppliedConfigurationSource`. The "Run now" branch-name field is free text — a VCS workspace with a mistyped/pasted `"remote-content"` value would otherwise get its **git URL** persisted as `overrideSource`, turning a clear "no configuration uploaded" error into a confusing tarball-download failure instead.

## Test plan

- [x] 6 new unit tests in `ExecutorServiceTest` covering: sets when unset, no-ops when already set (CLI path unaffected), no-ops for non-remote-content branch, no-ops for blank source, no-ops for VCS workspace, no-ops for SSH workspace
- [x] 1 new test in `SetupWorkspaceTest` (executor module) reproducing the original failure end-to-end via `prepareWorkspace()`
- [x] Full `api` module suite: 816 tests, 0 failures, 0 new errors (2 pre-existing/unrelated: a flaky RBAC integration test and an ARM64-emulation Testcontainers limitation — both confirmed present on unpatched `main` too)
- [x] Full `executor` module suite: 187/187 passing
- [x] Patch verified to apply cleanly (`git apply --check`) against current `main`

## Related

Follow-up to #3402.