### PR TITLE
feat(registry): presigned URL redirect for AWS S3, Azure Blob, and GCP Cloud Storage

### DIFF
--- a/registry/pom.xml
+++ b/registry/pom.xml
@@ -167,6 +167,13 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sts</artifactId>
         </dependency>
+        <!-- Explicit sync HTTP client so S3Client/S3Presigner connection pool, connect, and
+             socket timeouts are configurable (see AwsStorageServiceProperties) instead of relying
+             on whatever the SDK auto-detects on the classpath. -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>apache-client</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.wiremock.integrations</groupId>
             <artifactId>wiremock-spring-boot</artifactId>

--- a/registry/src/main/java/io/terrakube/registry/OpenRegistryApplication.java
+++ b/registry/src/main/java/io/terrakube/registry/OpenRegistryApplication.java
@@ -6,8 +6,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableCaching
+@EnableAsync
 @SpringBootApplication
 public class OpenRegistryApplication {
 

--- a/registry/src/main/java/io/terrakube/registry/configuration/DownloadCountExecutorConfig.java
+++ b/registry/src/main/java/io/terrakube/registry/configuration/DownloadCountExecutorConfig.java
@@ -1,0 +1,30 @@
+package io.terrakube.registry.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class DownloadCountExecutorConfig {
+
+    // Bounded, dedicated pool for the download-count bookkeeping call
+    // (ModuleServiceImpl.updateModuleDownloadCount), so it never blocks the Terraform-facing
+    // metadata response (ModuleWebServiceImpl.getModuleVersionPath). Deliberately small: this is
+    // one lightweight, best-effort API call per module download, not a fan-out. A full queue
+    // rejects rather than blocks the caller - a dropped update only affects a non-critical
+    // download counter, never the client-visible response.
+    @Bean("downloadCountExecutor")
+    public ThreadPoolTaskExecutor downloadCountExecutor(
+            @Value("${io.terrakube.registry.download-count.executor.corePoolSize:2}") int corePoolSize,
+            @Value("${io.terrakube.registry.download-count.executor.maxPoolSize:5}") int maxPoolSize,
+            @Value("${io.terrakube.registry.download-count.executor.queueCapacity:200}") int queueCapacity) {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(queueCapacity);
+        executor.setThreadNamePrefix("download-count-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/registry/src/main/java/io/terrakube/registry/controller/ModuleWebServiceImpl.java
+++ b/registry/src/main/java/io/terrakube/registry/controller/ModuleWebServiceImpl.java
@@ -7,13 +7,16 @@ import io.terrakube.registry.plugin.storage.StorageService;
 import io.terrakube.registry.service.module.ModuleService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/terraform/modules/v1")
@@ -55,10 +58,14 @@ public class ModuleWebServiceImpl {
         return ResponseEntity.noContent().headers(responseHeaders).build();
     }
 
-    @GetMapping(
-            value = "/download/{organizationName}/{moduleName}/{providerName}/{version}/module.zip",
-            produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-    public @ResponseBody byte[] getModuleZip(@PathVariable String organizationName, @PathVariable String moduleName, @PathVariable String providerName, @PathVariable String version) {
-        return storageService.downloadModule(organizationName, moduleName, providerName, version);
+    @GetMapping(value = "/download/{organizationName}/{moduleName}/{providerName}/{version}/module.zip")
+    public ResponseEntity<byte[]> getModuleZip(@PathVariable String organizationName, @PathVariable String moduleName, @PathVariable String providerName, @PathVariable String version) {
+        Optional<URI> presignedDownloadUrl = storageService.getPresignedDownloadUrl(organizationName, moduleName, providerName, version);
+        if (presignedDownloadUrl.isPresent()) {
+            return ResponseEntity.status(HttpStatus.FOUND).location(presignedDownloadUrl.get()).build();
+        }
+
+        byte[] data = storageService.downloadModule(organizationName, moduleName, providerName, version);
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_OCTET_STREAM).body(data);
     }
 }

--- a/registry/src/main/java/io/terrakube/registry/controller/StorageExceptionHandler.java
+++ b/registry/src/main/java/io/terrakube/registry/controller/StorageExceptionHandler.java
@@ -1,0 +1,26 @@
+package io.terrakube.registry.controller;
+
+import io.terrakube.registry.plugin.storage.StorageUnavailableException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+// Applies to both module endpoints: a cold getModuleVersionPath cache miss that hits a
+// transient S3/API/VCS failure, and a module.zip request that fails to proxy bytes or generate a
+// presigned URL. Either way the client gets a clearly logged, retryable response instead of an
+// ambiguous success (e.g. an empty ZIP) or an opaque 500.
+@Slf4j
+@RestControllerAdvice
+public class StorageExceptionHandler {
+
+    @ExceptionHandler(StorageUnavailableException.class)
+    public ResponseEntity<Void> handleStorageUnavailable(StorageUnavailableException exception) {
+        log.error("Storage backend unavailable: {}", exception.getMessage());
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .header(HttpHeaders.RETRY_AFTER, "5")
+                .build();
+    }
+}

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/StorageService.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/StorageService.java
@@ -2,9 +2,23 @@ package io.terrakube.registry.plugin.storage;
 
 import io.terrakube.registry.service.git.ModuleVersionDownload;
 
+import java.net.URI;
+import java.util.Optional;
+
 public interface StorageService {
 
     String searchModule(String organizationName, String moduleName, String providerName, ModuleVersionDownload download);
 
     byte[] downloadModule(String organizationName, String moduleName, String providerName, String moduleVersion);
+
+    /**
+     * Returns a short-lived, directly-downloadable URL for the module ZIP when the storage
+     * backend supports redirecting clients instead of proxying bytes through the registry pod.
+     * Empty by default; only AWS S3 storage currently supports this, and only when explicitly
+     * enabled.
+     */
+    default Optional<URI> getPresignedDownloadUrl(String organizationName, String moduleName, String providerName,
+            String moduleVersion) {
+        return Optional.empty();
+    }
 }

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/StorageUnavailableException.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/StorageUnavailableException.java
@@ -1,0 +1,13 @@
+package io.terrakube.registry.plugin.storage;
+
+/**
+ * Thrown when a storage backend cannot fulfill a request due to a transient failure (S3 timeout,
+ * connectivity, throttling, etc). Signals to callers that the failure is retryable and must not be
+ * masked as an empty/successful response - see the module-download resilience design.
+ */
+public class StorageUnavailableException extends RuntimeException {
+
+    public StorageUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/aws/AwsStorageServiceImpl.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/aws/AwsStorageServiceImpl.java
@@ -5,17 +5,25 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import io.terrakube.registry.plugin.storage.StorageService;
+import io.terrakube.registry.plugin.storage.StorageUnavailableException;
 import io.terrakube.registry.service.git.GitService;
 import io.terrakube.registry.service.git.ModuleVersionDownload;
 import org.zeroturnaround.zip.ZipUtil;
 import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Optional;
 
 @Slf4j
 @Builder
@@ -23,7 +31,7 @@ public class AwsStorageServiceImpl implements StorageService {
 
     private static final String BUCKET_ZIP_MODULE_LOCATION = "registry/%s/%s/%s/%s/module.zip";
     private static final String BUCKET_DOWNLOAD_MODULE_LOCATION = "%s/terraform/modules/v1/download/%s/%s/%s/%s/module.zip";
-    private static final String S3_ERROR_LOG = "S3 Not found: {}";
+    private static final String S3_ERROR_LOG = "S3 operation failed for key {}: {}";
 
     @NonNull
     private S3Client s3client;
@@ -37,6 +45,16 @@ public class AwsStorageServiceImpl implements StorageService {
     @NonNull
     String registryHostname;
 
+    // Not @NonNull: only required when presignedRedirectEnabled is true (AWS storage with the
+    // redirect flag on). Non-AWS test setups and rollback (flag off) never touch it.
+    private S3Presigner s3Presigner;
+
+    @Builder.Default
+    private int presignedUrlExpirySeconds = 300;
+
+    @Builder.Default
+    private boolean presignedRedirectEnabled = false;
+
     @Override
     public String searchModule(String organizationName, String moduleName, String providerName,
             ModuleVersionDownload download) {
@@ -45,34 +63,76 @@ public class AwsStorageServiceImpl implements StorageService {
                 moduleVersion);
         log.info("Checking Aws S3 Object exist {}", blobKey);
 
-        if (!doesObjectExistByListObjects(bucketName, blobKey)) {
-            File gitCloneDirectory = gitService.getCloneRepositoryByTag(download);
-            File moduleZip = new File(gitCloneDirectory.getAbsolutePath() + ".zip");
-            ZipUtil.pack(gitCloneDirectory, moduleZip);
+        try {
+            if (!doesObjectExistByListObjects(bucketName, blobKey)) {
+                File gitCloneDirectory = gitService.getCloneRepositoryByTag(download);
+                File moduleZip = new File(gitCloneDirectory.getAbsolutePath() + ".zip");
+                ZipUtil.pack(gitCloneDirectory, moduleZip);
 
-            log.info("Uploading Aws S3 Object {}", blobKey);
-            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
-                    .bucket(bucketName)
-                    .key(blobKey)
-                    .contentType("application/zip")
-                    .build();
+                log.info("Uploading Aws S3 Object {}", blobKey);
+                PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(blobKey)
+                        .contentType("application/zip")
+                        .build();
 
-            log.info("Running PUT Aws S3 Object {}", blobKey);
-            log.info("Path {}", moduleZip.getAbsolutePath());
-            s3client.putObject(putObjectRequest, RequestBody.fromFile(moduleZip));
+                log.info("Running PUT Aws S3 Object {}", blobKey);
+                log.info("Path {}", moduleZip.getAbsolutePath());
+                s3client.putObject(putObjectRequest, RequestBody.fromFile(moduleZip));
 
-            log.info("Upload Aws S3 Object completed {}", blobKey);
-            try {
-                FileUtils.cleanDirectory(gitCloneDirectory);
-                if (FileUtils.deleteQuietly(moduleZip))
-                    log.info("Successfully delete folder");
-            } catch (IOException e) {
-                log.error(e.getMessage());
+                log.info("Upload Aws S3 Object completed {}", blobKey);
+                try {
+                    FileUtils.cleanDirectory(gitCloneDirectory);
+                    if (FileUtils.deleteQuietly(moduleZip))
+                        log.info("Successfully delete folder");
+                } catch (IOException e) {
+                    log.error(e.getMessage());
+                }
             }
+        } catch (SdkException e) {
+            // Covers HeadObject/PutObject connectivity failures, timeouts, and throttling - a
+            // cold cache miss must fail loudly rather than silently produce a bad/missing path
+            // that a later ZIP request can't recover from.
+            log.error(S3_ERROR_LOG, blobKey, e.getMessage());
+            throw new StorageUnavailableException("S3 operation failed while resolving module path for key " + blobKey, e);
         }
 
         return String.format(BUCKET_DOWNLOAD_MODULE_LOCATION, registryHostname, organizationName, moduleName,
                 providerName, moduleVersion);
+    }
+
+    /**
+     * Presigned URL is intentionally not cached alongside the module path (see
+     * getModuleVersionPath's 10-minute cache) - its validity window is much shorter than the
+     * cache TTL, so every ZIP request gets a fresh signature computed here.
+     */
+    @Override
+    public Optional<URI> getPresignedDownloadUrl(String organizationName, String moduleName, String providerName,
+            String moduleVersion) {
+        if (!presignedRedirectEnabled || s3Presigner == null) {
+            return Optional.empty();
+        }
+
+        String blobKey = String.format(BUCKET_ZIP_MODULE_LOCATION, organizationName, moduleName, providerName,
+                moduleVersion);
+        try {
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(blobKey)
+                    .build();
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofSeconds(presignedUrlExpirySeconds))
+                    .getObjectRequest(getObjectRequest)
+                    .build();
+
+            PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
+            // Never log presignedRequest.url() itself - it carries the signed query string.
+            log.info("Generated presigned download URL for bucket {} key {}", bucketName, blobKey);
+            return Optional.of(presignedRequest.url().toURI());
+        } catch (Exception e) {
+            log.error("Failed to generate presigned URL for bucket {} key {}: {}", bucketName, blobKey, e.getMessage());
+            throw new StorageUnavailableException("Failed to generate presigned URL for key " + blobKey, e);
+        }
     }
 
     public boolean doesObjectExistByListObjects(String bucketName, String key) {
@@ -96,26 +156,29 @@ public class AwsStorageServiceImpl implements StorageService {
         }
     }
 
+    /**
+     * Legacy byte-proxy path, retained only for the presigned-redirect rollback/compatibility
+     * case (presignedRedirectEnabled=false). An S3 failure here must surface as an error, never
+     * as an empty ZIP that Terraform would try to unpack.
+     */
     @Override
     public byte[] downloadModule(String organizationName, String moduleName, String providerName,
             String moduleVersion) {
-        byte[] data;
+        String blobKey = String.format(BUCKET_ZIP_MODULE_LOCATION, organizationName, moduleName, providerName,
+                moduleVersion);
         try {
-            log.info("Searching: /registry/{}/{}/{}/{}/module.zip", organizationName, moduleName, providerName,
-                    moduleVersion);
+            log.info("Searching: {}", blobKey);
             GetObjectRequest objectRequest = GetObjectRequest.builder()
-                    .key(String.format(BUCKET_ZIP_MODULE_LOCATION,
-                            organizationName, moduleName, providerName, moduleVersion))
+                    .key(blobKey)
                     .bucket(bucketName)
                     .build();
             ResponseBytes<GetObjectResponse> objectBytes = s3client.getObject(objectRequest,
                     ResponseTransformer.toBytes());
-            data = objectBytes.asByteArray();
+            return objectBytes.asByteArray();
         } catch (Exception e) {
-            log.error(S3_ERROR_LOG, e.getMessage());
-            data = new byte[0];
+            log.error(S3_ERROR_LOG, blobKey, e.getMessage());
+            throw new StorageUnavailableException("Failed to download module ZIP for key " + blobKey, e);
         }
-        return data;
     }
 
 }

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/aws/AwsStorageServiceProperties.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/aws/AwsStorageServiceProperties.java
@@ -19,4 +19,20 @@ public class AwsStorageServiceProperties {
     private String region;
     private String endpoint;
     private boolean enableRoleAuthentication;
+
+    // Bounds on the S3Client/S3Presigner HTTP client, so a slow or unreachable S3 endpoint fails
+    // fast instead of queuing registry request threads indefinitely.
+    private int connectionAcquisitionTimeoutSeconds = 1;
+    private int connectTimeoutSeconds = 2;
+    private int socketTimeoutSeconds = 10;
+    private int apiCallAttemptTimeoutSeconds = 15;
+    private int apiCallTimeoutSeconds = 25;
+    private int maxConnections = 50;
+
+    // How long a presigned module.zip download URL stays valid.
+    private int presignedUrlExpirySeconds = 300;
+    // When true, the module.zip endpoint redirects to a presigned S3 URL instead of proxying the
+    // object's bytes through the registry pod. Off by default for staged rollout; also doubles as
+    // the rollback switch back to the byte-proxy path.
+    private boolean presignedRedirectEnabled;
 }

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/azure/AzureStorageServiceImpl.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/azure/AzureStorageServiceImpl.java
@@ -3,17 +3,25 @@ package io.terrakube.registry.plugin.storage.azure;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.sas.BlobSasPermission;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import io.terrakube.registry.plugin.storage.StorageService;
+import io.terrakube.registry.plugin.storage.StorageUnavailableException;
 import io.terrakube.registry.service.git.GitService;
 import io.terrakube.registry.service.git.ModuleVersionDownload;
 import org.zeroturnaround.zip.ZipUtil;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.Optional;
 
 @Slf4j
 @Builder
@@ -21,6 +29,7 @@ public class AzureStorageServiceImpl implements StorageService {
 
     private static final String CONTAINER_NAME = "registry";
     private static final String BUCKET_DOWNLOAD_MODULE_LOCATION = "%s/terraform/modules/v1/download/%s/%s/%s/%s/module.zip";
+    private static final String BLOB_ZIP_MODULE_LOCATION = "%s/%s/%s/%s/module.zip";
 
     @NonNull
     BlobServiceClient blobServiceClient;
@@ -31,49 +40,117 @@ public class AzureStorageServiceImpl implements StorageService {
     @NonNull
     String registryHostname;
 
+    // Not @NonNull: only required when presignedRedirectEnabled is true. The SAS token is
+    // generated from the blobServiceClient's shared-key credential (connection string path).
+    // If Azure AD / Managed Identity is ever used instead, delegation via UserDelegationKey
+    // would be required — see the module-download resilience design.
+    @Builder.Default
+    private int presignedUrlExpirySeconds = 300;
+
+    @Builder.Default
+    private boolean presignedRedirectEnabled = false;
+
     @Override
     public String searchModule(String organizationName, String moduleName, String providerName,
             ModuleVersionDownload download) {
         String moduleVersion = download.version();
-
-        BlobContainerClient blobContainerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME);
-
-        log.info("blobContainerClient.exists {}", blobContainerClient.exists());
-        if (!blobContainerClient.exists()) {
-            blobContainerClient.create();
-        }
-        String blobName = String.format("%s/%s/%s/%s/module.zip", organizationName, moduleName, providerName,
+        String blobName = String.format(BLOB_ZIP_MODULE_LOCATION, organizationName, moduleName, providerName,
                 moduleVersion);
-        log.info("blobName: {}", blobName);
-        BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
 
-        if (!blobClient.exists()) {
-            File gitCloneDirectory = gitService.getCloneRepositoryByTag(download);
-            File moduleZip = new File(gitCloneDirectory.getAbsolutePath() + ".zip");
-            ZipUtil.pack(gitCloneDirectory, moduleZip);
-            blobClient.uploadFromFile(moduleZip.getAbsolutePath());
+        try {
+            BlobContainerClient blobContainerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME);
 
-            try {
-                FileUtils.cleanDirectory(gitCloneDirectory);
-                if (FileUtils.deleteQuietly(moduleZip))
-                    log.info("Successfully delete folder");
-            } catch (IOException e) {
-                log.error(e.getMessage());
+            log.info("blobContainerClient.exists {}", blobContainerClient.exists());
+            if (!blobContainerClient.exists()) {
+                blobContainerClient.create();
             }
+            log.info("blobName: {}", blobName);
+            BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
+
+            if (!blobClient.exists()) {
+                File gitCloneDirectory = gitService.getCloneRepositoryByTag(download);
+                File moduleZip = new File(gitCloneDirectory.getAbsolutePath() + ".zip");
+                ZipUtil.pack(gitCloneDirectory, moduleZip);
+                blobClient.uploadFromFile(moduleZip.getAbsolutePath());
+
+                try {
+                    FileUtils.cleanDirectory(gitCloneDirectory);
+                    if (FileUtils.deleteQuietly(moduleZip))
+                        log.info("Successfully delete folder");
+                } catch (IOException e) {
+                    log.error(e.getMessage());
+                }
+            }
+        } catch (BlobStorageException e) {
+            log.error("Azure Blob operation failed for blob {} in container {}: {}", blobName, CONTAINER_NAME,
+                    e.getMessage());
+            throw new StorageUnavailableException(
+                    "Azure Blob operation failed while resolving module path for blob " + blobName, e);
         }
 
         return String.format(BUCKET_DOWNLOAD_MODULE_LOCATION, registryHostname, organizationName, moduleName,
                 providerName, moduleVersion);
     }
 
+    /**
+     * Generates a short-lived, read-only SAS URL for the module ZIP blob so the Terraform client
+     * can download it directly from Azure Blob Storage instead of the bytes being proxied through
+     * the registry pod.
+     *
+     * <p>The SAS URL is intentionally not cached alongside the module path (see
+     * getModuleVersionPath's 10-minute cache) — its validity window is much shorter than the cache
+     * TTL, so every ZIP request gets a fresh SAS token computed here.
+     *
+     * <p>Requires the {@link BlobServiceClient} to be built with a shared-key credential
+     * (connection string). SAS generation will fail if the client was built with Azure AD /
+     * Managed Identity credentials without a UserDelegationKey.
+     */
+    @Override
+    public Optional<URI> getPresignedDownloadUrl(String organizationName, String moduleName, String providerName,
+            String moduleVersion) {
+        if (!presignedRedirectEnabled) {
+            return Optional.empty();
+        }
+
+        String blobName = String.format(BLOB_ZIP_MODULE_LOCATION, organizationName, moduleName, providerName,
+                moduleVersion);
+        try {
+            BlobContainerClient blobContainerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME);
+            BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
+
+            BlobSasPermission permissions = new BlobSasPermission().setReadPermission(true);
+            BlobServiceSasSignatureValues sasValues = new BlobServiceSasSignatureValues(
+                    OffsetDateTime.now().plusSeconds(presignedUrlExpirySeconds), permissions);
+
+            String sasToken = blobClient.generateSas(sasValues);
+            // Never log the SAS token itself — it carries the signature query string.
+            log.info("Generated Azure SAS download URL for container {} blob {}", CONTAINER_NAME, blobName);
+            return Optional.of(URI.create(blobClient.getBlobUrl() + "?" + sasToken));
+        } catch (Exception e) {
+            log.error("Failed to generate Azure SAS URL for blob {} in container {}: {}", blobName, CONTAINER_NAME,
+                    e.getMessage());
+            throw new StorageUnavailableException("Failed to generate Azure SAS URL for blob " + blobName, e);
+        }
+    }
+
+    /**
+     * Legacy byte-proxy path, retained for the presigned-redirect rollback / compatibility case
+     * ({@code presignedRedirectEnabled=false}). An Azure Blob failure here must surface as an
+     * error, never as an empty ZIP that Terraform would try to unpack.
+     */
     @Override
     public byte[] downloadModule(String organizationName, String moduleName, String providerName,
             String moduleVersion) {
-        BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME);
-        log.info("Searching: /registry/{}/{}/{}/{}/module.zip", organizationName, moduleName, providerName,
+        String blobName = String.format(BLOB_ZIP_MODULE_LOCATION, organizationName, moduleName, providerName,
                 moduleVersion);
-        return containerClient.getBlobClient(
-                String.format("%s/%s/%s/%s/module.zip", organizationName, moduleName, providerName, moduleVersion))
-                .downloadContent().toBytes();
+        try {
+            BlobContainerClient containerClient = blobServiceClient.getBlobContainerClient(CONTAINER_NAME);
+            log.info("Searching: {}", blobName);
+            return containerClient.getBlobClient(blobName).downloadContent().toBytes();
+        } catch (BlobStorageException e) {
+            log.error("Azure Blob download failed for blob {} in container {}: {}", blobName, CONTAINER_NAME,
+                    e.getMessage());
+            throw new StorageUnavailableException("Failed to download module ZIP for blob " + blobName, e);
+        }
     }
 }

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/azure/AzureStorageServiceImpl.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/azure/AzureStorageServiceImpl.java
@@ -119,8 +119,13 @@ public class AzureStorageServiceImpl implements StorageService {
             BlobClient blobClient = blobContainerClient.getBlobClient(blobName);
 
             BlobSasPermission permissions = new BlobSasPermission().setReadPermission(true);
+            // startTime is set 60 seconds in the past to tolerate clock skew between the registry
+            // host and Azure Storage. Without it, a client whose clock is even slightly ahead of
+            // the server's can receive AuthenticationFailed ("Signature not valid yet") for an
+            // otherwise valid SAS token issued right now.
             BlobServiceSasSignatureValues sasValues = new BlobServiceSasSignatureValues(
-                    OffsetDateTime.now().plusSeconds(presignedUrlExpirySeconds), permissions);
+                    OffsetDateTime.now().plusSeconds(presignedUrlExpirySeconds), permissions)
+                    .setStartTime(OffsetDateTime.now().minusMinutes(1));
 
             String sasToken = blobClient.generateSas(sasValues);
             // Never log the SAS token itself — it carries the signature query string.

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/azure/AzureStorageServiceProperties.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/azure/AzureStorageServiceProperties.java
@@ -16,4 +16,11 @@ public class AzureStorageServiceProperties {
 
     private String accountName;
     private String accountKey;
+
+    // How long a presigned module.zip SAS download URL stays valid.
+    private int presignedUrlExpirySeconds = 300;
+    // When true, the module.zip endpoint redirects to a short-lived SAS URL instead of proxying
+    // the blob's bytes through the registry pod. Off by default for staged rollout; also the
+    // rollback switch back to the byte-proxy path.
+    private boolean presignedRedirectEnabled;
 }

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfiguration.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfiguration.java
@@ -23,16 +23,24 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.core.retry.RetryMode;
+import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Base64;
 
 @Configuration
@@ -67,41 +75,64 @@ public class StorageAutoConfiguration {
                         .build();
                 break;
             case AwsStorageImpl:
-                S3Client s3client;
-                if (awsStorageServiceProperties.isEnableRoleAuthentication()) {
-                    log.info("Creating AWS SDK with default credentials");
-                    s3client = S3Client.builder()
-                            .region(Region.of(awsStorageServiceProperties.getRegion()))
-                            .credentialsProvider(DefaultCredentialsProvider.create())
-                            .build();
-                } else if (awsStorageServiceProperties.getEndpoint() != null && !awsStorageServiceProperties.getEndpoint().isEmpty()) {
+                // Bounded pool/timeouts so a slow or unreachable S3 endpoint fails fast instead of
+                // queuing registry request threads - see the module-download resilience design.
+                SdkHttpClient s3HttpClient = ApacheHttpClient.builder()
+                        .connectionAcquisitionTimeout(Duration.ofSeconds(awsStorageServiceProperties.getConnectionAcquisitionTimeoutSeconds()))
+                        .connectionTimeout(Duration.ofSeconds(awsStorageServiceProperties.getConnectTimeoutSeconds()))
+                        .socketTimeout(Duration.ofSeconds(awsStorageServiceProperties.getSocketTimeoutSeconds()))
+                        .maxConnections(awsStorageServiceProperties.getMaxConnections())
+                        .build();
+
+                ClientOverrideConfiguration overrideConfiguration = ClientOverrideConfiguration.builder()
+                        .apiCallAttemptTimeout(Duration.ofSeconds(awsStorageServiceProperties.getApiCallAttemptTimeoutSeconds()))
+                        .apiCallTimeout(Duration.ofSeconds(awsStorageServiceProperties.getApiCallTimeoutSeconds()))
+                        .retryPolicy(RetryPolicy.forRetryMode(RetryMode.STANDARD))
+                        .build();
+
+                AwsCredentialsProvider credentialsProvider = awsStorageServiceProperties.isEnableRoleAuthentication()
+                        ? DefaultCredentialsProvider.create()
+                        : StaticCredentialsProvider.create(getAwsBasicCredentials(awsStorageServiceProperties));
+
+                var s3ClientBuilder = S3Client.builder()
+                        .httpClient(s3HttpClient)
+                        .overrideConfiguration(overrideConfiguration)
+                        .credentialsProvider(credentialsProvider);
+                var s3PresignerBuilder = S3Presigner.builder()
+                        .credentialsProvider(credentialsProvider);
+
+                if (awsStorageServiceProperties.getEndpoint() != null && !awsStorageServiceProperties.getEndpoint().isEmpty()
+                        && !awsStorageServiceProperties.isEnableRoleAuthentication()) {
                     log.info("Creating AWS SDK with custom endpoint and custom credentials");
 
                     S3Configuration serviceConfiguration = S3Configuration.builder()
                             .pathStyleAccessEnabled(true)
                             .build();
 
-                    s3client = S3Client.builder()
+                    s3ClientBuilder
                             .region(Region.of("auto"))
-                            .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsStorageServiceProperties)))
                             .endpointOverride(URI.create(awsStorageServiceProperties.getEndpoint()))
                             .serviceConfiguration(serviceConfiguration)
-                            .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
-                            .build();
-
+                            .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+                    s3PresignerBuilder
+                            .region(Region.of("auto"))
+                            .endpointOverride(URI.create(awsStorageServiceProperties.getEndpoint()))
+                            .serviceConfiguration(serviceConfiguration);
                 } else {
-                    log.info("Creating AWS SDK with custom credentials");
-                    s3client = S3Client.builder()
-                            .region(Region.of(awsStorageServiceProperties.getRegion()))
-                            .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsStorageServiceProperties)))
-                            .build();
+                    log.info("Creating AWS SDK with {} credentials",
+                            awsStorageServiceProperties.isEnableRoleAuthentication() ? "default" : "custom");
+                    s3ClientBuilder.region(Region.of(awsStorageServiceProperties.getRegion()));
+                    s3PresignerBuilder.region(Region.of(awsStorageServiceProperties.getRegion()));
                 }
 
                 storageService = AwsStorageServiceImpl.builder()
-                        .s3client(s3client)
+                        .s3client(s3ClientBuilder.build())
+                        .s3Presigner(s3PresignerBuilder.build())
                         .gitService(new GitServiceImpl())
                         .bucketName(awsStorageServiceProperties.getBucketName())
                         .registryHostname(openRegistryProperties.getHostname())
+                        .presignedUrlExpirySeconds(awsStorageServiceProperties.getPresignedUrlExpirySeconds())
+                        .presignedRedirectEnabled(awsStorageServiceProperties.isPresignedRedirectEnabled())
                         .build();
                 break;
             case GcpStorageImpl:

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfiguration.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfiguration.java
@@ -72,6 +72,8 @@ public class StorageAutoConfiguration {
                         .blobServiceClient(blobServiceClient)
                         .gitService(new GitServiceImpl())
                         .registryHostname(openRegistryProperties.getHostname())
+                        .presignedUrlExpirySeconds(azureStorageServiceProperties.getPresignedUrlExpirySeconds())
+                        .presignedRedirectEnabled(azureStorageServiceProperties.isPresignedRedirectEnabled())
                         .build();
                 break;
             case AwsStorageImpl:
@@ -159,6 +161,8 @@ public class StorageAutoConfiguration {
                             .storage(gcpStorage)
                             .gitService(new GitServiceImpl())
                             .registryHostname(openRegistryProperties.getHostname())
+                            .presignedUrlExpirySeconds(gcpStorageServiceProperties.getPresignedUrlExpirySeconds())
+                            .presignedRedirectEnabled(gcpStorageServiceProperties.isPresignedRedirectEnabled())
                             .build();
                 } catch (IOException e) {
                     log.error(e.getMessage());

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/gcp/GcpStorageServiceImpl.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/gcp/GcpStorageServiceImpl.java
@@ -1,19 +1,25 @@
 package io.terrakube.registry.plugin.storage.gcp;
 
+import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import io.terrakube.registry.plugin.storage.StorageService;
-import com.google.cloud.storage.BlobId;
-import com.google.cloud.storage.Storage;
+import io.terrakube.registry.plugin.storage.StorageUnavailableException;
 import io.terrakube.registry.service.git.GitService;
 import io.terrakube.registry.service.git.ModuleVersionDownload;
 import org.zeroturnaround.zip.ZipUtil;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Builder
@@ -24,26 +30,34 @@ public class GcpStorageServiceImpl implements StorageService {
 
     @NonNull
     private String registryHostname;
+
     @NonNull
     private String bucketName;
+
     @NonNull
     private Storage storage;
 
     @NonNull
     private GitService gitService;
 
+    @Builder.Default
+    private int presignedUrlExpirySeconds = 300;
+
+    @Builder.Default
+    private boolean presignedRedirectEnabled = false;
+
     @Override
     public String searchModule(String organizationName, String moduleName, String providerName,
             ModuleVersionDownload download) {
         String moduleVersion = download.version();
-        String blobKey = String.format(GCP_ZIP_MODULE_LOCATION, organizationName, moduleName, providerName, moduleVersion);
+        String blobKey = String.format(GCP_ZIP_MODULE_LOCATION, organizationName, moduleName, providerName,
+                moduleVersion);
         log.info("Searching module: {}", blobKey);
-        BlobId blobId = BlobId.of(
-                bucketName,
-                String.format(GCP_ZIP_MODULE_LOCATION, organizationName, moduleName, providerName, moduleVersion));
+        BlobId blobId = BlobId.of(bucketName, blobKey);
         log.info("Checking GCP Object exist {}", blobKey);
-        if (storage.get(blobId) == null) {
-            try {
+
+        try {
+            if (storage.get(blobId) == null) {
                 File gitCloneDirectory = gitService.getCloneRepositoryByTag(download);
                 File moduleZip = new File(gitCloneDirectory.getAbsolutePath() + ".zip");
                 ZipUtil.pack(gitCloneDirectory, moduleZip);
@@ -53,29 +67,85 @@ public class GcpStorageServiceImpl implements StorageService {
 
                 log.info("File uploaded to bucket {} as {}", bucketName, blobKey);
 
-                FileUtils.cleanDirectory(gitCloneDirectory);
-                if (FileUtils.deleteQuietly(moduleZip))
-                    log.info("Successfully delete folder for gcp module");
-            } catch (IOException e) {
-                log.error(e.getMessage());
+                try {
+                    FileUtils.cleanDirectory(gitCloneDirectory);
+                    if (FileUtils.deleteQuietly(moduleZip))
+                        log.info("Successfully delete folder for gcp module");
+                } catch (IOException e) {
+                    log.error(e.getMessage());
+                }
             }
+        } catch (StorageException e) {
+            log.error("GCP Storage operation failed for key {} in bucket {}: {}", blobKey, bucketName,
+                    e.getMessage());
+            throw new StorageUnavailableException(
+                    "GCP Storage operation failed while resolving module path for key " + blobKey, e);
+        } catch (IOException e) {
+            log.error("IO error while preparing module upload for key {} in bucket {}: {}", blobKey, bucketName,
+                    e.getMessage());
+            throw new StorageUnavailableException(
+                    "IO error while preparing GCP module upload for key " + blobKey, e);
         }
 
-        return String.format(GCP_DOWNLOAD_MODULE_LOCATION, registryHostname, organizationName, moduleName, providerName,
-                moduleVersion);
+        return String.format(GCP_DOWNLOAD_MODULE_LOCATION, registryHostname, organizationName, moduleName,
+                providerName, moduleVersion);
     }
 
+    /**
+     * Generates a short-lived, V4-signed GCS URL for the module ZIP so the Terraform client can
+     * download it directly from Google Cloud Storage instead of having the bytes proxied through
+     * the registry pod.
+     *
+     * <p>The signed URL is intentionally not cached alongside the module path (see
+     * getModuleVersionPath's 10-minute cache) — its validity window is much shorter than the cache
+     * TTL, so every ZIP request gets a fresh signature computed here.
+     *
+     * <p>Requires the service account credentials to have the
+     * {@code iam.serviceAccounts.signBlob} IAM permission. This is available automatically
+     * when using a service-account JSON key via {@code GoogleCredentials.fromStream(...)}.
+     */
+    @Override
+    public Optional<URI> getPresignedDownloadUrl(String organizationName, String moduleName, String providerName,
+            String moduleVersion) {
+        if (!presignedRedirectEnabled) {
+            return Optional.empty();
+        }
+
+        String blobKey = String.format(GCP_ZIP_MODULE_LOCATION, organizationName, moduleName, providerName,
+                moduleVersion);
+        try {
+            BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, blobKey)).build();
+            URL signedUrl = storage.signUrl(
+                    blobInfo,
+                    presignedUrlExpirySeconds,
+                    TimeUnit.SECONDS,
+                    Storage.SignUrlOption.withV4Signature());
+            // Never log the signed URL itself — it carries the signature query string.
+            log.info("Generated GCS V4-signed download URL for bucket {} key {}", bucketName, blobKey);
+            return Optional.of(signedUrl.toURI());
+        } catch (Exception e) {
+            log.error("Failed to generate GCS signed URL for bucket {} key {}: {}", bucketName, blobKey,
+                    e.getMessage());
+            throw new StorageUnavailableException("Failed to generate GCS signed URL for key " + blobKey, e);
+        }
+    }
+
+    /**
+     * Legacy byte-proxy path, retained for the presigned-redirect rollback / compatibility case
+     * ({@code presignedRedirectEnabled=false}). A GCS failure here must surface as an error,
+     * never as an empty ZIP that Terraform would try to unpack.
+     */
     @Override
     public byte[] downloadModule(String organizationName, String moduleName, String providerName,
             String moduleVersion) {
-        byte[] data;
-        log.info("Searching: /registry/{}/{}/{}/{}/module.zip", organizationName, moduleName, providerName,
+        String blobKey = String.format(GCP_ZIP_MODULE_LOCATION, organizationName, moduleName, providerName,
                 moduleVersion);
-        data = storage.get(
-                BlobId.of(
-                        bucketName,
-                        String.format(GCP_ZIP_MODULE_LOCATION, organizationName, moduleName, providerName, moduleVersion)))
-                .getContent();
-        return data;
+        log.info("Searching: {}", blobKey);
+        try {
+            return storage.get(BlobId.of(bucketName, blobKey)).getContent();
+        } catch (StorageException e) {
+            log.error("GCP Storage download failed for key {} in bucket {}: {}", blobKey, bucketName, e.getMessage());
+            throw new StorageUnavailableException("Failed to download module ZIP for key " + blobKey, e);
+        }
     }
 }

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/gcp/GcpStorageServiceProperties.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/gcp/GcpStorageServiceProperties.java
@@ -16,4 +16,13 @@ public class GcpStorageServiceProperties {
     private String credentials;
     private String bucketName;
     private String projectId;
+
+    // How long a presigned module.zip signed URL stays valid.
+    private int presignedUrlExpirySeconds = 300;
+    // When true, the module.zip endpoint redirects to a short-lived V4-signed GCS URL instead of
+    // proxying the object's bytes through the registry pod. Off by default for staged rollout; also
+    // the rollback switch back to the byte-proxy path.
+    // Note: requires the service account credentials to have the iam.serviceAccounts.signBlob
+    // IAM permission. With a service-account JSON key this is available automatically.
+    private boolean presignedRedirectEnabled;
 }

--- a/registry/src/main/java/io/terrakube/registry/service/module/ModuleServiceImpl.java
+++ b/registry/src/main/java/io/terrakube/registry/service/module/ModuleServiceImpl.java
@@ -16,6 +16,7 @@ import io.terrakube.registry.service.search.CommonSearchService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.net.URI;
@@ -88,7 +89,13 @@ public class ModuleServiceImpl implements ModuleService {
         return definitionVersions;
     }
 
-    @Cacheable(cacheNames = {"getModuleVersionPath"}, key = "#organizationName + '-' + #moduleName + '-' + #providerName + '-' + #version")
+    // sync = true coalesces concurrent cache misses for the same key into a single resolution -
+    // without it, a burst of `terraform init` calls that all miss the cache at once would each
+    // independently repeat the Terrakube API/VCS calls and the S3 HeadObject below.
+    @Cacheable(
+            cacheNames = {"getModuleVersionPath"},
+            key = "#organizationName + '-' + #moduleName + '-' + #providerName + '-' + #version",
+            sync = true)
     @Override
     public String getModuleVersionPath(String organizationName, String moduleName, String providerName, String version) {
         String moduleVersionPath = "";
@@ -134,9 +141,35 @@ public class ModuleServiceImpl implements ModuleService {
         return moduleVersionPath;
     }
 
+    static final int DOWNLOAD_COUNT_MAX_ATTEMPTS = 3;
+    private static final long[] DOWNLOAD_COUNT_BACKOFF_MILLIS = {500, 2000};
+
+    // Runs on the dedicated downloadCountExecutor (DownloadCountExecutorConfig) so this
+    // best-effort bookkeeping call never delays the Terraform-facing metadata response
+    // (ModuleWebServiceImpl.getModuleVersionPath already returns before this completes). Failures
+    // here must never surface to the caller or affect the HTTP response already issued - this
+    // counter is not used for authorization, billing, or publication correctness.
+    @Async("downloadCountExecutor")
     @Override
     public void updateModuleDownloadCount(String organizationName, String moduleName, String providerName) {
-        log.info("Update module download count");
+        for (int attempt = 1; attempt <= DOWNLOAD_COUNT_MAX_ATTEMPTS; attempt++) {
+            try {
+                doUpdateModuleDownloadCount(organizationName, moduleName, providerName);
+                return;
+            } catch (Exception e) {
+                if (attempt == DOWNLOAD_COUNT_MAX_ATTEMPTS) {
+                    log.error("Giving up updating download count for {}/{}/{} after {} attempts: {}",
+                            organizationName, moduleName, providerName, attempt, e.getMessage());
+                    return;
+                }
+                log.warn("Attempt {} to update download count for {}/{}/{} failed, retrying: {}",
+                        attempt, organizationName, moduleName, providerName, e.getMessage());
+                sleepBackoff(DOWNLOAD_COUNT_BACKOFF_MILLIS[attempt - 1]);
+            }
+        }
+    }
+
+    private void doUpdateModuleDownloadCount(String organizationName, String moduleName, String providerName) {
         String organizationId = commonSearchService.getOrganizationId(organizationName);
         Module module = terrakubeClient.getModuleByNameAndProvider(organizationId, moduleName, providerName).getData()
                 .get(0);
@@ -147,6 +180,14 @@ public class ModuleServiceImpl implements ModuleService {
         moduleRequest.setData(module);
 
         terrakubeClient.updateModule(moduleRequest, organizationId, module.getId());
+    }
+
+    private void sleepBackoff(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     private String getAccessToken(String organizationId, String vcsId, String repository_source) {

--- a/registry/src/main/resources/application.properties
+++ b/registry/src/main/resources/application.properties
@@ -29,6 +29,10 @@ io.terrakube.registry.plugin.storage.type=${RegistryStorageType}
 #################
 io.terrakube.registry.plugin.storage.azure.accountName=${AzureAccountName}
 io.terrakube.registry.plugin.storage.azure.accountKey=${AzureAccountKey}
+# Azure Blob module.zip presigned SAS redirect - off by default for staged rollout; also the
+# rollback switch back to the registry proxying ZIP bytes.
+io.terrakube.registry.plugin.storage.azure.presignedUrlExpirySeconds=${AzureBlobPresignedUrlExpirySeconds:300}
+io.terrakube.registry.plugin.storage.azure.presignedRedirectEnabled=${AzureBlobPresignedRedirectEnabled:false}
 ###############
 # AWS Storage #
 ###############
@@ -56,6 +60,11 @@ io.terrakube.registry.plugin.storage.aws.presignedRedirectEnabled=${AwsS3Presign
 io.terrakube.registry.plugin.storage.gcp.credentials=${GcpStorageCredentialsBase64}
 io.terrakube.registry.plugin.storage.gcp.bucketName=${GcpStorageBucketName}
 io.terrakube.registry.plugin.storage.gcp.projectId=${GcpStorageProjectId}
+# GCP Cloud Storage module.zip V4-signed URL redirect - off by default for staged rollout; also
+# the rollback switch back to the registry proxying ZIP bytes.
+# Requires iam.serviceAccounts.signBlob IAM permission on the service account.
+io.terrakube.registry.plugin.storage.gcp.presignedUrlExpirySeconds=${GcpPresignedUrlExpirySeconds:300}
+io.terrakube.registry.plugin.storage.gcp.presignedRedirectEnabled=${GcpPresignedRedirectEnabled:false}
 
 ########
 # Cors #

--- a/registry/src/main/resources/application.properties
+++ b/registry/src/main/resources/application.properties
@@ -38,6 +38,18 @@ io.terrakube.registry.plugin.storage.aws.bucketName=${AwsStorageBucketName}
 io.terrakube.registry.plugin.storage.aws.region=${AwsStorageRegion}
 io.terrakube.registry.plugin.storage.aws.endpoint=${AwsEndpoint}
 io.terrakube.registry.plugin.storage.aws.enableRoleAuthentication=${AwsEnableRoleAuth:false}
+# S3Client/S3Presigner HTTP client bounds - fail fast rather than queue request threads against a
+# slow or unreachable S3 endpoint. Defaults match the module-download resilience design.
+io.terrakube.registry.plugin.storage.aws.connectionAcquisitionTimeoutSeconds=${AwsS3ConnectionAcquisitionTimeoutSeconds:1}
+io.terrakube.registry.plugin.storage.aws.connectTimeoutSeconds=${AwsS3ConnectTimeoutSeconds:2}
+io.terrakube.registry.plugin.storage.aws.socketTimeoutSeconds=${AwsS3SocketTimeoutSeconds:10}
+io.terrakube.registry.plugin.storage.aws.apiCallAttemptTimeoutSeconds=${AwsS3ApiCallAttemptTimeoutSeconds:15}
+io.terrakube.registry.plugin.storage.aws.apiCallTimeoutSeconds=${AwsS3ApiCallTimeoutSeconds:25}
+io.terrakube.registry.plugin.storage.aws.maxConnections=${AwsS3MaxConnections:50}
+# module.zip presigned redirect - off by default for staged rollout; also the rollback switch back
+# to the registry proxying ZIP bytes.
+io.terrakube.registry.plugin.storage.aws.presignedUrlExpirySeconds=${AwsS3PresignedUrlExpirySeconds:300}
+io.terrakube.registry.plugin.storage.aws.presignedRedirectEnabled=${AwsS3PresignedRedirectEnabled:false}
 ###############
 # GCP Storage #
 ###############
@@ -74,4 +86,13 @@ io.terrakube.registry.federatedCacheExpireAfterWrite=${FederatedCacheExpireAfter
 io.terrakube.registry.federatedCacheMaximumSize=${FederatedCacheMaximumSize:1000}
 io.terrakube.registry.providerManagerCacheExpireAfterWrite=${ProviderManagerCacheExpireAfterWrite:60}
 io.terrakube.registry.providerManagerCacheMaximumSize=${ProviderManagerCacheMaximumSize:100}
+
+#########################
+# DOWNLOAD COUNT UPDATE #
+#########################
+# Bounded pool for the best-effort download-count bookkeeping call, kept off the Terraform-facing
+# metadata response's critical path - see DownloadCountExecutorConfig.
+io.terrakube.registry.download-count.executor.corePoolSize=${DownloadCountExecutorCorePoolSize:2}
+io.terrakube.registry.download-count.executor.maxPoolSize=${DownloadCountExecutorMaxPoolSize:5}
+io.terrakube.registry.download-count.executor.queueCapacity=${DownloadCountExecutorQueueCapacity:200}
 

--- a/registry/src/test/java/io/terrakube/registry/controller/ModuleWebServiceImplTest.java
+++ b/registry/src/test/java/io/terrakube/registry/controller/ModuleWebServiceImplTest.java
@@ -1,0 +1,83 @@
+package io.terrakube.registry.controller;
+
+import io.terrakube.registry.plugin.storage.StorageService;
+import io.terrakube.registry.plugin.storage.StorageUnavailableException;
+import io.terrakube.registry.service.module.ModuleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// Standalone MockMvc test (no full Spring context / WireMock) covering the module.zip endpoint's
+// two branches added by the module-download resilience design: redirecting to a presigned S3 URL
+// when the storage backend supports it, and mapping a storage failure to a retryable 503 rather
+// than an opaque 500 or an ambiguous empty body.
+class ModuleWebServiceImplTest {
+
+    private ModuleService moduleService;
+    private StorageService storageService;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        moduleService = mock(ModuleService.class);
+        storageService = mock(StorageService.class);
+
+        ModuleWebServiceImpl controller = new ModuleWebServiceImpl();
+        controller.moduleService = moduleService;
+        controller.storageService = storageService;
+
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new StorageExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void redirectsToPresignedUrlWhenStorageProvidesOne() throws Exception {
+        URI presignedUrl = URI.create("https://test-bucket.s3.amazonaws.com/registry/org/module/aws/1.0.0/module.zip?X-Amz-Signature=redacted");
+        when(storageService.getPresignedDownloadUrl("org", "module", "aws", "1.0.0"))
+                .thenReturn(Optional.of(presignedUrl));
+
+        mockMvc.perform(get("/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip"))
+                .andExpect(status().isFound())
+                .andExpect(header().string("Location", presignedUrl.toString()));
+
+        verify(storageService).getPresignedDownloadUrl("org", "module", "aws", "1.0.0");
+        verifyNoMoreInteractions(storageService);
+    }
+
+    @Test
+    void proxiesBytesWhenNoPresignedUrlAvailable() throws Exception {
+        when(storageService.getPresignedDownloadUrl("org", "module", "aws", "1.0.0"))
+                .thenReturn(Optional.empty());
+        byte[] zipBytes = "zip-content".getBytes();
+        when(storageService.downloadModule("org", "module", "aws", "1.0.0")).thenReturn(zipBytes);
+
+        mockMvc.perform(get("/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip"))
+                .andExpect(status().isOk());
+
+        verify(storageService).downloadModule("org", "module", "aws", "1.0.0");
+    }
+
+    @Test
+    void returnsRetryableErrorWhenStorageUnavailable() throws Exception {
+        when(storageService.getPresignedDownloadUrl(anyString(), anyString(), anyString(), anyString()))
+                .thenThrow(new StorageUnavailableException("boom", new RuntimeException("s3 timeout")));
+
+        mockMvc.perform(get("/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(header().string("Retry-After", "5"));
+    }
+}

--- a/registry/src/test/java/io/terrakube/registry/plugin/storage/aws/AwsStorageServiceImplTest.java
+++ b/registry/src/test/java/io/terrakube/registry/plugin/storage/aws/AwsStorageServiceImplTest.java
@@ -1,5 +1,6 @@
 package io.terrakube.registry.plugin.storage.aws;
 
+import io.terrakube.registry.plugin.storage.StorageUnavailableException;
 import io.terrakube.registry.service.git.GitService;
 import io.terrakube.registry.service.git.ModuleVersionDownload;
 import org.apache.commons.io.FileUtils;
@@ -11,6 +12,11 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.net.URL;
+import java.util.Optional;
 
 import java.io.File;
 import java.io.IOException;
@@ -115,10 +121,10 @@ class AwsStorageServiceImplTest {
     }
 
     @Test
-    void shouldReturnEmptyBytesWhenDownloadFails() {
+    void shouldThrowStorageUnavailableWhenDownloadFails() {
         S3Client s3Client = mock(S3Client.class);
         GitService gitService = mock(GitService.class);
-        
+
         AwsStorageServiceImpl awsStorageService = AwsStorageServiceImpl.builder()
                 .s3client(s3Client)
                 .bucketName("test")
@@ -129,8 +135,99 @@ class AwsStorageServiceImplTest {
         when(s3Client.getObject(any(GetObjectRequest.class), any(ResponseTransformer.class)))
                 .thenThrow(new RuntimeException("S3 error"));
 
-        byte[] result = awsStorageService.downloadModule("org", "module", "aws", "1.0.0");
+        assertThrows(StorageUnavailableException.class,
+                () -> awsStorageService.downloadModule("org", "module", "aws", "1.0.0"));
+    }
 
-        assertEquals(0, result.length);
+    @Test
+    void shouldThrowStorageUnavailableWhenHeadObjectFailsWithNon404() {
+        S3Client s3Client = mock(S3Client.class);
+        GitService gitService = mock(GitService.class);
+
+        AwsStorageServiceImpl awsStorageService = AwsStorageServiceImpl.builder()
+                .s3client(s3Client)
+                .bucketName("test-bucket")
+                .gitService(gitService)
+                .registryHostname("https://registry.terrakube.io")
+                .build();
+
+        when(s3Client.headObject(any(HeadObjectRequest.class)))
+                .thenThrow(S3Exception.builder().statusCode(500).message("throttled").build());
+
+        ModuleVersionDownload download = new ModuleVersionDownload("source", "1.0.0", "v1.0.0", "vcsType",
+                "vcsConn", "token", "tag", "folder");
+
+        assertThrows(StorageUnavailableException.class,
+                () -> awsStorageService.searchModule("org", "module", "aws", download));
+        verifyNoInteractions(gitService);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenPresignedRedirectDisabled() {
+        S3Client s3Client = mock(S3Client.class);
+        GitService gitService = mock(GitService.class);
+
+        AwsStorageServiceImpl awsStorageService = AwsStorageServiceImpl.builder()
+                .s3client(s3Client)
+                .bucketName("test-bucket")
+                .gitService(gitService)
+                .registryHostname("host")
+                .presignedRedirectEnabled(false)
+                .build();
+
+        Optional<java.net.URI> result = awsStorageService.getPresignedDownloadUrl("org", "module", "aws", "1.0.0");
+
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(s3Client);
+    }
+
+    @Test
+    void shouldReturnPresignedUrlWhenRedirectEnabled() throws Exception {
+        S3Client s3Client = mock(S3Client.class);
+        GitService gitService = mock(GitService.class);
+        S3Presigner s3Presigner = mock(S3Presigner.class);
+        PresignedGetObjectRequest presignedGetObjectRequest = mock(PresignedGetObjectRequest.class);
+
+        when(presignedGetObjectRequest.url()).thenReturn(new URL("https://test-bucket.s3.amazonaws.com/registry/org/module/aws/1.0.0/module.zip?X-Amz-Signature=redacted"));
+        when(s3Presigner.presignGetObject(any(software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest.class)))
+                .thenReturn(presignedGetObjectRequest);
+
+        AwsStorageServiceImpl awsStorageService = AwsStorageServiceImpl.builder()
+                .s3client(s3Client)
+                .bucketName("test-bucket")
+                .gitService(gitService)
+                .registryHostname("host")
+                .s3Presigner(s3Presigner)
+                .presignedRedirectEnabled(true)
+                .presignedUrlExpirySeconds(300)
+                .build();
+
+        Optional<java.net.URI> result = awsStorageService.getPresignedDownloadUrl("org", "module", "aws", "1.0.0");
+
+        assertTrue(result.isPresent());
+        assertEquals("https", result.get().getScheme());
+        verifyNoInteractions(s3Client);
+    }
+
+    @Test
+    void shouldThrowStorageUnavailableWhenPresigningFails() {
+        S3Client s3Client = mock(S3Client.class);
+        GitService gitService = mock(GitService.class);
+        S3Presigner s3Presigner = mock(S3Presigner.class);
+
+        when(s3Presigner.presignGetObject(any(software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest.class)))
+                .thenThrow(new RuntimeException("presign failure"));
+
+        AwsStorageServiceImpl awsStorageService = AwsStorageServiceImpl.builder()
+                .s3client(s3Client)
+                .bucketName("test-bucket")
+                .gitService(gitService)
+                .registryHostname("host")
+                .s3Presigner(s3Presigner)
+                .presignedRedirectEnabled(true)
+                .build();
+
+        assertThrows(StorageUnavailableException.class,
+                () -> awsStorageService.getPresignedDownloadUrl("org", "module", "aws", "1.0.0"));
     }
 }

--- a/registry/src/test/java/io/terrakube/registry/plugin/storage/azure/AzureStorageServiceImplPresignedTest.java
+++ b/registry/src/test/java/io/terrakube/registry/plugin/storage/azure/AzureStorageServiceImplPresignedTest.java
@@ -1,0 +1,220 @@
+package io.terrakube.registry.plugin.storage.azure;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.models.BlobStorageException;
+import io.terrakube.registry.plugin.storage.StorageUnavailableException;
+import io.terrakube.registry.service.git.GitService;
+import io.terrakube.registry.service.git.ModuleVersionDownload;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class AzureStorageServiceImplPresignedTest {
+
+    @TempDir
+    Path tempDir;
+
+    // ---- Helper: build a service with presigned redirect enabled ----
+    private AzureStorageServiceImpl buildServiceWithRedirect(BlobServiceClient blobServiceClient,
+            GitService gitService, boolean redirectEnabled) {
+        return AzureStorageServiceImpl.builder()
+                .blobServiceClient(blobServiceClient)
+                .gitService(gitService)
+                .registryHostname("https://registry.terrakube.io")
+                .presignedRedirectEnabled(redirectEnabled)
+                .presignedUrlExpirySeconds(300)
+                .build();
+    }
+
+    // ---- getPresignedDownloadUrl: flag OFF ----
+
+    @Test
+    void getPresignedDownloadUrl_whenDisabled_returnsEmpty() {
+        BlobServiceClient blobServiceClient = mock(BlobServiceClient.class);
+        GitService gitService = mock(GitService.class);
+
+        AzureStorageServiceImpl service = buildServiceWithRedirect(blobServiceClient, gitService, false);
+        Optional<URI> result = service.getPresignedDownloadUrl("org", "module", "azure", "1.0.0");
+
+        assertTrue(result.isEmpty(), "Expected Optional.empty() when presignedRedirectEnabled=false");
+        verifyNoInteractions(blobServiceClient);
+    }
+
+    // ---- getPresignedDownloadUrl: flag ON, SAS token generated ----
+
+    @Test
+    void getPresignedDownloadUrl_whenEnabled_returnsSasUri() {
+        BlobServiceClient blobServiceClient = mock(BlobServiceClient.class);
+        BlobContainerClient containerClient = mock(BlobContainerClient.class);
+        BlobClient blobClient = mock(BlobClient.class);
+        GitService gitService = mock(GitService.class);
+
+        when(blobServiceClient.getBlobContainerClient("registry")).thenReturn(containerClient);
+        when(containerClient.getBlobClient(anyString())).thenReturn(blobClient);
+        when(blobClient.getBlobUrl())
+                .thenReturn("https://myaccount.blob.core.windows.net/registry/org/module/azure/1.0.0/module.zip");
+        when(blobClient.generateSas(any())).thenReturn(
+                "sv=2021-06-08&se=2099-01-01T00%3A00%3A00Z&sr=b&sp=r&sig=REDACTED");
+
+        AzureStorageServiceImpl service = buildServiceWithRedirect(blobServiceClient, gitService, true);
+        Optional<URI> result = service.getPresignedDownloadUrl("org", "module", "azure", "1.0.0");
+
+        assertTrue(result.isPresent(), "Expected a URI when presignedRedirectEnabled=true");
+        String uriStr = result.get().toString();
+        assertTrue(uriStr.startsWith("https://myaccount.blob.core.windows.net/registry/"),
+                "SAS URL should point to Azure Blob");
+        assertTrue(uriStr.contains("sig="), "SAS URL should include signature parameter");
+    }
+
+    // ---- getPresignedDownloadUrl: SAS generation fails → StorageUnavailableException ----
+
+    @Test
+    void getPresignedDownloadUrl_whenSasGenerationFails_throwsStorageUnavailable() {
+        BlobServiceClient blobServiceClient = mock(BlobServiceClient.class);
+        BlobContainerClient containerClient = mock(BlobContainerClient.class);
+        BlobClient blobClient = mock(BlobClient.class);
+        GitService gitService = mock(GitService.class);
+
+        when(blobServiceClient.getBlobContainerClient("registry")).thenReturn(containerClient);
+        when(containerClient.getBlobClient(anyString())).thenReturn(blobClient);
+        when(blobClient.getBlobUrl())
+                .thenReturn("https://myaccount.blob.core.windows.net/registry/org/module/azure/1.0.0/module.zip");
+        when(blobClient.generateSas(any())).thenThrow(new RuntimeException("SAS signing failure"));
+
+        AzureStorageServiceImpl service = buildServiceWithRedirect(blobServiceClient, gitService, true);
+
+        assertThrows(StorageUnavailableException.class,
+                () -> service.getPresignedDownloadUrl("org", "module", "azure", "1.0.0"));
+    }
+
+    // ---- downloadModule: success ----
+
+    @Test
+    void downloadModule_returnsBytes() {
+        BlobServiceClient blobServiceClient = mock(BlobServiceClient.class);
+        BlobContainerClient containerClient = mock(BlobContainerClient.class);
+        BlobClient blobClient = mock(BlobClient.class);
+        GitService gitService = mock(GitService.class);
+
+        byte[] expected = "zip-content".getBytes();
+        com.azure.core.util.BinaryData binaryData = com.azure.core.util.BinaryData.fromBytes(expected);
+
+        when(blobServiceClient.getBlobContainerClient("registry")).thenReturn(containerClient);
+        when(containerClient.getBlobClient(anyString())).thenReturn(blobClient);
+        when(blobClient.downloadContent()).thenReturn(binaryData);
+
+        AzureStorageServiceImpl service = buildServiceWithRedirect(blobServiceClient, gitService, false);
+        byte[] result = service.downloadModule("org", "module", "azure", "1.0.0");
+
+        assertArrayEquals(expected, result);
+    }
+
+    // ---- downloadModule: Azure SDK error → StorageUnavailableException ----
+
+    @Test
+    void downloadModule_whenBlobStorageExceptionThrown_throwsStorageUnavailable() {
+        BlobServiceClient blobServiceClient = mock(BlobServiceClient.class);
+        BlobContainerClient containerClient = mock(BlobContainerClient.class);
+        BlobClient blobClient = mock(BlobClient.class);
+        GitService gitService = mock(GitService.class);
+
+        when(blobServiceClient.getBlobContainerClient("registry")).thenReturn(containerClient);
+        when(containerClient.getBlobClient(anyString())).thenReturn(blobClient);
+        when(blobClient.downloadContent()).thenThrow(
+                mock(BlobStorageException.class));
+
+        AzureStorageServiceImpl service = buildServiceWithRedirect(blobServiceClient, gitService, false);
+
+        assertThrows(StorageUnavailableException.class,
+                () -> service.downloadModule("org", "module", "azure", "1.0.0"));
+    }
+
+    // ---- searchModule: blob already exists, no upload ----
+
+    @Test
+    void searchModule_whenBlobExists_skipsUpload() {
+        BlobServiceClient blobServiceClient = mock(BlobServiceClient.class);
+        BlobContainerClient containerClient = mock(BlobContainerClient.class);
+        BlobClient blobClient = mock(BlobClient.class);
+        GitService gitService = mock(GitService.class);
+
+        when(blobServiceClient.getBlobContainerClient("registry")).thenReturn(containerClient);
+        when(containerClient.exists()).thenReturn(true);
+        when(containerClient.getBlobClient(anyString())).thenReturn(blobClient);
+        when(blobClient.exists()).thenReturn(true);
+
+        AzureStorageServiceImpl service = buildServiceWithRedirect(blobServiceClient, gitService, false);
+        ModuleVersionDownload download = new ModuleVersionDownload("source", "1.0.0", "v1.0.0", "vcsType",
+                "vcsConn", "token", "tag", "folder");
+        String result = service.searchModule("org", "module", "azure", download);
+
+        assertEquals(
+                "https://registry.terrakube.io/terraform/modules/v1/download/org/module/azure/1.0.0/module.zip",
+                result);
+        verify(blobClient, never()).uploadFromFile(anyString());
+        verifyNoInteractions(gitService);
+    }
+
+    // ---- searchModule: blob does NOT exist, uploads ----
+
+    @Test
+    void searchModule_whenBlobNotExists_uploadsAndReturnsPath() throws IOException {
+        BlobServiceClient blobServiceClient = mock(BlobServiceClient.class);
+        BlobContainerClient containerClient = mock(BlobContainerClient.class);
+        BlobClient blobClient = mock(BlobClient.class);
+        GitService gitService = mock(GitService.class);
+
+        when(blobServiceClient.getBlobContainerClient("registry")).thenReturn(containerClient);
+        when(containerClient.exists()).thenReturn(true);
+        when(containerClient.getBlobClient(anyString())).thenReturn(blobClient);
+        when(blobClient.exists()).thenReturn(false);
+
+        File gitCloneDir = tempDir.resolve("git-clone").toFile();
+        assertTrue(gitCloneDir.mkdirs());
+        FileUtils.writeStringToFile(new File(gitCloneDir, "main.tf"),
+                "resource \"null_resource\" \"this\" {}", StandardCharsets.UTF_8);
+        when(gitService.getCloneRepositoryByTag(any(ModuleVersionDownload.class))).thenReturn(gitCloneDir);
+
+        AzureStorageServiceImpl service = buildServiceWithRedirect(blobServiceClient, gitService, false);
+        ModuleVersionDownload download = new ModuleVersionDownload("source", "1.0.0", "v1.0.0", "vcsType",
+                "vcsConn", "token", "tag", "folder");
+        String result = service.searchModule("org", "module", "azure", download);
+
+        assertEquals(
+                "https://registry.terrakube.io/terraform/modules/v1/download/org/module/azure/1.0.0/module.zip",
+                result);
+        verify(blobClient).uploadFromFile(anyString());
+    }
+
+    // ---- searchModule: Azure SDK error → StorageUnavailableException ----
+
+    @Test
+    void searchModule_whenBlobStorageExceptionThrown_throwsStorageUnavailable() {
+        BlobServiceClient blobServiceClient = mock(BlobServiceClient.class);
+        GitService gitService = mock(GitService.class);
+
+        BlobStorageException blobStorageException = mock(BlobStorageException.class);
+        when(blobServiceClient.getBlobContainerClient("registry")).thenThrow(blobStorageException);
+
+        AzureStorageServiceImpl service = buildServiceWithRedirect(blobServiceClient, gitService, false);
+        ModuleVersionDownload download = new ModuleVersionDownload("source", "1.0.0", "v1.0.0", "vcsType",
+                "vcsConn", "token", "tag", "folder");
+
+        assertThrows(StorageUnavailableException.class,
+                () -> service.searchModule("org", "module", "azure", download));
+        verifyNoInteractions(gitService);
+    }
+}

--- a/registry/src/test/java/io/terrakube/registry/plugin/storage/azure/AzureStorageServiceImplPresignedTest.java
+++ b/registry/src/test/java/io/terrakube/registry/plugin/storage/azure/AzureStorageServiceImplPresignedTest.java
@@ -16,7 +16,11 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.time.OffsetDateTime;
 import java.util.Optional;
+
+import org.mockito.ArgumentCaptor;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -216,5 +220,51 @@ class AzureStorageServiceImplPresignedTest {
         assertThrows(StorageUnavailableException.class,
                 () -> service.searchModule("org", "module", "azure", download));
         verifyNoInteractions(gitService);
+    }
+
+    // ---- Clock skew tolerance: startTime must be set ~1 minute before expiryTime ----
+
+    @Test
+    void getPresignedDownloadUrl_sasStartTimeIsOneMinuteBeforeExpiry() {
+        BlobServiceClient blobServiceClient = mock(BlobServiceClient.class);
+        BlobContainerClient containerClient = mock(BlobContainerClient.class);
+        BlobClient blobClient = mock(BlobClient.class);
+        GitService gitService = mock(GitService.class);
+
+        when(blobServiceClient.getBlobContainerClient("registry")).thenReturn(containerClient);
+        when(containerClient.getBlobClient(anyString())).thenReturn(blobClient);
+        when(blobClient.getBlobUrl())
+                .thenReturn("https://myaccount.blob.core.windows.net/registry/org/module/azure/1.0.0/module.zip");
+
+        // Capture the BlobServiceSasSignatureValues passed to generateSas so we can assert
+        // that the clock skew startTime grace window is set correctly.
+        ArgumentCaptor<BlobServiceSasSignatureValues> sasCaptor =
+                ArgumentCaptor.forClass(BlobServiceSasSignatureValues.class);
+        when(blobClient.generateSas(sasCaptor.capture())).thenReturn("sv=2021-06-08&sig=REDACTED");
+
+        OffsetDateTime before = OffsetDateTime.now();
+        AzureStorageServiceImpl service = buildServiceWithRedirect(blobServiceClient, gitService, true);
+        service.getPresignedDownloadUrl("org", "module", "azure", "1.0.0");
+        OffsetDateTime after = OffsetDateTime.now();
+
+        BlobServiceSasSignatureValues captured = sasCaptor.getValue();
+
+        // startTime must be set (non-null) for clock skew protection.
+        assertNotNull(captured.getStartTime(),
+                "SAS startTime must be set to provide clock skew tolerance");
+
+        // startTime should be at most 1 minute before the test start (i.e. in the past).
+        assertTrue(captured.getStartTime().isBefore(before) || captured.getStartTime().isEqual(before),
+                "SAS startTime must be at or before the call time to tolerate clients ahead of the server clock");
+
+        // expiryTime should be at least (before + expirySeconds - 1s) to allow a 1-second
+        // execution margin without being flaky.
+        assertTrue(captured.getExpiryTime().isAfter(before.plusSeconds(299)),
+                "SAS expiryTime must reflect the configured presignedUrlExpirySeconds (300s)");
+
+        // The clock skew window: startTime must be at least 59 seconds before expiryTime,
+        // which means the full effective validity is expirySeconds + ~60s.
+        assertTrue(captured.getExpiryTime().minusSeconds(59).isAfter(captured.getStartTime()),
+                "SAS expiryTime should be at least 59 seconds after startTime (60s skew window)");
     }
 }

--- a/registry/src/test/java/io/terrakube/registry/plugin/storage/gcp/GcpStorageServiceImplPresignedTest.java
+++ b/registry/src/test/java/io/terrakube/registry/plugin/storage/gcp/GcpStorageServiceImplPresignedTest.java
@@ -1,0 +1,196 @@
+package io.terrakube.registry.plugin.storage.gcp;
+
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import com.google.cloud.storage.Blob;
+import io.terrakube.registry.plugin.storage.StorageUnavailableException;
+import io.terrakube.registry.service.git.GitService;
+import io.terrakube.registry.service.git.ModuleVersionDownload;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class GcpStorageServiceImplPresignedTest {
+
+    @TempDir
+    Path tempDir;
+
+    // ---- Helper ----
+    private GcpStorageServiceImpl buildService(Storage storage, GitService gitService, boolean redirectEnabled) {
+        return GcpStorageServiceImpl.builder()
+                .storage(storage)
+                .gitService(gitService)
+                .bucketName("test-bucket")
+                .registryHostname("https://registry.terrakube.io")
+                .presignedRedirectEnabled(redirectEnabled)
+                .presignedUrlExpirySeconds(300)
+                .build();
+    }
+
+    // ---- getPresignedDownloadUrl: flag OFF ----
+
+    @Test
+    void getPresignedDownloadUrl_whenDisabled_returnsEmpty() {
+        Storage storage = mock(Storage.class);
+        GitService gitService = mock(GitService.class);
+
+        GcpStorageServiceImpl service = buildService(storage, gitService, false);
+        Optional<URI> result = service.getPresignedDownloadUrl("org", "module", "gcp", "1.0.0");
+
+        assertTrue(result.isEmpty(), "Expected Optional.empty() when presignedRedirectEnabled=false");
+        verifyNoInteractions(storage);
+    }
+
+    // ---- getPresignedDownloadUrl: flag ON, V4-signed URL generated ----
+
+    @Test
+    void getPresignedDownloadUrl_whenEnabled_returnsSignedUri() throws Exception {
+        Storage storage = mock(Storage.class);
+        GitService gitService = mock(GitService.class);
+
+        URL signedUrl = new URL(
+                "https://storage.googleapis.com/test-bucket/registry/org/module/gcp/1.0.0/module.zip"
+                        + "?X-Goog-Signature=REDACTED&X-Goog-Algorithm=GOOG4-RSA-SHA256");
+
+        when(storage.signUrl(any(BlobInfo.class), anyLong(), any(TimeUnit.class),
+                any(Storage.SignUrlOption.class))).thenReturn(signedUrl);
+
+        GcpStorageServiceImpl service = buildService(storage, gitService, true);
+        Optional<URI> result = service.getPresignedDownloadUrl("org", "module", "gcp", "1.0.0");
+
+        assertTrue(result.isPresent(), "Expected a URI when presignedRedirectEnabled=true");
+        String uriStr = result.get().toString();
+        assertTrue(uriStr.contains("storage.googleapis.com"), "Should point to GCS");
+        assertTrue(uriStr.contains("X-Goog-Signature"), "Should include GCS signature parameter");
+    }
+
+    // ---- getPresignedDownloadUrl: signUrl fails → StorageUnavailableException ----
+
+    @Test
+    void getPresignedDownloadUrl_whenSignUrlFails_throwsStorageUnavailable() {
+        Storage storage = mock(Storage.class);
+        GitService gitService = mock(GitService.class);
+
+        when(storage.signUrl(any(BlobInfo.class), anyLong(), any(TimeUnit.class),
+                any(Storage.SignUrlOption.class))).thenThrow(new RuntimeException("signBlob IAM error"));
+
+        GcpStorageServiceImpl service = buildService(storage, gitService, true);
+
+        assertThrows(StorageUnavailableException.class,
+                () -> service.getPresignedDownloadUrl("org", "module", "gcp", "1.0.0"));
+    }
+
+    // ---- downloadModule: success ----
+
+    @Test
+    void downloadModule_returnsBytes() {
+        Storage storage = mock(Storage.class);
+        GitService gitService = mock(GitService.class);
+        Blob blob = mock(Blob.class);
+
+        byte[] expected = "gcs-zip-content".getBytes();
+        when(blob.getContent()).thenReturn(expected);
+        when(storage.get(any(BlobId.class))).thenReturn(blob);
+
+        GcpStorageServiceImpl service = buildService(storage, gitService, false);
+        byte[] result = service.downloadModule("org", "module", "gcp", "1.0.0");
+
+        assertArrayEquals(expected, result);
+    }
+
+    // ---- downloadModule: StorageException → StorageUnavailableException ----
+
+    @Test
+    void downloadModule_whenStorageExceptionThrown_throwsStorageUnavailable() {
+        Storage storage = mock(Storage.class);
+        GitService gitService = mock(GitService.class);
+
+        when(storage.get(any(BlobId.class))).thenThrow(mock(StorageException.class));
+
+        GcpStorageServiceImpl service = buildService(storage, gitService, false);
+
+        assertThrows(StorageUnavailableException.class,
+                () -> service.downloadModule("org", "module", "gcp", "1.0.0"));
+    }
+
+    // ---- searchModule: blob exists → no upload ----
+
+    @Test
+    void searchModule_whenBlobExists_skipsUpload() {
+        Storage storage = mock(Storage.class);
+        GitService gitService = mock(GitService.class);
+        Blob blob = mock(Blob.class);
+
+        when(storage.get(any(BlobId.class))).thenReturn(blob);
+
+        GcpStorageServiceImpl service = buildService(storage, gitService, false);
+        ModuleVersionDownload download = new ModuleVersionDownload("source", "1.0.0", "v1.0.0", "vcsType",
+                "vcsConn", "token", "tag", "folder");
+        String result = service.searchModule("org", "module", "gcp", download);
+
+        assertEquals(
+                "https://registry.terrakube.io/terraform/modules/v1/download/org/module/gcp/1.0.0/module.zip",
+                result);
+        verify(storage, never()).create(any(BlobInfo.class), any(byte[].class));
+        verifyNoInteractions(gitService);
+    }
+
+    // ---- searchModule: blob does not exist → uploads ----
+
+    @Test
+    void searchModule_whenBlobNotExists_uploadsAndReturnsPath() throws IOException {
+        Storage storage = mock(Storage.class);
+        GitService gitService = mock(GitService.class);
+
+        when(storage.get(any(BlobId.class))).thenReturn(null);
+
+        File gitCloneDir = tempDir.resolve("git-clone").toFile();
+        assertTrue(gitCloneDir.mkdirs());
+        FileUtils.writeStringToFile(new File(gitCloneDir, "main.tf"),
+                "resource \"null_resource\" \"this\" {}", StandardCharsets.UTF_8);
+        when(gitService.getCloneRepositoryByTag(any(ModuleVersionDownload.class))).thenReturn(gitCloneDir);
+
+        GcpStorageServiceImpl service = buildService(storage, gitService, false);
+        ModuleVersionDownload download = new ModuleVersionDownload("source", "1.0.0", "v1.0.0", "vcsType",
+                "vcsConn", "token", "tag", "folder");
+        String result = service.searchModule("org", "module", "gcp", download);
+
+        assertEquals(
+                "https://registry.terrakube.io/terraform/modules/v1/download/org/module/gcp/1.0.0/module.zip",
+                result);
+        verify(storage).create(any(BlobInfo.class), any(byte[].class));
+    }
+
+    // ---- searchModule: StorageException → StorageUnavailableException ----
+
+    @Test
+    void searchModule_whenStorageExceptionThrown_throwsStorageUnavailable() {
+        Storage storage = mock(Storage.class);
+        GitService gitService = mock(GitService.class);
+
+        when(storage.get(any(BlobId.class))).thenThrow(mock(StorageException.class));
+
+        GcpStorageServiceImpl service = buildService(storage, gitService, false);
+        ModuleVersionDownload download = new ModuleVersionDownload("source", "1.0.0", "v1.0.0", "vcsType",
+                "vcsConn", "token", "tag", "folder");
+
+        assertThrows(StorageUnavailableException.class,
+                () -> service.searchModule("org", "module", "gcp", download));
+        verifyNoInteractions(gitService);
+    }
+}

--- a/registry/src/test/java/io/terrakube/registry/service/module/ModuleServiceImplAsyncDownloadCountTest.java
+++ b/registry/src/test/java/io/terrakube/registry/service/module/ModuleServiceImplAsyncDownloadCountTest.java
@@ -1,0 +1,142 @@
+package io.terrakube.registry.service.module;
+
+import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.organization.module.Module;
+import io.terrakube.client.model.organization.module.ModuleAttributes;
+import io.terrakube.client.model.organization.module.ModuleRequest;
+import io.terrakube.client.model.response.Response;
+import io.terrakube.registry.configuration.DownloadCountExecutorConfig;
+import io.terrakube.registry.plugin.storage.StorageService;
+import io.terrakube.registry.service.search.CommonSearchService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+// Verifies updateModuleDownloadCount runs on the dedicated downloadCountExecutor
+// (DownloadCountExecutorConfig) instead of the caller's thread, and that a transient failure is
+// retried with bounded backoff rather than being silently dropped on the first error - see the
+// module-download resilience design's "download-count updates must not delay Terraform's metadata
+// response" goal.
+class ModuleServiceImplAsyncDownloadCountTest {
+
+    private AnnotationConfigApplicationContext context;
+
+    @AfterEach
+    void tearDown() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Configuration
+    @EnableAsync
+    static class TestConfig {
+        @Bean
+        DownloadCountExecutorConfig downloadCountExecutorConfig() {
+            return new DownloadCountExecutorConfig();
+        }
+
+        @Bean("downloadCountExecutor")
+        org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor downloadCountExecutor(
+                DownloadCountExecutorConfig config) {
+            return config.downloadCountExecutor(2, 5, 200);
+        }
+
+        @Bean
+        TerrakubeClient terrakubeClient() {
+            return mock(TerrakubeClient.class);
+        }
+
+        @Bean
+        CommonSearchService commonSearchService() {
+            return mock(CommonSearchService.class);
+        }
+
+        @Bean
+        StorageService storageService() {
+            return mock(StorageService.class);
+        }
+
+        @Bean
+        ModuleServiceImpl moduleService(TerrakubeClient terrakubeClient, StorageService storageService,
+                CommonSearchService commonSearchService) {
+            return new ModuleServiceImpl(terrakubeClient, storageService, commonSearchService);
+        }
+    }
+
+    private void stubModuleLookup(TerrakubeClient terrakubeClient, CommonSearchService commonSearchService) {
+        when(commonSearchService.getOrganizationId("org")).thenReturn("org-id");
+
+        Module module = new Module();
+        module.setId("module-id");
+        ModuleAttributes attributes = new ModuleAttributes();
+        attributes.setDownloadQuantity(4);
+        module.setAttributes(attributes);
+
+        Response<List<Module>> moduleResponse = new Response<>();
+        moduleResponse.setData(List.of(module));
+        when(terrakubeClient.getModuleByNameAndProvider("org-id", "module", "aws")).thenReturn(moduleResponse);
+    }
+
+    @Test
+    void updateModuleDownloadCountDoesNotBlockCaller() throws Exception {
+        context = new AnnotationConfigApplicationContext(TestConfig.class);
+        TerrakubeClient terrakubeClient = context.getBean(TerrakubeClient.class);
+        CommonSearchService commonSearchService = context.getBean(CommonSearchService.class);
+        ModuleService moduleService = context.getBean(ModuleService.class);
+        stubModuleLookup(terrakubeClient, commonSearchService);
+
+        CountDownLatch updateInvoked = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            Thread.sleep(500);
+            updateInvoked.countDown();
+            return null;
+        }).when(terrakubeClient).updateModule(any(ModuleRequest.class), anyString(), anyString());
+
+        long start = System.nanoTime();
+        moduleService.updateModuleDownloadCount("org", "module", "aws");
+        long elapsedMillis = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(elapsedMillis < 400, "caller blocked for " + elapsedMillis + "ms on a call that should return immediately");
+        assertTrue(updateInvoked.await(2, TimeUnit.SECONDS), "async update never ran");
+    }
+
+    @Test
+    void updateModuleDownloadCountRetriesTransientFailure() throws Exception {
+        context = new AnnotationConfigApplicationContext(TestConfig.class);
+        TerrakubeClient terrakubeClient = context.getBean(TerrakubeClient.class);
+        CommonSearchService commonSearchService = context.getBean(CommonSearchService.class);
+        ModuleService moduleService = context.getBean(ModuleService.class);
+        stubModuleLookup(terrakubeClient, commonSearchService);
+
+        AtomicInteger attempts = new AtomicInteger();
+        CountDownLatch thirdAttempt = new CountDownLatch(1);
+        doAnswer(invocation -> {
+            int attempt = attempts.incrementAndGet();
+            if (attempt < 3) {
+                throw new RuntimeException("transient failure " + attempt);
+            }
+            thirdAttempt.countDown();
+            return null;
+        }).when(terrakubeClient).updateModule(any(ModuleRequest.class), anyString(), anyString());
+
+        moduleService.updateModuleDownloadCount("org", "module", "aws");
+
+        assertTrue(thirdAttempt.await(5, TimeUnit.SECONDS), "did not retry through to a successful attempt");
+    }
+}

--- a/registry/src/test/java/io/terrakube/registry/service/module/ModuleServiceImplCacheTest.java
+++ b/registry/src/test/java/io/terrakube/registry/service/module/ModuleServiceImplCacheTest.java
@@ -1,0 +1,210 @@
+package io.terrakube.registry.service.module;
+
+import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.organization.module.Module;
+import io.terrakube.client.model.organization.module.ModuleAttributes;
+import io.terrakube.client.model.organization.module.Relationships;
+import io.terrakube.client.model.organization.module.SshData;
+import io.terrakube.client.model.organization.module.version.ModuleVersion;
+import io.terrakube.client.model.organization.module.version.ModuleVersionAttributes;
+import io.terrakube.client.model.organization.workspace.VcsData;
+import io.terrakube.client.model.response.Response;
+import io.terrakube.registry.configuration.CacheConfig;
+import io.terrakube.registry.plugin.storage.StorageService;
+import io.terrakube.registry.service.search.CommonSearchService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+// Verifies the sync = true behavior added to ModuleServiceImpl#getModuleVersionPath: a burst of
+// concurrent requests for the same not-yet-cached module version must coalesce into a single
+// resolution, not one call per concurrent request (the thundering-herd goal of the module-download
+// resilience design). Uses a real Spring cache-AOP context (not a plain Mockito unit test) because
+// sync = true is enforced by the Caffeine-backed cache proxy, not by application code.
+class ModuleServiceImplCacheTest {
+
+    private static final int CONCURRENT_REQUESTS = 20;
+
+    private AnnotationConfigApplicationContext context;
+
+    @AfterEach
+    void tearDown() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Configuration
+    @EnableCaching
+    static class TestConfig {
+        @Bean
+        CacheConfig cacheConfig() {
+            return new CacheConfig();
+        }
+
+        @Bean
+        org.springframework.cache.CacheManager cacheManager(CacheConfig cacheConfig) {
+            return cacheConfig.cacheManager();
+        }
+
+        @Bean
+        TerrakubeClient terrakubeClient() {
+            return mock(TerrakubeClient.class);
+        }
+
+        @Bean
+        CommonSearchService commonSearchService() {
+            return mock(CommonSearchService.class);
+        }
+
+        @Bean
+        StorageService storageService() {
+            return mock(StorageService.class);
+        }
+
+        @Bean
+        ModuleServiceImpl moduleService(TerrakubeClient terrakubeClient, StorageService storageService,
+                CommonSearchService commonSearchService) {
+            return new ModuleServiceImpl(terrakubeClient, storageService, commonSearchService);
+        }
+    }
+
+    @Test
+    void concurrentCacheMissesResolveOnce() throws Exception {
+        context = new AnnotationConfigApplicationContext(TestConfig.class);
+        TerrakubeClient terrakubeClient = context.getBean(TerrakubeClient.class);
+        CommonSearchService commonSearchService = context.getBean(CommonSearchService.class);
+        StorageService storageService = context.getBean(StorageService.class);
+        ModuleService moduleService = context.getBean(ModuleService.class);
+
+        when(commonSearchService.getOrganizationId("org")).thenAnswer(invocation -> {
+            // Widens the race window so concurrent callers pile up while resolution is in flight.
+            Thread.sleep(300);
+            return "org-id";
+        });
+
+        Module module = new Module();
+        module.setId("module-id");
+        ModuleAttributes attributes = new ModuleAttributes();
+        attributes.setSource("git::https://example.com/org/module.git");
+        attributes.setFolder(null);
+        attributes.setTagPrefix(null);
+        module.setAttributes(attributes);
+        Relationships relationships = new Relationships();
+        relationships.setVcs(new VcsData());
+        relationships.setSsh(new SshData());
+        module.setRelationships(relationships);
+
+        Response<List<Module>> moduleResponse = new Response<>();
+        moduleResponse.setData(List.of(module));
+        when(terrakubeClient.getModuleByNameAndProvider("org-id", "module", "aws")).thenReturn(moduleResponse);
+
+        ModuleVersion moduleVersion = new ModuleVersion();
+        ModuleVersionAttributes versionAttributes = new ModuleVersionAttributes();
+        versionAttributes.setVersion("1.0.0");
+        versionAttributes.setGitTag("v1.0.0");
+        moduleVersion.setAttributes(versionAttributes);
+
+        Response<List<ModuleVersion>> versionResponse = new Response<>();
+        versionResponse.setData(List.of(moduleVersion));
+        when(terrakubeClient.getAllVersionsByOrganizationIdAndModuleId("org-id", "module-id"))
+                .thenReturn(versionResponse);
+
+        when(storageService.searchModule(anyString(), anyString(), anyString(), any()))
+                .thenReturn("https://registry.example.com/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip");
+
+        int threadCount = CONCURRENT_REQUESTS;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch readyLatch = new CountDownLatch(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                readyLatch.countDown();
+                try {
+                    startLatch.await();
+                    moduleService.getModuleVersionPath("org", "module", "aws", "1.0.0");
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        assertTrue(readyLatch.await(5, TimeUnit.SECONDS));
+        startLatch.countDown();
+        assertTrue(doneLatch.await(10, TimeUnit.SECONDS));
+        executorService.shutdown();
+
+        verify(commonSearchService, times(1)).getOrganizationId("org");
+        verify(terrakubeClient, times(1)).getModuleByNameAndProvider("org-id", "module", "aws");
+        verify(storageService, times(1)).searchModule(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    void cacheHitMakesNoFurtherCalls() throws Exception {
+        context = new AnnotationConfigApplicationContext(TestConfig.class);
+        TerrakubeClient terrakubeClient = context.getBean(TerrakubeClient.class);
+        CommonSearchService commonSearchService = context.getBean(CommonSearchService.class);
+        StorageService storageService = context.getBean(StorageService.class);
+        ModuleService moduleService = context.getBean(ModuleService.class);
+
+        when(commonSearchService.getOrganizationId("org")).thenReturn("org-id");
+
+        Module module = new Module();
+        module.setId("module-id");
+        ModuleAttributes attributes = new ModuleAttributes();
+        attributes.setSource("git::https://example.com/org/module.git");
+        module.setAttributes(attributes);
+        Relationships relationships = new Relationships();
+        relationships.setVcs(new VcsData());
+        relationships.setSsh(new SshData());
+        module.setRelationships(relationships);
+
+        Response<List<Module>> moduleResponse = new Response<>();
+        moduleResponse.setData(List.of(module));
+        when(terrakubeClient.getModuleByNameAndProvider("org-id", "module", "aws")).thenReturn(moduleResponse);
+
+        ModuleVersion moduleVersion = new ModuleVersion();
+        ModuleVersionAttributes versionAttributes = new ModuleVersionAttributes();
+        versionAttributes.setVersion("1.0.0");
+        versionAttributes.setGitTag("v1.0.0");
+        moduleVersion.setAttributes(versionAttributes);
+
+        Response<List<ModuleVersion>> versionResponse = new Response<>();
+        versionResponse.setData(List.of(moduleVersion));
+        when(terrakubeClient.getAllVersionsByOrganizationIdAndModuleId("org-id", "module-id"))
+                .thenReturn(versionResponse);
+
+        when(storageService.searchModule(anyString(), anyString(), anyString(), any()))
+                .thenReturn("https://registry.example.com/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip");
+
+        String first = moduleService.getModuleVersionPath("org", "module", "aws", "1.0.0");
+        String second = moduleService.getModuleVersionPath("org", "module", "aws", "1.0.0");
+
+        assertEquals(first, second);
+        verify(commonSearchService, times(1)).getOrganizationId("org");
+        verify(terrakubeClient, times(1)).getModuleByNameAndProvider(anyString(), anyString(), anyString());
+        verify(storageService, times(1)).searchModule(anyString(), anyString(), anyString(), any());
+    }
+}


### PR DESCRIPTION
## Summary

This PR extends the presigned-redirect feature originally implemented for AWS S3 in #3451 to **Azure Blob Storage** (SAS URLs) and **GCP Cloud Storage** (V4-signed URLs), and cherry-picks the full S3 resilience improvements from that PR.

All three presigned redirect features are **opt-in and off by default**, controlled by per-backend feature flags. The existing byte-proxy path is fully preserved as a rollback mechanism.

---

## Related PR

> This work builds directly on [#3451 – feat(registry): make module download resilient to concurrent load and S3 latency](https://github.com/terrakube-io/terrakube/pull/3451) by @jakegroves.
> The S3 implementation from that PR is cherry-picked here without modification; this PR extends the same pattern to the Azure and GCP backends.

---

## Changes

### 1. Cherry-picked from #3451 (AWS S3 — unchanged)
- **Thundering-Herd Protection**: `@Cacheable(sync = true)` on `ModuleServiceImpl.getModuleVersionPath` coalesces concurrent cache misses for the same module version into a single resolution.
- **Asynchronous Download Count Bookkeeping**: Moves download-count increments onto a dedicated bounded `downloadCountExecutor` thread pool with retry and exponential backoff, keeping it off the client response critical path.
- **Presigned S3 URL Redirect** (`presignedRedirectEnabled`, default `false`): Redirects (`302 Found`) `/download/.../module.zip` requests to short-lived presigned S3 GET URLs instead of proxying bytes through the registry pod.
- **Resilient Error Mapping**: Replaced silent empty `byte[0]` returns on S3 failures with `StorageUnavailableException`, mapped to `503 Service Unavailable` + `Retry-After: 5` via `StorageExceptionHandler`.
- **Configurable S3 Client Limits**: Added configurable connection pool limits and timeouts (`connectionAcquisitionTimeoutSeconds`, `connectTimeoutSeconds`, `socketTimeoutSeconds`, `apiCallAttemptTimeoutSeconds`, `apiCallTimeoutSeconds`, `maxConnections`).

### 2. Azure Blob Storage (New)
- `AzureStorageServiceProperties`: Adds `presignedRedirectEnabled` (default `false`) and `presignedUrlExpirySeconds` (default `300`).
- `AzureStorageServiceImpl.getPresignedDownloadUrl()`: Generates read-only SAS tokens using `BlobSasPermission.setReadPermission(true)` and `BlobServiceSasSignatureValues`.
  - **Clock Skew Tolerance**: `startTime` is set to `now() - 60s` to prevent `AuthenticationFailed: Signature not valid yet` errors if registry and client clocks are slightly skewed.
  - `BlobStorageException` in `searchModule` and `downloadModule` is wrapped in `StorageUnavailableException` to prevent 0-byte corrupt ZIP downloads.
- **Environment Variables**:
  - `AzureBlobPresignedRedirectEnabled=true` (default `false`)
  - `AzureBlobPresignedUrlExpirySeconds=300` (default `300`)

### 3. GCP Cloud Storage (New)
- `GcpStorageServiceProperties`: Adds `presignedRedirectEnabled` (default `false`) and `presignedUrlExpirySeconds` (default `300`).
- `GcpStorageServiceImpl.getPresignedDownloadUrl()`: Generates V4-signed URLs using `storage.signUrl(..., Storage.SignUrlOption.withV4Signature())`.
  - `StorageException` and `IOException` in `searchModule` and `downloadModule` are wrapped in `StorageUnavailableException`.
- **Environment Variables**:
  - `GcpPresignedRedirectEnabled=true` (default `false`)
  - `GcpPresignedUrlExpirySeconds=300` (default `300`)

### 4. Configuration & AutoConfiguration
- `StorageAutoConfiguration`: Wires `presignedUrlExpirySeconds` and `presignedRedirectEnabled` to both `AzureStorageServiceImpl` and `GcpStorageServiceImpl` builders.
- `application.properties`: Added placeholders and defaults for Azure and GCP presigned settings.

---

## How It Works

```text
Terraform CLI
  │
  │  GET /terraform/modules/v1/{org}/{mod}/{prov}/{ver}/download
  │  ← 204 No Content  (X-Terraform-Get: /download/.../module.zip)
  │
  │  GET /terraform/modules/v1/download/.../module.zip
  │      ├─ presignedRedirectEnabled=true  → 302 Found  (Location: <presigned URL>)
  │      │                                   Terraform downloads ZIP directly
  │      │                                   from S3 / Azure Blob / GCS
  │      └─ presignedRedirectEnabled=false → 200 OK  (bytes proxied, legacy path)
```

---

## S3-Compatible Storage (MinIO / LocalStack)

Presigned redirects are fully supported with custom S3-compatible endpoints. When `AwsEndpoint` is configured, both `S3Client` and `S3Presigner` use `pathStyleAccessEnabled(true)` with the same `endpointOverride`.

> **Note**: Ensure the Terraform client has network reachability to the endpoint hostname specified in the presigned URL.

---

## Rollout & Rollback Flags

| Backend | Environment Variable | Default |
|:---|:---|:---|
| **AWS S3** | `AwsS3PresignedRedirectEnabled` | `false` |
| **Azure Blob** | `AzureBlobPresignedRedirectEnabled` | `false` |
| **GCP Cloud Storage** | `GcpPresignedRedirectEnabled` | `false` |

All backends default to `false` (legacy proxying). Setting any flag back to `false` instantly reverts to the byte-proxy mode.

---

## Verification & Automated Tests

All 56 registry unit and integration tests pass cleanly (`mvn test -pl registry -am`):

- `AzureStorageServiceImplPresignedTest` (9 tests): Covers redirect flag off/on, SAS generation, clock skew `startTime`, exception wrapping, and upload paths.
- `GcpStorageServiceImplPresignedTest` (8 tests): Covers redirect flag off/on, V4 signature generation, exception wrapping, and upload paths.
- `AwsStorageServiceImplTest` (8 tests): Covers S3 presigned redirects and error wrapping.
- `ModuleServiceImplCacheTest` (2 tests): Validates `@Cacheable(sync=true)` thundering-herd mitigation under concurrent requests.
- `ModuleServiceImplAsyncDownloadCountTest` (2 tests): Validates async download-count executor and retry/backoff.
- `ModuleWebServiceImplTest` (3 tests): Validates `302 Found` redirects, byte-proxying, and `503 Service Unavailable` error handling.