### PR TITLE
fix: initialize notification config collections before session closes

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/notification/NotificationConfigResolver.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/NotificationConfigResolver.java
@@ -3,7 +3,9 @@ package io.terrakube.api.plugin.notification;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import io.terrakube.api.repository.NotificationConfigurationRepository;
 import io.terrakube.api.rs.notification.NotificationConfiguration;
@@ -21,11 +23,28 @@ public class NotificationConfigResolver {
     // Purely additive: a workspace gets every active org-wide config plus every active config
     // scoped directly to it. No per-channel-type override/suppression - keeping the two scopes
     // simple and independent is the whole point.
+    //
+    // Transactional + explicit initialization: callers (JobNotificationTrigger, invoked from the
+    // Quartz/background dispatch path) read configuration.getTriggers() and getTemplates() long
+    // after this returns. Both are LAZY and spring.jpa.open-in-view=false, so without materializing
+    // them here every access throws LazyInitializationException ("no Session"). Only the two
+    // collections notification resolution actually needs are initialized - the relationships stay
+    // LAZY globally.
+    @Transactional(readOnly = true)
     public List<NotificationConfiguration> resolve(Workspace workspace) {
         List<NotificationConfiguration> workspaceConfigs = notificationConfigurationRepository
                 .findByWorkspaceIdAndActiveTrue(workspace.getId());
         List<NotificationConfiguration> orgConfigs = notificationConfigurationRepository
                 .findByOrganizationIdAndWorkspaceIsNullAndActiveTrue(workspace.getOrganization().getId());
-        return Stream.concat(workspaceConfigs.stream(), orgConfigs.stream()).toList();
+
+        List<NotificationConfiguration> configurations = Stream.concat(
+                workspaceConfigs.stream(), orgConfigs.stream()).toList();
+
+        configurations.forEach(configuration -> {
+            Hibernate.initialize(configuration.getTriggers());
+            Hibernate.initialize(configuration.getTemplates());
+        });
+
+        return configurations;
     }
 }

--- a/api/src/test/java/io/terrakube/api/NotificationConfigurationRepositoryTest.java
+++ b/api/src/test/java/io/terrakube/api/NotificationConfigurationRepositoryTest.java
@@ -1,5 +1,6 @@
 package io.terrakube.api;
 
+import io.terrakube.api.plugin.notification.NotificationConfigResolver;
 import io.terrakube.api.repository.NotificationConfigurationRepository;
 import io.terrakube.api.repository.NotificationTriggerRepository;
 import io.terrakube.api.repository.OrganizationRepository;
@@ -10,6 +11,7 @@ import io.terrakube.api.rs.notification.NotificationChannelType;
 import io.terrakube.api.rs.notification.NotificationConfiguration;
 import io.terrakube.api.rs.notification.NotificationTrigger;
 import io.terrakube.api.rs.workspace.Workspace;
+import org.hibernate.Hibernate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -31,6 +33,9 @@ class NotificationConfigurationRepositoryTest extends ServerApplicationTests {
 
     @Autowired
     WorkspaceRepository workspaceRepository;
+
+    @Autowired
+    NotificationConfigResolver notificationConfigResolver;
 
     @Test
     void savesWorkspaceScopedConfiguration_organizationIsDerivedFromWorkspace() {
@@ -74,5 +79,43 @@ class NotificationConfigurationRepositoryTest extends ServerApplicationTests {
                 .findByOrganizationIdAndWorkspaceIsNullAndActiveTrue(organization.getId());
 
         assertThat(found).extracting(NotificationConfiguration::getId).contains(configuration.getId());
+    }
+
+    @Test
+    void resolve_initializesTriggersAndTemplatesBeforeReturning() {
+        Workspace workspace = workspaceRepository
+                .findById(UUID.fromString("5ed411ca-7ab8-4d2f-b591-02d0d5788afc")).orElseThrow();
+
+        NotificationConfiguration configuration = new NotificationConfiguration();
+        configuration.setName("Workspace Completed Alerts");
+        configuration.setWorkspace(workspace);
+        configuration.setChannelType(NotificationChannelType.WEBHOOK);
+        configuration.setDestinationUrl("https://example.com/completed-hook");
+        configuration.setActive(true);
+        configuration = notificationConfigurationRepository.saveAndFlush(configuration);
+
+        NotificationTrigger trigger = new NotificationTrigger();
+        trigger.setConfiguration(configuration);
+        trigger.setJobStatus(JobStatus.completed);
+        notificationTriggerRepository.saveAndFlush(trigger);
+
+        UUID configurationId = configuration.getId();
+
+        // resolve() opens its own read-only transaction and closes it before returning. The
+        // background notification dispatch path reads getTriggers()/getTemplates() well after
+        // that - both are LAZY with open-in-view disabled, so resolve() must materialize them
+        // itself or those reads throw LazyInitializationException ("no Session").
+        List<NotificationConfiguration> resolved = notificationConfigResolver.resolve(workspace);
+
+        NotificationConfiguration resolvedConfig = resolved.stream()
+                .filter(c -> c.getId().equals(configurationId))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(Hibernate.isInitialized(resolvedConfig.getTriggers())).isTrue();
+        assertThat(Hibernate.isInitialized(resolvedConfig.getTemplates())).isTrue();
+        assertThat(resolvedConfig.getTriggers())
+                .extracting(NotificationTrigger::getJobStatus)
+                .containsExactly(JobStatus.completed);
     }
 }


### PR DESCRIPTION
## Problem

Job notifications fail for non-error statuses with `org.hibernate.LazyInitializationException: ... NotificationConfiguration.triggers: could not initialize proxy - no Session` (logged as `Failed to resolve/enqueue notifications for job <id>`).

`JobNotificationTrigger.enqueue()` runs on the Quartz/background dispatch path and reads the `LAZY` `NotificationConfiguration.getTriggers()` / `getTemplates()` after the repository query's session has closed. With `spring.jpa.open-in-view=false` there's no session to initialize against, so the access throws. The exception is caught and logged, so the job update succeeds but the notification is silently dropped.

## Fix

- `NotificationConfigResolver.resolve()` is now `@Transactional(readOnly = true)` and calls `Hibernate.initialize(...)` on `triggers` and `templates` before returning.
- Relationships stay `LAZY` globally — no eager fetch. Only the collections notification resolution needs are initialized.
- `Hibernate.initialize(...)` rather than `.size()` because it's null-safe, keeping the Mockito-based `NotificationConfigResolverTest` green.

## Tests

New integration test `NotificationConfigurationRepositoryTest#resolve_initializesTriggersAndTemplatesBeforeReturning`: creates an active config with a `completed` trigger, resolves via `NotificationConfigResolver`, then asserts (session closed) that `Hibernate.isInitialized(...)` is true for both collections and the trigger status still reads as `JobStatus.completed`. Confirmed it fails without the resolver change and passes with it.

Validation: `mvn -pl api -Dtest=NotificationConfigurationRepositoryTest,NotificationConfigResolverTest,JobNotificationTriggerTest test` → `Tests run: 16, Failures: 0, Errors: 0` (Java 25).

## Risk

Low — scoped to one resolver method, fetch strategy unchanged, added transaction is read-only and short-lived.