### PR TITLE
fix(registry): avoid NPE when module_version.git_tag is null (#1)

### DIFF
--- a/registry/src/main/java/io/terrakube/registry/service/module/ModuleServiceImpl.java
+++ b/registry/src/main/java/io/terrakube/registry/service/module/ModuleServiceImpl.java
@@ -111,13 +111,18 @@ public class ModuleServiceImpl implements ModuleService {
         String folder = module.getAttributes().getFolder();
         String tagPrefix = module.getAttributes().getTagPrefix();
 
+        // findFirst() must run before map(): Optional.of() (used internally by findFirst on a
+        // mapped stream) throws NPE if the mapped value is null, which getGitTag() can legitimately
+        // be for module_version rows the git-tag backfill migration skipped (provider alias issues
+        // or version collisions - see CanonicalModuleVersionMigration). Falling back to the semver
+        // version string mirrors the same fallback used by that migration and by ModuleRefreshJob.
         String gitTag = terrakubeClient.getAllVersionsByOrganizationIdAndModuleId(organizationId, module.getId())
                 .getData()
                 .stream()
                 .filter(moduleVersion -> version.equals(moduleVersion.getAttributes().getVersion()))
-                .map(moduleVersion -> moduleVersion.getAttributes().getGitTag())
                 .findFirst()
-                .orElse(null);
+                .map(moduleVersion -> moduleVersion.getAttributes().getGitTag())
+                .orElse(version);
 
         if (module.getRelationships().getVcs().getData() != null) {
             Vcs vcsInformation = getVcsInformation(organizationId,

--- a/registry/src/test/java/io/terrakube/registry/service/module/ModuleServiceImplCacheTest.java
+++ b/registry/src/test/java/io/terrakube/registry/service/module/ModuleServiceImplCacheTest.java
@@ -216,4 +216,52 @@ class ModuleServiceImplCacheTest {
         verify(terrakubeClient, times(1)).getModuleByNameAndProvider(anyString(), anyString(), anyString());
         verify(storageService, times(1)).searchModule(anyString(), anyString(), anyString(), any());
     }
+
+    // Regression test: module_version.git_tag is nullable and can legitimately be null for rows
+    // the git-tag backfill migration skipped (see CanonicalModuleVersionMigration). Previously,
+    // findFirst() ran on a stream already mapped to getGitTag(), so a matching row with a null tag
+    // made findFirst()'s internal Optional.of(null) throw an NPE instead of resolving the path.
+    @Test
+    void nullGitTagFallsBackToVersionInsteadOfThrowing() {
+        context = new AnnotationConfigApplicationContext(TestConfig.class);
+        TerrakubeClient terrakubeClient = context.getBean(TerrakubeClient.class);
+        CommonSearchService commonSearchService = context.getBean(CommonSearchService.class);
+        StorageService storageService = context.getBean(StorageService.class);
+        ModuleService moduleService = context.getBean(ModuleService.class);
+
+        when(commonSearchService.getOrganizationId("org")).thenReturn("org-id");
+
+        Module module = new Module();
+        module.setId("module-id");
+        ModuleAttributes attributes = new ModuleAttributes();
+        attributes.setSource("git::https://example.com/org/module.git");
+        module.setAttributes(attributes);
+        Relationships relationships = new Relationships();
+        relationships.setVcs(new VcsData());
+        relationships.setSsh(new SshData());
+        module.setRelationships(relationships);
+
+        Response<List<Module>> moduleResponse = new Response<>();
+        moduleResponse.setData(List.of(module));
+        when(terrakubeClient.getModuleByNameAndProvider("org-id", "module", "aws")).thenReturn(moduleResponse);
+
+        ModuleVersion moduleVersion = new ModuleVersion();
+        ModuleVersionAttributes versionAttributes = new ModuleVersionAttributes();
+        versionAttributes.setVersion("1.0.0");
+        versionAttributes.setGitTag(null);
+        moduleVersion.setAttributes(versionAttributes);
+
+        Response<List<ModuleVersion>> versionResponse = new Response<>();
+        versionResponse.setData(List.of(moduleVersion));
+        when(terrakubeClient.getAllVersionsByOrganizationIdAndModuleId("org-id", "module-id"))
+                .thenReturn(versionResponse);
+
+        when(storageService.searchModule(anyString(), anyString(), anyString(), any()))
+                .thenReturn("https://registry.example.com/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip");
+
+        String result = moduleService.getModuleVersionPath("org", "module", "aws", "1.0.0");
+
+        assertEquals("https://registry.example.com/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip",
+                result);
+    }
 }


### PR DESCRIPTION
getModuleVersionPath mapped the version stream to getGitTag() before calling findFirst(), so Optional.of(null) threw an NPE whenever a matching module_version row had a null git_tag. That column is nullable and CanonicalModuleVersionMigration intentionally leaves it null for modules it skips (invalid/unaliased provider or version collisions), so any terraform/tofu init against one of those modules returned a 500.

Reorder findFirst()/map() so the null-tolerant map runs on the resolved row, and fall back to the semver version string (matching the fallback already used by CanonicalModuleVersionMigration and ModuleRefreshJob) instead of null.

Adds a regression test covering the null git_tag case.