### PR TITLE
perf(ui): reduce initial bundle and cache assets

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -34,3 +34,4 @@ WORKDIR /usr/share/nginx/html
 COPY --from=builder /app/build .
 COPY --from=builder /etc/sbom /etc/sbom
 COPY conf/conf.d/terrakube-ui.conf /etc/nginx/conf.d/default.conf
+COPY conf/conf.d/gzip.conf /etc/nginx/conf.d/gzip.conf

--- a/ui/conf/conf.d/terrakube-ui.conf
+++ b/ui/conf/conf.d/terrakube-ui.conf
@@ -8,9 +8,22 @@ server {
     add_header Cache-Control "no-store" always;
   }
 
+  # Vite fingerprints build assets, so they are safe to cache across deployments.
+  location /assets/ {
+    root /usr/share/nginx/html/;
+    try_files $uri =404;
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+  }
+
+  location = /index.html {
+    root /usr/share/nginx/html/;
+    add_header Cache-Control "no-cache" always;
+  }
+
   location / {
     root   /usr/share/nginx/html/;
     index  index.html index.htm;
     try_files $uri $uri/ /index.html;
+    add_header Cache-Control "no-cache" always;
   }
 }

--- a/ui/vite.config.mts
+++ b/ui/vite.config.mts
@@ -46,58 +46,9 @@ export default defineConfig(({ mode }) => {
       chunkSizeWarningLimit: 1500,
       rollupOptions: {
         output: {
-          manualChunks(id) {
-            if (!id.includes("node_modules")) return undefined;
-
-            // React core — small, changes rarely, shared by everything
-            if (id.includes("/react-dom/") || id.includes("\\react-dom\\")) return "react-dom";
-            if (id.includes("/scheduler/") || id.includes("\\scheduler\\")) return "react-core";
-            if (/[\\/]react[\\/]/.test(id)) return "react-core";
-
-            // Router & auth
-            if (id.includes("react-router") || id.includes("@remix-run")) return "router";
-            if (id.includes("oidc-client-ts") || id.includes("react-oidc-context")) return "auth";
-
-            // Antd ecosystem — biggest single dep, isolate it
-            if (id.includes("/antd/") || id.includes("\\antd\\")) return "antd";
-            if (id.includes("@ant-design/icons") || id.includes("@ant-design/cssinjs") || id.includes("@rc-component"))
-              return "antd";
-            if (/[\\/]rc-[a-z-]+[\\/]/.test(id)) return "antd";
-
-            // Heavy/optional libs — only loaded by specific routes
-            if (id.includes("react-icons")) return "icons";
-            if (id.includes("reactflow") || id.includes("@reactflow")) return "reactflow";
-            if (id.includes("react-vis")) return "charts";
-            if (id.includes("@monaco-editor/react") || id.includes("monaco-editor")) return "monaco";
-            if (id.includes("/sucrase/") || id.includes("\\sucrase\\")) return "sucrase";
-
-            // Markdown ecosystem
-            if (
-              id.includes("react-markdown") ||
-              id.includes("remark-") ||
-              id.includes("rehype-") ||
-              id.includes("/unified/") ||
-              id.includes("/mdast") ||
-              id.includes("/hast") ||
-              id.includes("micromark")
-            )
-              return "markdown";
-
-            // Specialty parsers
-            if (id.includes("hcl2-parser")) return "hcl-parser";
-            if (id.includes("unzipit")) return "unzipit";
-            if (id.includes("html-to-image")) return "html-to-image";
-            if (id.includes("html-react-parser") || id.includes("/parse5") || id.includes("domhandler"))
-              return "html-parser";
-
-            // Utilities
-            if (id.includes("/luxon/")) return "luxon";
-            if (id.includes("/axios/")) return "axios";
-            if (id.includes("cron-to-quartz") || id.includes("cronstrue") || id.includes("react-js-cron"))
-              return "cron";
-
-            return "vendor";
-          },
+          // Preserve route-level dynamic-import boundaries. Forcing dependencies into global
+          // manual chunks made optional editors/parsers dependencies of the application entry,
+          // so the browser preloaded them before the user visited those routes.
         },
         plugins: analyze
           ? [


### PR DESCRIPTION
## Summary
- preserve route-level lazy boundaries by removing global manual chunk assignments
- enable the existing nginx gzip configuration in the runtime image
- cache fingerprinted assets for one year while keeping index.html and env-config.js fresh

## Evidence
- initial JavaScript: 12 files / 10.40 MB raw / 2.93 MB gzip before
- initial JavaScript: 9 files / 2.02 MB raw / 0.637 MB gzip after
- gzip transfer reduced by approximately 78%
- Monaco, cron, Markdown, HTML/HCL parsers, charts, and React Flow are no longer preloaded by index.html

## Verification
- bun run build
- git diff --check