### PR TITLE
fix(notification): stop spurious failed alerts for runs that recover and complete

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/logs/StepOutputReader.java
+++ b/api/src/main/java/io/terrakube/api/plugin/logs/StepOutputReader.java
@@ -1,0 +1,63 @@
+package io.terrakube.api.plugin.logs;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Service;
+
+import io.terrakube.api.plugin.storage.StorageTypeService;
+import io.terrakube.api.plugin.streaming.StreamingService;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.step.Step;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Reads a step's console output as plain text - live logs while the step is still streaming,
+ * the persisted object afterwards - with terminal colour codes stripped. Shared by every caller
+ * that needs the human-readable run text rather than the raw log stream (PR/MR comments,
+ * failure-notification summaries, ...).
+ */
+@Slf4j
+@Service
+public class StepOutputReader {
+
+    private static final Pattern ANSI_PATTERN = Pattern.compile(
+            "[\\u001b\\u009b][\\[()#;?]*(?:\\d{1,4}(?:;\\d{1,4})*)?[0-9A-ORZcf-nq-uy=><~]");
+
+    private final StorageTypeService storageTypeService;
+    private final StreamingService streamingService;
+
+    public StepOutputReader(StorageTypeService storageTypeService, StreamingService streamingService) {
+        this.storageTypeService = storageTypeService;
+        this.streamingService = streamingService;
+    }
+
+    /**
+     * ANSI-stripped console text for one step, or {@code null} when there is nothing to show or
+     * the lookup fails - reading run output is always a best-effort side concern and must never
+     * propagate an exception to its caller.
+     */
+    public String read(Job job, Step step) {
+        try {
+            String stepId = step.getId().toString();
+            String liveLogs = streamingService.getCurrentLogs(stepId, "");
+            if (liveLogs != null && !liveLogs.isEmpty()) {
+                return stripAnsi(liveLogs);
+            }
+            byte[] storedOutput = storageTypeService.getStepOutput(
+                    job.getOrganization().getId().toString(), String.valueOf(job.getId()), stepId);
+            if (storedOutput == null || storedOutput.length == 0) {
+                return null;
+            }
+            return stripAnsi(new String(storedOutput, StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            log.error("Error fetching step output for job {}: {}", job.getId(), e.getMessage());
+            return null;
+        }
+    }
+
+    public String stripAnsi(String text) {
+        return text == null ? null : ANSI_PATTERN.matcher(text).replaceAll("");
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/JobFailureSummaryService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/JobFailureSummaryService.java
@@ -1,0 +1,68 @@
+package io.terrakube.api.plugin.notification;
+
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import io.terrakube.api.plugin.logs.StepOutputReader;
+import io.terrakube.api.repository.StepRepository;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.step.Step;
+
+import lombok.extern.slf4j.Slf4j;
+
+// Builds the short "why did this run fail" blurb for a failure notification. There is no
+// failure-reason field on Job (job.output only ever holds vestigial "Step <id> completed"
+// markers - see the executor's UpdateJobStatusImpl), so this reads the console output of the
+// step that actually failed - the same source the job-details UI and PrCommentService use - and
+// returns a trimmed tail of it.
+@Slf4j
+@Service
+public class JobFailureSummaryService {
+
+    private static final int MAX_LENGTH = 500;
+
+    private final StepRepository stepRepository;
+    private final StepOutputReader stepOutputReader;
+
+    public JobFailureSummaryService(StepRepository stepRepository, StepOutputReader stepOutputReader) {
+        this.stepRepository = stepRepository;
+        this.stepOutputReader = stepOutputReader;
+    }
+
+    // Never throws: a failure notification must still go out even when the run output can't be
+    // read back. Returns null when there is nothing useful to show.
+    public String describeFailure(Job job) {
+        try {
+            Step failedStep = pickFailedStep(stepRepository.findByJobId(job.getId()));
+            if (failedStep == null) {
+                return null;
+            }
+            String output = stepOutputReader.read(job, failedStep);
+            if (output == null || output.isBlank()) {
+                return null;
+            }
+            output = output.strip();
+            return output.length() > MAX_LENGTH
+                    ? output.substring(output.length() - MAX_LENGTH).strip()
+                    : output;
+        } catch (Exception e) {
+            log.warn("Could not build failure summary for job {}: {}", job.getId(), e.getMessage());
+            return null;
+        }
+    }
+
+    // The step actually marked failed, if any; otherwise the last step that ran. A job can reach
+    // "failed" before any step is marked failed (e.g. a dispatch error), and a custom TCL
+    // template can append steps after the terraform step - so "highest step number" is the best
+    // fallback, not a guaranteed terraform step.
+    private Step pickFailedStep(List<Step> steps) {
+        return steps.stream()
+                .filter(step -> step.getStatus() == JobStatus.failed)
+                .max(Comparator.comparingInt(Step::getStepNumber))
+                .or(() -> steps.stream().max(Comparator.comparingInt(Step::getStepNumber)))
+                .orElse(null);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/JobNotificationTrigger.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/JobNotificationTrigger.java
@@ -1,7 +1,9 @@
 package io.terrakube.api.plugin.notification;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -12,6 +14,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import io.terrakube.api.plugin.notification.payload.NotificationContext;
 import io.terrakube.api.plugin.notification.payload.NotificationPayloadRenderer;
 import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.notification.NotificationConfiguration;
 import io.terrakube.api.rs.notification.NotificationOutbox;
 import io.terrakube.api.rs.notification.NotificationOutboxStatus;
@@ -40,30 +43,55 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 public class JobNotificationTrigger {
 
+    // Statuses a run can still leave for a non-error status afterwards. A job briefly flips to
+    // "failed" when the API↔executor dispatch call throws (see ScheduleJob.errorJobAtStep) even
+    // though the executor often accepted the job and is running it - its next status callback
+    // (setRunningStatus / setCompletedStatus) then moves the job back off "failed" and the run
+    // completes normally. A notification for such a status is held back briefly and re-validated
+    // against the job's live status before it is actually delivered (see
+    // NotificationOutboxTransactions.claim), so these transient flips never reach the channel.
+    private static final Set<JobStatus> RECOVERABLE_STATUSES = Set.of(JobStatus.failed);
+
     private final NotificationConfigResolver notificationConfigResolver;
     private final NotificationPayloadRenderer notificationPayloadRenderer;
     private final NotificationOutboxRepository notificationOutboxRepository;
     private final NotificationDispatchService notificationDispatchService;
+    private final JobFailureSummaryService jobFailureSummaryService;
 
     @Value("${io.terrakube.ui.url:}")
     private String uiUrl;
 
+    // How long to hold a notification for a potentially-transient status (RECOVERABLE_STATUSES)
+    // before the poller may deliver it, giving the executor's own status callback time to
+    // correct a dispatch-error flip. Only delays the delivery of these rows; every other status
+    // is still dispatched immediately.
+    @Value("${io.terrakube.notification.recoverableStatusGraceSeconds:90}")
+    private long recoverableStatusGraceSeconds;
+
     public JobNotificationTrigger(NotificationConfigResolver notificationConfigResolver,
             NotificationPayloadRenderer notificationPayloadRenderer,
             NotificationOutboxRepository notificationOutboxRepository,
-            NotificationDispatchService notificationDispatchService) {
+            NotificationDispatchService notificationDispatchService,
+            JobFailureSummaryService jobFailureSummaryService) {
         this.notificationConfigResolver = notificationConfigResolver;
         this.notificationPayloadRenderer = notificationPayloadRenderer;
         this.notificationOutboxRepository = notificationOutboxRepository;
         this.notificationDispatchService = notificationDispatchService;
+        this.jobFailureSummaryService = jobFailureSummaryService;
     }
 
+    // Returns the ids of rows that are due for immediate dispatch. A row rendered for a
+    // potentially-transient status (RECOVERABLE_STATUSES) is still inserted, but with a short
+    // nextAttemptAt in the future and its id withheld from the result - only the outbox poller
+    // picks it up, after the grace window, and only if the job's live status still matches by
+    // then. Callers dispatch exactly what is returned; the poller covers the rest.
     public List<UUID> enqueue(Job job) {
         if (job.getWorkspace() == null) {
             return List.of();
         }
         List<UUID> insertedIds = new ArrayList<>();
         try {
+            boolean deferDispatch = RECOVERABLE_STATUSES.contains(job.getStatus());
             List<NotificationConfiguration> configs = notificationConfigResolver.resolve(job.getWorkspace());
             for (NotificationConfiguration configuration : configs) {
                 boolean statusMatches = configuration.getTriggers() != null && configuration.getTriggers().stream()
@@ -71,23 +99,37 @@ public class JobNotificationTrigger {
                 if (!statusMatches || !templateMatches(configuration, job)) {
                     continue;
                 }
-                String payload = notificationPayloadRenderer.render(configuration.getChannelType(),
-                        buildContext(job, configuration));
-
-                NotificationOutbox outbox = new NotificationOutbox();
-                outbox.setId(UUID.randomUUID());
-                outbox.setJob(job);
-                outbox.setConfiguration(configuration);
-                outbox.setPayload(payload);
-                outbox.setStatus(NotificationOutboxStatus.PENDING);
-                notificationOutboxRepository.save(outbox);
-                insertedIds.add(outbox.getId());
+                UUID outboxId = saveOutboxRow(job, configuration, deferDispatch);
+                if (!deferDispatch) {
+                    insertedIds.add(outboxId);
+                }
             }
         } catch (Exception e) {
             // Never let a resolution/render failure fail the job status update itself.
             log.error("Failed to resolve/enqueue notifications for job {}", job.getId(), e);
         }
         return insertedIds;
+    }
+
+    // Renders and persists one PENDING outbox row. A deferred row (job in a RECOVERABLE_STATUS)
+    // gets a nextAttemptAt in the future so only the poller picks it up, after the grace window.
+    private UUID saveOutboxRow(Job job, NotificationConfiguration configuration, boolean deferred) {
+        String payload = notificationPayloadRenderer.render(configuration.getChannelType(),
+                buildContext(job, configuration));
+
+        NotificationOutbox outbox = new NotificationOutbox();
+        outbox.setId(UUID.randomUUID());
+        outbox.setJob(job);
+        outbox.setConfiguration(configuration);
+        outbox.setPayload(payload);
+        outbox.setStatus(NotificationOutboxStatus.PENDING);
+        outbox.setJobStatus(job.getStatus());
+        if (deferred) {
+            outbox.setNextAttemptAt(
+                    new Date(System.currentTimeMillis() + recoverableStatusGraceSeconds * 1000L));
+        }
+        notificationOutboxRepository.save(outbox);
+        return outbox.getId();
     }
 
     // Empty/null templates means "applies to every template" - this only ever narrows which
@@ -122,14 +164,13 @@ public class JobNotificationTrigger {
         String workspaceUrl = String.format("%s/organizations/%s/workspaces/%s", uiUrl,
                 job.getOrganization().getId(), job.getWorkspace().getId());
         String runUrl = workspaceUrl + "/runs/" + job.getId();
-        // job.output is the raw Terraform/OpenTofu run output; there is no dedicated
-        // failure-reason field on Job, so this trims the tail of that log as a
-        // best-effort summary rather than shipping the whole (possibly huge) output.
-        String failureReason = null;
-        if (job.getOutput() != null && !job.getOutput().isBlank()) {
-            String output = job.getOutput();
-            failureReason = output.length() > 500 ? output.substring(output.length() - 500) : output;
-        }
+        // Only a genuinely failed job carries a failure reason; for any other status there is
+        // nothing to explain. The text is the tail of the failing step's console output (see
+        // JobFailureSummaryService) - job.output itself only holds "Step <id> completed"
+        // markers and is useless here.
+        String failureReason = job.getStatus() == JobStatus.failed
+                ? jobFailureSummaryService.describeFailure(job)
+                : null;
         return new NotificationContext(
                 job.getOrganization().getName(),
                 job.getWorkspace().getName(),

--- a/api/src/main/java/io/terrakube/api/plugin/notification/NotificationOutboxTransactions.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/NotificationOutboxTransactions.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.terrakube.api.repository.NotificationOutboxRepository;
+import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.notification.NotificationOutbox;
 import io.terrakube.api.rs.notification.NotificationOutboxStatus;
 
@@ -49,6 +50,9 @@ public class NotificationOutboxTransactions {
         if (outbox == null) {
             return null;
         }
+        if (skipSupersededRow(outbox, now)) {
+            return null;
+        }
         // The delivery call happens after this transaction (and its Hibernate session) has
         // closed, so a still-lazy configuration proxy would blow up with a
         // LazyInitializationException the moment the sender reads a field off it. Force it to
@@ -56,6 +60,31 @@ public class NotificationOutboxTransactions {
         Hibernate.initialize(outbox.getConfiguration());
         return new ClaimedOutbox(outbox.getConfiguration(), outbox.getPayload(), outbox.getAttemptCount(),
                 outbox.getLastAttemptAt());
+    }
+
+    // False-alarm guard for a row that has just been claimed (PENDING -> SENDING). The payload
+    // was rendered for outbox.jobStatus; if the job has since moved to a different status that
+    // state no longer holds - the common case being a transient "failed" from a lost
+    // API->executor dispatch response (ScheduleJob.errorJobAtStep) that the executor's own
+    // status callback then corrected. Marks the row SKIPPED (terminal) and returns true so
+    // nothing is delivered and the poller never retries it. Rows written before the jobStatus
+    // column existed have null here and are always delivered, exactly as before.
+    private boolean skipSupersededRow(NotificationOutbox outbox, Date now) {
+        JobStatus renderedFor = outbox.getJobStatus();
+        JobStatus liveStatus = renderedFor == null ? null : outbox.getJob().getStatus();
+        if (renderedFor == null || liveStatus == renderedFor) {
+            return false;
+        }
+        // Same conditional-update discipline as the rest of this class - keyed on SENDING and
+        // the lastAttemptAt claimForDelivery just wrote - rather than a read-then-write.
+        notificationOutboxRepository.recordDeliveryResult(outbox.getId(), NotificationOutboxStatus.SENDING,
+                outbox.getLastAttemptAt(), NotificationOutboxStatus.SKIPPED,
+                "Job status changed from " + renderedFor + " to " + liveStatus
+                        + " before delivery; suppressed as a false alarm",
+                null, now);
+        log.info("Skipping notification outbox {} - job {} status moved from {} to {} before delivery",
+                outbox.getId(), outbox.getJob().getId(), renderedFor, liveStatus);
+        return true;
     }
 
     @Transactional
@@ -103,13 +132,15 @@ public class NotificationOutboxTransactions {
         }
     }
 
-    // Housekeeping: without this, notification_outbox grows forever - every SENT/FAILED row from
-    // every job status change with a matching trigger sits around indefinitely. Public for the
-    // same cross-package reason as sweepStuckSendingRows.
+    // Housekeeping: without this, notification_outbox grows forever - every SENT/FAILED/SKIPPED
+    // row from every job status change with a matching trigger sits around indefinitely. Public
+    // for the same cross-package reason as sweepStuckSendingRows.
     @Transactional
     public int pruneTerminalRowsOlderThan(Date cutoff) {
         int deleted = notificationOutboxRepository.deleteTerminalRowsCreatedBefore(
-                List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED), cutoff);
+                List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED,
+                        NotificationOutboxStatus.SKIPPED),
+                cutoff);
         if (deleted > 0) {
             log.info("Notification outbox retention sweep deleted {} row(s) older than {}", deleted, cutoff);
         }

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorService.java
@@ -13,6 +13,7 @@ import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
@@ -102,12 +103,17 @@ public class PersistentExecutorService {
                         executorUrlForRequest);
                 throw new ExecutorUnavailableException(new Throwable(ex.getMessage() + hint, ex));
             }
-            if (ex instanceof WebClientResponseException wcre
-                    && wcre.getStatusCode().equals(HttpStatus.SERVICE_UNAVAILABLE)) {
-                // The executor pod's per-pod capacity gate was already held by another job
-                // (persistent-executor-admission-control) - retryable, not a job failure.
+            if (ex instanceof WebClientResponseException wcre && isRetryableGatewayStatus(wcre.getStatusCode())) {
+                // 503: the executor pod's per-pod capacity gate was already held by another job
+                // (persistent-executor-admission-control). 502/504: a proxy/ingress between the
+                // API and the executor dropped or timed out the upstream connection - which can
+                // happen *after* the executor already accepted the job (its response, not the
+                // request, was lost). None of these mean the job is broken, and failing it here
+                // fires a spurious "failed" notification for a run the executor goes on to
+                // finish - so treat them all as retryable capacity/transport problems.
                 throw new ExecutorUnavailableException(new Throwable(
-                        "Executor at " + executorUrlForRequest + " is busy (503), will retry", ex));
+                        "Executor at " + executorUrlForRequest + " returned " + wcre.getStatusCode().value()
+                                + ", will retry", ex));
             }
             throw new ExecutionException(new Throwable(ex.getMessage(), ex));
         }
@@ -125,6 +131,15 @@ public class PersistentExecutorService {
                     response.getBody());
             throw new ExecutionException(new Throwable(message));
         }
+    }
+
+    // 503 (per-pod admission control) plus the two proxy/ingress statuses that show up when the
+    // hop between the API and the executor fails rather than the executor itself - retryable
+    // capacity/transport problems, not a broken job.
+    private static boolean isRetryableGatewayStatus(HttpStatusCode status) {
+        return status.equals(HttpStatus.SERVICE_UNAVAILABLE)
+                || status.equals(HttpStatus.BAD_GATEWAY)
+                || status.equals(HttpStatus.GATEWAY_TIMEOUT);
     }
 
     private String getExecutorUrl(Job job) throws URISyntaxException {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
@@ -2,8 +2,8 @@ package io.terrakube.api.plugin.vcs;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.api.plugin.logs.StepOutputReader;
 import io.terrakube.api.plugin.storage.StorageTypeService;
-import io.terrakube.api.plugin.streaming.StreamingService;
 import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
 import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
@@ -19,7 +19,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
@@ -44,16 +43,13 @@ public class PrCommentService {
             "(Plan: (?:\\d+ to import, )?\\d+ to add, \\d+ to change, \\d+ to destroy\\."
             + "|No changes\\. Your infrastructure matches the configuration\\."
             + "|Apply complete! Resources: \\d+ added, \\d+ changed, \\d+ destroyed\\.)");
-    private static final Pattern ANSI_PATTERN = Pattern.compile(
-            "[\\u001b\\u009b][\\[()#;?]*(?:\\d{1,4}(?:;\\d{1,4})*)?[0-9A-ORZcf-nq-uy=><~]");
-
     GitHubWebhookService gitHubWebhookService;
     GitLabWebhookService gitLabWebhookService;
     BitBucketWebhookService bitBucketWebhookService;
     JobRepository jobRepository;
     StepRepository stepRepository;
     StorageTypeService storageTypeService;
-    StreamingService streamingService;
+    StepOutputReader stepOutputReader;
     ObjectMapper objectMapper;
 
     @Value("${io.terrakube.ui.url:}")
@@ -61,14 +57,14 @@ public class PrCommentService {
 
     public PrCommentService(GitHubWebhookService gitHubWebhookService, GitLabWebhookService gitLabWebhookService,
             BitBucketWebhookService bitBucketWebhookService, JobRepository jobRepository, StepRepository stepRepository,
-            StorageTypeService storageTypeService, StreamingService streamingService, ObjectMapper objectMapper) {
+            StorageTypeService storageTypeService, StepOutputReader stepOutputReader, ObjectMapper objectMapper) {
         this.gitHubWebhookService = gitHubWebhookService;
         this.gitLabWebhookService = gitLabWebhookService;
         this.bitBucketWebhookService = bitBucketWebhookService;
         this.jobRepository = jobRepository;
         this.stepRepository = stepRepository;
         this.storageTypeService = storageTypeService;
-        this.streamingService = streamingService;
+        this.stepOutputReader = stepOutputReader;
         this.objectMapper = objectMapper;
     }
 
@@ -191,7 +187,7 @@ public class PrCommentService {
 
         String lastStepOutput = null;
         for (Step step : stepsNewestFirst) {
-            String output = readStepOutputText(job, step);
+            String output = stepOutputReader.read(job, step);
             if (lastStepOutput == null) {
                 lastStepOutput = output;
             }
@@ -201,30 +197,6 @@ public class PrCommentService {
         }
 
         return lastStepOutput;
-    }
-
-    private String readStepOutputText(Job job, Step step) {
-        try {
-            String stepId = step.getId().toString();
-            String liveLogs = streamingService.getCurrentLogs(stepId, "");
-            if (liveLogs != null && !liveLogs.isEmpty()) {
-                return stripAnsi(liveLogs);
-            }
-
-            byte[] storedOutput = storageTypeService.getStepOutput(
-                    job.getOrganization().getId().toString(), String.valueOf(job.getId()), stepId);
-            if (storedOutput == null || storedOutput.length == 0) {
-                return null;
-            }
-            return stripAnsi(new String(storedOutput, StandardCharsets.UTF_8));
-        } catch (Exception e) {
-            log.error("Error fetching step output for job {}: {}", job.getId(), e.getMessage());
-            return null;
-        }
-    }
-
-    private String stripAnsi(String text) {
-        return ANSI_PATTERN.matcher(text).replaceAll("");
     }
 
     private String matchRunSummary(String output) {

--- a/api/src/main/java/io/terrakube/api/repository/NotificationOutboxRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/NotificationOutboxRepository.java
@@ -88,9 +88,9 @@ public interface NotificationOutboxRepository extends JpaRepository<Notification
     int rearmFailedForRetry(@Param("id") UUID id, @Param("failed") NotificationOutboxStatus failed,
             @Param("pending") NotificationOutboxStatus pending, @Param("now") Date now);
 
-    // Retention sweep: only ever targets rows in a terminal state (SENT/FAILED) older than the
-    // cutoff - a row still PENDING/SENDING is mid-flight regardless of age and must never be
-    // deleted out from under the dispatch pipeline.
+    // Retention sweep: only ever targets rows in a terminal state (SENT/FAILED/SKIPPED) older
+    // than the cutoff - a row still PENDING/SENDING is mid-flight regardless of age and must
+    // never be deleted out from under the dispatch pipeline.
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM notification_outbox o WHERE o.status IN :terminalStatuses AND o.createdDate < :cutoff")
     int deleteTerminalRowsCreatedBefore(@Param("terminalStatuses") List<NotificationOutboxStatus> terminalStatuses,

--- a/api/src/main/java/io/terrakube/api/rs/notification/NotificationOutbox.java
+++ b/api/src/main/java/io/terrakube/api/rs/notification/NotificationOutbox.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.hibernate.annotations.JdbcTypeCode;
 import io.terrakube.api.plugin.security.audit.GenericAuditFields;
 import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -47,6 +48,16 @@ public class NotificationOutbox extends GenericAuditFields {
 
     @Enumerated(EnumType.STRING)
     private NotificationOutboxStatus status = NotificationOutboxStatus.PENDING;
+
+    // The job status this row's payload was rendered for. Re-checked against the job's live
+    // status when the row is claimed for delivery: if the job has since moved to a different
+    // status, this notification described a state that no longer holds (e.g. a transient
+    // "failed" from a lost executor-dispatch response that the executor callback then undid)
+    // and the row is marked SKIPPED instead of sent. Null on rows created before this column
+    // existed - those are always sent, exactly as before.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "job_status")
+    private JobStatus jobStatus;
 
     @Column(name = "attempt_count")
     private int attemptCount = 0;

--- a/api/src/main/java/io/terrakube/api/rs/notification/NotificationOutboxStatus.java
+++ b/api/src/main/java/io/terrakube/api/rs/notification/NotificationOutboxStatus.java
@@ -4,5 +4,10 @@ public enum NotificationOutboxStatus {
     PENDING,
     SENDING,
     SENT,
-    FAILED
+    FAILED,
+    // Terminal, like SENT/FAILED, but nothing was ever delivered: by the time this row was
+    // claimed for dispatch the job had already moved past the status the payload was rendered
+    // for (typically a transient "failed" that a lost executor-dispatch response caused, which
+    // the executor's own status callback then corrected). Sending it would be a false alarm.
+    SKIPPED
 }

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -122,4 +122,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-job-target-replace-addrs.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-provider-trust-signature.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-repo-webhook-delivery.xml" />
+    <include file="/db/changelog/local/changelog-2.33.1-notification-outbox-job-status.xml" />
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.1-notification-outbox-job-status.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.1-notification-outbox-job-status.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <!-- Follow-up to changelog-2.33.0-notification.xml (that file's changesets have shipped and
+         must not be edited). Adds the job status each outbox row's payload was rendered for, so
+         the dispatcher can re-check it against the job's live status at delivery time and drop a
+         row that no longer describes reality - typically a transient "failed" from a lost
+         API->executor dispatch response that the executor's own status callback then corrected.
+         Nullable: rows written before this column exists have null and are always delivered,
+         exactly as before. -->
+    <changeSet id="2-33-1-notification-outbox-job-status" author="jake">
+        <addColumn tableName="notification_outbox">
+            <column name="job_status" type="varchar(20)" />
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/plugin/logs/StepOutputReaderTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/logs/StepOutputReaderTest.java
@@ -1,0 +1,94 @@
+package io.terrakube.api.plugin.logs;
+
+import io.terrakube.api.plugin.storage.StorageTypeService;
+import io.terrakube.api.plugin.streaming.StreamingService;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.step.Step;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StepOutputReaderTest {
+
+    @Mock
+    StorageTypeService storageTypeService;
+    @Mock
+    StreamingService streamingService;
+
+    @InjectMocks
+    StepOutputReader subject;
+
+    private Job job() {
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+        Job job = new Job();
+        job.setId(721);
+        job.setOrganization(organization);
+        return job;
+    }
+
+    private Step step() {
+        Step step = new Step();
+        step.setId(UUID.randomUUID());
+        return step;
+    }
+
+    @Test
+    void prefersLiveLogsAndStripsAnsi() {
+        Job job = job();
+        Step step = step();
+        when(streamingService.getCurrentLogs(step.getId().toString(), ""))
+                .thenReturn("[31mError: quota exceeded[0m");
+
+        assertThat(subject.read(job, step)).isEqualTo("Error: quota exceeded");
+        verify(storageTypeService, never()).getStepOutput(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void fallsBackToStoredOutputWhenLiveLogsAreEmpty() {
+        Job job = job();
+        Step step = step();
+        when(streamingService.getCurrentLogs(anyString(), anyString())).thenReturn("");
+        when(storageTypeService.getStepOutput(job.getOrganization().getId().toString(), "721",
+                step.getId().toString())).thenReturn("stored output".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(subject.read(job, step)).isEqualTo("stored output");
+    }
+
+    @Test
+    void returnsNullWhenNeitherSourceHasContent() {
+        Job job = job();
+        Step step = step();
+        when(streamingService.getCurrentLogs(anyString(), anyString())).thenReturn(null);
+        when(storageTypeService.getStepOutput(anyString(), anyString(), anyString())).thenReturn(new byte[0]);
+
+        assertThat(subject.read(job, step)).isNull();
+    }
+
+    @Test
+    void returnsNullInsteadOfPropagatingAnException() {
+        Job job = job();
+        Step step = step();
+        when(streamingService.getCurrentLogs(anyString(), anyString())).thenThrow(new RuntimeException("boom"));
+
+        assertThat(subject.read(job, step)).isNull();
+    }
+
+    @Test
+    void stripAnsiToleratesNull() {
+        assertThat(subject.stripAnsi(null)).isNull();
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/JobFailureSummaryServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/JobFailureSummaryServiceTest.java
@@ -1,0 +1,118 @@
+package io.terrakube.api.plugin.notification;
+
+import io.terrakube.api.plugin.logs.StepOutputReader;
+import io.terrakube.api.repository.StepRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.step.Step;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JobFailureSummaryServiceTest {
+
+    @Mock
+    StepRepository stepRepository;
+    @Mock
+    StepOutputReader stepOutputReader;
+
+    @InjectMocks
+    JobFailureSummaryService subject;
+
+    private Job job() {
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+        Job job = new Job();
+        job.setId(721);
+        job.setStatus(JobStatus.failed);
+        job.setOrganization(organization);
+        return job;
+    }
+
+    private Step step(int number, JobStatus status) {
+        Step step = new Step();
+        step.setId(UUID.randomUUID());
+        step.setStepNumber(number);
+        step.setStatus(status);
+        return step;
+    }
+
+    @Test
+    void readsTheFailedStepsOutputAndTrimsTheTail() {
+        Job job = job();
+        Step planStep = step(100, JobStatus.completed);
+        Step applyStep = step(200, JobStatus.failed);
+        when(stepRepository.findByJobId(721)).thenReturn(List.of(planStep, applyStep));
+        String longOutput = "x".repeat(900) + "\nError: creating instance: quota exceeded\n";
+        when(stepOutputReader.read(job, applyStep)).thenReturn(longOutput);
+
+        String reason = subject.describeFailure(job);
+
+        assertThat(reason).endsWith("Error: creating instance: quota exceeded");
+        assertThat(reason.length()).isLessThanOrEqualTo(500);
+    }
+
+    @Test
+    void picksTheFailedStepNotTheHighestNumbered() {
+        Job job = job();
+        Step failed = step(100, JobStatus.failed);
+        Step laterCancelled = step(200, JobStatus.cancelled);
+        when(stepRepository.findByJobId(721)).thenReturn(List.of(failed, laterCancelled));
+        when(stepOutputReader.read(any(), any())).thenReturn("boom");
+
+        subject.describeFailure(job);
+
+        ArgumentCaptor<Step> captor = ArgumentCaptor.forClass(Step.class);
+        verify(stepOutputReader).read(eq(job), captor.capture());
+        assertThat(captor.getValue()).isSameAs(failed);
+    }
+
+    @Test
+    void fallsBackToTheLastStepWhenNoStepIsMarkedFailed() {
+        Job job = job();
+        Step first = step(100, JobStatus.completed);
+        Step last = step(200, JobStatus.running);
+        when(stepRepository.findByJobId(721)).thenReturn(List.of(first, last));
+        when(stepOutputReader.read(job, last)).thenReturn("dispatch error");
+
+        assertThat(subject.describeFailure(job)).isEqualTo("dispatch error");
+    }
+
+    @Test
+    void returnsNullWhenThereAreNoSteps() {
+        when(stepRepository.findByJobId(721)).thenReturn(List.of());
+
+        assertThat(subject.describeFailure(job())).isNull();
+    }
+
+    @Test
+    void returnsNullWhenTheStepHasNoOutput() {
+        Job job = job();
+        Step applyStep = step(200, JobStatus.failed);
+        when(stepRepository.findByJobId(721)).thenReturn(List.of(applyStep));
+        when(stepOutputReader.read(job, applyStep)).thenReturn("   ");
+
+        assertThat(subject.describeFailure(job)).isNull();
+    }
+
+    @Test
+    void neverThrows() {
+        when(stepRepository.findByJobId(721)).thenThrow(new RuntimeException("db down"));
+
+        assertThat(subject.describeFailure(job())).isNull();
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/JobNotificationTriggerTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/JobNotificationTriggerTest.java
@@ -12,7 +12,9 @@ import io.terrakube.api.rs.notification.NotificationTrigger;
 import io.terrakube.api.rs.template.Template;
 import io.terrakube.api.rs.workspace.Workspace;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -39,9 +41,16 @@ class JobNotificationTriggerTest {
     NotificationOutboxRepository notificationOutboxRepository;
     @Mock
     NotificationDispatchService notificationDispatchService;
+    @Mock
+    JobFailureSummaryService jobFailureSummaryService;
 
     @InjectMocks
     JobNotificationTrigger subject;
+
+    @BeforeEach
+    void setGraceWindow() {
+        ReflectionTestUtils.setField(subject, "recoverableStatusGraceSeconds", 90L);
+    }
 
     @AfterEach
     void clearTransactionSynchronization() {
@@ -78,9 +87,9 @@ class JobNotificationTriggerTest {
 
     @Test
     void enqueue_matchingConfigInsertsExactlyOneOutboxRow() {
-        Job job = jobWithStatus(JobStatus.failed);
-        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
-        NotificationConfiguration nonMatching = configWithTrigger(NotificationChannelType.WEBHOOK, JobStatus.completed);
+        Job job = jobWithStatus(JobStatus.completed);
+        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.completed);
+        NotificationConfiguration nonMatching = configWithTrigger(NotificationChannelType.WEBHOOK, JobStatus.failed);
         when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(matching, nonMatching));
         when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");
 
@@ -90,7 +99,29 @@ class JobNotificationTriggerTest {
         verify(notificationOutboxRepository, times(1)).save(captor.capture());
         assertThat(captor.getValue().getConfiguration()).isEqualTo(matching);
         assertThat(captor.getValue().getJob()).isEqualTo(job);
+        assertThat(captor.getValue().getJobStatus()).isEqualTo(JobStatus.completed);
+        assertThat(captor.getValue().getNextAttemptAt()).isNull();
         assertThat(ids).containsExactly(captor.getValue().getId());
+    }
+
+    @Test
+    void enqueue_recoverableStatusRowIsInsertedButDeferredNotDispatchedImmediately() {
+        // A job briefly flips to "failed" when the API->executor dispatch call throws even
+        // though the executor is running it; the row is held back (nextAttemptAt in the future,
+        // id withheld from the result) so the poller can re-validate it against the job's live
+        // status before delivering - see JobNotificationTrigger.RECOVERABLE_STATUSES.
+        Job job = jobWithStatus(JobStatus.failed);
+        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(matching));
+        when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");
+
+        List<UUID> ids = subject.enqueue(job);
+
+        ArgumentCaptor<NotificationOutbox> captor = ArgumentCaptor.forClass(NotificationOutbox.class);
+        verify(notificationOutboxRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getJobStatus()).isEqualTo(JobStatus.failed);
+        assertThat(captor.getValue().getNextAttemptAt()).isAfter(new java.util.Date());
+        assertThat(ids).isEmpty();
     }
 
     @Test
@@ -129,8 +160,8 @@ class JobNotificationTriggerTest {
 
     @Test
     void notifyStatusChanged_dispatchesEveryEnqueuedOutboxRowImmediately() {
-        Job job = jobWithStatus(JobStatus.failed);
-        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        Job job = jobWithStatus(JobStatus.completed);
+        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.completed);
         when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(matching));
         when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");
 
@@ -143,8 +174,8 @@ class JobNotificationTriggerTest {
 
     @Test
     void notifyStatusChanged_defersDispatchUntilAfterCommitWhenATransactionIsActive() {
-        Job job = jobWithStatus(JobStatus.failed);
-        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        Job job = jobWithStatus(JobStatus.completed);
+        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.completed);
         when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(matching));
         when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");
 
@@ -178,10 +209,10 @@ class JobNotificationTriggerTest {
 
     @Test
     void enqueue_configScopedToTheJobsTemplateMatches() {
-        Job job = jobWithStatus(JobStatus.failed);
+        Job job = jobWithStatus(JobStatus.completed);
         UUID templateId = UUID.randomUUID();
         job.setTemplateReference(templateId.toString());
-        NotificationConfiguration configuration = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        NotificationConfiguration configuration = configWithTrigger(NotificationChannelType.SLACK, JobStatus.completed);
         Template matchingTemplate = new Template();
         matchingTemplate.setId(templateId);
         configuration.setTemplates(List.of(matchingTemplate));
@@ -196,9 +227,9 @@ class JobNotificationTriggerTest {
 
     @Test
     void enqueue_configWithNoTemplatesSelectedMatchesEveryTemplate() {
-        Job job = jobWithStatus(JobStatus.failed);
+        Job job = jobWithStatus(JobStatus.completed);
         job.setTemplateReference(UUID.randomUUID().toString());
-        NotificationConfiguration configuration = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        NotificationConfiguration configuration = configWithTrigger(NotificationChannelType.SLACK, JobStatus.completed);
         // templates left null/unset - see NotificationConfiguration.templates javadoc.
         when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(configuration));
         when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");

--- a/api/src/test/java/io/terrakube/api/plugin/notification/NotificationOutboxTransactionsTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/NotificationOutboxTransactionsTest.java
@@ -59,6 +59,50 @@ class NotificationOutboxTransactionsTest {
     }
 
     @Test
+    void claimSkipsTheRowWhenTheJobHasMovedPastTheRenderedStatus() {
+        UUID id = UUID.randomUUID();
+        Date lastAttemptAt = new Date();
+        io.terrakube.api.rs.job.Job job = new io.terrakube.api.rs.job.Job();
+        job.setId(721);
+        job.setStatus(io.terrakube.api.rs.job.JobStatus.completed);
+        NotificationOutbox row = new NotificationOutbox();
+        row.setId(id);
+        row.setPayload("{}");
+        row.setLastAttemptAt(lastAttemptAt);
+        row.setJob(job);
+        row.setJobStatus(io.terrakube.api.rs.job.JobStatus.failed);
+        when(notificationOutboxRepository.claimForDelivery(eq(id), eq(NotificationOutboxStatus.PENDING),
+                eq(NotificationOutboxStatus.SENDING), any())).thenReturn(1);
+        when(notificationOutboxRepository.findById(id)).thenReturn(Optional.of(row));
+
+        assertThat(subject.claim(id)).isNull();
+
+        verify(notificationOutboxRepository).recordDeliveryResult(eq(id), eq(NotificationOutboxStatus.SENDING),
+                eq(lastAttemptAt), eq(NotificationOutboxStatus.SKIPPED), any(), isNull(), any());
+    }
+
+    @Test
+    void claimDeliversTheRowWhenTheJobStillMatchesTheRenderedStatus() {
+        UUID id = UUID.randomUUID();
+        io.terrakube.api.rs.job.Job job = new io.terrakube.api.rs.job.Job();
+        job.setId(721);
+        job.setStatus(io.terrakube.api.rs.job.JobStatus.failed);
+        NotificationOutbox row = new NotificationOutbox();
+        row.setId(id);
+        row.setPayload("{}");
+        row.setLastAttemptAt(new Date());
+        row.setJob(job);
+        row.setJobStatus(io.terrakube.api.rs.job.JobStatus.failed);
+        when(notificationOutboxRepository.claimForDelivery(eq(id), eq(NotificationOutboxStatus.PENDING),
+                eq(NotificationOutboxStatus.SENDING), any())).thenReturn(1);
+        when(notificationOutboxRepository.findById(id)).thenReturn(Optional.of(row));
+
+        assertThat(subject.claim(id)).isNotNull();
+        verify(notificationOutboxRepository, never()).recordDeliveryResult(any(), any(), any(),
+                eq(NotificationOutboxStatus.SKIPPED), any(), any(), any());
+    }
+
+    @Test
     void recordResultDelegatesToTheConditionalUpdate() {
         UUID id = UUID.randomUUID();
         Date lastAttemptAt = new Date();
@@ -89,13 +133,15 @@ class NotificationOutboxTransactionsTest {
     void pruneTerminalRowsOlderThanDelegatesToTheDeleteQuery() {
         Date cutoff = new Date();
         when(notificationOutboxRepository.deleteTerminalRowsCreatedBefore(
-                eq(java.util.List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED)), eq(cutoff)))
+                eq(java.util.List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED,
+                        NotificationOutboxStatus.SKIPPED)), eq(cutoff)))
                 .thenReturn(5);
 
         int deleted = subject.pruneTerminalRowsOlderThan(cutoff);
 
         assertThat(deleted).isEqualTo(5);
         verify(notificationOutboxRepository).deleteTerminalRowsCreatedBefore(
-                eq(java.util.List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED)), eq(cutoff));
+                eq(java.util.List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED,
+                        NotificationOutboxStatus.SKIPPED)), eq(cutoff));
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorServiceTest.java
@@ -169,6 +169,38 @@ public class PersistentExecutorServiceTest {
     }
 
     @Test
+    public void badGatewayResponseBecomesExecutorUnavailableException() {
+        // A proxy/ingress between the API and the executor dropped the upstream connection -
+        // possibly after the executor already accepted the job. Retryable, not a job failure.
+        WebClientResponseException badGateway = WebClientResponseException.create(
+                502, "Bad Gateway", HttpHeaders.EMPTY, new byte[0], null);
+        doReturn(Mono.error(badGateway)).when(responseSpec).toEntity(ExecutorContext.class);
+
+        assertThrows(ExecutorUnavailableException.class, () -> subject().send(jobOnDefaultExecutor(), context()));
+    }
+
+    @Test
+    public void gatewayTimeoutResponseBecomesExecutorUnavailableException() {
+        WebClientResponseException gatewayTimeout = WebClientResponseException.create(
+                504, "Gateway Timeout", HttpHeaders.EMPTY, new byte[0], null);
+        doReturn(Mono.error(gatewayTimeout)).when(responseSpec).toEntity(ExecutorContext.class);
+
+        assertThrows(ExecutorUnavailableException.class, () -> subject().send(jobOnDefaultExecutor(), context()));
+    }
+
+    @Test
+    public void otherHttpErrorResponseStaysAHardExecutionException() {
+        WebClientResponseException serverError = WebClientResponseException.create(
+                500, "Internal Server Error", HttpHeaders.EMPTY, new byte[0], null);
+        doReturn(Mono.error(serverError)).when(responseSpec).toEntity(ExecutorContext.class);
+
+        ExecutionException thrown = assertThrows(ExecutionException.class,
+                () -> subject().send(jobOnDefaultExecutor(), context()));
+        // not the retryable subclass
+        org.junit.jupiter.api.Assertions.assertFalse(thrown instanceof ExecutorUnavailableException);
+    }
+
+    @Test
     public void postsToConfiguredExecutor() throws ExecutionException, URISyntaxException {
         Globalvar executorUrl = new Globalvar();
         executorUrl.setValue("http://ze-executor/");

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.terrakube.api.plugin.logs.StepOutputReader;
 import io.terrakube.api.plugin.storage.StorageTypeService;
 import io.terrakube.api.plugin.streaming.StreamingService;
 import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
@@ -55,6 +56,7 @@ public class PrCommentServiceTest {
     StepRepository stepRepository;
     StorageTypeService storageTypeService;
     StreamingService streamingService;
+    StepOutputReader stepOutputReader;
     ObjectMapper objectMapper;
 
     PrCommentService subject;
@@ -68,6 +70,10 @@ public class PrCommentServiceTest {
         stepRepository = mock(StepRepository.class);
         storageTypeService = mock(StorageTypeService.class);
         streamingService = mock(StreamingService.class);
+        // Real reader over the mocked storage/streaming beans, so the existing getCurrentLogs /
+        // getStepOutput stubs below keep exercising the same read-then-fallback behaviour that
+        // now lives in StepOutputReader.
+        stepOutputReader = new StepOutputReader(storageTypeService, streamingService);
         objectMapper = new ObjectMapper();
 
         subject = new PrCommentService(
@@ -77,7 +83,7 @@ public class PrCommentServiceTest {
                 jobRepository,
                 stepRepository,
                 storageTypeService,
-                streamingService,
+                stepOutputReader,
                 objectMapper);
     }
 

--- a/executor/src/main/java/io/terrakube/executor/service/status/UpdateJobStatusImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/status/UpdateJobStatusImpl.java
@@ -115,9 +115,11 @@ public class UpdateJobStatusImpl implements UpdateJobStatus {
         log.info("output: {}", jobOutput.length());
         log.info("outputError: {}", jobErrorOutput.length());
 
-        job.getAttributes().setOutput(
-                job.getAttributes().getOutput() == null ? "" : job.getAttributes().getOutput() + " Step " + stepId + " completed\n"
-        );
+        // Append-only per-step marker. The null check guards the first step (no prior output),
+        // it must not also swallow the marker itself - the parenthesised ternary is the base
+        // string, the marker is always appended.
+        String existingOutput = job.getAttributes().getOutput() == null ? "" : job.getAttributes().getOutput();
+        job.getAttributes().setOutput(existingOutput + " Step " + stepId + " completed\n");
         job.getAttributes().setTerraformPlan(jobPlan);
         job.getAttributes().setCommitId(commitId);
 

--- a/executor/src/test/java/io/terrakube/executor/service/executor/AdmissionControlIntegrationTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/executor/AdmissionControlIntegrationTest.java
@@ -101,13 +101,19 @@ class AdmissionControlIntegrationTest {
         ResponseEntity<TerraformJob> secondResponse = controller.terraformJob(secondJob);
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE, secondResponse.getStatusCode());
 
-        // Let the first job finish, which releases the gate.
+        // Let the first job finish. ExecutorJobImpl releases the gate in its finally block
+        // *before* publishReadiness/publishExecutorAvailable and before the pool Runnable
+        // returns - so waiting only for the gate to free up races the pool thread still being
+        // busy, and the third submit below would then hit the queue-capacity-0 pool and be
+        // rejected (503) even though capacity is logically available. Wait for the pool thread
+        // to actually go idle instead.
         releaseFirstJob.countDown();
         long deadline = System.currentTimeMillis() + 5000;
-        while (gate.tryAcquire() == false && System.currentTimeMillis() < deadline) {
+        while (pool.getThreadPoolExecutor().getActiveCount() > 0 && System.currentTimeMillis() < deadline) {
             Thread.sleep(20);
         }
-        gate.release();
+        assertEquals(0, pool.getThreadPoolExecutor().getActiveCount(),
+                "first job's pool task did not finish within the timeout");
 
         // Third request after completion: pod accepts again.
         TerraformJob thirdJob = new TerraformJob();


### PR DESCRIPTION
## Summary

Fixes #3496. Target release: **`2.33.1`** (bug fix for the notification system shipped in `2.33.0`, #3401).

A notification set to trigger on **Failed** + **Completed** was sending "Failed" alerts mid-run even when the run completed fine — a successful run produced two "❌ Failed" messages plus the final "✅ Completed", one with a nonsensical `Failure reason: Step <uuid> completed`.

## Root cause

A transient API→executor dispatch error (proxy `502`/`503`/`504`, or a lost `202` after the executor already accepted the job) makes `ScheduleJob.errorJobAtStep()` flip the job to `failed` and notify. The executor is still running it, its next callback overwrites `failed`, and the run finishes — but the alert already went out. `JobNotificationTrigger` never checked whether the status was a real terminal transition, and the "Failure reason" was just the tail of `job.output` (which only holds `Step <id> completed` markers).

## Changes

- **`PersistentExecutorService`** — gateway `502`/`504` now retry (like `503`) instead of hard-failing the job.
- **`NotificationOutbox.job_status`** (new nullable column) records the status each payload was rendered for.
- **`JobNotificationTrigger`** — a `failed` notification is held for a grace window (`io.terrakube.notification.recoverableStatusGraceSeconds`, default `90`); only the poller delivers it.
- **`NotificationOutboxTransactions.claim()`** — at delivery, if the job's live status no longer matches the rendered status, the row is marked `SKIPPED` (new terminal status) and nothing is sent.
- **`JobFailureSummaryService`** + extracted shared **`StepOutputReader`** — failure reason now comes from the failing step's console output, not `job.output`.
- Drive-by: fix an inverted null-check in the executor's `UpdateJobStatusImpl`; fix a pre-existing flake in `AdmissionControlIntegrationTest`.

## Behaviour changes (for 2.33.1 notes)

- Failure notifications are delayed ~90s (configurable) so transient flips don't alert.
- Delivery history shows a new `SKIPPED` status for suppressed false alarms.
- "Failure reason" is now the failing step's console tail.

## Migration

`changelog-2.33.1-notification-outbox-job-status.xml` — one additive nullable `varchar(20)` column, no backfill, no lock. Pre-existing rows have `null` and deliver unconditionally. `changelog-2.33.0-notification.xml` untouched.

## Rollback

`recoverableStatusGraceSeconds=0` removes the delay (revalidation still applies). The other guards only ever *suppress* a notification for a state the job has already left.

---

## Verification

`mvn test` for the affected suites is green — notification, PR-comment, executor-dispatch and executor-status packages, plus the full unchanged `PrCommentServiceTest` and `AdmissionControlIntegrationTest` (run 5×).

New tests:

- `StepOutputReaderTest` (5)
- `JobFailureSummaryServiceTest` (6)
- `NotificationOutboxTransactionsTest` — superseded-row skip + delivery-when-still-matching
- `JobNotificationTriggerTest` — recoverable-status deferral, `jobStatus` recorded
- `PersistentExecutorServiceTest` — `502`/`504` retryable, other 5xx still hard-fail