### PR TITLE
fix(registry): handle null gitTag in module version path resolution (#3481)

### DIFF
--- a/registry/src/main/java/io/terrakube/registry/service/module/ModuleServiceImpl.java
+++ b/registry/src/main/java/io/terrakube/registry/service/module/ModuleServiceImpl.java
@@ -10,6 +10,7 @@ import io.terrakube.client.model.organization.module.ModuleRequest;
 import io.terrakube.client.model.organization.ssh.Ssh;
 import io.terrakube.client.model.organization.vcs.Vcs;
 import io.terrakube.client.model.organization.vcs.github_app_token.GitHubAppToken;
+import io.terrakube.client.model.response.Response;
 import io.terrakube.registry.plugin.storage.StorageService;
 import io.terrakube.registry.service.git.ModuleVersionDownload;
 import io.terrakube.registry.service.search.CommonSearchService;
@@ -20,7 +21,9 @@ import org.springframework.stereotype.Service;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @AllArgsConstructor
@@ -103,12 +106,13 @@ public class ModuleServiceImpl implements ModuleService {
         String folder = module.getAttributes().getFolder();
         String tagPrefix = module.getAttributes().getTagPrefix();
 
-        String gitTag = terrakubeClient.getAllVersionsByOrganizationIdAndModuleId(organizationId, module.getId())
-                .getData()
+        String gitTag = Optional.ofNullable(terrakubeClient.getAllVersionsByOrganizationIdAndModuleId(organizationId, module.getId()))
+                .map(Response::getData)
+                .orElseGet(Collections::emptyList)
                 .stream()
                 .filter(moduleVersion -> version.equals(moduleVersion.getAttributes().getVersion()))
-                .map(moduleVersion -> moduleVersion.getAttributes().getGitTag())
                 .findFirst()
+                .map(moduleVersion -> moduleVersion.getAttributes().getGitTag())
                 .orElse(null);
 
         if (module.getRelationships().getVcs().getData() != null) {

--- a/registry/src/test/java/io/terrakube/registry/service/module/ModuleServiceImplCacheTest.java
+++ b/registry/src/test/java/io/terrakube/registry/service/module/ModuleServiceImplCacheTest.java
@@ -1,0 +1,208 @@
+package io.terrakube.registry.service.module;
+
+import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.organization.module.Module;
+import io.terrakube.client.model.organization.module.ModuleAttributes;
+import io.terrakube.client.model.organization.module.Relationships;
+import io.terrakube.client.model.organization.module.SshData;
+import io.terrakube.client.model.organization.module.version.ModuleVersion;
+import io.terrakube.client.model.organization.module.version.ModuleVersionAttributes;
+import io.terrakube.client.model.organization.workspace.VcsData;
+import io.terrakube.client.model.response.Response;
+import io.terrakube.registry.configuration.CacheConfig;
+import io.terrakube.registry.plugin.storage.StorageService;
+import io.terrakube.registry.service.search.CommonSearchService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ModuleServiceImplCacheTest {
+
+    private AnnotationConfigApplicationContext context;
+
+    @AfterEach
+    void tearDown() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Configuration
+    @EnableCaching
+    static class TestConfig {
+        @Bean
+        CacheConfig cacheConfig() {
+            return new CacheConfig();
+        }
+
+        @Bean
+        org.springframework.cache.CacheManager cacheManager(CacheConfig cacheConfig) {
+            return cacheConfig.cacheManager();
+        }
+
+        @Bean
+        TerrakubeClient terrakubeClient() {
+            return mock(TerrakubeClient.class);
+        }
+
+        @Bean
+        CommonSearchService commonSearchService() {
+            return mock(CommonSearchService.class);
+        }
+
+        @Bean
+        StorageService storageService() {
+            return mock(StorageService.class);
+        }
+
+        @Bean
+        ModuleServiceImpl moduleService(TerrakubeClient terrakubeClient, StorageService storageService,
+                CommonSearchService commonSearchService) {
+            return new ModuleServiceImpl(terrakubeClient, storageService, commonSearchService);
+        }
+    }
+
+    @Test
+    void cacheHitMakesNoFurtherCalls() throws Exception {
+        context = new AnnotationConfigApplicationContext(TestConfig.class);
+        TerrakubeClient terrakubeClient = context.getBean(TerrakubeClient.class);
+        CommonSearchService commonSearchService = context.getBean(CommonSearchService.class);
+        StorageService storageService = context.getBean(StorageService.class);
+        ModuleService moduleService = context.getBean(ModuleService.class);
+
+        when(commonSearchService.getOrganizationId("org")).thenReturn("org-id");
+
+        Module module = new Module();
+        module.setId("module-id");
+        ModuleAttributes attributes = new ModuleAttributes();
+        attributes.setSource("git::https://example.com/org/module.git");
+        module.setAttributes(attributes);
+        Relationships relationships = new Relationships();
+        relationships.setVcs(new VcsData());
+        relationships.setSsh(new SshData());
+        module.setRelationships(relationships);
+
+        Response<List<Module>> moduleResponse = new Response<>();
+        moduleResponse.setData(List.of(module));
+        when(terrakubeClient.getModuleByNameAndProvider("org-id", "module", "aws")).thenReturn(moduleResponse);
+
+        ModuleVersion moduleVersion = new ModuleVersion();
+        ModuleVersionAttributes versionAttributes = new ModuleVersionAttributes();
+        versionAttributes.setVersion("1.0.0");
+        versionAttributes.setGitTag("v1.0.0");
+        moduleVersion.setAttributes(versionAttributes);
+
+        Response<List<ModuleVersion>> versionResponse = new Response<>();
+        versionResponse.setData(List.of(moduleVersion));
+        when(terrakubeClient.getAllVersionsByOrganizationIdAndModuleId("org-id", "module-id"))
+                .thenReturn(versionResponse);
+
+        when(storageService.searchModule(anyString(), anyString(), anyString(), any()))
+                .thenReturn("https://registry.example.com/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip");
+
+        String first = moduleService.getModuleVersionPath("org", "module", "aws", "1.0.0");
+        String second = moduleService.getModuleVersionPath("org", "module", "aws", "1.0.0");
+
+        assertEquals(first, second);
+        verify(commonSearchService, times(1)).getOrganizationId("org");
+        verify(terrakubeClient, times(1)).getModuleByNameAndProvider(anyString(), anyString(), anyString());
+        verify(storageService, times(1)).searchModule(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    void getModuleVersionPathWithNullGitTagDoesNotThrowException() {
+        context = new AnnotationConfigApplicationContext(TestConfig.class);
+        TerrakubeClient terrakubeClient = context.getBean(TerrakubeClient.class);
+        CommonSearchService commonSearchService = context.getBean(CommonSearchService.class);
+        StorageService storageService = context.getBean(StorageService.class);
+        ModuleService moduleService = context.getBean(ModuleService.class);
+
+        when(commonSearchService.getOrganizationId("org")).thenReturn("org-id");
+
+        Module module = new Module();
+        module.setId("module-id");
+        ModuleAttributes attributes = new ModuleAttributes();
+        attributes.setSource("git::https://example.com/org/module.git");
+        module.setAttributes(attributes);
+        Relationships relationships = new Relationships();
+        relationships.setVcs(new VcsData());
+        relationships.setSsh(new SshData());
+        module.setRelationships(relationships);
+
+        Response<List<Module>> moduleResponse = new Response<>();
+        moduleResponse.setData(List.of(module));
+        when(terrakubeClient.getModuleByNameAndProvider("org-id", "module", "aws")).thenReturn(moduleResponse);
+
+        ModuleVersion moduleVersion = new ModuleVersion();
+        ModuleVersionAttributes versionAttributes = new ModuleVersionAttributes();
+        versionAttributes.setVersion("1.0.0");
+        versionAttributes.setGitTag(null);
+        moduleVersion.setAttributes(versionAttributes);
+
+        Response<List<ModuleVersion>> versionResponse = new Response<>();
+        versionResponse.setData(List.of(moduleVersion));
+        when(terrakubeClient.getAllVersionsByOrganizationIdAndModuleId("org-id", "module-id"))
+                .thenReturn(versionResponse);
+
+        org.mockito.ArgumentCaptor<io.terrakube.registry.service.git.ModuleVersionDownload> captor =
+                org.mockito.ArgumentCaptor.forClass(io.terrakube.registry.service.git.ModuleVersionDownload.class);
+        when(storageService.searchModule(anyString(), anyString(), anyString(), captor.capture()))
+                .thenReturn("https://registry.example.com/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip");
+
+        String result = moduleService.getModuleVersionPath("org", "module", "aws", "1.0.0");
+
+        assertEquals("https://registry.example.com/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip", result);
+        org.junit.jupiter.api.Assertions.assertNull(captor.getValue().gitTag());
+    }
+
+    @Test
+    void getModuleVersionPathWithNullVersionResponseDoesNotThrowException() {
+        context = new AnnotationConfigApplicationContext(TestConfig.class);
+        TerrakubeClient terrakubeClient = context.getBean(TerrakubeClient.class);
+        CommonSearchService commonSearchService = context.getBean(CommonSearchService.class);
+        StorageService storageService = context.getBean(StorageService.class);
+        ModuleService moduleService = context.getBean(ModuleService.class);
+
+        when(commonSearchService.getOrganizationId("org")).thenReturn("org-id");
+
+        Module module = new Module();
+        module.setId("module-id");
+        ModuleAttributes attributes = new ModuleAttributes();
+        attributes.setSource("git::https://example.com/org/module.git");
+        module.setAttributes(attributes);
+        Relationships relationships = new Relationships();
+        relationships.setVcs(new VcsData());
+        relationships.setSsh(new SshData());
+        module.setRelationships(relationships);
+
+        Response<List<Module>> moduleResponse = new Response<>();
+        moduleResponse.setData(List.of(module));
+        when(terrakubeClient.getModuleByNameAndProvider("org-id", "module", "aws")).thenReturn(moduleResponse);
+
+        when(terrakubeClient.getAllVersionsByOrganizationIdAndModuleId("org-id", "module-id"))
+                .thenReturn(null);
+
+        org.mockito.ArgumentCaptor<io.terrakube.registry.service.git.ModuleVersionDownload> captor =
+                org.mockito.ArgumentCaptor.forClass(io.terrakube.registry.service.git.ModuleVersionDownload.class);
+        when(storageService.searchModule(anyString(), anyString(), anyString(), captor.capture()))
+                .thenReturn("https://registry.example.com/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip");
+
+        String result = moduleService.getModuleVersionPath("org", "module", "aws", "1.0.0");
+
+        assertEquals("https://registry.example.com/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip", result);
+        org.junit.jupiter.api.Assertions.assertNull(captor.getValue().gitTag());
+    }
+}


### PR DESCRIPTION
Backports commit `520ce91a8e47221d7ebfc25a3a04a3d2049d73a3` (PR #3481) to `release/2.33.X`.

## Description

Prevents `NullPointerException` in `ModuleServiceImpl.getModuleVersionPath` when resolving module versions that either have a null `gitTag` or when the Terrakube API returns a null/empty version list.

### Changes Included:
- **`ModuleServiceImpl.java`**:
  - Safely extract module versions using `Optional.ofNullable(...)` and fallback to `Collections.emptyList()` if `getData()` is null.
  - Safely retrieve `gitTag` attribute using optional mapping to handle missing/null tag values gracefully.
- **`ModuleServiceImplCacheTest.java`**:
  - Added unit test `getModuleVersionPathWithNullGitTagDoesNotThrowException()` to verify path resolution when `gitTag` is null.
  - Added unit test `getModuleVersionPathWithNullVersionResponseDoesNotThrowException()` to verify behavior when version response is null.

## Verification
- Executed `mvn clean test` under `terrakube/registry` (Java 25 via SDKMAN).
- All 31 unit and integration tests passed successfully.
