### PR TITLE
fix(vcs): match webhook headers case-insensitively

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookDispatchService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookDispatchService.java
@@ -84,8 +84,11 @@ public class RepoWebhookDispatchService {
     }
 
     private Map<String, String> deserializeHeaders(String headersJson) throws Exception {
-        return objectMapper.readValue(headersJson, new TypeReference<Map<String, String>>() {
-        });
+        // Stored as plain JSON, so it rehydrates into a case-sensitive map - re-wrap it so the
+        // provider services' lowercase header lookups keep working (see WebhookHeaders).
+        return WebhookHeaders.caseInsensitive(
+                objectMapper.readValue(headersJson, new TypeReference<Map<String, String>>() {
+                }));
     }
 
     private long backoffMillis(int attemptCount) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
@@ -177,6 +177,8 @@ public class RepoWebhookService {
     // deliveryId and calls dispatchAsync, the enqueue is already committed and visible.
     @Transactional
     public UUID acceptV2Webhook(String repoWebhookId, String jsonPayload, Map<String, String> headers) {
+        // HTTP header names are case-insensitive; downstream verification looks them up in lowercase.
+        headers = WebhookHeaders.caseInsensitive(headers);
         RepoWebhook repoWebhook = repoWebhookRepository.findById(UUID.fromString(repoWebhookId))
                 .orElseThrow(() -> new IllegalArgumentException("Repo webhook not found: " + repoWebhookId));
 
@@ -207,6 +209,7 @@ public class RepoWebhookService {
     }
 
     public void processClaimedDelivery(RepoWebhook repoWebhook, String jsonPayload, Map<String, String> headers) {
+        headers = WebhookHeaders.caseInsensitive(headers);
         boolean azureDevOps = isAzureDevOps(repoWebhook);
         boolean gitlab = isGitLab(repoWebhook);
 

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookHeaders.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookHeaders.java
@@ -1,0 +1,41 @@
+package io.terrakube.api.plugin.vcs;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.springframework.util.LinkedCaseInsensitiveMap;
+
+/**
+ * HTTP header names are case-insensitive (RFC 9110 section 5.1), but the rest of the webhook
+ * pipeline looks headers up with hard-coded lowercase keys ({@code headers.get("x-hub-signature-256")}
+ * and friends). That only worked as long as something upstream happened to hand us lowercase keys -
+ * older Spring MVC / servlet container versions did, but Spring Framework 7 (Spring Boot 4) now
+ * resolves {@code @RequestHeader Map<String, String>} preserving the exact casing the client sent,
+ * so GitHub's {@code X-Hub-Signature-256} stopped matching and every signed webhook failed
+ * verification.
+ *
+ * <p>Rather than chase every {@code .get(...)} call site (and every future one), normalize the map
+ * once at each point headers enter the pipeline - the public entry methods of {@link WebhookService}
+ * and {@link RepoWebhookService}, and the JSON rehydration of a stored delivery in
+ * {@link RepoWebhookDispatchService} - into a case-insensitive view. Callers keep using lowercase
+ * keys and it just works regardless of what casing the client or the framework used.
+ */
+public final class WebhookHeaders {
+
+    private WebhookHeaders() {
+    }
+
+    /**
+     * Wraps {@code headers} in a case-insensitive map so lookups by any casing succeed. Returns an
+     * empty (but still case-insensitive) map for {@code null} input. The returned map preserves
+     * insertion order and the original key casing on iteration/serialization; only lookups are
+     * case-insensitive.
+     */
+    public static Map<String, String> caseInsensitive(Map<String, String> headers) {
+        LinkedCaseInsensitiveMap<String> result = new LinkedCaseInsensitiveMap<>(Locale.ROOT);
+        if (headers != null) {
+            result.putAll(headers);
+        }
+        return result;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
@@ -48,6 +48,8 @@ public class WebhookService {
 
     @Transactional
     public String processWebhook(String webhookId, String jsonPayload, Map<String, String> headers) {
+        // HTTP header names are case-insensitive; provider services look them up in lowercase.
+        headers = WebhookHeaders.caseInsensitive(headers);
         String result = "";
         Webhook webhook = webhookRepository.getReferenceById(UUID.fromString(webhookId));
         if (webhook == null) {

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
@@ -459,6 +459,28 @@ class RepoWebhookServiceTest {
             verify(repoWebhookDeliveryTransactions).enqueue(eq(rw), eq(payload), headersJsonCaptor.capture());
             assertThat(headersJsonCaptor.getValue()).contains("x-github-event").contains("push");
         }
+
+        @Test
+        void acceptsSignatureWhenHeaderNamesUseOriginalCasing() throws Exception {
+            // GitHub sends "X-Hub-Signature-256"; header names are case-insensitive (RFC 9110) and
+            // Spring 7 / Spring Boot 4 no longer lowercases them for @RequestHeader Map. The service
+            // must still verify the signature regardless of the casing it receives.
+            String secret = "test-secret";
+            String payload = "{\"ref\":\"refs/heads/main\"}";
+            RepoWebhook rw = repoWebhookWith("https://github.com/owner/repo", secret);
+            when(repoWebhookRepository.findById(rw.getId())).thenReturn(Optional.of(rw));
+            UUID deliveryId = UUID.randomUUID();
+            when(repoWebhookDeliveryTransactions.enqueue(eq(rw), eq(payload), any())).thenReturn(deliveryId);
+
+            String sig = computeHmac(secret, payload);
+            Map<String, String> headers = Map.of(
+                    "X-Hub-Signature-256", sig,
+                    "X-GitHub-Event", "push");
+
+            UUID result = subject.acceptV2Webhook(rw.getId().toString(), payload, headers);
+
+            assertThat(result).isEqualTo(deliveryId);
+        }
     }
 
     @Nested


### PR DESCRIPTION
Fixes #3498

**should be marked for 3.33.1 bugfix**

VCS webhook signature/token verification broke for **every provider** after the Spring Boot 4.1.1 upgrade (#3470). All signed GitHub / GitLab / Azure DevOps / Bitbucket webhooks were rejected with:

```
ERROR i.t.api.plugin.vcs.RepoWebhookService : x-hub-signature-256 header is missing!
ERROR i.t.api.plugin.vcs.RepoWebhookService : Signature verification failed for repo webhook <id>
WARN  i.t.a.p.v.controller.WebHookController : V2 webhook request rejected
```

## Why

`WebHookController` reads request headers via `@RequestHeader Map<String, String> headers`. Spring Framework 7 (bundled with Spring Boot 4.x) reworked `HttpHeaders` — it no longer extends `MultiValueMap`, and `@RequestHeader Map<String, String>` now populates the map with the **original header casing sent by the client** instead of lowercasing the keys.

The webhook pipeline looks headers up with hard-coded lowercase keys (`x-hub-signature-256`, `x-github-event`, `x-gitlab-token`, `x-terrakube-token`, `x-event-key`, …). GitHub sends `X-Hub-Signature-256`, the lookup misses, and verification fails. HTTP header names are case-insensitive per RFC 9110 §5.1, so depending on a particular case was always fragile — it just happened to work on older Spring.

## How

Normalize the header map into a case-insensitive view (Spring's `LinkedCaseInsensitiveMap`) once at each point headers enter the webhook pipeline, rather than touching every `.get()` call site:

| Entry point | Path |
|---|---|
| `WebhookService.processWebhook` | v1 (`/webhook/v1/**`) |
| `RepoWebhookService.acceptV2Webhook` / `processClaimedDelivery` | v2 (`/webhook/v2/**`) |
| `RepoWebhookDispatchService.deserializeHeaders` | v2 retry/poller — headers are JSON-persisted per delivery and rehydrate case-sensitive |

New helper `WebhookHeaders.caseInsensitive(Map)` encapsulates the wrapping and documents the regression. Callers keep using lowercase keys; iteration/serialization still preserves the original casing, so persisted delivery rows are unchanged.

Providers covered — both webhook versions:

| Provider | Header(s) | v1 | v2 |
|---|---|:-:|:-:|
| GitHub | `x-hub-signature-256`, `x-github-event` | ✅ | ✅ |
| GitLab | `x-gitlab-token`, `x-gitlab-event` | ✅ | ✅ |
| Azure DevOps | `x-terrakube-token` | ✅ | ✅ |
| Bitbucket | `x-event-key` | ✅ | — (no v2 path) |

`HttpServletRequest.getHeader(...)` usages elsewhere (e.g. Dex auth) are unaffected — that API is case-insensitive by the Servlet spec; only the `@RequestHeader Map` form regressed.

## Testing

- New `RepoWebhookServiceTest.acceptsSignatureWhenHeaderNamesUseOriginalCasing` — sends `X-Hub-Signature-256` / `X-GitHub-Event` (the real GitHub casing) through `acceptV2Webhook` and asserts the delivery is accepted.
- `mvn test` green for `RepoWebhookServiceTest`, `WebhookServiceTest`, `RepoWebhookDispatchServiceTest`, `RepoWebhookAcceptV2WebhookIntegrationTest`, `GitHubWebhookServiceTest`.
