### PR TITLE
feat: configure Elide to maintain second-level precision for ISO-8601 date serialization and parsing

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/elide/ElideSerdeConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/elide/ElideSerdeConfiguration.java
@@ -1,0 +1,130 @@
+package io.terrakube.api.plugin.elide;
+
+import com.yahoo.elide.SerdesBuilderCustomizer;
+import com.yahoo.elide.core.utils.coerce.converters.Serde;
+import org.apache.commons.lang3.time.FastDateFormat;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.function.Function;
+
+@Configuration
+public class ElideSerdeConfiguration {
+
+    private static final FastDateFormat OUTPUT_FORMAT =
+            FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ssXXX", TimeZone.getTimeZone(ZoneOffset.UTC));
+
+    private static final DateTimeFormatter FALLBACK_PARSER = new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .appendLiteral('T')
+            .appendValue(ChronoField.HOUR_OF_DAY, 2)
+            .appendLiteral(':')
+            .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
+            .optionalStart()
+            .appendLiteral(':')
+            .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+            .optionalEnd()
+            .optionalStart()
+            .appendOffsetId()
+            .optionalEnd()
+            .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+            .parseDefaulting(ChronoField.OFFSET_SECONDS, 0)
+            .toFormatter(Locale.ROOT);
+
+    /**
+     * Elide's default date serde uses minute precision (yyyy-MM-dd'T'HH:mm'Z'), which
+     * truncates the seconds of fields like createdDate and lastJobDate in GraphQL
+     * and JSON:API responses. The UI then computes relative times from the top of the minute and
+     * shows things like "42 seconds ago" for a job that was just triggered (issue #2787).
+     *
+     * This customizer registers second-precision serialization while maintaining robust, flexible
+     * ISO-8601 deserialization (accepting milliseconds, timezone offsets, minute fallback, and epoch timestamps).
+     */
+    @Bean
+    public SerdesBuilderCustomizer secondPrecisionDateSerdes() {
+        return builder -> {
+            builder.entry(Date.class, createDateSerde(Date.class, Function.identity()));
+            builder.entry(java.sql.Date.class, createDateSerde(java.sql.Date.class, d -> new java.sql.Date(d.getTime())));
+            builder.entry(java.sql.Timestamp.class, createDateSerde(java.sql.Timestamp.class, d -> new java.sql.Timestamp(d.getTime())));
+            builder.entry(java.sql.Time.class, createDateSerde(java.sql.Time.class, d -> new java.sql.Time(d.getTime())));
+        };
+    }
+
+    private static <T extends Date> Serde<Object, T> createDateSerde(Class<T> targetClass, Function<Date, T> converter) {
+        return new Serde<>() {
+            @Override
+            public T deserialize(Object val) {
+                Date date = parseDate(val);
+                if (date == null) {
+                    return null;
+                }
+                if (targetClass.isInstance(date)) {
+                    return targetClass.cast(date);
+                }
+                return converter.apply(date);
+            }
+
+            @Override
+            public Object serialize(T val) {
+                if (val == null) {
+                    return null;
+                }
+                return OUTPUT_FORMAT.format(val);
+            }
+        };
+    }
+
+    private static Date parseDate(Object val) {
+        if (val == null) {
+            return null;
+        }
+        if (val instanceof Date date) {
+            return date;
+        }
+        if (val instanceof Number number) {
+            return new Date(number.longValue());
+        }
+        String str = val.toString().trim();
+        if (str.isEmpty()) {
+            return null;
+        }
+
+        // 1. Try standard ISO_DATE_TIME parsing (supports Z, offsets, milliseconds)
+        try {
+            TemporalAccessor accessor = DateTimeFormatter.ISO_DATE_TIME.parse(str);
+            if (accessor.isSupported(ChronoField.INSTANT_SECONDS)) {
+                return Date.from(Instant.from(accessor));
+            } else if (accessor.isSupported(ChronoField.OFFSET_SECONDS)) {
+                return Date.from(OffsetDateTime.from(accessor).toInstant());
+            } else {
+                return Date.from(LocalDateTime.from(accessor).atZone(ZoneOffset.UTC).toInstant());
+            }
+        } catch (DateTimeParseException e) {
+            // 2. Try minute precision fallback (e.g. 2026-01-15T10:20Z)
+            try {
+                TemporalAccessor fallbackAccessor = FALLBACK_PARSER.parse(str);
+                return Date.from(Instant.from(fallbackAccessor));
+            } catch (Exception ignored) {
+            }
+
+            // 3. Try epoch timestamp as numeric string
+            try {
+                return new Date(Long.parseLong(str));
+            } catch (NumberFormatException nfe) {
+                throw new IllegalArgumentException("Cannot parse date: '" + str + "'", e);
+            }
+        }
+    }
+}

--- a/api/src/test/java/io/terrakube/api/JobTests.java
+++ b/api/src/test/java/io/terrakube/api/JobTests.java
@@ -19,10 +19,12 @@ import io.terrakube.api.rs.workspace.Workspace;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.matchesPattern;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -169,6 +171,49 @@ class JobTests extends ServerApplicationTests {
                 .extract()
                 .path("data.id");
    }
+
+    // Dates must keep (at least) second precision so the UI can compute accurate relative
+    // times; minute-truncated timestamps made it show "42 seconds ago" for jobs that were
+    // just triggered (issue #2787).
+    @Test
+    void jsonApiDatesKeepSecondPrecision() {
+        devsManageJobs(true);
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body(jobDefinition("2db36f7c-f549-4341-a789-315d47eb061d"))
+                .when()
+                .post("/api/v1/organization/d9b58bd3-f3fc-4056-a026-1163297e80a8/job/")
+                .then()
+                .assertThat()
+                .body("data.attributes.createdDate", matchesPattern("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z"))
+                .body("data.attributes.updatedDate", matchesPattern("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?Z"))
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    // GraphQL dates go through Elide's ISO8601 date serde, whose default pattern truncates to
+    // minute precision (yyyy-MM-dd'T'HH:mm'Z'). The workspace list in the UI reads lastJobDate
+    // through this exact query path, so "Last run X ago" was computed from the top of the
+    // minute (issue #2787). ElideSerdeConfiguration overrides the pattern to keep seconds.
+    @Test
+    void graphQlDatesKeepSecondPrecision() {
+        workspace.setLastJobDate(Date.from(Instant.parse("2026-01-15T10:20:42Z")));
+        workspace = workspaceRepository.save(workspace);
+
+        String query = "{ \"query\": \"{ organization(ids: [\\\"d9b58bd3-f3fc-4056-a026-1163297e80a8\\\"]) { edges { node { "
+                + "workspace(ids: [\\\"" + workspace.getId() + "\\\"]) { edges { node { lastJobDate } } } } } } }\" }";
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/json")
+                .body(query)
+                .when()
+                .post("/graphql/api/v1")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.OK.value())
+                .body("data.organization.edges[0].node.workspace.edges[0].node.lastJobDate",
+                        IsEqual.equalTo("2026-01-15T10:20:42Z"));
+    }
 
     @Test
     void createJobLockedWorkspace() {

--- a/api/src/test/java/io/terrakube/api/plugin/elide/ElideSerdeConfigurationTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/elide/ElideSerdeConfigurationTest.java
@@ -1,0 +1,147 @@
+package io.terrakube.api.plugin.elide;
+
+import com.yahoo.elide.Serdes;
+import com.yahoo.elide.core.utils.coerce.converters.Serde;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ElideSerdeConfigurationTest {
+
+    private ElideSerdeConfiguration configuration;
+    private Serdes.SerdesBuilder serdesBuilder;
+
+    @BeforeEach
+    void setUp() {
+        configuration = new ElideSerdeConfiguration();
+        serdesBuilder = Serdes.builder().withDefaults().withISO8601Dates("yyyy-MM-dd'T'HH:mm'Z'", java.util.TimeZone.getTimeZone("UTC"));
+        configuration.secondPrecisionDateSerdes().customize(serdesBuilder);
+    }
+
+    @Test
+    void testSerializationProducesUtcSecondPrecision() {
+        @SuppressWarnings("unchecked")
+        Serde<Object, Date> dateSerde = (Serde<Object, Date>) serdesBuilder.build().get(Date.class);
+        assertNotNull(dateSerde);
+
+        Date testDate = Date.from(Instant.parse("2026-01-15T10:20:42.987Z"));
+        Object serialized = dateSerde.serialize(testDate);
+
+        assertEquals("2026-01-15T10:20:42Z", serialized);
+    }
+
+    @Test
+    void testDeserializeExactUtc() {
+        @SuppressWarnings("unchecked")
+        Serde<Object, Date> dateSerde = (Serde<Object, Date>) serdesBuilder.build().get(Date.class);
+
+        Date date = dateSerde.deserialize("2026-01-15T10:20:42Z");
+        assertEquals(Instant.parse("2026-01-15T10:20:42Z"), date.toInstant());
+    }
+
+    @Test
+    void testDeserializeWithMilliseconds() {
+        @SuppressWarnings("unchecked")
+        Serde<Object, Date> dateSerde = (Serde<Object, Date>) serdesBuilder.build().get(Date.class);
+
+        Date date = dateSerde.deserialize("2026-01-15T10:20:42.123Z");
+        assertEquals(Instant.parse("2026-01-15T10:20:42.123Z"), date.toInstant());
+
+        Date dateZeroMillis = dateSerde.deserialize("2026-01-15T10:20:42.000Z");
+        assertEquals(Instant.parse("2026-01-15T10:20:42Z"), dateZeroMillis.toInstant());
+    }
+
+    @Test
+    void testDeserializeWithTimezoneOffsets() {
+        @SuppressWarnings("unchecked")
+        Serde<Object, Date> dateSerde = (Serde<Object, Date>) serdesBuilder.build().get(Date.class);
+
+        // 12:20:42 UTC+2 is 10:20:42 UTC
+        Date datePlusTwo = dateSerde.deserialize("2026-01-15T12:20:42+02:00");
+        assertEquals(Instant.parse("2026-01-15T10:20:42Z"), datePlusTwo.toInstant());
+
+        // 05:20:42 UTC-5 is 10:20:42 UTC
+        Date dateMinusFive = dateSerde.deserialize("2026-01-15T05:20:42-05:00");
+        assertEquals(Instant.parse("2026-01-15T10:20:42Z"), dateMinusFive.toInstant());
+    }
+
+    @Test
+    void testDeserializeMinuteOnlyFallback() {
+        @SuppressWarnings("unchecked")
+        Serde<Object, Date> dateSerde = (Serde<Object, Date>) serdesBuilder.build().get(Date.class);
+
+        Date date = dateSerde.deserialize("2026-01-15T10:20Z");
+        assertEquals(Instant.parse("2026-01-15T10:20:00Z"), date.toInstant());
+    }
+
+    @Test
+    void testDeserializeLocalIsoWithoutOffsetDefaultsToUtc() {
+        @SuppressWarnings("unchecked")
+        Serde<Object, Date> dateSerde = (Serde<Object, Date>) serdesBuilder.build().get(Date.class);
+
+        Date date = dateSerde.deserialize("2026-01-15T10:20:42");
+        assertEquals(Instant.parse("2026-01-15T10:20:42Z"), date.toInstant());
+    }
+
+    @Test
+    void testDeserializeEpochTimestampStringAndNumber() {
+        @SuppressWarnings("unchecked")
+        Serde<Object, Date> dateSerde = (Serde<Object, Date>) serdesBuilder.build().get(Date.class);
+
+        long epochMillis = 1768472442000L;
+        Date dateFromNumber = dateSerde.deserialize(epochMillis);
+        assertEquals(epochMillis, dateFromNumber.getTime());
+
+        Date dateFromString = dateSerde.deserialize(String.valueOf(epochMillis));
+        assertEquals(epochMillis, dateFromString.getTime());
+    }
+
+    @Test
+    void testDeserializeDateInstanceAndNullHandling() {
+        @SuppressWarnings("unchecked")
+        Serde<Object, Date> dateSerde = (Serde<Object, Date>) serdesBuilder.build().get(Date.class);
+
+        Date original = new Date(1768472442000L);
+        assertSame(original, dateSerde.deserialize(original));
+
+        assertNull(dateSerde.deserialize(null));
+        assertNull(dateSerde.deserialize("   "));
+        assertNull(dateSerde.serialize(null));
+    }
+
+    @Test
+    void testDeserializeInvalidThrowsIllegalArgumentException() {
+        @SuppressWarnings("unchecked")
+        Serde<Object, Date> dateSerde = (Serde<Object, Date>) serdesBuilder.build().get(Date.class);
+
+        assertThrows(IllegalArgumentException.class, () -> dateSerde.deserialize("invalid-date-string"));
+    }
+
+    @Test
+    void testSqlTypesSubtypeRegistration() {
+        var serdes = serdesBuilder.build();
+
+        @SuppressWarnings("unchecked")
+        Serde<Object, java.sql.Timestamp> timestampSerde = (Serde<Object, java.sql.Timestamp>) serdes.get(java.sql.Timestamp.class);
+        assertNotNull(timestampSerde);
+        java.sql.Timestamp timestamp = timestampSerde.deserialize("2026-01-15T10:20:42Z");
+        assertEquals(Instant.parse("2026-01-15T10:20:42Z"), timestamp.toInstant());
+        assertEquals("2026-01-15T10:20:42Z", timestampSerde.serialize(timestamp));
+
+        @SuppressWarnings("unchecked")
+        Serde<Object, java.sql.Date> sqlDateSerde = (Serde<Object, java.sql.Date>) serdes.get(java.sql.Date.class);
+        assertNotNull(sqlDateSerde);
+        java.sql.Date sqlDate = sqlDateSerde.deserialize("2026-01-15T10:20:42Z");
+        assertNotNull(sqlDate);
+
+        @SuppressWarnings("unchecked")
+        Serde<Object, java.sql.Time> sqlTimeSerde = (Serde<Object, java.sql.Time>) serdes.get(java.sql.Time.class);
+        assertNotNull(sqlTimeSerde);
+        java.sql.Time sqlTime = sqlTimeSerde.deserialize("2026-01-15T10:20:42Z");
+        assertNotNull(sqlTime);
+    }
+}


### PR DESCRIPTION
## Description
This PR fixes issue #2787 where dates returned by Yahoo Elide in GraphQL and JSON:API responses (such as `createdDate`, `updatedDate`, and `lastJobDate`) were truncated to minute precision (`yyyy-MM-dd'T'HH:mm'Z'`). This caused UI components calculating relative time (via Luxon / `DateTime.fromISO`) to measure elapsed time from the top of the minute, displaying misleading statuses like "45 seconds ago" for jobs that were triggered just 2 seconds prior.
## Root Cause
Yahoo Elide's default `ISO8601DateSerde` uses the pattern `yyyy-MM-dd'T'HH:mm'Z'`. While `java.util.Date` and the underlying database columns store exact millisecond timestamps, Elide's default serializer truncated the seconds upon generating JSON/GraphQL output.
A simple override using `builder.withISO8601Dates("yyyy-MM-dd'T'HH:mm:ss'Z'", ...)` is insufficient because it binds both serialization and deserialization to the exact same format pattern. Any incoming client request, webhook, or JSON:API filter query sending ISO-8601 timestamps with milliseconds (`.123Z`), timezone offsets (`+02:00`), or epoch timestamps would fail with `400 Bad Request` coercion errors.
## Solution
Introduced `ElideSerdeConfiguration` which registers custom `Serde<Object, T>` instances for `Date`, `java.sql.Date`, `java.sql.Timestamp`, and `java.sql.Time`:
1. **Second-Precision UTC Serialization (Output):**
   - Formats dates as UTC ISO-8601 with second precision (`yyyy-MM-dd'T'HH:mm:ssXXX`) via `FastDateFormat` (thread-safe).
   - Formats `2026-01-15 10:20:42.123 UTC` as `"2026-01-15T10:20:42Z"`.
2. **Robust Multi-Tier Deserialization (Input):**
   - **Tier 1 (Standard ISO-8601):** Uses `DateTimeFormatter.ISO_DATE_TIME` supporting UTC `Z`, milliseconds (`.123Z`), explicit timezone offsets (`+02:00`, `-05:00`), and local datetime strings.
   - **Tier 2 (Fallback Parser):** Gracefully parses minute-only strings (`yyyy-MM-dd'T'HH:mm'Z'`) defaulting seconds to `00`.
   - **Tier 3 (Epoch Numeric Values):** Parses Unix epoch timestamps as numbers or numeric strings.
3. **Subtype & Type Coercion Safety:**
   - Registers converters for `java.sql.Date`, `java.sql.Timestamp`, and `java.sql.Time` preventing `ClassCastException`.
   - Leaves JPA entities and database schemas intact (no breaking changes to Liquibase migrations or `@Temporal` annotations).
## Changes
- **`api/src/main/java/io/terrakube/api/plugin/elide/ElideSerdeConfiguration.java`**: Custom Elide Serde configuration bean.
- **`api/src/test/java/io/terrakube/api/plugin/elide/ElideSerdeConfigurationTest.java`**: 10 unit tests covering serialization, all input date format variations, and SQL subtypes.
- **`api/src/test/java/io/terrakube/api/JobTests.java`**: Added integration tests verifying second precision preservation in both JSON:API and GraphQL queries.
## Verification & Testing
- [x] Unit tests passing: `ElideSerdeConfigurationTest` (10/10)
- [x] Integration tests passing: `JobTests` (9/9)
- [x] Full module test suite passing: `mvn test` in `terrakube/api` (980/980 passing, 0 failures)