### PR TITLE
feat: optional S3 endpoint region, chunked encoding and checksum validation parameters

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/storage/aws/AwsStorageTypeProperties.java
+++ b/api/src/main/java/io/terrakube/api/plugin/storage/aws/AwsStorageTypeProperties.java
@@ -25,4 +25,11 @@ public class AwsStorageTypeProperties {
     private int apiCallTimeoutSeconds = 10;
     private int apiCallAttemptTimeoutSeconds = 3;
     private int maxRetryAttempts = 2;
+
+    // S3-compatible backends (Qumulo, MinIO, ...) may require a real signing region instead of
+    // "auto" and may not support chunked transfer encoding or checksum validation. Defaults keep
+    // the previous behavior for custom endpoints.
+    private String endpointRegion = "auto";
+    private boolean chunkedEncodingEnabled = true;
+    private boolean checksumValidationEnabled = true;
 }

--- a/api/src/main/java/io/terrakube/api/plugin/storage/configuration/StorageTypeAutoConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/storage/configuration/StorageTypeAutoConfiguration.java
@@ -57,6 +57,14 @@ public class StorageTypeAutoConfiguration {
                 .build();
     }
 
+    static S3Configuration s3ServiceConfiguration(AwsStorageTypeProperties props) {
+        return S3Configuration.builder()
+                .pathStyleAccessEnabled(true)
+                .chunkedEncodingEnabled(props.isChunkedEncodingEnabled())
+                .checksumValidationEnabled(props.isChecksumValidationEnabled())
+                .build();
+    }
+
     @Bean
     public StorageTypeService terraformOutput(StreamingService streamingService, StorageTypeProperties storageTypeProperties, AzureStorageTypeProperties azureStorageTypeProperties, AwsStorageTypeProperties awsStorageTypeProperties, GcpStorageTypeProperties gcpStorageTypeProperties) {
         StorageTypeService storageTypeService = null;
@@ -87,12 +95,10 @@ public class StorageTypeAutoConfiguration {
                 } else if (awsStorageTypeProperties.getEndpoint() != null && !awsStorageTypeProperties.getEndpoint().isEmpty()) {
                     log.info("Creating AWS SDK with custom endpoint and custom credentials");
 
-                    S3Configuration serviceConfiguration = S3Configuration.builder()
-                            .pathStyleAccessEnabled(true)
-                            .build();
+                    S3Configuration serviceConfiguration = s3ServiceConfiguration(awsStorageTypeProperties);
 
                     s3client = S3Client.builder()
-                            .region(Region.of("auto"))
+                            .region(Region.of(awsStorageTypeProperties.getEndpointRegion()))
                             .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsStorageTypeProperties)))
                             .endpointOverride(URI.create(awsStorageTypeProperties.getEndpoint()))
                             .serviceConfiguration(serviceConfiguration)

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -203,6 +203,10 @@ io.terrakube.storage.aws.bucketName=${AwsStorageBucketName}
 io.terrakube.storage.aws.region=${AwsStorageRegion}
 io.terrakube.storage.aws.endpoint=${AwsEndpoint}
 io.terrakube.storage.aws.enableRoleAuthentication=${AwsEnableRoleAuth:false}
+# S3-compatible backends (Qumulo, MinIO, ...) that need a real signing region or no chunked/checksum support
+io.terrakube.storage.aws.endpointRegion=${AwsEndpointRegion:auto}
+io.terrakube.storage.aws.chunkedEncodingEnabled=${AwsChunkedEncodingEnabled:true}
+io.terrakube.storage.aws.checksumValidationEnabled=${AwsChecksumValidationEnabled:true}
 # Storage read resilience - a hung object read fails within apiCallTimeout instead of the SDK's
 # multi-minute default retry ladder. Step-log objects are KB-sized; sub-second latency is normal.
 io.terrakube.storage.aws.apiCallTimeoutSeconds=${StorageApiCallTimeoutSeconds:10}

--- a/api/src/test/java/io/terrakube/api/plugin/storage/configuration/StorageClientResilienceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/storage/configuration/StorageClientResilienceTest.java
@@ -4,10 +4,13 @@ import io.terrakube.api.plugin.storage.aws.AwsStorageTypeProperties;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.services.s3.S3Configuration;
 
 import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StorageClientResilienceTest {
 
@@ -33,5 +36,32 @@ class StorageClientResilienceTest {
         assertEquals(10, props.getApiCallTimeoutSeconds());
         assertEquals(3, props.getApiCallAttemptTimeoutSeconds());
         assertEquals(2, props.getMaxRetryAttempts());
+    }
+
+    @Test
+    void s3ServiceConfigurationDefaultsPreserveCurrentBehavior() {
+        AwsStorageTypeProperties props = new AwsStorageTypeProperties();
+
+        S3Configuration config = StorageTypeAutoConfiguration.s3ServiceConfiguration(props);
+
+        assertEquals("auto", props.getEndpointRegion());
+        assertTrue(config.pathStyleAccessEnabled());
+        assertTrue(config.chunkedEncodingEnabled());
+        assertTrue(config.checksumValidationEnabled());
+    }
+
+    @Test
+    void s3ServiceConfigurationHonorsS3CompatibleOverrides() {
+        AwsStorageTypeProperties props = new AwsStorageTypeProperties();
+        props.setEndpointRegion("us-east-1");
+        props.setChunkedEncodingEnabled(false);
+        props.setChecksumValidationEnabled(false);
+
+        S3Configuration config = StorageTypeAutoConfiguration.s3ServiceConfiguration(props);
+
+        assertEquals("us-east-1", props.getEndpointRegion());
+        assertFalse(config.chunkedEncodingEnabled());
+        assertFalse(config.checksumValidationEnabled());
+        assertTrue(config.pathStyleAccessEnabled());
     }
 }

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateProperties.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateProperties.java
@@ -22,4 +22,11 @@ public class AwsTerraformStateProperties {
     private boolean includeBackendKeys;
     private boolean enableRoleAuthentication;
     private boolean useLockfile;
+
+    // S3-compatible backends (Qumulo, MinIO, ...) may require a real signing region instead of
+    // "auto" and may not support chunked transfer encoding or checksum validation. Defaults keep
+    // the previous behavior for custom endpoints.
+    private String endpointRegion = "auto";
+    private boolean chunkedEncodingEnabled = true;
+    private boolean checksumValidationEnabled = true;
 }

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
@@ -87,11 +87,13 @@ public class TerraformStateAutoConfiguration {
 
                         S3Configuration serviceConfiguration = S3Configuration.builder()
                                 .pathStyleAccessEnabled(true)
+                                .chunkedEncodingEnabled(awsTerraformStateProperties.isChunkedEncodingEnabled())
+                                .checksumValidationEnabled(awsTerraformStateProperties.isChecksumValidationEnabled())
                                 .build();
 
                         s3client = S3Client.builder()
                                 .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsTerraformStateProperties)))
-                                .region(Region.of("auto"))
+                                .region(Region.of(awsTerraformStateProperties.getEndpointRegion()))
                                 .endpointOverride(URI.create(awsTerraformStateProperties.getEndpoint()))
                                 .serviceConfiguration(serviceConfiguration)
                                 .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -43,6 +43,10 @@ io.terrakube.executor.plugin.tfstate.aws.endpoint=${AwsEndpoint}
 io.terrakube.executor.plugin.tfstate.aws.includeBackendKeys=${AwsIncludeBackendKeys:true}
 io.terrakube.executor.plugin.tfstate.aws.enableRoleAuthentication=${AwsEnableRoleAuth:false}
 io.terrakube.executor.plugin.tfstate.aws.useLockfile=${AwsUseLockfile:false}
+# S3-compatible backends (Qumulo, MinIO, ...) that need a real signing region or no chunked/checksum support
+io.terrakube.executor.plugin.tfstate.aws.endpointRegion=${AwsEndpointRegion:auto}
+io.terrakube.executor.plugin.tfstate.aws.chunkedEncodingEnabled=${AwsChunkedEncodingEnabled:true}
+io.terrakube.executor.plugin.tfstate.aws.checksumValidationEnabled=${AwsChecksumValidationEnabled:true}
 
 ###################
 #Storage Gcp State#

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/aws/AwsStorageServiceProperties.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/aws/AwsStorageServiceProperties.java
@@ -35,4 +35,11 @@ public class AwsStorageServiceProperties {
     // object's bytes through the registry pod. Off by default for staged rollout; also doubles as
     // the rollback switch back to the byte-proxy path.
     private boolean presignedRedirectEnabled;
+
+    // S3-compatible backends (Qumulo, MinIO, ...) may require a real signing region instead of
+    // "auto" and may not support chunked transfer encoding or checksum validation. Defaults keep
+    // the previous behavior for custom endpoints.
+    private String endpointRegion = "auto";
+    private boolean chunkedEncodingEnabled = true;
+    private boolean checksumValidationEnabled = true;
 }

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfiguration.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfiguration.java
@@ -109,15 +109,17 @@ public class StorageAutoConfiguration {
 
                     S3Configuration serviceConfiguration = S3Configuration.builder()
                             .pathStyleAccessEnabled(true)
+                            .chunkedEncodingEnabled(awsStorageServiceProperties.isChunkedEncodingEnabled())
+                            .checksumValidationEnabled(awsStorageServiceProperties.isChecksumValidationEnabled())
                             .build();
 
                     s3ClientBuilder
-                            .region(Region.of("auto"))
+                            .region(Region.of(awsStorageServiceProperties.getEndpointRegion()))
                             .endpointOverride(URI.create(awsStorageServiceProperties.getEndpoint()))
                             .serviceConfiguration(serviceConfiguration)
                             .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
                     s3PresignerBuilder
-                            .region(Region.of("auto"))
+                            .region(Region.of(awsStorageServiceProperties.getEndpointRegion()))
                             .endpointOverride(URI.create(awsStorageServiceProperties.getEndpoint()))
                             .serviceConfiguration(serviceConfiguration);
                 } else {

--- a/registry/src/main/resources/application.properties
+++ b/registry/src/main/resources/application.properties
@@ -42,6 +42,10 @@ io.terrakube.registry.plugin.storage.aws.bucketName=${AwsStorageBucketName}
 io.terrakube.registry.plugin.storage.aws.region=${AwsStorageRegion}
 io.terrakube.registry.plugin.storage.aws.endpoint=${AwsEndpoint}
 io.terrakube.registry.plugin.storage.aws.enableRoleAuthentication=${AwsEnableRoleAuth:false}
+# S3-compatible backends (Qumulo, MinIO, ...) that need a real signing region or no chunked/checksum support
+io.terrakube.registry.plugin.storage.aws.endpointRegion=${AwsEndpointRegion:auto}
+io.terrakube.registry.plugin.storage.aws.chunkedEncodingEnabled=${AwsChunkedEncodingEnabled:true}
+io.terrakube.registry.plugin.storage.aws.checksumValidationEnabled=${AwsChecksumValidationEnabled:true}
 # S3Client/S3Presigner HTTP client bounds - fail fast rather than queue request threads against a
 # slow or unreachable S3 endpoint. Defaults match the module-download resilience design.
 io.terrakube.registry.plugin.storage.aws.connectionAcquisitionTimeoutSeconds=${AwsS3ConnectionAcquisitionTimeoutSeconds:1}


### PR DESCRIPTION
Fixes #2824

S3-compatible backends such as Qumulo need a real signing region instead of the hardcoded `Region.of("auto")` used on the custom-endpoint path, and don't support chunked transfer encoding or checksum validation. As discussed in the issue, this adds three optional parameters to the S3 clients in the api, registry and executor modules, all defaulting to the current behavior so existing setups are unaffected:

| Env var | Property | Default |
|---|---|---|
| `AwsEndpointRegion` | `...aws.endpointRegion` | `auto` |
| `AwsChunkedEncodingEnabled` | `...aws.chunkedEncodingEnabled` | `true` |
| `AwsChecksumValidationEnabled` | `...aws.checksumValidationEnabled` | `true` |

The env var names are shared across the three modules, following the existing `AwsEndpoint` / `AwsEnableRoleAuth` pattern, so a Qumulo setup would just set `AwsEndpointRegion=us-east-1`, `AwsChunkedEncodingEnabled=false`, `AwsChecksumValidationEnabled=false` once. The region override and the two `S3Configuration` flags are only applied on the custom-endpoint branch; the plain AWS paths are untouched. In the registry the S3Presigner picks up the same region and service configuration as the client.

Added unit tests in the api module covering the defaults and the overrides (`mvn -pl api test -Dtest=StorageClientResilienceTest`: 4 tests pass); all three modules compile.

Helm chart variables would be a follow-up in the helm-chart repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)