### PR TITLE
fix(ui): restore workspace card click navigation in card view

### DIFF
--- a/ui/src/__verify_ctrl_click.test.tsx
+++ b/ui/src/__verify_ctrl_click.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { List } from "antd";
+import { Link, MemoryRouter } from "react-router-dom";
 import OrganizationTable from "./modules/organizations/components/OrganizationTable/OrganizationTable";
 import OrganizationGridItem from "./modules/organizations/components/OrganizationGrid/OrganizationGridItem";
 import WorkspaceTable from "./modules/workspaces/components/WorkspaceTable/WorkspaceTable";
+import WorkspaceCard from "./modules/workspaces/components/WorkspaceCard";
 
 jest.mock("@/modules/permissions/useOrgPermissions", () => ({
   useOrgPermissions: () => ({ permissions: { managePermission: false }, loading: false }),
@@ -54,6 +56,37 @@ test("organization grid card is a real anchor pointing at the org workspaces URL
   expect(link.tagName).toBe("A");
   expect(link.getAttribute("href")).toBe("/organizations/org-1/workspaces");
   expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+});
+
+test("workspace card list item overlays a real anchor that stacks above the card", () => {
+  // The card list in OrganizationDetailsPage puts an absolutely-positioned <Link>
+  // behind each <WorkspaceCard>. antd's `.ant-card` is `position: relative`, so the
+  // card and its content paint in the same layer as (and, being later in the DOM,
+  // on top of) an overlay link with `z-index: 0` — which swallows every click.
+  // The overlay must carry a positive z-index to sit above the card.
+  render(
+    <MemoryRouter>
+      <List
+        dataSource={[workspace]}
+        renderItem={(item) => (
+          <List.Item style={{ position: "relative" }}>
+            <Link
+              to={`/organizations/org-1/workspaces/${item.id}`}
+              aria-label={`Open workspace ${item.name}`}
+              style={{ position: "absolute", inset: 0, zIndex: 1 }}
+            />
+            <WorkspaceCard tags={[]} item={item} />
+          </List.Item>
+        )}
+      />
+    </MemoryRouter>
+  );
+
+  const link = screen.getByRole("link", { name: /open workspace my workspace/i });
+  expect(link.tagName).toBe("A");
+  expect(link.getAttribute("href")).toBe("/organizations/org-1/workspaces/ws-1");
+  expect(link.style.position).toBe("absolute");
+  expect(Number(link.style.zIndex)).toBeGreaterThan(0);
 });
 
 test("workspace table row is a real anchor pointing at the workspace URL", () => {

--- a/ui/src/modules/organizations/OrganizationDetailsPage.tsx
+++ b/ui/src/modules/organizations/OrganizationDetailsPage.tsx
@@ -211,7 +211,7 @@ export default function OrganizationsDetailPage({ organizationName, setOrganizat
                 <Link
                   to={`/organizations/${id}/workspaces/${item.id}`}
                   aria-label={`Open workspace ${item.name}`}
-                  style={{ position: "absolute", inset: 0, zIndex: 0 }}
+                  style={{ position: "absolute", inset: 0, zIndex: 1 }}
                 />
                 <WorkspaceCard tags={tags} item={item} />
               </List.Item>

--- a/ui/src/modules/workspaces/components/WorkspaceCard.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceCard.tsx
@@ -62,7 +62,7 @@ export default function WorkspaceCard({ item, tags }: Props) {
                 target="_blank"
                 rel="noreferrer"
                 onClick={(e) => e.stopPropagation()}
-                style={{ position: "relative", zIndex: 1 }}
+                style={{ position: "relative", zIndex: 2 }}
               >
                 {item.normalizedSource ? getVcsNameFromUrl(item.normalizedSource) : "Unknown"}
               </Typography.Link>


### PR DESCRIPTION
## What

Workspace cards in the organization workspace list ("cards" view toggle) are not clickable — clicking a card does nothing. The "compact" view works fine

**Fixes** #3477 

## Why

The cards view renders an absolutely-positioned overlay `<Link>` behind each `<WorkspaceCard>`:

```tsx
<List.Item style={{ position: "relative" }}>
  <Link ... style={{ position: "absolute", inset: 0, zIndex: 0 }} />
  <WorkspaceCard ... />
</List.Item>
```

antd's `.ant-card` is `position: relative`. Per CSS stacking rules, a positioned element with `z-index: auto` (the card) paints in the same layer as — and, being later in the DOM, on top of — a positioned sibling with `z-index: 0` (the overlay link). So the card and all its content sit above the link and swallow every click.

The compact view uses the same overlay technique (`.workspace-row-link`) but works because its sibling cells are plain non-positioned `<div>`s, which paint *below* the `z-index: 0` link.

This has been broken since #3410 (which replaced the old `List.Item` `onClick` handler with the overlay link) for anyone who switched the toggle to "cards" — the default is "compact", which is why it went unnoticed.

## How

- `OrganizationDetailsPage.tsx`: overlay link `zIndex: 0` → `1` (positive z-index = higher paint layer than the card).
- `WorkspaceCard.tsx`: the in-card VCS source link `zIndex: 1` → `2`, so that one genuinely-interactive element stays above the overlay (mirrors the `z-index: 1` carve-outs already used in `WorkspaceTable.css`).

Audited the other card/list views — projects (plain table) and the registry module/provider card lists (`<Link>` wraps the whole card) use a different pattern and are not affected.

## Testing

- Added a regression test in `__verify_ctrl_click.test.tsx` asserting the workspace card overlay is a real anchor with a positive `z-index`.
- `yarn jest src/modules/workspaces src/modules/organizations` → 161 passed
- `yarn tsc --noEmit` clean, `yarn eslint` clean on changed files

## Release

Should be marked for **2.33.1**.