### PR TITLE
fix(executor): preserve streamed plan/apply output when the terraform client fails

### DIFF
--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -196,17 +196,18 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     };
 
                     TerraformClient jsonPlanClient = buildJsonEnabledPlanClient();
+                    Consumer<String> guardedJsonLineConsumer = guardConsumer(jsonLineConsumer);
 
                     if (isDestroy) {
                         log.warn("Executor running a plan to destroy resources...");
                         exitCode = jsonPlanClient.planDestroyDetailExitCode(
                                 getTerraformProcessData(terraformJob, terraformWorkingDir, executorTempDirectory),
-                                jsonLineConsumer,
+                                guardedJsonLineConsumer,
                                 null).get();
                     } else {
                         exitCode = jsonPlanClient.planDetailExitCode(
                                 getTerraformProcessData(terraformJob, terraformWorkingDir, executorTempDirectory),
-                                jsonLineConsumer,
+                                guardedJsonLineConsumer,
                                 null).get();
                     }
 
@@ -271,7 +272,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             result.setPlan(true);
             result.setExitCode(exitCode);
         } catch (IOException | ExecutionException | InterruptedException exception) {
-            result = setError(exception);
+            result = setError(exception, jobOutput.toString());
+            result.setPlan(true);
             result.setExitCode(1);
         }
         return result;
@@ -351,7 +353,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             waitForStreamCompletion(terraformJob.getJobId(), 300);
             result = generateJobResult(scriptAfterSuccess, terraformOutput.toString(), terraformErrorOutput.toString());
         } catch (IOException | ExecutionException | InterruptedException exception) {
-            result = setError(exception);
+            result = setError(exception, terraformOutput.toString());
+            result.setExitCode(1);
         }
         return result;
     }
@@ -365,7 +368,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             // No plan structured output to seed from (custom TCL with 0/2+ plan steps, or plan
             // publishing failed) — fall back to a plain apply through the shared client, exactly
             // as before this feature existed.
-            return terraformClient.apply(terraformProcessData, applyOutput, null).get();
+            return terraformClient.apply(terraformProcessData, guardConsumer(applyOutput), null).get();
         }
 
         List<Map<String, Object>> jobDiagnostics = new ArrayList<>();
@@ -395,7 +398,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
         TerraformClient jsonApplyClient = buildJsonEnabledApplyClient();
 
-        boolean execution = jsonApplyClient.apply(terraformProcessData, jsonLineConsumer, null).get();
+        boolean execution = jsonApplyClient.apply(terraformProcessData, guardConsumer(jsonLineConsumer), null).get();
 
         String stateJson = getCurrentStateJson(terraformJob, terraformProcessData);
         if (stateJson != null) {
@@ -443,7 +446,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
         TerraformClient jsonDestroyClient = buildJsonEnabledDestroyClient();
 
-        boolean execution = jsonDestroyClient.destroy(terraformProcessData, jsonLineConsumer, null).get();
+        boolean execution = jsonDestroyClient.destroy(terraformProcessData, guardConsumer(jsonLineConsumer), null).get();
 
         applyStructuredOutputService.publishApplyProgress(
                 terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), changes, jobDiagnostics);
@@ -476,7 +479,11 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             payload.put("jobDiagnostics", Map.of(terraformJob.getStepId(), jobDiagnostics));
             logsService.sendStructuredUpdate(Integer.valueOf(terraformJob.getJobId()), terraformJob.getStepId(),
                     objectMapper.writeValueAsString(payload));
-        } catch (JsonProcessingException e) {
+        } catch (Exception e) {
+            // Best-effort: a serialization error, a null stepId in Map.of, or a transport failure
+            // in sendStructuredUpdate must never abort the plan/apply - some of these call sites
+            // run on terraform-spring-boot's output-reader thread, where an uncaught exception
+            // kills stream capture entirely.
             log.warn("Unable to push live structured update for job {} step {}", terraformJob.getJobId(), terraformJob.getStepId(), e);
         }
     }
@@ -579,7 +586,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             waitForStreamCompletion(terraformJob.getJobId(), 300);
             result = generateJobResult(scriptAfterSuccess, jobOutput.toString(), jobErrorOutput.toString());
         } catch (IOException | ExecutionException | InterruptedException exception) {
-            result = setError(exception);
+            result = setError(exception, jobOutput.toString());
+            result.setExitCode(1);
         }
         return result;
     }
@@ -771,13 +779,54 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
     }
 
     private ExecutorJobResult setError(Exception exception) {
-        ExecutorJobResult error = generateJobResult(false, "", exception.getMessage());
-        log.error(exception.getMessage());
+        return setError(exception, "");
+    }
+
+    // Keep everything Terraform/OpenTofu already streamed to the console before the failure. The
+    // previous behaviour replaced it all with just exception.getMessage(), so an operation that
+    // failed late - a data source erroring after the plan diff was already printed, or the
+    // terraform-spring-boot client's stream-drain watchdog firing on a large burst of output -
+    // reached the UI and CLI as a bare "java.lang.RuntimeException: Failed to capture process
+    // output stream" with none of the real Terraform output, and none of the real error (the
+    // "Error: External Program Lookup Failed" / missing-python diagnostic, in the reported case)
+    // that actually caused it.
+    private ExecutorJobResult setError(Exception exception, String partialConsoleOutput) {
+        String message = exception.getMessage() != null ? exception.getMessage() : exception.toString();
+        log.error("Terraform operation failed: {}", message, exception);
+
+        TextStringBuilder consoleOutput = new TextStringBuilder();
+        if (partialConsoleOutput != null && !partialConsoleOutput.isBlank()) {
+            consoleOutput.append(partialConsoleOutput);
+            if (!partialConsoleOutput.endsWith("\n")) {
+                consoleOutput.appendNewLine();
+            }
+            consoleOutput.appendNewLine();
+        }
+        consoleOutput.appendln("Error: the Terrakube executor could not finish this operation");
+        consoleOutput.appendln(message);
+
+        ExecutorJobResult error = generateJobResult(false, consoleOutput.toString(), message);
 
         if (exception instanceof InterruptedException) {
             Thread.currentThread().interrupt();
         }
         return error;
+    }
+
+    // terraform-spring-boot invokes the -json line consumer from inside its process-output reader
+    // loop; any exception thrown out of the consumer propagates back into that loop, kills the
+    // reader thread and fails the whole run with "Failed to capture process output stream",
+    // discarding every line already read. A dropped structured-progress update is recoverable; a
+    // killed reader is not. (LogsServiceRedis.sendLogs guards the plain-log consumer for the same
+    // reason.)
+    private Consumer<String> guardConsumer(Consumer<String> lineConsumer) {
+        return line -> {
+            try {
+                lineConsumer.accept(line);
+            } catch (Exception e) {
+                log.warn("Skipping a terraform output line that could not be processed: {}", e.getMessage(), e);
+            }
+        };
     }
 
     private boolean prepareTerraformOperation(TerraformJob terraformJob, File executorTempDirectory, File terraformWorkingDirectory, Consumer<String> output)

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
@@ -535,4 +535,74 @@ class TerraformExecutorServiceImplTest {
                 "To work with null_resource.fails its original provider configuration is required."),
                 result.getOutputLog());
     }
+
+    // Regression test for the reported bug: a plan that fails late (a data source erroring after
+    // the diff was already streamed) surfaced in the UI/CLI as a bare
+    // "java.lang.RuntimeException: Failed to capture process output stream" - the executor's
+    // catch block replaced every line Terraform had already printed with just the exception
+    // message. The console output that was already collected must be preserved.
+    @Test
+    void planKeepsAlreadyStreamedOutputWhenTheClientFutureFails() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        String plannedChangeLine = "{\"type\":\"planned_change\",\"change\":{\"resource\":"
+                + "{\"addr\":\"aws_instance.example\"},\"action\":\"create\"},"
+                + "\"@message\":\"aws_instance.example: Plan to create\"}";
+
+        TerraformClient jsonPlanClient = Mockito.mock(TerraformClient.class);
+        when(jsonPlanClient.planDetailExitCode(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenAnswer(invocation -> {
+                    Consumer<String> lineConsumer = invocation.getArgument(1);
+                    lineConsumer.accept(plannedChangeLine);
+                    return CompletableFuture.failedFuture(
+                            new RuntimeException("Failed to capture process output stream"));
+                });
+        doReturn(jsonPlanClient).when(subject).buildJsonEnabledPlanClient();
+
+        ExecutorJobResult result = subject.plan(terraformJob, tempDir.toFile(), false);
+
+        assertFalse(result.isSuccessfulExecution());
+        assertEquals(1, result.getExitCode());
+        assertTrue(result.getOutputLog().contains("aws_instance.example: Plan to create"), result.getOutputLog());
+        assertTrue(result.getOutputLog().contains("Failed to capture process output stream"), result.getOutputLog());
+        assertTrue(result.getOutputErrorLog().contains("Failed to capture process output stream"));
+    }
+
+    // A failure inside the -json line consumer (here: the live structured-update push blowing up)
+    // must not propagate into terraform-spring-boot's process-output reader loop - that kills the
+    // reader and fails the whole run with "Failed to capture process output stream", losing the
+    // console output that had already been read.
+    @Test
+    void planSurvivesAFailureRaisedFromInsideTheJsonLineConsumer() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        Mockito.doThrow(new RuntimeException("redis is unreachable"))
+                .when(logsService).sendStructuredUpdate(anyInt(), anyString(), anyString());
+
+        String plannedChangeLine = "{\"type\":\"planned_change\",\"change\":{\"resource\":"
+                + "{\"addr\":\"aws_instance.example\"},\"action\":\"create\"},"
+                + "\"@message\":\"aws_instance.example: Plan to create\"}";
+
+        TerraformClient jsonPlanClient = Mockito.mock(TerraformClient.class);
+        when(jsonPlanClient.planDetailExitCode(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenAnswer(invocation -> {
+                    Consumer<String> lineConsumer = invocation.getArgument(1);
+                    lineConsumer.accept(plannedChangeLine);
+                    return CompletableFuture.completedFuture(2);
+                });
+        doReturn(jsonPlanClient).when(subject).buildJsonEnabledPlanClient();
+
+        ExecutorJobResult result = subject.plan(terraformJob, tempDir.toFile(), false);
+
+        assertEquals(2, result.getExitCode());
+        assertTrue(result.getOutputLog().contains("aws_instance.example: Plan to create"), result.getOutputLog());
+    }
 }


### PR DESCRIPTION
Fixes #3490

## Problem

When a `plan`/`apply`/`destroy` fails *after* Terraform has already streamed output, the executor discards everything it captured and reports only the exception.

`terraform-spring-boot-starter` 1.6.0's `ProcessLauncher` has a 60s stream-drain watchdog that throws `RuntimeException("Failed to capture process output stream")` if the reader thread can't drain in time or a listener throws. Our `-json` line consumer does synchronous HTTP (`/context/v1`) + Redis on that reader thread, so a large plan that bursts its diff + diagnostics at process exit can exceed 60s. The resulting `ExecutionException` is caught and passed to `setError`, which builds `generateJobResult(false, "", exception.getMessage())` — the accumulated buffer is thrown away. The UI then shows only the bare `Failed to capture process output stream` and the CLI shows nothing after the refresh lines; the real error (e.g. `python3` not on `PATH` in a `data "external"`) survives only in the executor pod log.

## Changes

`TerraformExecutorServiceImpl`:

- `setError` now takes the accumulated console buffer; `plan`/`apply`/`destroy` catch blocks pass it, so the result keeps the full Terraform output plus an error footer with the underlying message. Exit code set to `1` on all three paths.
- `guardConsumer(...)` wraps every `-json` line consumer so a publish/parse failure can't propagate into the library's reader loop and kill stream capture (same principle as `LogsServiceRedis.sendLogs`).
- `pushLiveStructuredUpdate` catches `Exception`, not just `JsonProcessingException`.

Two regression tests in `TerraformExecutorServiceImplTest`.

## Result

The UI and CLI show the full Terraform output and the real error instead of an opaque one-liner.

## Notes

- Doesn't remove the underlying trigger — the executor still does synchronous HTTP/Redis on the reader thread. Moving that off-thread is a follow-up.
- Complementary to #3483 (already in history): that fix covers the client returning normally; this covers the client's future throwing.

## Testing

`mvn -pl executor test -Dtest=TerraformExecutorServiceImplTest` — 19/19 pass.