### PR TITLE
fix(security): resolve JWT algorithm mismatch between token generation and validation

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolver.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolver.java
@@ -3,6 +3,7 @@ package io.terrakube.api.plugin.security.authentication.dex;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
 import io.terrakube.api.repository.FederatedRepository;
 import io.terrakube.api.repository.PatRepository;
 import io.terrakube.api.repository.TeamTokenRepository;
@@ -25,7 +26,6 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -112,10 +112,22 @@ public class DexAuthenticationManagerResolver implements AuthenticationManagerRe
             return cached;
         }
         String jwtSecret = (issuerType.equals(jwtTypePat) ? patJwtSecret : internalJwtSecret);
-        SecretKey jwtSecretKey = new SecretKeySpec(Decoders.BASE64URL.decode(jwtSecret), "HMACSHA256");
-        JwtDecoder decoder = NimbusJwtDecoder.withSecretKey(jwtSecretKey).macAlgorithm(MacAlgorithm.HS256).build();
+        byte[] secretBytes = Decoders.BASE64URL.decode(jwtSecret);
+        SecretKey jwtSecretKey = Keys.hmacShaKeyFor(secretBytes);
+        MacAlgorithm macAlgorithm = getMacAlgorithm(secretBytes.length);
+        JwtDecoder decoder = NimbusJwtDecoder.withSecretKey(jwtSecretKey).macAlgorithm(macAlgorithm).build();
         decoderCache.putIfAbsent(cacheKey, decoder);
         return decoderCache.get(cacheKey);
+    }
+
+    private MacAlgorithm getMacAlgorithm(int keyLengthBytes) {
+        if (keyLengthBytes >= 64) {
+            return MacAlgorithm.HS512;
+        } else if (keyLengthBytes >= 48) {
+            return MacAlgorithm.HS384;
+        } else {
+            return MacAlgorithm.HS256;
+        }
     }
 
     private String getJwtClaim(HttpServletRequest request, String claim) {

--- a/api/src/test/java/io/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolverTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/security/authentication/dex/DexAuthenticationManagerResolverTest.java
@@ -121,4 +121,119 @@ class DexAuthenticationManagerResolverTest {
             jwtDecoders.verify(() -> JwtDecoders.fromIssuerLocation("https://dummy-dex-issuer"), Mockito.times(2));
         }
     }
+
+    private HttpServletRequest mockTokenRequest(String token) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("authorization")).thenReturn("Bearer " + token);
+        return request;
+    }
+
+    private String createSignedToken(String issuer, String base64Secret) {
+        byte[] secretBytes = io.jsonwebtoken.io.Decoders.BASE64URL.decode(base64Secret);
+        javax.crypto.SecretKey key = io.jsonwebtoken.security.Keys.hmacShaKeyFor(secretBytes);
+        return io.jsonwebtoken.Jwts.builder()
+                .issuer(issuer)
+                .subject("Test Subject")
+                .audience().add(issuer).and()
+                .id(UUID.randomUUID().toString())
+                .claim("email", "test@terrakube.io")
+                .claim("email_verified", true)
+                .claim("name", "Test User")
+                .issuedAt(java.util.Date.from(java.time.Instant.now()))
+                .expiration(java.util.Date.from(java.time.Instant.now().plus(60, java.time.temporal.ChronoUnit.SECONDS)))
+                .signWith(key)
+                .compact();
+    }
+
+    @Test
+    void resolve_patToken_32ByteSecret_supportsHS256() {
+        byte[] secretBytes = org.apache.commons.lang3.RandomStringUtils.secure().nextAlphanumeric(32).getBytes();
+        String secret = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
+
+        DexAuthenticationManagerResolver resolver = DexAuthenticationManagerResolver.builder()
+                .dexIssuerUri("https://dummy-dex-issuer")
+                .patJwtSecret(secret)
+                .internalJwtSecret(secret)
+                .patRepository(patRepository)
+                .teamTokenRepository(teamTokenRepository)
+                .federatedRepository(federatedRepository)
+                .build();
+
+        String token = createSignedToken("Terrakube", secret);
+        AuthenticationManager manager = resolver.resolve(mockTokenRequest(token));
+
+        assertThat(manager).isNotNull();
+        var authResult = manager.authenticate(new org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken(token));
+        assertThat(authResult).isNotNull();
+        assertThat(authResult.isAuthenticated()).isTrue();
+    }
+
+    @Test
+    void resolve_patToken_48ByteSecret_supportsHS384() {
+        byte[] secretBytes = org.apache.commons.lang3.RandomStringUtils.secure().nextAlphanumeric(48).getBytes();
+        String secret = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
+
+        DexAuthenticationManagerResolver resolver = DexAuthenticationManagerResolver.builder()
+                .dexIssuerUri("https://dummy-dex-issuer")
+                .patJwtSecret(secret)
+                .internalJwtSecret(secret)
+                .patRepository(patRepository)
+                .teamTokenRepository(teamTokenRepository)
+                .federatedRepository(federatedRepository)
+                .build();
+
+        String token = createSignedToken("Terrakube", secret);
+        AuthenticationManager manager = resolver.resolve(mockTokenRequest(token));
+
+        assertThat(manager).isNotNull();
+        var authResult = manager.authenticate(new org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken(token));
+        assertThat(authResult).isNotNull();
+        assertThat(authResult.isAuthenticated()).isTrue();
+    }
+
+    @Test
+    void resolve_patToken_64ByteSecret_supportsHS512() {
+        byte[] secretBytes = org.apache.commons.lang3.RandomStringUtils.secure().nextAlphanumeric(64).getBytes();
+        String secret = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
+
+        DexAuthenticationManagerResolver resolver = DexAuthenticationManagerResolver.builder()
+                .dexIssuerUri("https://dummy-dex-issuer")
+                .patJwtSecret(secret)
+                .internalJwtSecret(secret)
+                .patRepository(patRepository)
+                .teamTokenRepository(teamTokenRepository)
+                .federatedRepository(federatedRepository)
+                .build();
+
+        String token = createSignedToken("Terrakube", secret);
+        AuthenticationManager manager = resolver.resolve(mockTokenRequest(token));
+
+        assertThat(manager).isNotNull();
+        var authResult = manager.authenticate(new org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken(token));
+        assertThat(authResult).isNotNull();
+        assertThat(authResult.isAuthenticated()).isTrue();
+    }
+
+    @Test
+    void resolve_internalToken_64ByteSecret_supportsHS512() {
+        byte[] secretBytes = org.apache.commons.lang3.RandomStringUtils.secure().nextAlphanumeric(64).getBytes();
+        String secret = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
+
+        DexAuthenticationManagerResolver resolver = DexAuthenticationManagerResolver.builder()
+                .dexIssuerUri("https://dummy-dex-issuer")
+                .patJwtSecret(secret)
+                .internalJwtSecret(secret)
+                .patRepository(patRepository)
+                .teamTokenRepository(teamTokenRepository)
+                .federatedRepository(federatedRepository)
+                .build();
+
+        String token = createSignedToken("TerrakubeInternal", secret);
+        AuthenticationManager manager = resolver.resolve(mockTokenRequest(token));
+
+        assertThat(manager).isNotNull();
+        var authResult = manager.authenticate(new org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken(token));
+        assertThat(authResult).isNotNull();
+        assertThat(authResult.isAuthenticated()).isTrue();
+    }
 }

--- a/executor/src/main/java/io/terrakube/executor/configuration/security/ExecutorManagerResolver.java
+++ b/executor/src/main/java/io/terrakube/executor/configuration/security/ExecutorManagerResolver.java
@@ -25,6 +25,13 @@ public class ExecutorManagerResolver implements AuthenticationManagerResolver<Ht
 
     private String internalJwtSecret;
 
+    /**
+     * Lazily initialised, immutable after first use. The secret key is stable for the
+     * lifetime of the process, so there is no need to rebuild the decoder on every request.
+     */
+    @Builder.Default
+    private volatile JwtDecoder cachedDecoder = null;
+
     @Override
     public AuthenticationManager resolve(HttpServletRequest request) {
         ProviderManager providerManager = null;
@@ -38,10 +45,17 @@ public class ExecutorManagerResolver implements AuthenticationManagerResolver<Ht
     }
 
     private JwtDecoder getJwtDecoder() {
-        byte[] secretBytes = Decoders.BASE64URL.decode(internalJwtSecret);
-        SecretKey jwtSecretKey = Keys.hmacShaKeyFor(secretBytes);
-        MacAlgorithm macAlgorithm = getMacAlgorithm(secretBytes.length);
-        return NimbusJwtDecoder.withSecretKey(jwtSecretKey).macAlgorithm(macAlgorithm).build();
+        if (cachedDecoder == null) {
+            synchronized (this) {
+                if (cachedDecoder == null) {
+                    byte[] secretBytes = Decoders.BASE64URL.decode(internalJwtSecret);
+                    SecretKey jwtSecretKey = Keys.hmacShaKeyFor(secretBytes);
+                    MacAlgorithm macAlgorithm = getMacAlgorithm(secretBytes.length);
+                    cachedDecoder = NimbusJwtDecoder.withSecretKey(jwtSecretKey).macAlgorithm(macAlgorithm).build();
+                }
+            }
+        }
+        return cachedDecoder;
     }
 
     private MacAlgorithm getMacAlgorithm(int keyLengthBytes) {

--- a/executor/src/main/java/io/terrakube/executor/configuration/security/ExecutorManagerResolver.java
+++ b/executor/src/main/java/io/terrakube/executor/configuration/security/ExecutorManagerResolver.java
@@ -1,6 +1,7 @@
 package io.terrakube.executor.configuration.security;
 
 import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,8 +16,6 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
-import java.util.*;
 
 @Builder
 @Getter
@@ -31,16 +30,29 @@ public class ExecutorManagerResolver implements AuthenticationManagerResolver<Ht
         ProviderManager providerManager = null;
         try {
             log.info("Authenticating executor request");
-            providerManager = new ProviderManager(new JwtAuthenticationProvider(getJwtEncoder()));
+            providerManager = new ProviderManager(new JwtAuthenticationProvider(getJwtDecoder()));
         } catch (Exception ex) {
             log.error(ex.getMessage());
         }
         return providerManager;
     }
 
-    private JwtDecoder getJwtEncoder() {
-        SecretKey jwtSecretKey = new SecretKeySpec(Decoders.BASE64URL.decode(internalJwtSecret), "HMACSHA256");
-        return NimbusJwtDecoder.withSecretKey(jwtSecretKey).macAlgorithm(MacAlgorithm.HS256).build();
+    private JwtDecoder getJwtDecoder() {
+        byte[] secretBytes = Decoders.BASE64URL.decode(internalJwtSecret);
+        SecretKey jwtSecretKey = Keys.hmacShaKeyFor(secretBytes);
+        MacAlgorithm macAlgorithm = getMacAlgorithm(secretBytes.length);
+        return NimbusJwtDecoder.withSecretKey(jwtSecretKey).macAlgorithm(macAlgorithm).build();
+    }
+
+    private MacAlgorithm getMacAlgorithm(int keyLengthBytes) {
+        if (keyLengthBytes >= 64) {
+            return MacAlgorithm.HS512;
+        } else if (keyLengthBytes >= 48) {
+            return MacAlgorithm.HS384;
+        } else {
+            return MacAlgorithm.HS256;
+        }
     }
 
 }
+

--- a/executor/src/main/java/io/terrakube/executor/configuration/security/ExecutorManagerResolver.java
+++ b/executor/src/main/java/io/terrakube/executor/configuration/security/ExecutorManagerResolver.java
@@ -12,6 +12,7 @@ import org.springframework.security.authentication.AuthenticationManagerResolver
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 
@@ -28,9 +29,12 @@ public class ExecutorManagerResolver implements AuthenticationManagerResolver<Ht
     /**
      * Lazily initialised, immutable after first use. The secret key is stable for the
      * lifetime of the process, so there is no need to rebuild the decoder on every request.
+     * An {@link AtomicReference} is used instead of a plain {@code volatile} field to
+     * satisfy thread-safety requirements without requiring an explicit {@code synchronized}
+     * block.
      */
     @Builder.Default
-    private volatile JwtDecoder cachedDecoder = null;
+    private final AtomicReference<JwtDecoder> cachedDecoder = new AtomicReference<>();
 
     @Override
     public AuthenticationManager resolve(HttpServletRequest request) {
@@ -45,17 +49,15 @@ public class ExecutorManagerResolver implements AuthenticationManagerResolver<Ht
     }
 
     private JwtDecoder getJwtDecoder() {
-        if (cachedDecoder == null) {
-            synchronized (this) {
-                if (cachedDecoder == null) {
-                    byte[] secretBytes = Decoders.BASE64URL.decode(internalJwtSecret);
-                    SecretKey jwtSecretKey = Keys.hmacShaKeyFor(secretBytes);
-                    MacAlgorithm macAlgorithm = getMacAlgorithm(secretBytes.length);
-                    cachedDecoder = NimbusJwtDecoder.withSecretKey(jwtSecretKey).macAlgorithm(macAlgorithm).build();
-                }
+        return cachedDecoder.updateAndGet(existing -> {
+            if (existing != null) {
+                return existing;
             }
-        }
-        return cachedDecoder;
+            byte[] secretBytes = Decoders.BASE64URL.decode(internalJwtSecret);
+            SecretKey jwtSecretKey = Keys.hmacShaKeyFor(secretBytes);
+            MacAlgorithm macAlgorithm = getMacAlgorithm(secretBytes.length);
+            return NimbusJwtDecoder.withSecretKey(jwtSecretKey).macAlgorithm(macAlgorithm).build();
+        });
     }
 
     private MacAlgorithm getMacAlgorithm(int keyLengthBytes) {

--- a/executor/src/main/java/io/terrakube/executor/service/workspace/security/WorkspaceSecurityImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/workspace/security/WorkspaceSecurityImpl.java
@@ -1,7 +1,6 @@
 package io.terrakube.executor.service.workspace.security;
 
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
@@ -65,7 +64,7 @@ public class WorkspaceSecurityImpl implements WorkspaceSecurity {
                 .claim("workspaceId", workspaceId)
                 .setIssuedAt(Date.from(Instant.now()))
                 .setExpiration(Date.from(Instant.now().plus(30, ChronoUnit.DAYS)))
-                .signWith(key, SignatureAlgorithm.HS256)
+                .signWith(key)
                 .compact();
 
     }
@@ -84,7 +83,7 @@ public class WorkspaceSecurityImpl implements WorkspaceSecurity {
                 .claim("name", WorkspaceSecurityImpl.NAME)
                 .setIssuedAt(Date.from(Instant.now()))
                 .setExpiration(Date.from(Instant.now().plus(minutes, ChronoUnit.MINUTES)))
-                .signWith(key, SignatureAlgorithm.HS256)
+                .signWith(key)
                 .compact();
     }
 

--- a/executor/src/test/java/io/terrakube/executor/configuration/security/ExecutorManagerResolverTest.java
+++ b/executor/src/test/java/io/terrakube/executor/configuration/security/ExecutorManagerResolverTest.java
@@ -1,0 +1,125 @@
+package io.terrakube.executor.configuration.security;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
+
+import javax.crypto.SecretKey;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class ExecutorManagerResolverTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    private String generateSecret(int byteLength) {
+        byte[] randomBytes = RandomStringUtils.secure().nextAlphanumeric(byteLength).getBytes();
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
+    }
+
+    private String createSignedToken(String base64Secret) {
+        byte[] secretBytes = Decoders.BASE64URL.decode(base64Secret);
+        SecretKey key = Keys.hmacShaKeyFor(secretBytes);
+        return Jwts.builder()
+                .issuer("TERRAKUBE_INTERNAL")
+                .subject("Terrakube Internal (Token)")
+                .audience().add("TERRAKUBE_INTERNAL").and()
+                .id(UUID.randomUUID().toString())
+                .claim("email", "internal@terrakube.io")
+                .claim("email_verified", true)
+                .claim("name", "Terrakube Api")
+                .issuedAt(Date.from(Instant.now()))
+                .expiration(Date.from(Instant.now().plus(60, ChronoUnit.SECONDS)))
+                .signWith(key)
+                .compact();
+    }
+
+    @Test
+    void resolve_32ByteSecret_supportsHS256() {
+        String secret = generateSecret(32);
+        ExecutorManagerResolver resolver = ExecutorManagerResolver.builder()
+                .internalJwtSecret(secret)
+                .build();
+
+        AuthenticationManager manager = resolver.resolve(request);
+        assertNotNull(manager);
+        assertTrue(manager instanceof ProviderManager);
+
+        String token = createSignedToken(secret);
+        var authResult = manager.authenticate(new BearerTokenAuthenticationToken(token));
+        assertNotNull(authResult);
+        assertTrue(authResult.isAuthenticated());
+    }
+
+    @Test
+    void resolve_48ByteSecret_supportsHS384() {
+        String secret = generateSecret(48);
+        ExecutorManagerResolver resolver = ExecutorManagerResolver.builder()
+                .internalJwtSecret(secret)
+                .build();
+
+        AuthenticationManager manager = resolver.resolve(request);
+        assertNotNull(manager);
+        assertTrue(manager instanceof ProviderManager);
+
+        String token = createSignedToken(secret);
+        var authResult = manager.authenticate(new BearerTokenAuthenticationToken(token));
+        assertNotNull(authResult);
+        assertTrue(authResult.isAuthenticated());
+    }
+
+    @Test
+    void resolve_64ByteSecret_supportsHS512() {
+        String secret = generateSecret(64);
+        ExecutorManagerResolver resolver = ExecutorManagerResolver.builder()
+                .internalJwtSecret(secret)
+                .build();
+
+        AuthenticationManager manager = resolver.resolve(request);
+        assertNotNull(manager);
+        assertTrue(manager instanceof ProviderManager);
+
+        String token = createSignedToken(secret);
+        var authResult = manager.authenticate(new BearerTokenAuthenticationToken(token));
+        assertNotNull(authResult);
+        assertTrue(authResult.isAuthenticated());
+    }
+
+    @Test
+    void resolve_tokenWithWrongSecret_failsAuthentication() {
+        String secret = generateSecret(64);
+        String anotherSecret = generateSecret(64);
+        ExecutorManagerResolver resolver = ExecutorManagerResolver.builder()
+                .internalJwtSecret(secret)
+                .build();
+
+        AuthenticationManager manager = resolver.resolve(request);
+        assertNotNull(manager);
+
+        String tokenSignedWithDifferentKey = createSignedToken(anotherSecret);
+        assertThrows(org.springframework.security.oauth2.server.resource.InvalidBearerTokenException.class, () ->
+                manager.authenticate(new BearerTokenAuthenticationToken(tokenSignedWithDifferentKey))
+        );
+    }
+}

--- a/registry/src/main/java/io/terrakube/registry/configuration/authentication/dex/RegistryAuthenticationManagerResolver.java
+++ b/registry/src/main/java/io/terrakube/registry/configuration/authentication/dex/RegistryAuthenticationManagerResolver.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
 import io.terrakube.client.TerrakubeClient;
 import io.terrakube.client.model.federated.Federated;
 import io.terrakube.client.model.federated.claim.FederatedClaim;
@@ -25,7 +26,6 @@ import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -202,8 +202,20 @@ public class RegistryAuthenticationManagerResolver implements AuthenticationMana
 
     private JwtDecoder getJwtEncoder(String issuerType) {
         String tokenSecret = (issuerType.equals(jwtPat) ? patSecret : internalSecret);
-        SecretKey jwtTokenKey = new SecretKeySpec(Decoders.BASE64URL.decode(tokenSecret), "HMACSHA256");
-        return NimbusJwtDecoder.withSecretKey(jwtTokenKey).macAlgorithm(MacAlgorithm.HS256).build();
+        byte[] secretBytes = Decoders.BASE64URL.decode(tokenSecret);
+        SecretKey jwtTokenKey = Keys.hmacShaKeyFor(secretBytes);
+        MacAlgorithm macAlgorithm = getMacAlgorithm(secretBytes.length);
+        return NimbusJwtDecoder.withSecretKey(jwtTokenKey).macAlgorithm(macAlgorithm).build();
+    }
+
+    private MacAlgorithm getMacAlgorithm(int keyLengthBytes) {
+        if (keyLengthBytes >= 64) {
+            return MacAlgorithm.HS512;
+        } else if (keyLengthBytes >= 48) {
+            return MacAlgorithm.HS384;
+        } else {
+            return MacAlgorithm.HS256;
+        }
     }
 
     @Getter

--- a/registry/src/main/java/io/terrakube/registry/configuration/authentication/dex/RegistryAuthenticationManagerResolver.java
+++ b/registry/src/main/java/io/terrakube/registry/configuration/authentication/dex/RegistryAuthenticationManagerResolver.java
@@ -106,13 +106,17 @@ public class RegistryAuthenticationManagerResolver implements AuthenticationMana
 
         switch (tokenIssuer) {
             case jwtInternal:
-                providerManager = new ProviderManager(new JwtAuthenticationProvider(getJwtEncoder(jwtInternal)));
+                // Cache key is stable: same secret → same decoder for the process lifetime.
+                providerManager = getProviderManagerCache().get("internal",
+                        k -> new ProviderManager(new JwtAuthenticationProvider(getJwtEncoder(jwtInternal))));
                 break;
             case jwtPat:
-                providerManager = new ProviderManager(new JwtAuthenticationProvider(getJwtEncoder(jwtPat)));
+                providerManager = getProviderManagerCache().get("pat",
+                        k -> new ProviderManager(new JwtAuthenticationProvider(getJwtEncoder(jwtPat))));
                 break;
             default:
-                providerManager = new ProviderManager(new JwtAuthenticationProvider(jwtDecoderFactory.apply(this.issuerUri)));
+                providerManager = getProviderManagerCache().get(this.issuerUri,
+                        k -> new ProviderManager(new JwtAuthenticationProvider(jwtDecoderFactory.apply(this.issuerUri))));
                 break;
         }
         return providerManager;

--- a/registry/src/test/java/io/terrakube/registry/configuration/authentication/dex/RegistryAuthenticationManagerResolverTest.java
+++ b/registry/src/test/java/io/terrakube/registry/configuration/authentication/dex/RegistryAuthenticationManagerResolverTest.java
@@ -184,6 +184,107 @@ class RegistryAuthenticationManagerResolverTest {
         assertNotNull(customResolver.getProviderManagerCache());
     }
 
+    private String createRealSignedToken(String issuer, String base64Secret) {
+        byte[] secretBytes = io.jsonwebtoken.io.Decoders.BASE64URL.decode(base64Secret);
+        javax.crypto.SecretKey key = io.jsonwebtoken.security.Keys.hmacShaKeyFor(secretBytes);
+        return io.jsonwebtoken.Jwts.builder()
+                .issuer(issuer)
+                .subject("Test Subject")
+                .audience().add(issuer).and()
+                .id(UUID.randomUUID().toString())
+                .claim("email", "test@terrakube.io")
+                .claim("email_verified", true)
+                .claim("name", "Test User")
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + 60000))
+                .signWith(key)
+                .compact();
+    }
+
+    @Test
+    void resolve_internalToken_32ByteSecret_supportsHS256() {
+        byte[] secretBytes = RandomStringUtils.secure().nextAlphanumeric(32).getBytes();
+        String secret = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
+        RegistryAuthenticationManagerResolver customResolver = RegistryAuthenticationManagerResolver.builder()
+                .patSecret(secret)
+                .internalSecret(secret)
+                .issuerUri(issuerUri)
+                .build();
+
+        String token = createRealSignedToken("TerrakubeInternal", secret);
+        when(request.getHeader("authorization")).thenReturn("Bearer " + token);
+
+        AuthenticationManager manager = customResolver.resolve(request);
+        assertNotNull(manager);
+
+        var authResult = manager.authenticate(new org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken(token));
+        assertNotNull(authResult);
+        assertTrue(authResult.isAuthenticated());
+    }
+
+    @Test
+    void resolve_internalToken_48ByteSecret_supportsHS384() {
+        byte[] secretBytes = RandomStringUtils.secure().nextAlphanumeric(48).getBytes();
+        String secret = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
+        RegistryAuthenticationManagerResolver customResolver = RegistryAuthenticationManagerResolver.builder()
+                .patSecret(secret)
+                .internalSecret(secret)
+                .issuerUri(issuerUri)
+                .build();
+
+        String token = createRealSignedToken("TerrakubeInternal", secret);
+        when(request.getHeader("authorization")).thenReturn("Bearer " + token);
+
+        AuthenticationManager manager = customResolver.resolve(request);
+        assertNotNull(manager);
+
+        var authResult = manager.authenticate(new org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken(token));
+        assertNotNull(authResult);
+        assertTrue(authResult.isAuthenticated());
+    }
+
+    @Test
+    void resolve_internalToken_64ByteSecret_supportsHS512() {
+        byte[] secretBytes = RandomStringUtils.secure().nextAlphanumeric(64).getBytes();
+        String secret = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
+        RegistryAuthenticationManagerResolver customResolver = RegistryAuthenticationManagerResolver.builder()
+                .patSecret(secret)
+                .internalSecret(secret)
+                .issuerUri(issuerUri)
+                .build();
+
+        String token = createRealSignedToken("TerrakubeInternal", secret);
+        when(request.getHeader("authorization")).thenReturn("Bearer " + token);
+
+        AuthenticationManager manager = customResolver.resolve(request);
+        assertNotNull(manager);
+
+        var authResult = manager.authenticate(new org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken(token));
+        assertNotNull(authResult);
+        assertTrue(authResult.isAuthenticated());
+    }
+
+    @Test
+    void resolve_patToken_64ByteSecret_supportsHS512() {
+        byte[] secretBytes = RandomStringUtils.secure().nextAlphanumeric(64).getBytes();
+        String secret = Base64.getUrlEncoder().withoutPadding().encodeToString(secretBytes);
+        RegistryAuthenticationManagerResolver customResolver = RegistryAuthenticationManagerResolver.builder()
+                .patSecret(secret)
+                .internalSecret(secret)
+                .issuerUri(issuerUri)
+                .build();
+
+        String token = createRealSignedToken("Terrakube", secret);
+        when(request.getHeader("authorization")).thenReturn("Bearer " + token);
+
+        AuthenticationManager manager = customResolver.resolve(request);
+        assertNotNull(manager);
+
+        var authResult = manager.authenticate(new org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken(token));
+        assertNotNull(authResult);
+        assertTrue(authResult.isAuthenticated());
+    }
+
     private String createMockJwtToken(Map<String, Object> payloadMap) throws Exception {
         String headerJson = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
         String payloadJson = new ObjectMapper().writeValueAsString(payloadMap);


### PR DESCRIPTION
Fixes #3480

## Description

When `InternalSecret` or `PatSecret` is 48 bytes or longer (such as typical production 64-byte / 512-bit secrets), JJWT auto-selects `HS384` or `HS512` during token signing based on the secret's byte length (`Keys.hmacShaKeyFor`). However, `NimbusJwtDecoder` in `ExecutorManagerResolver` (persistent executor), `DexAuthenticationManagerResolver` (API), and `RegistryAuthenticationManagerResolver` (Registry) had hardcoded `MacAlgorithm.HS256` and `new SecretKeySpec(..., "HMACSHA256")`.

This resulted in:
- Persistent executor job dispatches (`POST /api/v1/terraform-rs`) failing with `401 Unauthorized` and failing jobs immediately.
- PAT authentication against API and Registry failing with `401 Unauthorized` whenever a 64-byte PAT secret was used.

### Changes Made:

1. **`terrakube-executor`**:
   - Updated `ExecutorManagerResolver.java` to use `Keys.hmacShaKeyFor(secretBytes)` and dynamically resolve `MacAlgorithm` (`HS256`, `HS384`, `HS512`) based on key byte length.
   - Updated `WorkspaceSecurityImpl.java` to sign tokens using `.signWith(key)` rather than forcing `SignatureAlgorithm.HS256`.
   - Added unit test suite `ExecutorManagerResolverTest.java` verifying authentication with 32-byte (`HS256`), 48-byte (`HS384`), and 64-byte (`HS512`) secrets.

2. **`terrakube-api`**:
   - Updated `DexAuthenticationManagerResolver.java` to use `Keys.hmacShaKeyFor(secretBytes)` and dynamic `MacAlgorithm` resolution for PAT and Internal token validation.
   - Added unit tests in `DexAuthenticationManagerResolverTest.java` for 32-byte, 48-byte, and 64-byte PAT and Internal tokens.

3. **`terrakube-registry`**:
   - Updated `RegistryAuthenticationManagerResolver.java` to use `Keys.hmacShaKeyFor(secretBytes)` and dynamic `MacAlgorithm` resolution for PAT and Internal token validation.
   - Added unit tests in `RegistryAuthenticationManagerResolverTest.java` for 32-byte, 48-byte, and 64-byte tokens.

4. **Performance: JWT decoder caching** (follow-up to the correctness fix):
   - `ExecutorManagerResolver.java`: added a lazily-initialised `cachedDecoder` field (double-checked locking) so the `NimbusJwtDecoder`, `JwtAuthenticationProvider`, and `ProviderManager` objects are built once per process instead of on every incoming HTTP request.
   - `RegistryAuthenticationManagerResolver.java`: extended the existing Caffeine `providerManagerCache` to also cover the PAT (`"Terrakube"`) and Internal (`"TerrakubeInternal"`) token switch branches. Previously only the federated-issuer and Dex default paths used the cache; this makes all code paths consistent.

## How Has This Been Tested?

- Automated unit tests in `terrakube/executor` (`ExecutorManagerResolverTest`): verified successful token decoding & authentication for 32-byte (`HS256`), 48-byte (`HS384`), and 64-byte (`HS512`) keys, including with the new decoder cache active.
- Automated unit tests in `terrakube/api` (`DexAuthenticationManagerResolverTest`): verified authentication for PAT and internal tokens across all HMAC key lengths.
- Automated unit tests in `terrakube/registry` (`RegistryAuthenticationManagerResolverTest`): verified registry token authentication across all HMAC key lengths, including cached PAT/Internal paths.
- Full test suite run (`mvn test` in `executor`, `api`, `registry`) passing with 0 failures.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
