### PR TITLE
fix: serialize dates with second precision instead of truncating to the minute

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/elide/ElideSerdeConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/elide/ElideSerdeConfiguration.java
@@ -1,0 +1,23 @@
+package io.terrakube.api.plugin.elide;
+
+import com.yahoo.elide.SerdesBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.TimeZone;
+
+@Configuration
+public class ElideSerdeConfiguration {
+
+    /**
+     * Elide's default date serde uses minute precision (yyyy-MM-dd'T'HH:mm'Z'), which
+     * truncates the seconds of fields like createdDate and lastJobDate in GraphQL
+     * responses. The UI then computes relative times from the top of the minute and
+     * shows things like "42 seconds ago" for a job that was just triggered (issue
+     * #2787). Serialize with second precision instead.
+     */
+    @Bean
+    public SerdesBuilderCustomizer secondPrecisionDateSerdes() {
+        return builder -> builder.withISO8601Dates("yyyy-MM-dd'T'HH:mm:ss'Z'", TimeZone.getTimeZone("UTC"));
+    }
+}

--- a/api/src/test/java/io/terrakube/api/JobTests.java
+++ b/api/src/test/java/io/terrakube/api/JobTests.java
@@ -19,10 +19,12 @@ import io.terrakube.api.rs.workspace.Workspace;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -169,6 +171,49 @@ class JobTests extends ServerApplicationTests {
                 .extract()
                 .path("data.id");
    }
+
+    // Dates must keep (at least) second precision so the UI can compute accurate relative
+    // times; minute-truncated timestamps made it show "42 seconds ago" for jobs that were
+    // just triggered (issue #2787).
+    @Test
+    void jsonApiDatesKeepSecondPrecision() {
+        devsManageJobs(true);
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body(jobDefinition("2db36f7c-f549-4341-a789-315d47eb061d"))
+                .when()
+                .post("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/job/")
+                .then()
+                .assertThat()
+                .body("data.attributes.createdDate", matchesPattern("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z"))
+                .body("data.attributes.updatedDate", matchesPattern("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z"))
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    // GraphQL dates go through Elide's ISO8601 date serde, whose default pattern truncates to
+    // minute precision (yyyy-MM-dd'T'HH:mm'Z'). The workspace list in the UI reads lastJobDate
+    // through this exact query path, so "Last run X ago" was computed from the top of the
+    // minute (issue #2787). ElideSerdeConfiguration overrides the pattern to keep seconds.
+    @Test
+    void graphQlDatesKeepSecondPrecision() {
+        workspace.setLastJobDate(Date.from(Instant.parse("2026-01-15T10:20:42Z")));
+        workspace = workspaceRepository.save(workspace);
+
+        String query = "{ \"query\": \"{ organization(ids: [\\\"d9b58bd3-f3fc-4056-a026-1163297e80a8\\\"]) { edges { node { "
+                + "workspace(ids: [\\\"" + workspace.getId() + "\\\"]) { edges { node { lastJobDate } } } } } } }\" }";
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/json")
+                .body(query)
+                .when()
+                .post("/graphql/api/v1")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.OK.value())
+                .body("data.organization.edges[0].node.workspace.edges[0].node.lastJobDate",
+                        IsEqual.equalTo("2026-01-15T10:20:42Z"));
+    }
 
     @Test
     void createJobLockedWorkspace() {


### PR DESCRIPTION
## Problem

The console computes relative times ("Triggered from UI 42 seconds ago", "Last run X ago") from timestamps the API truncates to the top of the minute, so a job triggered late in the minute immediately shows 40-50+ seconds of elapsed time.

## Root cause

Elide's default ISO8601 date serde uses the pattern `yyyy-MM-dd'T'HH:mm'Z'` (see `serdesBuilder()` in Elide's `ElideAutoConfiguration`), so every `java.util.Date` attribute served through the serde loses its seconds. Reproduced against current `main` with the new test in this PR: GraphQL returns `lastJobDate` as `2026-01-15T10:20Z` for a value stored as `2026-01-15T10:20:42Z`.

Two serialization paths are affected differently on current `main`:

- **GraphQL** (`GraphQLScalars` → `CoerceUtil.lookup(Date.class)` → serde): still truncates to the minute. This is the path the workspace list reads `lastJobDate` from ("Last run X ago").
- **JSON:API**: was truncating when #2787 was filed, but the Spring Boot 4 / Jackson 3 upgrade (#3470) changed this path to Jackson's default `Date` serialization, which already keeps milliseconds. It no longer truncates today.

This also explains why #2818/#2819 didn't pan out: the truncation never happened in the database or in Spring's Jackson config, it happens in Elide's serde.

## Fix

Register a `SerdesBuilderCustomizer` (Elide's intended extension point for this) that overrides the date pattern to `yyyy-MM-dd'T'HH:mm:ss'Z'`.

Note on inputs: the serde also parses date strings (GraphQL date arguments, JSON:API date attributes/filters), which now expect seconds as well. Nothing in the UI or executor sends date literals to the API, and the previous minute-only pattern rejected full ISO timestamps anyway, so accepting the standard form is strictly more useful.

## Tests

- `graphQlDatesKeepSecondPrecision`: stores a `lastJobDate` with non-zero seconds and asserts GraphQL (same organization → workspace query shape the UI uses) returns it unchanged. Fails on `main` with `2026-01-15T10:20Z`.
- `jsonApiDatesKeepSecondPrecision`: pins job `createdDate`/`updatedDate` in JSON:API responses to at least second precision so the incidental Jackson 3 behavior can't silently regress to minutes.

Both pass with `mvn -pl api test`.

Fixes #2787

🤖 Generated with [Claude Code](https://claude.com/claude-code)
