### PR TITLE
feat: Job Details resilience for transient S3/context unavailability

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/context/ContextController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/context/ContextController.java
@@ -44,24 +44,34 @@ public class ContextController {
 
     private final StreamingService streamingService;
 
+    private final ContextStorageMetrics contextStorageMetrics;
+
     @GetMapping(value = "/{jobId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<String> getContext(@PathVariable("jobId") int jobId) throws IOException {
-        String context = storageTypeService.getContext(jobId);
-        if (context == null || context.isBlank()) {
-            context = "{}";
+    public ResponseEntity<String> getContext(@PathVariable("jobId") int jobId) {
+        try {
+            String context = contextStorageMetrics.time("read", () -> storageTypeService.getContext(jobId));
+            if (context == null || context.isBlank()) {
+                context = "{}";
+            }
+            return new ResponseEntity<>(contextSanitizer.sanitize(context), HttpStatus.OK);
+        } catch (IOException | RuntimeException e) {
+            log.warn("Controlled failure reading context for job {}: {}", jobId, e.getMessage());
+            return new ResponseEntity<>("{}", HttpStatus.SERVICE_UNAVAILABLE);
         }
-        return new ResponseEntity<>(contextSanitizer.sanitize(context), HttpStatus.OK);
     }
 
     @PostMapping(value = "/{jobId}", produces = MediaType.APPLICATION_JSON_VALUE)
     @Transactional
-    public ResponseEntity<String> saveContext(@PathVariable("jobId") int jobId, @RequestBody String context) throws IOException {
+    public ResponseEntity<String> saveContext(@PathVariable("jobId") int jobId, @RequestBody String context) {
         String sanitizedContext;
         try {
             sanitizedContext = contextSanitizer.sanitize(context);
         } catch (JacksonException e) {
             log.warn("Invalid context payload for job {}", jobId, e);
             return new ResponseEntity<>("{}", HttpStatus.BAD_REQUEST);
+        } catch (IOException e) {
+            log.warn("Controlled failure sanitizing context for job {}: {}", jobId, e.getMessage());
+            return new ResponseEntity<>("{}", HttpStatus.SERVICE_UNAVAILABLE);
         }
 
         Optional<Job> jobOptional = jobRepository.findById(jobId);
@@ -76,7 +86,14 @@ public class ContextController {
             return new ResponseEntity<>("{}", HttpStatus.CONFLICT);
         }
 
-        String savedContext = storageTypeService.saveContext(jobId, sanitizedContext);
+        String savedContext;
+        try {
+            String contextToSave = sanitizedContext;
+            savedContext = contextStorageMetrics.time("write", () -> storageTypeService.saveContext(jobId, contextToSave));
+        } catch (IOException | RuntimeException e) {
+            log.warn("Controlled failure saving context for job {}: {}", jobId, e.getMessage());
+            return new ResponseEntity<>("{}", HttpStatus.SERVICE_UNAVAILABLE);
+        }
         return new ResponseEntity<>(savedContext, HttpStatus.OK);
     }
 

--- a/api/src/main/java/io/terrakube/api/plugin/context/ContextController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/context/ContextController.java
@@ -36,6 +36,8 @@ public class ContextController {
             JobStatus.completed,
             JobStatus.noChanges);
 
+    private static final String PENDING_BODY = "{\"structuredOutputStatus\":{\"state\":\"PENDING\"}}";
+
     private final StorageTypeService storageTypeService;
 
     private final JobRepository jobRepository;
@@ -46,18 +48,38 @@ public class ContextController {
 
     private final ContextStorageMetrics contextStorageMetrics;
 
+    private final ContextReadService contextReadService;
+
+    private final ContextProperties contextProperties;
+
     @GetMapping(value = "/{jobId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> getContext(@PathVariable("jobId") int jobId) {
+        String context;
         try {
-            String context = contextStorageMetrics.time("read", () -> storageTypeService.getContext(jobId));
-            if (context == null || context.isBlank()) {
-                context = "{}";
-            }
-            return new ResponseEntity<>(contextSanitizer.sanitize(context), HttpStatus.OK);
-        } catch (IOException | RuntimeException e) {
-            log.warn("Controlled failure reading context for job {}: {}", jobId, e.getMessage());
-            return new ResponseEntity<>("{}", HttpStatus.SERVICE_UNAVAILABLE);
+            context = contextReadService.read(jobId);
+        } catch (RuntimeException e) {
+            log.warn("Controlled context-read failure for job {}: {}", jobId, e.getMessage());
+            return unavailable();
         }
+
+        // A missing object is "not persisted yet", distinct from an empty plan and from an outage.
+        if (context == null || context.isBlank()) {
+            return new ResponseEntity<>(PENDING_BODY, HttpStatus.OK);
+        }
+
+        try {
+            return new ResponseEntity<>(contextSanitizer.sanitize(context), HttpStatus.OK);
+        } catch (IOException e) {
+            log.warn("Controlled failure sanitizing context for job {}: {}", jobId, e.getMessage());
+            return unavailable();
+        }
+    }
+
+    private ResponseEntity<String> unavailable() {
+        int retryAfter = contextProperties.getRetryAfterSeconds();
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .header("Retry-After", String.valueOf(retryAfter))
+                .body("{\"structuredOutputStatus\":{\"state\":\"UNAVAILABLE\"},\"retryAfterSeconds\":" + retryAfter + "}");
     }
 
     @PostMapping(value = "/{jobId}", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -94,6 +116,8 @@ public class ContextController {
             log.warn("Controlled failure saving context for job {}: {}", jobId, e.getMessage());
             return new ResponseEntity<>("{}", HttpStatus.SERVICE_UNAVAILABLE);
         }
+        // Refresh the read cache so a Job Details page open right after the write sees this snapshot.
+        contextReadService.invalidate(jobId, savedContext);
         return new ResponseEntity<>(savedContext, HttpStatus.OK);
     }
 

--- a/api/src/main/java/io/terrakube/api/plugin/context/ContextProperties.java
+++ b/api/src/main/java/io/terrakube/api/plugin/context/ContextProperties.java
@@ -29,4 +29,10 @@ public class ContextProperties {
 
     /** Retry hint (seconds) returned to clients when context is temporarily unavailable. */
     private int retryAfterSeconds = 5;
+
+    /** Bounded object-store read worker pool size. */
+    private int readWorkers = 4;
+
+    /** Bounded queue in front of the read worker pool; saturation returns a controlled 503. */
+    private int readQueueCapacity = 64;
 }

--- a/api/src/main/java/io/terrakube/api/plugin/context/ContextProperties.java
+++ b/api/src/main/java/io/terrakube/api/plugin/context/ContextProperties.java
@@ -1,0 +1,32 @@
+package io.terrakube.api.plugin.context;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * Tuning knobs for the {@code /context/v1} read path: a short per-pod cache in front of object
+ * storage, single-flight coalescing of concurrent misses, and an overall read timeout applied
+ * independently of the shared S3 client timeouts.
+ */
+@Component
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "io.terrakube.context")
+public class ContextProperties {
+
+    /** How long a successfully read context stays cached per API pod. */
+    private Duration cacheTtl = Duration.ofSeconds(30);
+
+    /** Maximum number of distinct job contexts held in the per-pod cache. */
+    private int cacheMaxEntries = 500;
+
+    /** Overall budget for a single object-store context read before returning a controlled 503. */
+    private Duration readTimeout = Duration.ofSeconds(8);
+
+    /** Retry hint (seconds) returned to clients when context is temporarily unavailable. */
+    private int retryAfterSeconds = 5;
+}

--- a/api/src/main/java/io/terrakube/api/plugin/context/ContextReadService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/context/ContextReadService.java
@@ -1,0 +1,132 @@
+package io.terrakube.api.plugin.context;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.terrakube.api.plugin.storage.StorageTypeService;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Fast, coalesced {@code /context/v1} reads. A short per-pod Caffeine cache absorbs repeat opens of
+ * the same Job Details page; concurrent cache misses for one job are collapsed into a single
+ * object-store request (single-flight) so an intermittent S3 delay is not amplified by request
+ * fan-out. Failures ({@code 503}, timeout, malformed) are never negative-cached.
+ */
+@Slf4j
+@Service
+public class ContextReadService {
+
+    private final StorageTypeService storageTypeService;
+    private final ContextStorageMetrics contextStorageMetrics;
+    private final ContextProperties properties;
+    private final MeterRegistry meterRegistry;
+
+    private final Cache<Integer, String> cache;
+    private final ConcurrentHashMap<Integer, CompletableFuture<String>> inFlight = new ConcurrentHashMap<>();
+    private final ExecutorService ioPool;
+
+    public ContextReadService(StorageTypeService storageTypeService,
+                              ContextStorageMetrics contextStorageMetrics,
+                              ContextProperties properties,
+                              MeterRegistry meterRegistry) {
+        this.storageTypeService = storageTypeService;
+        this.contextStorageMetrics = contextStorageMetrics;
+        this.properties = properties;
+        this.meterRegistry = meterRegistry;
+        this.cache = Caffeine.newBuilder()
+                .maximumSize(Math.max(1, properties.getCacheMaxEntries()))
+                .expireAfterWrite(properties.getCacheTtl())
+                .build();
+        AtomicInteger threadIndex = new AtomicInteger();
+        this.ioPool = Executors.newFixedThreadPool(4, r -> {
+            Thread t = new Thread(r, "context-read-" + threadIndex.incrementAndGet());
+            t.setDaemon(true);
+            return t;
+        });
+        Gauge.builder("terrakube.api.context.inflight.reads", inFlight, Map::size)
+                .description("In-flight object-store context reads (single-flight)")
+                .register(meterRegistry);
+    }
+
+    @PreDestroy
+    void shutdown() {
+        ioPool.shutdownNow();
+    }
+
+    /**
+     * @return the raw stored context JSON, {@code null} when the object does not exist yet.
+     * @throws ContextUnavailableException on timeout or a storage failure (never negative-cached).
+     */
+    public String read(int jobId) {
+        String cached = cache.getIfPresent(jobId);
+        if (cached != null) {
+            countRequest("hit");
+            return cached;
+        }
+
+        boolean[] owner = {false};
+        CompletableFuture<String> future = inFlight.computeIfAbsent(jobId, id -> {
+            owner[0] = true;
+            return CompletableFuture.supplyAsync(() -> loadFromStore(id), ioPool);
+        });
+        countRequest(owner[0] ? "miss" : "coalesced");
+
+        try {
+            String result = future.get(properties.getReadTimeout().toMillis(), TimeUnit.MILLISECONDS);
+            if (result != null && !result.isBlank()) {
+                cache.put(jobId, result);
+            }
+            return result;
+        } catch (TimeoutException e) {
+            countRequest("failure");
+            throw new ContextUnavailableException("context read timed out for job " + jobId, e);
+        } catch (ExecutionException e) {
+            countRequest("failure");
+            throw new ContextUnavailableException("context read failed for job " + jobId, e.getCause());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            countRequest("failure");
+            throw new ContextUnavailableException("context read interrupted for job " + jobId, e);
+        } finally {
+            if (owner[0]) {
+                inFlight.remove(jobId, future);
+            }
+        }
+    }
+
+    /** Refresh (or clear) the cached context after a successful write, so the next read sees it. */
+    public void invalidate(int jobId, String freshContext) {
+        if (freshContext == null || freshContext.isBlank()) {
+            cache.invalidate(jobId);
+        } else {
+            cache.put(jobId, freshContext);
+        }
+    }
+
+    private String loadFromStore(int jobId) {
+        try {
+            return contextStorageMetrics.time("read", () -> storageTypeService.getContext(jobId));
+        } catch (IOException | RuntimeException e) {
+            throw new CompletionException(e);
+        }
+    }
+
+    private void countRequest(String result) {
+        meterRegistry.counter("terrakube.api.context.cache.requests", "result", result).increment();
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/context/ContextReadService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/context/ContextReadService.java
@@ -11,12 +11,12 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -38,7 +38,7 @@ public class ContextReadService {
 
     private final Cache<Integer, String> cache;
     private final ConcurrentHashMap<Integer, CompletableFuture<String>> inFlight = new ConcurrentHashMap<>();
-    private final ExecutorService ioPool;
+    private final ThreadPoolExecutor ioPool;
 
     public ContextReadService(StorageTypeService storageTypeService,
                               ContextStorageMetrics contextStorageMetrics,
@@ -53,11 +53,16 @@ public class ContextReadService {
                 .expireAfterWrite(properties.getCacheTtl())
                 .build();
         AtomicInteger threadIndex = new AtomicInteger();
-        this.ioPool = Executors.newFixedThreadPool(4, r -> {
-            Thread t = new Thread(r, "context-read-" + threadIndex.incrementAndGet());
-            t.setDaemon(true);
-            return t;
-        });
+        int workers = Math.max(1, properties.getReadWorkers());
+        this.ioPool = new ThreadPoolExecutor(
+                Math.min(2, workers), workers, 60, TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(Math.max(1, properties.getReadQueueCapacity())),
+                r -> {
+                    Thread t = new Thread(r, "context-read-" + threadIndex.incrementAndGet());
+                    t.setDaemon(true);
+                    return t;
+                },
+                new ThreadPoolExecutor.AbortPolicy());
         Gauge.builder("terrakube.api.context.inflight.reads", inFlight, Map::size)
                 .description("In-flight object-store context reads (single-flight)")
                 .register(meterRegistry);
@@ -70,7 +75,8 @@ public class ContextReadService {
 
     /**
      * @return the raw stored context JSON, {@code null} when the object does not exist yet.
-     * @throws ContextUnavailableException on timeout or a storage failure (never negative-cached).
+     * @throws ContextUnavailableException on timeout, storage failure, or worker saturation
+     *         (never negative-cached).
      */
     public String read(int jobId) {
         String cached = cache.getIfPresent(jobId);
@@ -82,8 +88,13 @@ public class ContextReadService {
         boolean[] owner = {false};
         CompletableFuture<String> future = inFlight.computeIfAbsent(jobId, id -> {
             owner[0] = true;
-            return CompletableFuture.supplyAsync(() -> loadFromStore(id), ioPool);
+            return startLoad(id);
         });
+        if (owner[0]) {
+            // Lifecycle is tied to the backing object-store operation, NOT to any waiting caller:
+            // the in-flight entry is removed only when this future completes.
+            future.whenComplete((value, error) -> onLoadComplete(jobId, future, value, error));
+        }
         countRequest(owner[0] ? "miss" : "coalesced");
 
         try {
@@ -93,6 +104,9 @@ public class ContextReadService {
             }
             return result;
         } catch (TimeoutException e) {
+            // This caller's budget expired; the backing read keeps running and later callers still
+            // coalesce onto it. Do NOT remove the in-flight entry here.
+            meterRegistry.counter("terrakube.api.context.read.waiter.timeouts").increment();
             countRequest("failure");
             throw new ContextUnavailableException("context read timed out for job " + jobId, e);
         } catch (ExecutionException e) {
@@ -102,10 +116,37 @@ public class ContextReadService {
             Thread.currentThread().interrupt();
             countRequest("failure");
             throw new ContextUnavailableException("context read interrupted for job " + jobId, e);
-        } finally {
-            if (owner[0]) {
-                inFlight.remove(jobId, future);
+        }
+    }
+
+    private CompletableFuture<String> startLoad(int jobId) {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        try {
+            ioPool.execute(() -> {
+                try {
+                    future.complete(loadFromStore(jobId));
+                } catch (Throwable t) {
+                    future.completeExceptionally(t);
+                }
+            });
+        } catch (RejectedExecutionException saturated) {
+            countRequest("saturation");
+            log.warn("Context read worker pool saturated for job {}", jobId);
+            future.completeExceptionally(saturated);
+        }
+        return future;
+    }
+
+    private void onLoadComplete(int jobId, CompletableFuture<String> future, String value, Throwable error) {
+        inFlight.remove(jobId, future);
+        if (error == null) {
+            if (value != null && !value.isBlank()) {
+                cache.put(jobId, value);
             }
+            meterRegistry.counter("terrakube.api.context.singleflight.completions", "outcome", "success").increment();
+        } else {
+            // Never negative-cache: nothing is stored for a failed/malformed read.
+            meterRegistry.counter("terrakube.api.context.singleflight.completions", "outcome", "failure").increment();
         }
     }
 
@@ -122,7 +163,7 @@ public class ContextReadService {
         try {
             return contextStorageMetrics.time("read", () -> storageTypeService.getContext(jobId));
         } catch (IOException | RuntimeException e) {
-            throw new CompletionException(e);
+            throw new ContextUnavailableException("context storage read failed for job " + jobId, e);
         }
     }
 

--- a/api/src/main/java/io/terrakube/api/plugin/context/ContextStorageMetrics.java
+++ b/api/src/main/java/io/terrakube/api/plugin/context/ContextStorageMetrics.java
@@ -1,0 +1,48 @@
+package io.terrakube.api.plugin.context;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * Records how long {@code /context/v1} storage reads and writes take and how often they fail, so a
+ * slow or unavailable object store is observable rather than surfacing to the executor as an
+ * unhandled 500. Labelled by {@code operation} (read|write) and {@code outcome} (success|failure)
+ * only - never by job, step, or context content.
+ */
+@Slf4j
+@Component
+public class ContextStorageMetrics {
+
+    @FunctionalInterface
+    public interface StorageCall<T> {
+        T call() throws IOException;
+    }
+
+    private final MeterRegistry meterRegistry;
+
+    public ContextStorageMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    public <T> T time(String operation, StorageCall<T> call) throws IOException {
+        Timer.Sample sample = Timer.start(meterRegistry);
+        String outcome = "success";
+        try {
+            return call.call();
+        } catch (IOException | RuntimeException e) {
+            outcome = "failure";
+            meterRegistry.counter("terrakube.api.context.storage.failures", "operation", operation).increment();
+            log.warn("Context storage {} failed: {}", operation, e.getMessage());
+            throw e;
+        } finally {
+            sample.stop(Timer.builder("terrakube.api.context.storage.duration")
+                    .tag("operation", operation)
+                    .tag("outcome", outcome)
+                    .register(meterRegistry));
+        }
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/context/ContextUnavailableException.java
+++ b/api/src/main/java/io/terrakube/api/plugin/context/ContextUnavailableException.java
@@ -1,0 +1,12 @@
+package io.terrakube.api.plugin.context;
+
+/**
+ * Thrown when a {@code /context/v1} object-store read times out or fails. Mapped by
+ * {@link ContextController} to a controlled {@code 503 Service Unavailable} with a retry hint -
+ * never a servlet {@code 500}. Failures are not negative-cached.
+ */
+public class ContextUnavailableException extends RuntimeException {
+    public ContextUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/logs/StepLogService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/logs/StepLogService.java
@@ -2,6 +2,7 @@ package io.terrakube.api.plugin.logs;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.terrakube.api.plugin.storage.StorageTypeService;
 import io.terrakube.api.plugin.storage.model.ByteRange;
 import io.terrakube.api.plugin.storage.model.StepOutputStream;
@@ -28,12 +29,15 @@ public class StepLogService {
     private final StorageTypeService storage;
     private final StepRepository stepRepository;
     private final LogsProperties properties;
+    private final MeterRegistry meterRegistry;
     private final Cache<String, byte[]> cache;
 
-    public StepLogService(StorageTypeService storage, StepRepository stepRepository, LogsProperties properties) {
+    public StepLogService(StorageTypeService storage, StepRepository stepRepository, LogsProperties properties,
+                          MeterRegistry meterRegistry) {
         this.storage = storage;
         this.stepRepository = stepRepository;
         this.properties = properties;
+        this.meterRegistry = meterRegistry;
         this.cache = Caffeine.newBuilder()
                 .maximumWeight(properties.getCacheMaxWeightBytes())
                 .weigher((String k, byte[] v) -> v.length)
@@ -111,9 +115,10 @@ public class StepLogService {
                 return StepLog.cached(body);
             }
             return StepLog.streamable(len);
-        } catch (IOException e) {
-            log.error("Failed reading step log {}: {}", key, e.getMessage());
-            throw new RuntimeException(e);
+        } catch (IOException | RuntimeException e) {
+            meterRegistry.counter("terrakube.api.step.log.storage.failures").increment();
+            log.warn("Failed reading step log {}: {}", key, e.getMessage());
+            throw new StepLogUnavailableException("step log read failed for " + key, e);
         }
     }
 

--- a/api/src/main/java/io/terrakube/api/plugin/logs/StepLogUnavailableException.java
+++ b/api/src/main/java/io/terrakube/api/plugin/logs/StepLogUnavailableException.java
@@ -1,0 +1,13 @@
+package io.terrakube.api.plugin.logs;
+
+/**
+ * Thrown when an archived step-log object read fails or times out. Mapped by
+ * {@code TerraformOutputController} to a controlled {@code 503 Service Unavailable} with a
+ * {@code Retry-After} hint - never a servlet {@code 500} - so a transient S3 problem stays local to
+ * that step in the UI instead of triggering the application-wide backend-error page.
+ */
+public class StepLogUnavailableException extends RuntimeException {
+    public StepLogUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorService.java
@@ -83,7 +83,12 @@ public class PersistentExecutorService {
             throw new ExecutionException(e);
         }
 
-        ResponseEntity<ExecutorContext> response = null;
+        // The executor answers POST /api/v1/terraform-rs with 202 Accepted the moment it has
+        // queued the job for asynchronous execution. Its response body is NOT an API/executor
+        // compatibility contract - deserializing it as ExecutorContext once meant a completed
+        // run could be marked failed just because the acknowledgement body was shaped for a
+        // different executor version. Read a bodyless entity: dispatch success is the 202 alone.
+        ResponseEntity<Void> response = null;
         try {
             response = webClient.post()
                     .uri(executorUrlForRequest)
@@ -91,7 +96,7 @@ public class PersistentExecutorService {
                     .header("Authorization", "Bearer " + generateSystemToken())
                     .bodyValue(executorContext)
                     .retrieve()
-                    .toEntity(ExecutorContext.class)
+                    .toBodilessEntity()
                     .block();
         } catch (Exception ex) {
             if (ex instanceof WebClientRequestException) {
@@ -125,10 +130,7 @@ public class PersistentExecutorService {
         log.info("Response Status: {}", response.getStatusCode().value());
 
         if (!response.getStatusCode().equals(HttpStatus.ACCEPTED)) {
-            String message = String.format(
-                    "Executor error status %s: %s",
-                    response.getStatusCode(),
-                    response.getBody());
+            String message = String.format("Executor error status %s", response.getStatusCode());
             throw new ExecutionException(new Throwable(message));
         }
     }

--- a/api/src/main/java/io/terrakube/api/plugin/storage/controller/TerraformOutputController.java
+++ b/api/src/main/java/io/terrakube/api/plugin/storage/controller/TerraformOutputController.java
@@ -2,6 +2,7 @@ package io.terrakube.api.plugin.storage.controller;
 
 import io.terrakube.api.plugin.logs.StepLogResponses;
 import io.terrakube.api.plugin.logs.StepLogService;
+import io.terrakube.api.plugin.logs.StepLogUnavailableException;
 import io.terrakube.api.plugin.storage.model.ByteRange;
 import io.terrakube.api.plugin.storage.model.StepOutputStream;
 import io.terrakube.api.plugin.streaming.JobLogBroadcasterRegistry;
@@ -77,6 +78,16 @@ public class TerraformOutputController {
 
     @ExceptionHandler(SseCapacityExceededException.class)
     public ResponseEntity<Void> onSseCapacityExceeded() {
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .header(HttpHeaders.RETRY_AFTER, "5")
+                .build();
+    }
+
+    // A transient archived-log storage failure is local to this step in the UI, not a global
+    // backend outage - return a controlled 503 with a retry hint, no stack trace.
+    @ExceptionHandler(StepLogUnavailableException.class)
+    public ResponseEntity<Void> onStepLogUnavailable(StepLogUnavailableException e) {
+        log.warn("Archived step log temporarily unavailable: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
                 .header(HttpHeaders.RETRY_AFTER, "5")
                 .build();

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -209,6 +209,11 @@ io.terrakube.storage.aws.chunkedEncodingEnabled=${AwsChunkedEncodingEnabled:true
 io.terrakube.storage.aws.checksumValidationEnabled=${AwsChecksumValidationEnabled:true}
 # Storage read resilience - a hung object read fails within apiCallTimeout instead of the SDK's
 # multi-minute default retry ladder. Step-log objects are KB-sized; sub-second latency is normal.
+# These same timeouts also bound /context/v1 structured-output reads and writes. The 10s/3s
+# defaults are known-insufficient for some observed S3 latencies (see
+# docs/job-execution-and-structured-output-resilience-spec.md); a context-store timeout now returns
+# a controlled 503 (terrakube_api_context_storage_failures_total) rather than a 500. Tune from the
+# terrakube_api_context_storage_duration histogram before raising globally.
 io.terrakube.storage.aws.apiCallTimeoutSeconds=${StorageApiCallTimeoutSeconds:10}
 io.terrakube.storage.aws.apiCallAttemptTimeoutSeconds=${StorageApiCallAttemptTimeoutSeconds:3}
 io.terrakube.storage.aws.maxRetryAttempts=${StorageMaxRetryAttempts:2}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -218,6 +218,14 @@ io.terrakube.storage.aws.apiCallTimeoutSeconds=${StorageApiCallTimeoutSeconds:10
 io.terrakube.storage.aws.apiCallAttemptTimeoutSeconds=${StorageApiCallAttemptTimeoutSeconds:3}
 io.terrakube.storage.aws.maxRetryAttempts=${StorageMaxRetryAttempts:2}
 
+# /context/v1 read path: short per-pod cache + single-flight coalescing of concurrent misses, plus
+# an overall read budget applied on top of the shared S3 client timeouts above. A read timeout
+# returns a controlled 503 with a Retry-After hint (never a servlet 500) and is not negative-cached.
+io.terrakube.context.cache-ttl=${ContextCacheTtl:30s}
+io.terrakube.context.cache-max-entries=${ContextCacheMaxEntries:500}
+io.terrakube.context.read-timeout=${ContextReadTimeout:8s}
+io.terrakube.context.retry-after-seconds=${ContextRetryAfterSeconds:5}
+
 ###############
 # GCP Storage #
 ###############

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -225,6 +225,8 @@ io.terrakube.context.cache-ttl=${ContextCacheTtl:30s}
 io.terrakube.context.cache-max-entries=${ContextCacheMaxEntries:500}
 io.terrakube.context.read-timeout=${ContextReadTimeout:8s}
 io.terrakube.context.retry-after-seconds=${ContextRetryAfterSeconds:5}
+io.terrakube.context.read-workers=${ContextReadWorkers:4}
+io.terrakube.context.read-queue-capacity=${ContextReadQueueCapacity:64}
 
 ###############
 # GCP Storage #

--- a/api/src/test/java/io/terrakube/api/plugin/context/ContextControllerTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/context/ContextControllerTest.java
@@ -1,6 +1,8 @@
 package io.terrakube.api.plugin.context;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.terrakube.api.plugin.storage.StorageTypeService;
 import io.terrakube.api.plugin.streaming.StreamingService;
 import io.terrakube.api.repository.JobRepository;
@@ -25,7 +27,12 @@ import static org.mockito.Mockito.when;
 class ContextControllerTest {
 
     private ContextController controller(StorageTypeService storageTypeService, JobRepository jobRepository) {
-        return new ContextController(storageTypeService, jobRepository, new ContextSanitizer(new ObjectMapper()), Mockito.mock(StreamingService.class));
+        return controller(storageTypeService, jobRepository, new SimpleMeterRegistry());
+    }
+
+    private ContextController controller(StorageTypeService storageTypeService, JobRepository jobRepository, MeterRegistry meterRegistry) {
+        return new ContextController(storageTypeService, jobRepository, new ContextSanitizer(new ObjectMapper()),
+                Mockito.mock(StreamingService.class), new ContextStorageMetrics(meterRegistry));
     }
 
     @Test
@@ -249,11 +256,46 @@ class ContextControllerTest {
     }
 
     @Test
+    void storageReadFailureReturnsServiceUnavailableNotFiveHundred() throws IOException {
+        StorageTypeService storageTypeService = Mockito.mock(StorageTypeService.class);
+        JobRepository jobRepository = Mockito.mock(JobRepository.class);
+        when(storageTypeService.getContext(9)).thenThrow(new RuntimeException("apiCallTimeout"));
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        ContextController controller = controller(storageTypeService, jobRepository, registry);
+
+        ResponseEntity<String> response = controller.getContext(9);
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+        assertEquals("{}", response.getBody());
+        assertEquals(1.0, registry.get("terrakube.api.context.storage.failures")
+                .tag("operation", "read").counter().count());
+    }
+
+    @Test
+    void storageWriteFailureReturnsServiceUnavailableNotFiveHundred() throws IOException {
+        StorageTypeService storageTypeService = Mockito.mock(StorageTypeService.class);
+        JobRepository jobRepository = Mockito.mock(JobRepository.class);
+        Job job = Mockito.mock(Job.class);
+        when(job.getStatus()).thenReturn(JobStatus.running);
+        when(jobRepository.findById(1)).thenReturn(Optional.of(job));
+        when(storageTypeService.saveContext(Mockito.eq(1), Mockito.anyString()))
+                .thenThrow(new RuntimeException("S3 unavailable"));
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        ContextController controller = controller(storageTypeService, jobRepository, registry);
+
+        ResponseEntity<String> response = controller.saveContext(1, "{\"planStructuredOutput\":{}}");
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+        assertEquals(1.0, registry.get("terrakube.api.context.storage.failures")
+                .tag("operation", "write").counter().count());
+    }
+
+    @Test
     void streamEndpointDelegatesToStreamingServiceWithJobId() {
         StorageTypeService storageTypeService = Mockito.mock(StorageTypeService.class);
         JobRepository jobRepository = Mockito.mock(JobRepository.class);
         StreamingService streamingService = Mockito.mock(StreamingService.class);
-        ContextController controller = new ContextController(storageTypeService, jobRepository, new ContextSanitizer(new ObjectMapper()), streamingService);
+        ContextController controller = new ContextController(storageTypeService, jobRepository, new ContextSanitizer(new ObjectMapper()), streamingService, new ContextStorageMetrics(new SimpleMeterRegistry()));
 
         controller.streamContext("42", null);
 

--- a/api/src/test/java/io/terrakube/api/plugin/context/ContextControllerTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/context/ContextControllerTest.java
@@ -31,8 +31,11 @@ class ContextControllerTest {
     }
 
     private ContextController controller(StorageTypeService storageTypeService, JobRepository jobRepository, MeterRegistry meterRegistry) {
+        ContextProperties properties = new ContextProperties();
+        ContextStorageMetrics storageMetrics = new ContextStorageMetrics(meterRegistry);
+        ContextReadService readService = new ContextReadService(storageTypeService, storageMetrics, properties, meterRegistry);
         return new ContextController(storageTypeService, jobRepository, new ContextSanitizer(new ObjectMapper()),
-                Mockito.mock(StreamingService.class), new ContextStorageMetrics(meterRegistry));
+                Mockito.mock(StreamingService.class), storageMetrics, readService, properties);
     }
 
     @Test
@@ -266,9 +269,42 @@ class ContextControllerTest {
         ResponseEntity<String> response = controller.getContext(9);
 
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
-        assertEquals("{}", response.getBody());
+        assertTrue(response.getBody().contains("\"state\":\"UNAVAILABLE\""));
+        assertEquals("5", response.getHeaders().getFirst("Retry-After"));
         assertEquals(1.0, registry.get("terrakube.api.context.storage.failures")
                 .tag("operation", "read").counter().count());
+    }
+
+    @Test
+    void missingContextReturnsPendingNotEmptyPlan() {
+        StorageTypeService storageTypeService = Mockito.mock(StorageTypeService.class);
+        JobRepository jobRepository = Mockito.mock(JobRepository.class);
+        when(storageTypeService.getContext(4)).thenReturn(null);
+        ContextController controller = controller(storageTypeService, jobRepository);
+
+        ResponseEntity<String> response = controller.getContext(4);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().contains("\"state\":\"PENDING\""));
+    }
+
+    @Test
+    void successfulWriteRefreshesTheReadCache() throws IOException {
+        StorageTypeService storageTypeService = Mockito.mock(StorageTypeService.class);
+        JobRepository jobRepository = Mockito.mock(JobRepository.class);
+        Job job = Mockito.mock(Job.class);
+        when(job.getStatus()).thenReturn(JobStatus.running);
+        when(jobRepository.findById(1)).thenReturn(Optional.of(job));
+        when(storageTypeService.saveContext(Mockito.eq(1), Mockito.anyString()))
+                .thenAnswer(invocation -> invocation.getArgument(1));
+        ContextController controller = controller(storageTypeService, jobRepository);
+
+        controller.saveContext(1, "{\"planStructuredOutput\":{\"step-1\":[]}}");
+        ResponseEntity<String> read = controller.getContext(1);
+
+        assertEquals(HttpStatus.OK, read.getStatusCode());
+        assertTrue(read.getBody().contains("\"planStructuredOutput\""));
+        verify(storageTypeService, never()).getContext(1);
     }
 
     @Test
@@ -295,7 +331,12 @@ class ContextControllerTest {
         StorageTypeService storageTypeService = Mockito.mock(StorageTypeService.class);
         JobRepository jobRepository = Mockito.mock(JobRepository.class);
         StreamingService streamingService = Mockito.mock(StreamingService.class);
-        ContextController controller = new ContextController(storageTypeService, jobRepository, new ContextSanitizer(new ObjectMapper()), streamingService, new ContextStorageMetrics(new SimpleMeterRegistry()));
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        ContextProperties properties = new ContextProperties();
+        ContextStorageMetrics storageMetrics = new ContextStorageMetrics(registry);
+        ContextController controller = new ContextController(storageTypeService, jobRepository,
+                new ContextSanitizer(new ObjectMapper()), streamingService, storageMetrics,
+                new ContextReadService(storageTypeService, storageMetrics, properties, registry), properties);
 
         controller.streamContext("42", null);
 

--- a/api/src/test/java/io/terrakube/api/plugin/context/ContextReadServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/context/ContextReadServiceTest.java
@@ -31,10 +31,18 @@ class ContextReadServiceTest {
         return new ContextReadService(storage, new ContextStorageMetrics(registry), properties, registry);
     }
 
-    private double cacheRequests(String result) {
-        return registry.find("terrakube.api.context.cache.requests").tag("result", result).counter() == null
+    private double counter(String name, String tagKey, String tagValue) {
+        return registry.find(name).tag(tagKey, tagValue).counter() == null
                 ? 0.0
-                : registry.get("terrakube.api.context.cache.requests").tag("result", result).counter().count();
+                : registry.get(name).tag(tagKey, tagValue).counter().count();
+    }
+
+    private double counter(String name) {
+        return registry.find(name).counter() == null ? 0.0 : registry.get(name).counter().count();
+    }
+
+    private double cacheRequests(String result) {
+        return counter("terrakube.api.context.cache.requests", "result", result);
     }
 
     @Test
@@ -49,6 +57,7 @@ class ContextReadServiceTest {
         verify(storage, times(1)).getContext(1);
         assertEquals(1.0, cacheRequests("hit"));
         assertEquals(1.0, cacheRequests("miss"));
+        assertEquals(1.0, counter("terrakube.api.context.singleflight.completions", "outcome", "success"));
     }
 
     @Test
@@ -110,25 +119,55 @@ class ContextReadServiceTest {
     }
 
     @Test
-    void storeTimeoutThrowsControlledExceptionAndIsNotNegativeCached() {
+    void ownerTimeoutLeavesTheInFlightReadForLaterCallersToCoalesceOnto() throws Exception {
         AtomicInteger calls = new AtomicInteger();
+        CountDownLatch release = new CountDownLatch(1);
         StorageTypeService storage = Mockito.mock(StorageTypeService.class);
         when(storage.getContext(5)).thenAnswer(inv -> {
-            if (calls.getAndIncrement() == 0) {
-                Thread.sleep(500);
-                return "late";
-            }
+            calls.incrementAndGet();
+            release.await(2, TimeUnit.SECONDS);
             return "{\"planStructuredOutput\":{}}";
         });
         ContextProperties properties = new ContextProperties();
         properties.setReadTimeout(Duration.ofMillis(100));
         ContextReadService service = service(storage, properties);
 
+        // Owner starts the read and times out at 100ms while the store call is still blocked.
         assertThrows(ContextUnavailableException.class, () -> service.read(5));
-        assertEquals(1.0, cacheRequests("failure"));
+        assertEquals(1.0, counter("terrakube.api.context.read.waiter.timeouts"));
 
-        // A recovered object must be visible on the next request (no negative cache).
+        // A second caller arrives before the store call finishes - it must coalesce, not start a
+        // duplicate read (and it also times out on its own budget).
+        assertThrows(ContextUnavailableException.class, () -> service.read(5));
+
+        // Let the single backing read finish; its result must land in the cache.
+        release.countDown();
+        Thread.sleep(300);
+
         assertEquals("{\"planStructuredOutput\":{}}", service.read(5));
+        assertEquals(1, calls.get(), "exactly one object-store read despite the owner timing out");
+        assertEquals(1.0, counter("terrakube.api.context.singleflight.completions", "outcome", "success"));
+    }
+
+    @Test
+    void storageFailureIsNotNegativeCached() throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        StorageTypeService storage = Mockito.mock(StorageTypeService.class);
+        when(storage.getContext(6)).thenAnswer(inv -> {
+            if (calls.getAndIncrement() == 0) {
+                throw new RuntimeException("S3 503");
+            }
+            return "{\"planStructuredOutput\":{}}";
+        });
+        ContextReadService service = service(storage);
+
+        assertThrows(ContextUnavailableException.class, () -> service.read(6));
+        Thread.sleep(50);
+        assertEquals(1.0, counter("terrakube.api.context.singleflight.completions", "outcome", "failure"));
+
+        // A recovered object must be visible on the next request.
+        assertEquals("{\"planStructuredOutput\":{}}", service.read(6));
+        assertEquals(2, calls.get());
     }
 
     @Test
@@ -140,5 +179,34 @@ class ContextReadServiceTest {
         assertNull(service.read(9));
         assertNull(service.read(9));
         verify(storage, times(2)).getContext(9);
+    }
+
+    @Test
+    void workerPoolSaturationReturnsControlledUnavailable() throws Exception {
+        CountDownLatch release = new CountDownLatch(1);
+        StorageTypeService storage = Mockito.mock(StorageTypeService.class);
+        when(storage.getContext(anyInt())).thenAnswer(inv -> {
+            release.await(3, TimeUnit.SECONDS);
+            return "{}";
+        });
+        ContextProperties properties = new ContextProperties();
+        properties.setReadWorkers(1);
+        properties.setReadQueueCapacity(1);
+        properties.setReadTimeout(Duration.ofMillis(200));
+        ContextReadService service = service(storage, properties);
+
+        // Fill the one worker + one queue slot with distinct jobs, then a third distinct job is rejected.
+        Thread a = new Thread(() -> { try { service.read(100); } catch (RuntimeException ignored) { } });
+        Thread b = new Thread(() -> { try { service.read(101); } catch (RuntimeException ignored) { } });
+        a.start();
+        b.start();
+        Thread.sleep(100);
+
+        assertThrows(ContextUnavailableException.class, () -> service.read(102));
+        assertTrue(cacheRequests("saturation") >= 1.0);
+
+        release.countDown();
+        a.join(2000);
+        b.join(2000);
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/context/ContextReadServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/context/ContextReadServiceTest.java
@@ -1,0 +1,144 @@
+package io.terrakube.api.plugin.context;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.terrakube.api.plugin.storage.StorageTypeService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ContextReadServiceTest {
+
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+    private ContextReadService service(StorageTypeService storage) {
+        return service(storage, new ContextProperties());
+    }
+
+    private ContextReadService service(StorageTypeService storage, ContextProperties properties) {
+        return new ContextReadService(storage, new ContextStorageMetrics(registry), properties, registry);
+    }
+
+    private double cacheRequests(String result) {
+        return registry.find("terrakube.api.context.cache.requests").tag("result", result).counter() == null
+                ? 0.0
+                : registry.get("terrakube.api.context.cache.requests").tag("result", result).counter().count();
+    }
+
+    @Test
+    void cacheHitSkipsTheStore() {
+        StorageTypeService storage = Mockito.mock(StorageTypeService.class);
+        when(storage.getContext(1)).thenReturn("{\"planStructuredOutput\":{}}");
+        ContextReadService service = service(storage);
+
+        assertEquals("{\"planStructuredOutput\":{}}", service.read(1));
+        assertEquals("{\"planStructuredOutput\":{}}", service.read(1));
+
+        verify(storage, times(1)).getContext(1);
+        assertEquals(1.0, cacheRequests("hit"));
+        assertEquals(1.0, cacheRequests("miss"));
+    }
+
+    @Test
+    void concurrentMissesAreCoalescedIntoOneStoreRead() throws Exception {
+        CountDownLatch release = new CountDownLatch(1);
+        AtomicInteger calls = new AtomicInteger();
+        StorageTypeService storage = Mockito.mock(StorageTypeService.class);
+        when(storage.getContext(7)).thenAnswer(inv -> {
+            calls.incrementAndGet();
+            release.await(2, TimeUnit.SECONDS);
+            return "{\"applyStructuredOutput\":{}}";
+        });
+        ContextReadService service = service(storage);
+
+        int callers = 8;
+        CountDownLatch ready = new CountDownLatch(callers);
+        CountDownLatch go = new CountDownLatch(1);
+        String[] results = new String[callers];
+        Thread[] threads = new Thread[callers];
+        for (int i = 0; i < callers; i++) {
+            int idx = i;
+            threads[i] = new Thread(() -> {
+                ready.countDown();
+                try {
+                    go.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                results[idx] = service.read(7);
+            });
+            threads[i].start();
+        }
+        ready.await();
+        go.countDown();
+        Thread.sleep(100);
+        release.countDown();
+        for (Thread t : threads) {
+            t.join(3000);
+        }
+
+        assertEquals(1, calls.get());
+        for (String r : results) {
+            assertEquals("{\"applyStructuredOutput\":{}}", r);
+        }
+        assertEquals(1.0, cacheRequests("miss"));
+        assertTrue(cacheRequests("coalesced") >= callers - 1);
+    }
+
+    @Test
+    void invalidateMakesTheNextReadReturnTheFreshValueWithoutAStoreCall() {
+        StorageTypeService storage = Mockito.mock(StorageTypeService.class);
+        ContextReadService service = service(storage);
+
+        service.invalidate(3, "{\"terraformOutputs\":{}}");
+
+        assertEquals("{\"terraformOutputs\":{}}", service.read(3));
+        verify(storage, Mockito.never()).getContext(anyInt());
+        assertEquals(1.0, cacheRequests("hit"));
+    }
+
+    @Test
+    void storeTimeoutThrowsControlledExceptionAndIsNotNegativeCached() {
+        AtomicInteger calls = new AtomicInteger();
+        StorageTypeService storage = Mockito.mock(StorageTypeService.class);
+        when(storage.getContext(5)).thenAnswer(inv -> {
+            if (calls.getAndIncrement() == 0) {
+                Thread.sleep(500);
+                return "late";
+            }
+            return "{\"planStructuredOutput\":{}}";
+        });
+        ContextProperties properties = new ContextProperties();
+        properties.setReadTimeout(Duration.ofMillis(100));
+        ContextReadService service = service(storage, properties);
+
+        assertThrows(ContextUnavailableException.class, () -> service.read(5));
+        assertEquals(1.0, cacheRequests("failure"));
+
+        // A recovered object must be visible on the next request (no negative cache).
+        assertEquals("{\"planStructuredOutput\":{}}", service.read(5));
+    }
+
+    @Test
+    void missingObjectReturnsNullAndIsNotCached() {
+        StorageTypeService storage = Mockito.mock(StorageTypeService.class);
+        when(storage.getContext(9)).thenReturn(null);
+        ContextReadService service = service(storage);
+
+        assertNull(service.read(9));
+        assertNull(service.read(9));
+        verify(storage, times(2)).getContext(9);
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/context/ContextSanitizerTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/context/ContextSanitizerTest.java
@@ -30,4 +30,14 @@ class ContextSanitizerTest {
 
         assertTrue(sanitized.contains("\"value\":null"));
     }
+
+    @Test
+    void preservesStructuredOutputStatusMetadata() throws Exception {
+        String context = "{\"structuredOutputStatus\":{\"state\":\"PERSISTED\",\"updatedAtEpochMs\":123,\"phase\":\"apply\"}}";
+
+        String sanitized = subject().sanitize(context);
+
+        assertTrue(sanitized.contains("\"state\":\"PERSISTED\""));
+        assertTrue(sanitized.contains("\"updatedAtEpochMs\":123"));
+    }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/context/ContextSanitizerTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/context/ContextSanitizerTest.java
@@ -40,4 +40,15 @@ class ContextSanitizerTest {
         assertTrue(sanitized.contains("\"state\":\"PERSISTED\""));
         assertTrue(sanitized.contains("\"updatedAtEpochMs\":123"));
     }
+
+    @Test
+    void preservesNoChangePlanMarkerAndExplicitEmptyPlanArray() throws Exception {
+        String context = "{\"noChangePlan\":{\"planStepId\":\"step-1\"},"
+                + "\"planStructuredOutput\":{\"step-1\":[]}}";
+
+        String sanitized = subject().sanitize(context);
+
+        assertTrue(sanitized.contains("\"noChangePlan\":{\"planStepId\":\"step-1\"}"), sanitized);
+        assertTrue(sanitized.contains("\"planStructuredOutput\":{\"step-1\":[]}"), sanitized);
+    }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/logs/StepLogServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/logs/StepLogServiceTest.java
@@ -1,5 +1,6 @@
 package io.terrakube.api.plugin.logs;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.terrakube.api.plugin.storage.StorageTypeService;
 import io.terrakube.api.plugin.storage.model.StepOutputStream;
 import io.terrakube.api.repository.StepRepository;
@@ -28,6 +29,7 @@ class StepLogServiceTest {
 
     StepLogService service;
     LogsProperties props;
+    SimpleMeterRegistry registry;
 
     UUID stepId = UUID.randomUUID();
 
@@ -37,7 +39,8 @@ class StepLogServiceTest {
         props.setCacheMaxWeightBytes(1_000_000);
         props.setCacheTtl(Duration.ofMinutes(10));
         props.setCacheableMaxObjectBytes(1_000_000);
-        service = new StepLogService(storage, stepRepository, props);
+        registry = new SimpleMeterRegistry();
+        service = new StepLogService(storage, stepRepository, props, registry);
     }
 
     private void stepWithStatus(JobStatus status) {
@@ -60,6 +63,16 @@ class StepLogServiceTest {
         assertArrayEquals(data, first.getBody());
         assertArrayEquals(data, second.getBody());
         verify(storage, times(1)).getStepOutputStream("o", "j", stepId.toString(), null);
+    }
+
+    @Test
+    void storageFailureSurfacesAsStepLogUnavailableAndIsCounted() {
+        stepWithStatus(JobStatus.completed);
+        when(storage.getStepOutputStream("o", "j", stepId.toString(), null))
+                .thenThrow(new RuntimeException("S3 timeout"));
+
+        assertThrows(StepLogUnavailableException.class, () -> service.resolve("o", "j", stepId.toString()));
+        assertEquals(1.0, registry.get("terrakube.api.step.log.storage.failures").counter().count());
     }
 
     @Test

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -51,7 +52,7 @@ public class PersistentExecutorServiceTest {
     @SuppressWarnings("rawtypes")
     private RequestHeadersSpec requestHeadersSpec;
     private ResponseSpec responseSpec;
-    private ResponseEntity<ExecutorContext> responseEntity;
+    private ResponseEntity<Void> responseEntity;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
@@ -77,7 +78,7 @@ public class PersistentExecutorServiceTest {
         doReturn(requestBodySpec).when(requestBodySpec).header(anyString(), anyString());
         doReturn(requestHeadersSpec).when(requestBodySpec).bodyValue(any(ExecutorContext.class));
         doReturn(responseSpec).when(requestHeadersSpec).retrieve();
-        doReturn(Mono.just(responseEntity)).when(responseSpec).toEntity(ExecutorContext.class);
+        doReturn(Mono.just(responseEntity)).when(responseSpec).toBodilessEntity();
     }
 
     private PersistentExecutorService subject() {
@@ -121,19 +122,28 @@ public class PersistentExecutorServiceTest {
                 .build();
     }
 
-    private ExecutorContext response() {
-        return ExecutorContext.builder().build();
-    }
-
     @Test
     public void postsToDefaultExecutor() throws ExecutionException {
         doReturn(HttpStatus.ACCEPTED).when(responseEntity).getStatusCode();
-        doReturn(response()).when(responseEntity).getBody();
 
         subject().send(jobOnDefaultExecutor(), context());
 
         verify(requestBodyUriSpec).uri("http://default-executor/");
         verify(requestHeadersSpec, times(1)).retrieve();
+    }
+
+    @Test
+    public void acknowledgementBodyIsNeverDeserialized() throws ExecutionException {
+        // toEntity(ExecutorContext.class) is deliberately NOT stubbed. A regression to reading a
+        // typed body makes that unstubbed call throw via FailUnkownMethod and fails this test,
+        // protecting the "202 is a bodyless acknowledgement" contract without depending on any
+        // particular executor response body.
+        doReturn(HttpStatus.ACCEPTED).when(responseEntity).getStatusCode();
+
+        subject().send(jobOnDefaultExecutor(), context());
+
+        verify(responseSpec, times(1)).toBodilessEntity();
+        verify(responseSpec, never()).toEntity(ExecutorContext.class);
     }
 
     @Test
@@ -150,7 +160,6 @@ public class PersistentExecutorServiceTest {
     @Test
     public void propagatesHttpFailures() throws ExecutionException {
         doReturn(HttpStatus.BAD_REQUEST).when(responseEntity).getStatusCode();
-        doReturn(response()).when(responseEntity).getBody();
 
         assertThrows(ExecutionException.class, () -> subject().send(jobOnDefaultExecutor(), context()));
 
@@ -161,7 +170,7 @@ public class PersistentExecutorServiceTest {
     public void busyExecutorResponseBecomesExecutorUnavailableException() {
         WebClientResponseException busy = WebClientResponseException.create(
                 503, "Service Unavailable", HttpHeaders.EMPTY, new byte[0], null);
-        doReturn(Mono.error(busy)).when(responseSpec).toEntity(ExecutorContext.class);
+        doReturn(Mono.error(busy)).when(responseSpec).toBodilessEntity();
 
         assertThrows(ExecutorUnavailableException.class, () -> subject().send(jobOnDefaultExecutor(), context()));
 
@@ -174,7 +183,7 @@ public class PersistentExecutorServiceTest {
         // possibly after the executor already accepted the job. Retryable, not a job failure.
         WebClientResponseException badGateway = WebClientResponseException.create(
                 502, "Bad Gateway", HttpHeaders.EMPTY, new byte[0], null);
-        doReturn(Mono.error(badGateway)).when(responseSpec).toEntity(ExecutorContext.class);
+        doReturn(Mono.error(badGateway)).when(responseSpec).toBodilessEntity();
 
         assertThrows(ExecutorUnavailableException.class, () -> subject().send(jobOnDefaultExecutor(), context()));
     }
@@ -183,7 +192,7 @@ public class PersistentExecutorServiceTest {
     public void gatewayTimeoutResponseBecomesExecutorUnavailableException() {
         WebClientResponseException gatewayTimeout = WebClientResponseException.create(
                 504, "Gateway Timeout", HttpHeaders.EMPTY, new byte[0], null);
-        doReturn(Mono.error(gatewayTimeout)).when(responseSpec).toEntity(ExecutorContext.class);
+        doReturn(Mono.error(gatewayTimeout)).when(responseSpec).toBodilessEntity();
 
         assertThrows(ExecutorUnavailableException.class, () -> subject().send(jobOnDefaultExecutor(), context()));
     }
@@ -192,7 +201,7 @@ public class PersistentExecutorServiceTest {
     public void otherHttpErrorResponseStaysAHardExecutionException() {
         WebClientResponseException serverError = WebClientResponseException.create(
                 500, "Internal Server Error", HttpHeaders.EMPTY, new byte[0], null);
-        doReturn(Mono.error(serverError)).when(responseSpec).toEntity(ExecutorContext.class);
+        doReturn(Mono.error(serverError)).when(responseSpec).toBodilessEntity();
 
         ExecutionException thrown = assertThrows(ExecutionException.class,
                 () -> subject().send(jobOnDefaultExecutor(), context()));
@@ -206,7 +215,6 @@ public class PersistentExecutorServiceTest {
         executorUrl.setValue("http://ze-executor/");
         doReturn(Optional.of(executorUrl)).when(globalVarRepository).findByOrganizationAndKey(any(), any());
         doReturn(HttpStatus.ACCEPTED).when(responseEntity).getStatusCode();
-        doReturn(response()).when(responseEntity).getBody();
 
         subject().send(jobOnDefaultExecutor(), context());
 
@@ -217,7 +225,6 @@ public class PersistentExecutorServiceTest {
     @Test
     public void postsToAgent() throws ExecutionException {
         doReturn(HttpStatus.ACCEPTED).when(responseEntity).getStatusCode();
-        doReturn(response()).when(responseEntity).getBody();
 
         subject().send(jobOnAgent(), context());
 

--- a/api/src/test/java/io/terrakube/api/plugin/storage/controller/TerraformOutputControllerTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/storage/controller/TerraformOutputControllerTest.java
@@ -1,6 +1,7 @@
 package io.terrakube.api.plugin.storage.controller;
 
 import io.terrakube.api.plugin.logs.StepLogService;
+import io.terrakube.api.plugin.logs.StepLogUnavailableException;
 import io.terrakube.api.plugin.storage.model.StepOutputStream;
 import io.terrakube.api.plugin.streaming.JobLogBroadcasterRegistry;
 import io.terrakube.api.plugin.streaming.SseCapacityExceededException;
@@ -40,6 +41,15 @@ class TerraformOutputControllerTest {
         ResponseEntity<?> response = controller.getFile("o", "j", "s", null);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    void stepLogUnavailableMapsToControlled503WithRetryHint() {
+        ResponseEntity<?> response = controller.onStepLogUnavailable(
+                new StepLogUnavailableException("step log read failed", new RuntimeException("S3 timeout")));
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+        assertEquals("5", response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER));
     }
 
     @Test

--- a/executor/pom.xml
+++ b/executor/pom.xml
@@ -82,6 +82,10 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>io.terrakube.terraform</groupId>
 			<artifactId>terraform-spring-boot-starter</artifactId>
 			<version>${terraform-spring-boot-starter.version}</version>

--- a/executor/src/main/java/io/terrakube/executor/configuration/ExecutorFlagsProperties.java
+++ b/executor/src/main/java/io/terrakube/executor/configuration/ExecutorFlagsProperties.java
@@ -19,4 +19,9 @@ public class ExecutorFlagsProperties {
     private String batchJobFile;
     private boolean disableAcknowledge;
 
+    // When true, structured plan/apply context persistence is handed to a bounded async queue
+    // instead of running synchronously on the Terraform process-output reader thread. Set false to
+    // fall back to the previous synchronous behaviour.
+    private boolean asyncStructuredOutput = true;
+
 }

--- a/executor/src/main/java/io/terrakube/executor/configuration/ExecutorFlagsProperties.java
+++ b/executor/src/main/java/io/terrakube/executor/configuration/ExecutorFlagsProperties.java
@@ -24,4 +24,8 @@ public class ExecutorFlagsProperties {
     // fall back to the previous synchronous behaviour.
     private boolean asyncStructuredOutput = true;
 
+    // When true, a snapshot that exhausts its normal retry budget is retained and retried on a
+    // slow scheduled cadence so a brief context-store outage does not permanently lose it.
+    private boolean structuredOutputRecovery = true;
+
 }

--- a/executor/src/main/java/io/terrakube/executor/configuration/StructuredOutputProperties.java
+++ b/executor/src/main/java/io/terrakube/executor/configuration/StructuredOutputProperties.java
@@ -1,0 +1,27 @@
+package io.terrakube.executor.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+/**
+ * Tuning knobs for the asynchronous structured-output persistence queue. Defaults are conservative;
+ * {@code queueCapacity} bounds memory, and the backoff/attempt budget is sized so a transient
+ * context-store outage is ridden out without ever failing or blocking a Terraform run.
+ */
+@Component
+@Getter
+@Setter
+@PropertySource(value = "classpath:application.properties", ignoreResourceNotFound = true)
+@PropertySource(value = "classpath:application-${spring.profiles.active}.properties", ignoreResourceNotFound = true)
+@ConfigurationProperties(prefix = "io.terrakube.executor.structured-output")
+public class StructuredOutputProperties {
+
+    private int queueCapacity = 256;
+    private int maxPersistAttempts = 4;
+    private long initialBackoffMs = 250;
+    private long maxBackoffMs = 4000;
+    private long drainTimeoutMs = 30000;
+}

--- a/executor/src/main/java/io/terrakube/executor/configuration/StructuredOutputProperties.java
+++ b/executor/src/main/java/io/terrakube/executor/configuration/StructuredOutputProperties.java
@@ -24,4 +24,12 @@ public class StructuredOutputProperties {
     private long initialBackoffMs = 250;
     private long maxBackoffMs = 4000;
     private long drainTimeoutMs = 30000;
+
+    // Delayed recovery: after the normal retry budget is exhausted, the newest snapshot per
+    // (jobId, stepId, phase) is retained and retried on a slow scheduled cadence until it persists
+    // or the retention period expires.
+    private long recoveryRetentionMs = 600_000;
+    private long recoveryInitialDelayMs = 15_000;
+    private long recoveryMaxDelayMs = 60_000;
+    private int recoveryMaxRetained = 64;
 }

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/ApplyStructuredOutputService.java
@@ -2,7 +2,11 @@ package io.terrakube.executor.service.terraform;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.executor.configuration.ExecutorFlagsProperties;
+import io.terrakube.executor.service.terraform.structured.StructuredOutputPersistenceQueue;
+import io.terrakube.executor.service.terraform.structured.StructuredSnapshot;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -20,12 +24,32 @@ public class ApplyStructuredOutputService {
 
     private final JobContextService jobContextService;
     private final ObjectMapper objectMapper;
+    private final StructuredOutputPersistenceQueue persistenceQueue;
+    private final ExecutorFlagsProperties executorFlagsProperties;
 
+    @Autowired
+    public ApplyStructuredOutputService(
+            JobContextService jobContextService,
+            ObjectMapper objectMapper,
+            StructuredOutputPersistenceQueue persistenceQueue,
+            ExecutorFlagsProperties executorFlagsProperties) {
+        this.jobContextService = jobContextService;
+        this.objectMapper = objectMapper;
+        this.persistenceQueue = persistenceQueue;
+        this.executorFlagsProperties = executorFlagsProperties;
+    }
+
+    // Convenience constructor for tests and callers that keep the previous synchronous behaviour.
     public ApplyStructuredOutputService(
             JobContextService jobContextService,
             ObjectMapper objectMapper) {
-        this.jobContextService = jobContextService;
-        this.objectMapper = objectMapper;
+        this(jobContextService, objectMapper, null, synchronousFlags());
+    }
+
+    private static ExecutorFlagsProperties synchronousFlags() {
+        ExecutorFlagsProperties flags = new ExecutorFlagsProperties();
+        flags.setAsyncStructuredOutput(false);
+        return flags;
     }
 
     public List<Map<String, Object>> seedFromPlan(String organizationId, String jobId) {
@@ -94,6 +118,32 @@ public class ApplyStructuredOutputService {
     }
 
     void publishApplyProgress(String organizationId, String jobId, String stepId, List<Map<String, Object>> changes, List<Map<String, Object>> jobDiagnostics) {
+        publishApplyStructured(organizationId, jobId, stepId, changes, jobDiagnostics, false);
+    }
+
+    /** Persist the last word on an apply/destroy step - attempted whether it succeeded or failed. */
+    public void publishFinalApplySnapshot(String organizationId, String jobId, String stepId,
+                                          List<Map<String, Object>> changes, List<Map<String, Object>> jobDiagnostics) {
+        publishApplyStructured(organizationId, jobId, stepId, changes, jobDiagnostics, true);
+    }
+
+    private void publishApplyStructured(String organizationId, String jobId, String stepId,
+                                        List<Map<String, Object>> changes, List<Map<String, Object>> jobDiagnostics,
+                                        boolean finalSnapshot) {
+        if (executorFlagsProperties.isAsyncStructuredOutput() && persistenceQueue != null) {
+            try {
+                StructuredSnapshot snapshot = StructuredSnapshot.copyOf(organizationId, jobId, stepId,
+                        StructuredSnapshot.Phase.APPLY, persistenceQueue.nextSequence(), finalSnapshot,
+                        changes, jobDiagnostics, objectMapper);
+                persistenceQueue.submit(snapshot);
+            } catch (StructuredSnapshot.SnapshotSerializationException e) {
+                persistenceQueue.dropSerialization();
+            } catch (RuntimeException e) {
+                log.warn("Unable to enqueue structured apply snapshot for job {} step {}", jobId, stepId, e);
+            }
+            return;
+        }
+
         try {
             Map<String, Object> context = getCurrentContext(organizationId, jobId);
             Map<String, Object> updatedContext = updateApplyContext(context, stepId, changes, jobDiagnostics);

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/DefaultStructuredSnapshotPersister.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/DefaultStructuredSnapshotPersister.java
@@ -1,0 +1,78 @@
+package io.terrakube.executor.service.terraform;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.executor.service.logs.ProcessLogs;
+import io.terrakube.executor.service.terraform.structured.StructuredSnapshot;
+import io.terrakube.executor.service.terraform.structured.StructuredSnapshotPersister;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Runs entirely on the {@code structured-output-persistence} worker thread: reads the current job
+ * context, merges this step's plan/apply changes + diagnostics, POSTs it back, and - only on a
+ * successful write - emits the best-effort SSE live update. Any failure returns {@code false} so the
+ * queue can retry; nothing here can reach a Terraform reader thread.
+ */
+@Slf4j
+@Service
+public class DefaultStructuredSnapshotPersister implements StructuredSnapshotPersister {
+
+    private final JobContextService jobContextService;
+    private final PlanStructuredOutputService planStructuredOutputService;
+    private final ApplyStructuredOutputService applyStructuredOutputService;
+    private final ProcessLogs processLogs;
+    private final ObjectMapper objectMapper;
+
+    public DefaultStructuredSnapshotPersister(JobContextService jobContextService,
+                                              PlanStructuredOutputService planStructuredOutputService,
+                                              ApplyStructuredOutputService applyStructuredOutputService,
+                                              ProcessLogs processLogs,
+                                              ObjectMapper objectMapper) {
+        this.jobContextService = jobContextService;
+        this.planStructuredOutputService = planStructuredOutputService;
+        this.applyStructuredOutputService = applyStructuredOutputService;
+        this.processLogs = processLogs;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public boolean persist(StructuredSnapshot snapshot) {
+        String organizationId = snapshot.getOrganizationId();
+        String jobId = snapshot.getJobId();
+        String stepId = snapshot.getStepId();
+        boolean planPhase = snapshot.getPhase() == StructuredSnapshot.Phase.PLAN;
+        try {
+            Map<String, Object> context = jobContextService.getCurrentContext(organizationId, jobId);
+            Map<String, Object> updated = planPhase
+                    ? planStructuredOutputService.updateContext(context, stepId, snapshot.getChanges(), snapshot.getJobDiagnostics())
+                    : applyStructuredOutputService.updateApplyContext(context, stepId, snapshot.getChanges(), snapshot.getJobDiagnostics());
+
+            boolean saved = jobContextService.saveContextChecked(organizationId, jobId, updated);
+            if (saved) {
+                pushLiveUpdate(planPhase ? "plan" : "apply", jobId, stepId, snapshot);
+            }
+            return saved;
+        } catch (Throwable t) {
+            log.warn("Unable to persist structured output for job {} step {} phase {}: {}",
+                    jobId, stepId, planPhase ? "plan" : "apply", t.toString());
+            return false;
+        }
+    }
+
+    private void pushLiveUpdate(String phase, String jobId, String stepId, StructuredSnapshot snapshot) {
+        try {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("phase", phase);
+            payload.put("changes", Map.of(stepId, snapshot.getChanges()));
+            payload.put("jobDiagnostics", Map.of(stepId, snapshot.getJobDiagnostics()));
+            processLogs.sendStructuredUpdate(Integer.valueOf(jobId), stepId, objectMapper.writeValueAsString(payload));
+        } catch (Exception e) {
+            // Best-effort: an SSE/serialization failure must not turn a successful context write
+            // into a retried (and eventually failed) persist.
+            log.warn("Unable to push live structured update for job {} step {}: {}", jobId, stepId, e.getMessage());
+        }
+    }
+}

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/DefaultStructuredSnapshotPersister.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/DefaultStructuredSnapshotPersister.java
@@ -57,6 +57,9 @@ public class DefaultStructuredSnapshotPersister implements StructuredSnapshotPer
                     "stepId", stepId,
                     "phase", planPhase ? "plan" : "apply",
                     "finalSnapshot", snapshot.isFinalSnapshot()));
+            if (planPhase && snapshot.isFinalSnapshot()) {
+                PlanStructuredOutputService.applyNoChangePlanMarker(updated, stepId, snapshot.getChanges());
+            }
 
             boolean saved = jobContextService.saveContextChecked(organizationId, jobId, updated);
             if (saved) {

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/DefaultStructuredSnapshotPersister.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/DefaultStructuredSnapshotPersister.java
@@ -49,6 +49,14 @@ public class DefaultStructuredSnapshotPersister implements StructuredSnapshotPer
             Map<String, Object> updated = planPhase
                     ? planStructuredOutputService.updateContext(context, stepId, snapshot.getChanges(), snapshot.getJobDiagnostics())
                     : applyStructuredOutputService.updateApplyContext(context, stepId, snapshot.getChanges(), snapshot.getJobDiagnostics());
+            // Machine-readable persistence status the API/UI can reason about without reading any
+            // Terraform payload content. Carries no variable values or secrets.
+            updated.put("structuredOutputStatus", Map.of(
+                    "state", "PERSISTED",
+                    "updatedAtEpochMs", snapshot.getCreatedAtEpochMs(),
+                    "stepId", stepId,
+                    "phase", planPhase ? "plan" : "apply",
+                    "finalSnapshot", snapshot.isFinalSnapshot()));
 
             boolean saved = jobContextService.saveContextChecked(organizationId, jobId, updated);
             if (saved) {

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/JobContextService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/JobContextService.java
@@ -21,23 +21,40 @@ import java.util.Map;
 @Service
 public class JobContextService {
 
-    private static final int CONNECT_TIMEOUT_MS = 5000;
-    private static final int READ_TIMEOUT_MS = 10000;
+    private static final int DEFAULT_CONNECT_TIMEOUT_MS = 5000;
+    private static final int DEFAULT_READ_TIMEOUT_MS = 15000;
 
     private final WorkspaceSecurity workspaceSecurity;
     private final ObjectMapper objectMapper;
     private final String terrakubeApiUrl;
     private final TerrakubeClient terrakubeClient;
+    private final int connectTimeoutMs;
+    private final int readTimeoutMs;
 
+    @org.springframework.beans.factory.annotation.Autowired
     public JobContextService(
             WorkspaceSecurity workspaceSecurity,
             ObjectMapper objectMapper,
             @Value("${io.terrakube.api.url}") String terrakubeApiUrl,
-            TerrakubeClient terrakubeClient) {
+            TerrakubeClient terrakubeClient,
+            @Value("${io.terrakube.executor.context.connect-timeout-ms:5000}") int connectTimeoutMs,
+            @Value("${io.terrakube.executor.context.read-timeout-ms:15000}") int readTimeoutMs) {
         this.workspaceSecurity = workspaceSecurity;
         this.objectMapper = objectMapper;
         this.terrakubeApiUrl = terrakubeApiUrl;
         this.terrakubeClient = terrakubeClient;
+        this.connectTimeoutMs = connectTimeoutMs > 0 ? connectTimeoutMs : DEFAULT_CONNECT_TIMEOUT_MS;
+        this.readTimeoutMs = readTimeoutMs > 0 ? readTimeoutMs : DEFAULT_READ_TIMEOUT_MS;
+    }
+
+    // Kept for tests and callers that do not tune the timeouts.
+    public JobContextService(
+            WorkspaceSecurity workspaceSecurity,
+            ObjectMapper objectMapper,
+            String terrakubeApiUrl,
+            TerrakubeClient terrakubeClient) {
+        this(workspaceSecurity, objectMapper, terrakubeApiUrl, terrakubeClient,
+                DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_READ_TIMEOUT_MS);
     }
 
     public Map<String, Object> getCurrentContext(String organizationId, String jobId) {
@@ -74,13 +91,24 @@ public class JobContextService {
     }
 
     public void saveContext(String organizationId, String jobId, Map<String, Object> context) {
+        saveContextChecked(organizationId, jobId, context);
+    }
+
+    /**
+     * Same as {@link #saveContext} but reports the outcome instead of only logging it, so the
+     * structured-output queue worker can decide whether to retry. Never throws.
+     *
+     * @return {@code true} only when the context write returned a non-error status.
+     */
+    public boolean saveContextChecked(String organizationId, String jobId, Map<String, Object> context) {
         HttpURLConnection connection = null;
         try {
             io.terrakube.client.model.organization.job.Job jobInfo = terrakubeClient.getJobById(organizationId, jobId).getData();
             if (jobInfo.getAttributes().getStatus().equals("running")) {
                 log.info("Job {} exists, Terrakube should be able to save the context", jobId);
             } else {
-                throw new IllegalStateException("Job is not running, cannot save context");
+                log.warn("Job {} is not running, cannot save context", jobId);
+                return false;
             }
             connection = buildConnection(terrakubeApiUrl + "/context/v1/" + jobInfo.getId(), "POST");
             connection.setDoOutput(true);
@@ -93,9 +121,12 @@ public class JobContextService {
             if (statusCode >= 400) {
                 log.warn("Unable to save context for job {}. Response status: {} Body: {}", jobId, statusCode,
                         readResponseBody(connection));
+                return false;
             }
+            return true;
         } catch (Exception e) {
-            log.warn("Unable to save context for job {}", jobId, e);
+            log.warn("Unable to save context for job {}: {}", jobId, e.getMessage());
+            return false;
         } finally {
             if (connection != null) {
                 connection.disconnect();
@@ -106,8 +137,8 @@ public class JobContextService {
     HttpURLConnection buildConnection(String endpoint, String method) throws IOException {
         HttpURLConnection connection = (HttpURLConnection) new URL(endpoint).openConnection();
         connection.setRequestMethod(method);
-        connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
-        connection.setReadTimeout(READ_TIMEOUT_MS);
+        connection.setConnectTimeout(connectTimeoutMs);
+        connection.setReadTimeout(readTimeoutMs);
         connection.setRequestProperty("Authorization", "Bearer " + workspaceSecurity.generateAccessToken(1));
         connection.setRequestProperty("Content-Type", "application/json");
         connection.setUseCaches(false);

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/PlanStructuredOutputService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/PlanStructuredOutputService.java
@@ -2,10 +2,14 @@ package io.terrakube.executor.service.terraform;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.executor.configuration.ExecutorFlagsProperties;
+import io.terrakube.executor.service.terraform.structured.StructuredOutputPersistenceQueue;
+import io.terrakube.executor.service.terraform.structured.StructuredSnapshot;
 import io.terrakube.terraform.TerraformClient;
 import io.terrakube.terraform.TerraformProcessData;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.TextStringBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import io.terrakube.executor.service.mode.TerraformJob;
 
@@ -33,14 +37,35 @@ public class PlanStructuredOutputService {
     private final JobContextService jobContextService;
     private final ObjectMapper objectMapper;
     TerraformClient terraformClient;
+    private final StructuredOutputPersistenceQueue persistenceQueue;
+    private final ExecutorFlagsProperties executorFlagsProperties;
 
+    @Autowired
+    public PlanStructuredOutputService(
+            JobContextService jobContextService,
+            ObjectMapper objectMapper,
+            TerraformClient terraformClient,
+            StructuredOutputPersistenceQueue persistenceQueue,
+            ExecutorFlagsProperties executorFlagsProperties) {
+        this.jobContextService = jobContextService;
+        this.objectMapper = objectMapper;
+        this.terraformClient = terraformClient;
+        this.persistenceQueue = persistenceQueue;
+        this.executorFlagsProperties = executorFlagsProperties;
+    }
+
+    // Convenience constructor for tests and callers that keep the previous synchronous behaviour.
     public PlanStructuredOutputService(
             JobContextService jobContextService,
             ObjectMapper objectMapper,
             TerraformClient terraformClient) {
-        this.jobContextService = jobContextService;
-        this.objectMapper = objectMapper;
-        this.terraformClient = terraformClient;
+        this(jobContextService, objectMapper, terraformClient, null, synchronousFlags());
+    }
+
+    private static ExecutorFlagsProperties synchronousFlags() {
+        ExecutorFlagsProperties flags = new ExecutorFlagsProperties();
+        flags.setAsyncStructuredOutput(false);
+        return flags;
     }
 
     public void publishPlanSummary(TerraformJob terraformJob, File terraformWorkingDir, List<Map<String, Object>> liveChanges, List<Map<String, Object>> jobDiagnostics) {
@@ -66,6 +91,36 @@ public class PlanStructuredOutputService {
     }
 
     void publishPlanProgress(String organizationId, String jobId, String stepId, List<Map<String, Object>> liveChanges, List<Map<String, Object>> jobDiagnostics) {
+        publishPlanStructured(organizationId, jobId, stepId, liveChanges, jobDiagnostics, false);
+    }
+
+    /**
+     * Persist the last word on a plan step - attempted for both a successful and a failed plan, so
+     * the UI can show real diagnostics (e.g. an unset required variable) instead of a stale "no
+     * changes" state.
+     */
+    public void publishFinalPlanSnapshot(String organizationId, String jobId, String stepId,
+                                         List<Map<String, Object>> liveChanges, List<Map<String, Object>> jobDiagnostics) {
+        publishPlanStructured(organizationId, jobId, stepId, liveChanges, jobDiagnostics, true);
+    }
+
+    private void publishPlanStructured(String organizationId, String jobId, String stepId,
+                                       List<Map<String, Object>> liveChanges, List<Map<String, Object>> jobDiagnostics,
+                                       boolean finalSnapshot) {
+        if (executorFlagsProperties.isAsyncStructuredOutput() && persistenceQueue != null) {
+            try {
+                StructuredSnapshot snapshot = StructuredSnapshot.copyOf(organizationId, jobId, stepId,
+                        StructuredSnapshot.Phase.PLAN, persistenceQueue.nextSequence(), finalSnapshot,
+                        liveChanges, jobDiagnostics, objectMapper);
+                persistenceQueue.submit(snapshot);
+            } catch (StructuredSnapshot.SnapshotSerializationException e) {
+                persistenceQueue.dropSerialization();
+            } catch (RuntimeException e) {
+                log.warn("Unable to enqueue structured plan snapshot for job {} step {}", jobId, stepId, e);
+            }
+            return;
+        }
+
         try {
             Map<String, Object> context = getCurrentContext(organizationId, jobId);
             Map<String, Object> updatedContext = updateContext(context, stepId, liveChanges, jobDiagnostics);

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/PlanStructuredOutputService.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/PlanStructuredOutputService.java
@@ -32,6 +32,7 @@ public class PlanStructuredOutputService {
     private static final String CONTEXT_PLAN_KEY = "planStructuredOutput";
     private static final String CONTEXT_UI_KEY = "terrakubeUI";
     private static final String CONTEXT_JOB_DIAGNOSTICS_KEY = "jobDiagnostics";
+    static final String CONTEXT_NO_CHANGE_PLAN_KEY = "noChangePlan";
     private static final String STRUCTURED_PLAN_MARKER = "<div data-terrakube-structured-plan=\"true\"></div>";
 
     private final JobContextService jobContextService;
@@ -80,6 +81,7 @@ public class PlanStructuredOutputService {
                     : buildChangesFromPlanJson(planJson);
             Map<String, Object> context = getCurrentContext(terraformJob.getOrganizationId(), terraformJob.getJobId());
             Map<String, Object> updatedContext = updateContext(context, terraformJob.getStepId(), changes, jobDiagnostics);
+            applyNoChangePlanMarker(updatedContext, terraformJob.getStepId(), changes);
             saveContext(terraformJob.getOrganizationId(), terraformJob.getJobId(), updatedContext);
         } catch (InterruptedException e) {
             log.error("Interrupted while publishing plan summary", e);
@@ -124,6 +126,9 @@ public class PlanStructuredOutputService {
         try {
             Map<String, Object> context = getCurrentContext(organizationId, jobId);
             Map<String, Object> updatedContext = updateContext(context, stepId, liveChanges, jobDiagnostics);
+            if (finalSnapshot) {
+                applyNoChangePlanMarker(updatedContext, stepId, liveChanges);
+            }
             saveContext(organizationId, jobId, updatedContext);
         } catch (Exception e) {
             log.warn("Unable to publish live plan progress for job {} step {}", jobId, stepId, e);
@@ -290,6 +295,20 @@ public class PlanStructuredOutputService {
         updatedContext.put(CONTEXT_JOB_DIAGNOSTICS_KEY, jobDiagnosticsByStep);
 
         return updatedContext;
+    }
+
+    /**
+     * A no-change plan writes an explicit {@code noChangePlan} marker (with its plan step id) so the
+     * UI can treat the associated standard apply as a valid no-op without inferring it from an empty
+     * array or console text. The marker is cleared as soon as a real change is recorded for the step.
+     * Only written from authoritative final writes (plan summary / final snapshot), never progress.
+     */
+    static void applyNoChangePlanMarker(Map<String, Object> context, String stepId, List<?> changes) {
+        if (changes == null || changes.isEmpty()) {
+            context.put(CONTEXT_NO_CHANGE_PLAN_KEY, Map.of("planStepId", stepId));
+        } else {
+            context.remove(CONTEXT_NO_CHANGE_PLAN_KEY);
+        }
     }
 
     private Map<String, Object> getCurrentContext(String organizationId, String jobId) {

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -806,9 +806,18 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
     // output stream" with none of the real Terraform output, and none of the real error (the
     // "Error: External Program Lookup Failed" / missing-python diagnostic, in the reported case)
     // that actually caused it.
-    private ExecutorJobResult setError(Exception exception, String partialConsoleOutput) {
+    ExecutorJobResult setError(Exception exception, String partialConsoleOutput) {
         String message = exception.getMessage() != null ? exception.getMessage() : exception.toString();
         log.error("Terraform operation failed: {}", message, exception);
+
+        // A terraform-spring-boot stream-drain watchdog failure is an executor-side symptom, not the
+        // Terraform diagnostic - the real error (an unset required variable, a missing provider) is
+        // already in partialConsoleOutput above. Count it and keep it clearly secondary so it never
+        // masks the diagnostic the user actually needs.
+        boolean streamDrainFailure = messageChainContains(exception, "Failed to capture process output stream");
+        if (streamDrainFailure && meterRegistry != null) {
+            meterRegistry.counter("terrakube.executor.process.stream.drain.timeouts").increment();
+        }
 
         TextStringBuilder consoleOutput = new TextStringBuilder();
         if (partialConsoleOutput != null && !partialConsoleOutput.isBlank()) {
@@ -819,7 +828,12 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             consoleOutput.appendNewLine();
         }
         consoleOutput.appendln("Error: the Terrakube executor could not finish this operation");
-        consoleOutput.appendln(message);
+        if (streamDrainFailure) {
+            consoleOutput.appendln("(secondary, executor-side) " + message);
+            consoleOutput.appendln("The Terraform/OpenTofu diagnostic above is the primary error.");
+        } else {
+            consoleOutput.appendln(message);
+        }
 
         ExecutorJobResult error = generateJobResult(false, consoleOutput.toString(), message);
 
@@ -827,6 +841,15 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             Thread.currentThread().interrupt();
         }
         return error;
+    }
+
+    private static boolean messageChainContains(Throwable throwable, String needle) {
+        for (Throwable current = throwable; current != null && current != current.getCause(); current = current.getCause()) {
+            if (current.getMessage() != null && current.getMessage().contains(needle)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // terraform-spring-boot invokes the -json line consumer from inside its process-output reader

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -3,12 +3,16 @@ package io.terrakube.executor.service.terraform;
 import com.diogonunes.jcolor.AnsiFormat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.terrakube.executor.configuration.ExecutorFlagsProperties;
+import io.terrakube.executor.configuration.StructuredOutputProperties;
 import io.terrakube.executor.plugin.tfstate.TerraformState;
 import io.terrakube.executor.service.executor.ExecutorJobResult;
 import io.terrakube.executor.service.logs.LogsConsumer;
 import io.terrakube.executor.service.logs.ProcessLogs;
 import io.terrakube.executor.service.mode.TerraformJob;
 import io.terrakube.executor.service.scripts.ScriptEngineService;
+import io.terrakube.executor.service.terraform.structured.StructuredOutputPersistenceQueue;
 import io.terrakube.terraform.TerraformClient;
 import io.terrakube.terraform.TerraformDownloader;
 import io.terrakube.terraform.TerraformProcessData;
@@ -65,8 +69,12 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
     ApplyStructuredOutputService applyStructuredOutputService;
     TerraformOutputsService terraformOutputsService;
     ObjectMapper objectMapper;
+    StructuredOutputPersistenceQueue structuredOutputPersistenceQueue;
+    ExecutorFlagsProperties executorFlagsProperties;
+    StructuredOutputProperties structuredOutputProperties;
+    MeterRegistry meterRegistry;
 
-    public TerraformExecutorServiceImpl(TerraformClient terraformClient, TerraformState terraformState, ScriptEngineService scriptEngineService, ProcessLogs logsService, PlanStructuredOutputService planStructuredOutputService, ApplyStructuredOutputService applyStructuredOutputService, TerraformOutputsService terraformOutputsService, ObjectMapper objectMapper, @Value("${io.terrakube.terraform.flags.enableColor}") boolean enableColorOutput, RedisTemplate redisTemplate, @Value("${io.terrakube.executor.redis.timeout}") int redisTimeout) {
+    public TerraformExecutorServiceImpl(TerraformClient terraformClient, TerraformState terraformState, ScriptEngineService scriptEngineService, ProcessLogs logsService, PlanStructuredOutputService planStructuredOutputService, ApplyStructuredOutputService applyStructuredOutputService, TerraformOutputsService terraformOutputsService, ObjectMapper objectMapper, @Value("${io.terrakube.terraform.flags.enableColor}") boolean enableColorOutput, RedisTemplate redisTemplate, @Value("${io.terrakube.executor.redis.timeout}") int redisTimeout, StructuredOutputPersistenceQueue structuredOutputPersistenceQueue, ExecutorFlagsProperties executorFlagsProperties, StructuredOutputProperties structuredOutputProperties, MeterRegistry meterRegistry) {
         this.terraformClient = terraformClient;
         this.terraformState = terraformState;
         this.scriptEngineService = scriptEngineService;
@@ -78,6 +86,10 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         this.objectMapper = objectMapper;
         this.enableColorOutput = enableColorOutput;
         this.redisTimeout = redisTimeout;
+        this.structuredOutputPersistenceQueue = structuredOutputPersistenceQueue;
+        this.executorFlagsProperties = executorFlagsProperties;
+        this.structuredOutputProperties = structuredOutputProperties;
+        this.meterRegistry = meterRegistry;
     }
 
     public File getTerraformWorkingDir(TerraformJob terraformJob, File workingDirectory) throws IOException {
@@ -145,6 +157,10 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
         TextStringBuilder jobOutput = new TextStringBuilder();
         TextStringBuilder jobErrorOutput = new TextStringBuilder();
+        // Method-scoped so a mid-stream failure (see the catch below) can still publish a final
+        // structured snapshot carrying whatever changes/diagnostics were parsed before it broke.
+        List<Map<String, Object>> liveChanges = new ArrayList<>();
+        List<Map<String, Object>> jobDiagnostics = new ArrayList<>();
         try {
             File terraformWorkingDir = getTerraformWorkingDir(terraformJob, executorTempDirectory);
             boolean executionPlan = false;
@@ -169,8 +185,6 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
                 if (scriptBeforeSuccessPlan) {
                     planCommandExecuted = true;
-                    List<Map<String, Object>> liveChanges = new ArrayList<>();
-                    List<Map<String, Object>> jobDiagnostics = new ArrayList<>();
                     TerraformJsonEventParser eventParser = new TerraformJsonEventParser(objectMapper);
                     // Starting at 0 (not now()) guarantees the very first json line always
                     // passes the "now - lastFlush > interval" check below and flushes
@@ -186,12 +200,14 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                             acceptConsoleLines(planOutput, humanMessage);
                         }
 
+                        // Cheap pre-filter only: the persistence queue coalesces per step, so this
+                        // just bounds how often we build a snapshot copy on the reader thread. The
+                        // GET/merge/POST and the SSE push happen on the queue worker, never here.
                         long now = System.currentTimeMillis();
                         if (now - lastFlush.get() > APPLY_PROGRESS_FLUSH_INTERVAL_MS) {
                             lastFlush.set(now);
                             planStructuredOutputService.publishPlanProgress(
                                     terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), liveChanges, jobDiagnostics);
-                            pushLiveStructuredUpdate("plan", terraformJob, liveChanges, jobDiagnostics);
                         }
                     };
 
@@ -211,16 +227,14 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                                 null).get();
                     }
 
-                    // Unconditional final flush, mirroring runJsonApply's trailing push - the
-                    // periodic flush above only fires when a json line arrives more than
-                    // APPLY_PROGRESS_FLUSH_INTERVAL_MS after the last one, so a plan whose lines
-                    // all land in a single burst (typical for small/fast plans) would otherwise
-                    // exit having pushed nothing, live or final - and if the plan then failed,
-                    // publishPlanSummary below (gated on executionPlan) would never run either,
-                    // leaving stale/empty progress data as the last word on this step.
-                    planStructuredOutputService.publishPlanProgress(
+                    // Unconditional final snapshot - the periodic flush above only fires when a json
+                    // line arrives more than APPLY_PROGRESS_FLUSH_INTERVAL_MS after the last one, so
+                    // a plan whose lines all land in a single burst (typical for small/fast plans)
+                    // would otherwise exit having enqueued nothing. Attempted even when the plan
+                    // failed, so a diagnostic (e.g. an unset required variable) is the last word on
+                    // this step rather than stale/empty progress data.
+                    planStructuredOutputService.publishFinalPlanSnapshot(
                             terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), liveChanges, jobDiagnostics);
-                    pushLiveStructuredUpdate("plan", terraformJob, liveChanges, jobDiagnostics);
 
                     terraformJob.setLiveChanges(liveChanges);
                     terraformJob.setJobDiagnostics(jobDiagnostics);
@@ -261,6 +275,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             scriptAfterSuccessPlan = executePostOperationScripts(terraformJob, terraformWorkingDir, planOutput, executionPlan);
 
             waitForStreamCompletion(terraformJob.getJobId(), 300);
+            drainStructuredOutputQueue(terraformJob.getJobId());
 
             result = generateJobResult(scriptAfterSuccessPlan, jobOutput.toString(), jobErrorOutput.toString());
             result.setPlanFile(executionPlan ? terraformState.saveTerraformPlan(terraformJob.getOrganizationId(),
@@ -272,11 +287,36 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             result.setPlan(true);
             result.setExitCode(exitCode);
         } catch (IOException | ExecutionException | InterruptedException exception) {
+            // A stream-drain failure or late exception must not swallow the plan diagnostics the
+            // UI needs - publish what was parsed before it broke, then let it drain.
+            try {
+                planStructuredOutputService.publishFinalPlanSnapshot(
+                        terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(),
+                        liveChanges, jobDiagnostics);
+                drainStructuredOutputQueue(terraformJob.getJobId());
+            } catch (Exception e) {
+                log.warn("Unable to publish final plan snapshot after failure for job {}", terraformJob.getJobId(), e);
+            }
             result = setError(exception, jobOutput.toString());
             result.setPlan(true);
             result.setExitCode(1);
         }
         return result;
+    }
+
+    // Give the async structured-output queue a bounded window to finish persisting before the job
+    // result is finalised. A timeout is logged, never fatal - the run's outcome does not depend on
+    // best-effort context writes.
+    private void drainStructuredOutputQueue(String jobId) {
+        if (structuredOutputPersistenceQueue == null || executorFlagsProperties == null
+                || !executorFlagsProperties.isAsyncStructuredOutput()) {
+            return;
+        }
+        long drainTimeoutMs = structuredOutputProperties != null ? structuredOutputProperties.getDrainTimeoutMs() : 30000L;
+        boolean drained = structuredOutputPersistenceQueue.awaitDrain(java.time.Duration.ofMillis(drainTimeoutMs));
+        if (!drained) {
+            log.warn("Structured-output queue did not drain within {} ms for job {}", drainTimeoutMs, jobId);
+        }
     }
 
     @Override
@@ -351,8 +391,10 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             scriptAfterSuccess = executePostOperationScripts(terraformJob, terraformWorkingDir, applyOutput, execution || terraformJob.isIgnoreError());
 
             waitForStreamCompletion(terraformJob.getJobId(), 300);
+            drainStructuredOutputQueue(terraformJob.getJobId());
             result = generateJobResult(scriptAfterSuccess, terraformOutput.toString(), terraformErrorOutput.toString());
         } catch (IOException | ExecutionException | InterruptedException exception) {
+            drainStructuredOutputQueue(terraformJob.getJobId());
             result = setError(exception, terraformOutput.toString());
             result.setExitCode(1);
         }
@@ -392,7 +434,6 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                 lastFlush.set(now);
                 applyStructuredOutputService.publishApplyProgress(
                         terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), changes, jobDiagnostics);
-                pushLiveStructuredUpdate("apply", terraformJob, changes, jobDiagnostics);
             }
         };
 
@@ -405,9 +446,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             applyStructuredOutputService.resolveFinalValues(changes, stateJson);
         }
 
-        applyStructuredOutputService.publishApplyProgress(
+        applyStructuredOutputService.publishFinalApplySnapshot(
                 terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), changes, jobDiagnostics);
-        pushLiveStructuredUpdate("apply", terraformJob, changes, jobDiagnostics);
 
         return execution;
     }
@@ -440,7 +480,6 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                 // third parallel structured-output shape for what's functionally the same view.
                 applyStructuredOutputService.publishApplyProgress(
                         terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), changes, jobDiagnostics);
-                pushLiveStructuredUpdate("apply", terraformJob, changes, jobDiagnostics);
             }
         };
 
@@ -448,9 +487,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
         boolean execution = jsonDestroyClient.destroy(terraformProcessData, guardConsumer(jsonLineConsumer), null).get();
 
-        applyStructuredOutputService.publishApplyProgress(
+        applyStructuredOutputService.publishFinalApplySnapshot(
                 terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), changes, jobDiagnostics);
-        pushLiveStructuredUpdate("apply", terraformJob, changes, jobDiagnostics);
 
         return execution;
     }
@@ -461,30 +499,6 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
     private static void acceptConsoleLines(Consumer<String> output, String message) {
         for (String line : message.split("\n", -1)) {
             output.accept(line);
-        }
-    }
-
-    // Best-effort live push over the new structured-output SSE channel - never lets a
-    // serialization failure abort the plan/apply itself, mirroring how publishApplyProgress/
-    // publishPlanProgress already swallow their own failures. changes/jobDiagnostics get keyed
-    // by stepId (matching /context/v1's shape) so the UI's existing normalizeStructuredPlanOutput/
-    // normalizeStructuredApplyOutput can consume the push unchanged, and phase is tagged so the
-    // UI merges into the right one of planStructuredOutput/applyStructuredOutput without
-    // clobbering the other.
-    private void pushLiveStructuredUpdate(String phase, TerraformJob terraformJob, List<Map<String, Object>> changes, List<Map<String, Object>> jobDiagnostics) {
-        try {
-            Map<String, Object> payload = new HashMap<>();
-            payload.put("phase", phase);
-            payload.put("changes", Map.of(terraformJob.getStepId(), changes));
-            payload.put("jobDiagnostics", Map.of(terraformJob.getStepId(), jobDiagnostics));
-            logsService.sendStructuredUpdate(Integer.valueOf(terraformJob.getJobId()), terraformJob.getStepId(),
-                    objectMapper.writeValueAsString(payload));
-        } catch (Exception e) {
-            // Best-effort: a serialization error, a null stepId in Map.of, or a transport failure
-            // in sendStructuredUpdate must never abort the plan/apply - some of these call sites
-            // run on terraform-spring-boot's output-reader thread, where an uncaught exception
-            // kills stream capture entirely.
-            log.warn("Unable to push live structured update for job {} step {}", terraformJob.getJobId(), terraformJob.getStepId(), e);
         }
     }
 
@@ -584,8 +598,10 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             scriptAfterSuccess = executePostOperationScripts(terraformJob, terraformWorkingDir, outputDestroy, execution);
 
             waitForStreamCompletion(terraformJob.getJobId(), 300);
+            drainStructuredOutputQueue(terraformJob.getJobId());
             result = generateJobResult(scriptAfterSuccess, jobOutput.toString(), jobErrorOutput.toString());
         } catch (IOException | ExecutionException | InterruptedException exception) {
+            drainStructuredOutputQueue(terraformJob.getJobId());
             result = setError(exception, jobOutput.toString());
             result.setExitCode(1);
         }

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/structured/StructuredOutputPersistenceQueue.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/structured/StructuredOutputPersistenceQueue.java
@@ -1,0 +1,240 @@
+package io.terrakube.executor.service.terraform.structured;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.terrakube.executor.configuration.StructuredOutputProperties;
+import io.terrakube.executor.service.terraform.structured.StructuredSnapshot.Key;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Bounded, coalescing, retrying hand-off between the Terraform/OpenTofu process-output reader
+ * threads and job-context persistence.
+ *
+ * <ul>
+ *   <li>{@link #submit} never blocks and never throws - it coalesces by {@code (jobId, stepId,
+ *       phase)} so only the newest unsaved snapshot for a step survives, and evicts an older
+ *       snapshot (preferring one for the same job/step) when full.</li>
+ *   <li>A single worker thread does the GET/merge/POST + SSE via {@link StructuredSnapshotPersister},
+ *       retrying with capped exponential backoff.</li>
+ *   <li>Saturation, HTTP/S3/Redis/serialization/SSE failures are counted and logged; none of them
+ *       change or block a Terraform run.</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+public class StructuredOutputPersistenceQueue {
+
+    private final Map<Key, StructuredSnapshot> pending = new ConcurrentHashMap<>();
+    private final Semaphore signal = new Semaphore(0);
+    private final Object drainLock = new Object();
+    private final AtomicLong sequence = new AtomicLong();
+
+    private final int capacity;
+    private final int maxAttempts;
+    private final long initialBackoffMs;
+    private final long maxBackoffMs;
+    private final MeterRegistry meterRegistry;
+    private final StructuredSnapshotPersister persister;
+
+    private volatile boolean running;
+    private volatile boolean persisting;
+    private Thread worker;
+
+    public StructuredOutputPersistenceQueue(StructuredOutputProperties properties,
+                                            MeterRegistry meterRegistry,
+                                            StructuredSnapshotPersister persister) {
+        this.capacity = Math.max(1, properties.getQueueCapacity());
+        this.maxAttempts = Math.max(1, properties.getMaxPersistAttempts());
+        this.initialBackoffMs = Math.max(0, properties.getInitialBackoffMs());
+        this.maxBackoffMs = Math.max(this.initialBackoffMs, properties.getMaxBackoffMs());
+        this.meterRegistry = meterRegistry;
+        this.persister = persister;
+        Gauge.builder("terrakube.executor.structured.output.queue.depth", pending, Map::size)
+                .description("Structured-output snapshots waiting to be persisted")
+                .register(meterRegistry);
+    }
+
+    @PostConstruct
+    public synchronized void start() {
+        if (running) {
+            return;
+        }
+        running = true;
+        worker = new Thread(this::runLoop, "structured-output-persistence");
+        worker.setDaemon(true);
+        worker.start();
+    }
+
+    @PreDestroy
+    public synchronized void stop() {
+        if (!running) {
+            return;
+        }
+        running = false;
+        signal.release();
+        if (worker != null) {
+            worker.interrupt();
+            try {
+                worker.join(Duration.ofSeconds(5).toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /** Monotonic sequence for snapshot ordering / eviction. */
+    public long nextSequence() {
+        return sequence.incrementAndGet();
+    }
+
+    /** Record that a snapshot could not be built (serialization failure) - never fails the run. */
+    public void dropSerialization() {
+        meterRegistry.counter("terrakube.executor.structured.output.dropped", "reason", "serialization").increment();
+    }
+
+    /** Non-blocking, never-throwing hand-off. Safe to call from a Terraform reader thread. */
+    public void submit(StructuredSnapshot snapshot) {
+        try {
+            Key key = snapshot.key();
+            if (!pending.containsKey(key) && pending.size() >= capacity) {
+                evictOne(key);
+            }
+            pending.put(key, snapshot);
+            signal.release();
+        } catch (Throwable t) {
+            log.warn("Dropping structured-output snapshot for job {} step {}: {}",
+                    snapshot.getJobId(), snapshot.getStepId(), t.toString());
+        }
+    }
+
+    /** Blocks up to {@code timeout} for the queue to empty. Returns false on timeout (caller warns). */
+    public boolean awaitDrain(Duration timeout) {
+        long deadlineNanos = System.nanoTime() + timeout.toNanos();
+        synchronized (drainLock) {
+            while (!pending.isEmpty() || persisting) {
+                long remainingMs = (deadlineNanos - System.nanoTime()) / 1_000_000L;
+                if (remainingMs <= 0) {
+                    return false;
+                }
+                try {
+                    drainLock.wait(Math.min(remainingMs, 100));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    int queueDepth() {
+        return pending.size();
+    }
+
+    private void evictOne(Key incoming) {
+        Map.Entry<Key, StructuredSnapshot> victim = null;
+        boolean victimSameJobStep = false;
+        for (Map.Entry<Key, StructuredSnapshot> candidate : pending.entrySet()) {
+            boolean sameJobStep = candidate.getKey().jobId().equals(incoming.jobId())
+                    && candidate.getKey().stepId().equals(incoming.stepId());
+            if (victim == null
+                    || (sameJobStep && !victimSameJobStep)
+                    || (sameJobStep == victimSameJobStep
+                        && candidate.getValue().getSequence() < victim.getValue().getSequence())) {
+                victim = candidate;
+                victimSameJobStep = sameJobStep;
+            }
+        }
+        if (victim != null && pending.remove(victim.getKey(), victim.getValue())) {
+            meterRegistry.counter("terrakube.executor.structured.output.dropped", "reason", "capacity").increment();
+            log.warn("Structured-output queue full ({}); dropped an older snapshot for job {} step {}",
+                    capacity, victim.getKey().jobId(), victim.getKey().stepId());
+        }
+    }
+
+    private void runLoop() {
+        while (running) {
+            try {
+                signal.acquire();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+            signal.drainPermits();
+            drainOnce();
+        }
+        drainOnce();
+    }
+
+    private void drainOnce() {
+        for (Key key : new ArrayList<>(pending.keySet())) {
+            StructuredSnapshot snapshot = pending.remove(key);
+            if (snapshot == null) {
+                continue;
+            }
+            persisting = true;
+            try {
+                persistWithRetry(snapshot);
+            } catch (Throwable t) {
+                log.warn("structured-output worker skipped a snapshot for job {} step {}: {}",
+                        snapshot.getJobId(), snapshot.getStepId(), t.toString());
+            } finally {
+                persisting = false;
+            }
+        }
+        synchronized (drainLock) {
+            drainLock.notifyAll();
+        }
+    }
+
+    private void persistWithRetry(StructuredSnapshot snapshot) {
+        long start = System.currentTimeMillis();
+        String phase = snapshot.getPhase() == StructuredSnapshot.Phase.PLAN ? "plan" : "apply";
+        for (int attempt = 0; attempt < maxAttempts && running; attempt++) {
+            if (attempt > 0) {
+                sleepBackoff(attempt - 1);
+                if (!running) {
+                    break;
+                }
+            }
+            boolean ok = false;
+            try {
+                ok = persister.persist(snapshot);
+            } catch (Throwable t) {
+                log.warn("structured-output persist threw for job {} step {} phase {}: {}",
+                        snapshot.getJobId(), snapshot.getStepId(), phase, t.toString());
+            }
+            if (ok) {
+                meterRegistry.counter("terrakube.executor.structured.output.persist", "outcome", "success").increment();
+                return;
+            }
+        }
+        meterRegistry.counter("terrakube.executor.structured.output.persist", "outcome", "failure").increment();
+        meterRegistry.counter("terrakube.executor.structured.output.persist.failures", "phase", phase).increment();
+        log.warn("structured-output persist gave up after {} attempts for job {} step {} phase {} ({} ms elapsed)",
+                maxAttempts, snapshot.getJobId(), snapshot.getStepId(), phase, System.currentTimeMillis() - start);
+    }
+
+    private void sleepBackoff(int retryIndex) {
+        int shift = Math.min(retryIndex, 20);
+        long backoff = Math.min(maxBackoffMs, initialBackoffMs << shift);
+        if (backoff <= 0) {
+            return;
+        }
+        try {
+            Thread.sleep(backoff);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/structured/StructuredOutputPersistenceQueue.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/structured/StructuredOutputPersistenceQueue.java
@@ -7,6 +7,7 @@ import io.terrakube.executor.service.terraform.structured.StructuredSnapshot.Key
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -52,7 +53,10 @@ public class StructuredOutputPersistenceQueue {
 
     public StructuredOutputPersistenceQueue(StructuredOutputProperties properties,
                                             MeterRegistry meterRegistry,
-                                            StructuredSnapshotPersister persister) {
+                                            // @Lazy breaks the construction cycle: the persister
+                                            // depends (transitively) on Plan/ApplyStructuredOutputService,
+                                            // which depend on this queue.
+                                            @Lazy StructuredSnapshotPersister persister) {
         this.capacity = Math.max(1, properties.getQueueCapacity());
         this.maxAttempts = Math.max(1, properties.getMaxPersistAttempts());
         this.initialBackoffMs = Math.max(0, properties.getInitialBackoffMs());

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/structured/StructuredOutputPersistenceQueue.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/structured/StructuredOutputPersistenceQueue.java
@@ -2,6 +2,7 @@ package io.terrakube.executor.service.terraform.structured;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.terrakube.executor.configuration.ExecutorFlagsProperties;
 import io.terrakube.executor.configuration.StructuredOutputProperties;
 import io.terrakube.executor.service.terraform.structured.StructuredSnapshot.Key;
 import jakarta.annotation.PostConstruct;
@@ -12,9 +13,14 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -24,9 +30,12 @@ import java.util.concurrent.atomic.AtomicLong;
  * <ul>
  *   <li>{@link #submit} never blocks and never throws - it coalesces by {@code (jobId, stepId,
  *       phase)} so only the newest unsaved snapshot for a step survives, and evicts an older
- *       snapshot (preferring one for the same job/step) when full.</li>
+ *       snapshot (preferring a non-final one for the same job/step) when full.</li>
  *   <li>A single worker thread does the GET/merge/POST + SSE via {@link StructuredSnapshotPersister},
  *       retrying with capped exponential backoff.</li>
+ *   <li>On retry-budget exhaustion the newest snapshot per key is <em>retained</em> and retried by a
+ *       separate scheduled thread on a slow jittered cadence until it persists or the recovery
+ *       retention period expires - so a brief context-store outage does not permanently lose it.</li>
  *   <li>Saturation, HTTP/S3/Redis/serialization/SSE failures are counted and logged; none of them
  *       change or block a Terraform run.</li>
  * </ul>
@@ -36,6 +45,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class StructuredOutputPersistenceQueue {
 
     private final Map<Key, StructuredSnapshot> pending = new ConcurrentHashMap<>();
+    private final Map<Key, RetainedSnapshot> retained = new ConcurrentHashMap<>();
     private final Semaphore signal = new Semaphore(0);
     private final Object drainLock = new Object();
     private final AtomicLong sequence = new AtomicLong();
@@ -44,14 +54,36 @@ public class StructuredOutputPersistenceQueue {
     private final int maxAttempts;
     private final long initialBackoffMs;
     private final long maxBackoffMs;
+    private final boolean recoveryEnabled;
+    private final long recoveryRetentionMs;
+    private final long recoveryInitialDelayMs;
+    private final long recoveryMaxDelayMs;
+    private final int recoveryMaxRetained;
     private final MeterRegistry meterRegistry;
     private final StructuredSnapshotPersister persister;
 
     private volatile boolean running;
     private volatile boolean persisting;
     private Thread worker;
+    private ScheduledExecutorService recoveryScheduler;
+
+    /** One snapshot held for delayed recovery after its normal retry budget was spent. */
+    private static final class RetainedSnapshot {
+        private volatile StructuredSnapshot snapshot;
+        private final long firstRetainedAtEpochMs;
+        private volatile long nextAttemptAtEpochMs;
+        private volatile long currentDelayMs;
+
+        RetainedSnapshot(StructuredSnapshot snapshot, long now, long initialDelayMs) {
+            this.snapshot = snapshot;
+            this.firstRetainedAtEpochMs = now;
+            this.currentDelayMs = initialDelayMs;
+            this.nextAttemptAtEpochMs = now + jitter(initialDelayMs);
+        }
+    }
 
     public StructuredOutputPersistenceQueue(StructuredOutputProperties properties,
+                                            ExecutorFlagsProperties flags,
                                             MeterRegistry meterRegistry,
                                             // @Lazy breaks the construction cycle: the persister
                                             // depends (transitively) on Plan/ApplyStructuredOutputService,
@@ -61,10 +93,18 @@ public class StructuredOutputPersistenceQueue {
         this.maxAttempts = Math.max(1, properties.getMaxPersistAttempts());
         this.initialBackoffMs = Math.max(0, properties.getInitialBackoffMs());
         this.maxBackoffMs = Math.max(this.initialBackoffMs, properties.getMaxBackoffMs());
+        this.recoveryEnabled = flags.isStructuredOutputRecovery();
+        this.recoveryRetentionMs = Math.max(0, properties.getRecoveryRetentionMs());
+        this.recoveryInitialDelayMs = Math.max(100, properties.getRecoveryInitialDelayMs());
+        this.recoveryMaxDelayMs = Math.max(this.recoveryInitialDelayMs, properties.getRecoveryMaxDelayMs());
+        this.recoveryMaxRetained = Math.max(1, properties.getRecoveryMaxRetained());
         this.meterRegistry = meterRegistry;
         this.persister = persister;
         Gauge.builder("terrakube.executor.structured.output.queue.depth", pending, Map::size)
                 .description("Structured-output snapshots waiting to be persisted")
+                .register(meterRegistry);
+        Gauge.builder("terrakube.executor.structured.output.recovery.pending", retained, Map::size)
+                .description("Structured-output snapshots retained for delayed recovery")
                 .register(meterRegistry);
     }
 
@@ -77,6 +117,14 @@ public class StructuredOutputPersistenceQueue {
         worker = new Thread(this::runLoop, "structured-output-persistence");
         worker.setDaemon(true);
         worker.start();
+        if (recoveryEnabled) {
+            recoveryScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "structured-output-recovery");
+                t.setDaemon(true);
+                return t;
+            });
+            recoveryScheduler.scheduleWithFixedDelay(this::recoverRetained, 5, 5, TimeUnit.SECONDS);
+        }
     }
 
     @PreDestroy
@@ -94,6 +142,12 @@ public class StructuredOutputPersistenceQueue {
                 Thread.currentThread().interrupt();
             }
         }
+        if (recoveryScheduler != null) {
+            recoveryScheduler.shutdownNow();
+        }
+        // Best-effort single pass over anything still retained - bounded, never blocks pod exit
+        // beyond the small window below.
+        drainRetainedOnce(Duration.ofSeconds(5));
     }
 
     /** Monotonic sequence for snapshot ordering / eviction. */
@@ -110,6 +164,12 @@ public class StructuredOutputPersistenceQueue {
     public void submit(StructuredSnapshot snapshot) {
         try {
             Key key = snapshot.key();
+            // A newer snapshot supersedes anything retained for delayed recovery for this key.
+            RetainedSnapshot alreadyRetained = retained.get(key);
+            if (alreadyRetained != null && snapshot.getSequence() > alreadyRetained.snapshot.getSequence()) {
+                alreadyRetained.snapshot = snapshot;
+                alreadyRetained.nextAttemptAtEpochMs = System.currentTimeMillis();
+            }
             if (!pending.containsKey(key) && pending.size() >= capacity) {
                 evictOne(key);
             }
@@ -145,25 +205,40 @@ public class StructuredOutputPersistenceQueue {
         return pending.size();
     }
 
+    int retainedDepth() {
+        return retained.size();
+    }
+
     private void evictOne(Key incoming) {
         Map.Entry<Key, StructuredSnapshot> victim = null;
-        boolean victimSameJobStep = false;
+        int victimRank = Integer.MIN_VALUE;
         for (Map.Entry<Key, StructuredSnapshot> candidate : pending.entrySet()) {
-            boolean sameJobStep = candidate.getKey().jobId().equals(incoming.jobId())
-                    && candidate.getKey().stepId().equals(incoming.stepId());
-            if (victim == null
-                    || (sameJobStep && !victimSameJobStep)
-                    || (sameJobStep == victimSameJobStep
-                        && candidate.getValue().getSequence() < victim.getValue().getSequence())) {
+            int rank = evictionRank(candidate, incoming);
+            if (victim == null || rank > victimRank
+                    || (rank == victimRank && candidate.getValue().getSequence() < victim.getValue().getSequence())) {
                 victim = candidate;
-                victimSameJobStep = sameJobStep;
+                victimRank = rank;
             }
         }
         if (victim != null && pending.remove(victim.getKey(), victim.getValue())) {
             meterRegistry.counter("terrakube.executor.structured.output.dropped", "reason", "capacity").increment();
-            log.warn("Structured-output queue full ({}); dropped an older snapshot for job {} step {}",
-                    capacity, victim.getKey().jobId(), victim.getKey().stepId());
+            log.warn("Structured-output queue full ({}); dropped a {} snapshot for job {} step {}",
+                    capacity, victim.getValue().isFinalSnapshot() ? "final" : "progress",
+                    victim.getKey().jobId(), victim.getKey().stepId());
         }
+    }
+
+    // Higher rank = better eviction candidate: prefer non-final over final, then same job/step.
+    private int evictionRank(Map.Entry<Key, StructuredSnapshot> candidate, Key incoming) {
+        int rank = 0;
+        if (!candidate.getValue().isFinalSnapshot()) {
+            rank += 2;
+        }
+        if (candidate.getKey().jobId().equals(incoming.jobId())
+                && candidate.getKey().stepId().equals(incoming.stepId())) {
+            rank += 1;
+        }
+        return rank;
     }
 
     private void runLoop() {
@@ -211,15 +286,8 @@ public class StructuredOutputPersistenceQueue {
                     break;
                 }
             }
-            boolean ok = false;
-            try {
-                ok = persister.persist(snapshot);
-            } catch (Throwable t) {
-                log.warn("structured-output persist threw for job {} step {} phase {}: {}",
-                        snapshot.getJobId(), snapshot.getStepId(), phase, t.toString());
-            }
-            if (ok) {
-                meterRegistry.counter("terrakube.executor.structured.output.persist", "outcome", "success").increment();
+            if (tryPersist(snapshot, phase)) {
+                supersedeRetained(snapshot);
                 return;
             }
         }
@@ -227,6 +295,127 @@ public class StructuredOutputPersistenceQueue {
         meterRegistry.counter("terrakube.executor.structured.output.persist.failures", "phase", phase).increment();
         log.warn("structured-output persist gave up after {} attempts for job {} step {} phase {} ({} ms elapsed)",
                 maxAttempts, snapshot.getJobId(), snapshot.getStepId(), phase, System.currentTimeMillis() - start);
+        retain(snapshot);
+    }
+
+    private boolean tryPersist(StructuredSnapshot snapshot, String phase) {
+        try {
+            if (persister.persist(snapshot)) {
+                meterRegistry.counter("terrakube.executor.structured.output.persist", "outcome", "success").increment();
+                return true;
+            }
+        } catch (Throwable t) {
+            log.warn("structured-output persist threw for job {} step {} phase {}: {}",
+                    snapshot.getJobId(), snapshot.getStepId(), phase, t.toString());
+        }
+        return false;
+    }
+
+    // Only ever called from the single persistence-worker thread (persistWithRetry), so the
+    // size-check-then-put below is not racing another retain().
+    private void retain(StructuredSnapshot snapshot) {
+        if (!recoveryEnabled) {
+            return;
+        }
+        Key key = snapshot.key();
+        RetainedSnapshot existing = retained.get(key);
+        if (existing != null) {
+            if (snapshot.getSequence() >= existing.snapshot.getSequence()) {
+                existing.snapshot = snapshot;
+            }
+            return;
+        }
+        if (retained.size() >= recoveryMaxRetained) {
+            evictRetained();
+        }
+        log.info("Retaining {} structured snapshot for job {} step {} phase {} for delayed recovery (ts={})",
+                snapshot.isFinalSnapshot() ? "final" : "progress", snapshot.getJobId(), snapshot.getStepId(),
+                snapshot.getPhase(), snapshot.getCreatedAtEpochMs());
+        retained.put(key, new RetainedSnapshot(snapshot, System.currentTimeMillis(), recoveryInitialDelayMs));
+    }
+
+    private void evictRetained() {
+        retained.entrySet().stream()
+                // prefer evicting non-final (rank 1) over final (rank 0), then the oldest
+                .min(Comparator
+                        .<Map.Entry<Key, RetainedSnapshot>>comparingInt(e -> e.getValue().snapshot.isFinalSnapshot() ? 1 : 0)
+                        .thenComparingLong(e -> e.getValue().firstRetainedAtEpochMs))
+                .ifPresent(victim -> {
+                    if (retained.remove(victim.getKey(), victim.getValue())) {
+                        meterRegistry.counter("terrakube.executor.structured.output.recovery.evictions").increment();
+                        log.warn("Recovery retention full ({}); evicted a {} snapshot for job {} step {}",
+                                recoveryMaxRetained, victim.getValue().snapshot.isFinalSnapshot() ? "final" : "progress",
+                                victim.getKey().jobId(), victim.getKey().stepId());
+                    }
+                });
+    }
+
+    private void supersedeRetained(StructuredSnapshot persisted) {
+        RetainedSnapshot existing = retained.get(persisted.key());
+        if (existing != null && persisted.getSequence() >= existing.snapshot.getSequence()) {
+            retained.remove(persisted.key(), existing);
+        }
+    }
+
+    // package-private for deterministic testing (production drives it from the scheduled task)
+    void recoverRetained() {
+        long now = System.currentTimeMillis();
+        for (Map.Entry<Key, RetainedSnapshot> entry : new ArrayList<>(retained.entrySet())) {
+            RetainedSnapshot held = entry.getValue();
+            if (now < held.nextAttemptAtEpochMs) {
+                continue;
+            }
+            if (now - held.firstRetainedAtEpochMs >= recoveryRetentionMs) {
+                if (retained.remove(entry.getKey(), held)) {
+                    meterRegistry.counter("terrakube.executor.structured.output.recovery.expired").increment();
+                    log.warn("Recovery retention expired for job {} step {} phase {} after {} ms",
+                            entry.getKey().jobId(), entry.getKey().stepId(), entry.getKey().phase(),
+                            now - held.firstRetainedAtEpochMs);
+                }
+                continue;
+            }
+            attemptRecovery(entry.getKey(), held, now);
+        }
+    }
+
+    private void attemptRecovery(Key key, RetainedSnapshot held, long now) {
+        StructuredSnapshot snapshot = held.snapshot;
+        String phase = snapshot.getPhase() == StructuredSnapshot.Phase.PLAN ? "plan" : "apply";
+        meterRegistry.counter("terrakube.executor.structured.output.recovery.attempts").increment();
+        boolean ok;
+        try {
+            ok = persister.persist(snapshot);
+        } catch (Throwable t) {
+            ok = false;
+            log.warn("Recovery persist threw for job {} step {} phase {}: {}",
+                    snapshot.getJobId(), snapshot.getStepId(), phase, t.toString());
+        }
+        if (ok) {
+            retained.remove(key, held);
+            log.info("Recovered structured snapshot for job {} step {} phase {} (retained {} ms, ts={})",
+                    snapshot.getJobId(), snapshot.getStepId(), phase, now - held.firstRetainedAtEpochMs,
+                    snapshot.getCreatedAtEpochMs());
+            return;
+        }
+        held.currentDelayMs = Math.min(recoveryMaxDelayMs, held.currentDelayMs * 2);
+        held.nextAttemptAtEpochMs = now + jitter(held.currentDelayMs);
+    }
+
+    private void drainRetainedOnce(Duration budget) {
+        long deadline = System.nanoTime() + budget.toNanos();
+        for (Map.Entry<Key, RetainedSnapshot> entry : new ArrayList<>(retained.entrySet())) {
+            if (System.nanoTime() >= deadline) {
+                return;
+            }
+            try {
+                if (persister.persist(entry.getValue().snapshot)) {
+                    retained.remove(entry.getKey(), entry.getValue());
+                }
+            } catch (Throwable t) {
+                log.warn("Shutdown recovery pass failed for job {} step {}: {}",
+                        entry.getKey().jobId(), entry.getKey().stepId(), t.toString());
+            }
+        }
     }
 
     private void sleepBackoff(int retryIndex) {
@@ -240,5 +429,10 @@ public class StructuredOutputPersistenceQueue {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+    }
+
+    private static long jitter(long delayMs) {
+        long span = Math.max(1, delayMs / 4);
+        return delayMs + ThreadLocalRandom.current().nextLong(-span, span + 1);
     }
 }

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/structured/StructuredSnapshot.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/structured/StructuredSnapshot.java
@@ -1,0 +1,83 @@
+package io.terrakube.executor.service.terraform.structured;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An immutable, deep-copied point-in-time view of one job step's structured output, handed from a
+ * Terraform/OpenTofu process-output reader thread to {@link StructuredOutputPersistenceQueue}.
+ *
+ * <p>The reader thread must never block on or be failed by context persistence, so the only work it
+ * does per flush is build one of these (a bounded CPU-only copy) and enqueue it. Everything after -
+ * the GET/merge/POST to {@code /context/v1}, retries, and the SSE live update - happens on the queue
+ * worker thread.
+ */
+@Getter
+public final class StructuredSnapshot {
+
+    public enum Phase {
+        PLAN, APPLY
+    }
+
+    /** Coalescing identity: only the newest unsaved snapshot for a given key is kept. */
+    public record Key(String jobId, String stepId, Phase phase) {
+    }
+
+    /** Thrown by {@link #copyOf} when the supplied changes/diagnostics cannot be serialized. */
+    public static final class SnapshotSerializationException extends RuntimeException {
+        public SnapshotSerializationException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    private static final TypeReference<List<Map<String, Object>>> LIST_OF_MAPS = new TypeReference<>() {
+    };
+
+    private final String organizationId;
+    private final String jobId;
+    private final String stepId;
+    private final Phase phase;
+    private final long sequence;
+    private final boolean finalSnapshot;
+    private final List<Map<String, Object>> changes;
+    private final List<Map<String, Object>> jobDiagnostics;
+
+    private StructuredSnapshot(String organizationId, String jobId, String stepId, Phase phase, long sequence,
+                              boolean finalSnapshot, List<Map<String, Object>> changes,
+                              List<Map<String, Object>> jobDiagnostics) {
+        this.organizationId = organizationId;
+        this.jobId = jobId;
+        this.stepId = stepId;
+        this.phase = phase;
+        this.sequence = sequence;
+        this.finalSnapshot = finalSnapshot;
+        this.changes = changes;
+        this.jobDiagnostics = jobDiagnostics;
+    }
+
+    public static StructuredSnapshot copyOf(String organizationId, String jobId, String stepId, Phase phase,
+                                            long sequence, boolean finalSnapshot,
+                                            List<Map<String, Object>> changes,
+                                            List<Map<String, Object>> jobDiagnostics,
+                                            ObjectMapper objectMapper) {
+        try {
+            List<Map<String, Object>> safeChanges = objectMapper.convertValue(
+                    changes == null ? List.of() : changes, LIST_OF_MAPS);
+            List<Map<String, Object>> safeDiagnostics = objectMapper.convertValue(
+                    jobDiagnostics == null ? List.of() : jobDiagnostics, LIST_OF_MAPS);
+            return new StructuredSnapshot(organizationId, jobId, stepId, phase, sequence, finalSnapshot,
+                    Collections.unmodifiableList(safeChanges), Collections.unmodifiableList(safeDiagnostics));
+        } catch (IllegalArgumentException e) {
+            throw new SnapshotSerializationException(e);
+        }
+    }
+
+    public Key key() {
+        return new Key(jobId, stepId, phase);
+    }
+}

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/structured/StructuredSnapshot.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/structured/StructuredSnapshot.java
@@ -44,11 +44,12 @@ public final class StructuredSnapshot {
     private final Phase phase;
     private final long sequence;
     private final boolean finalSnapshot;
+    private final long createdAtEpochMs;
     private final List<Map<String, Object>> changes;
     private final List<Map<String, Object>> jobDiagnostics;
 
     private StructuredSnapshot(String organizationId, String jobId, String stepId, Phase phase, long sequence,
-                              boolean finalSnapshot, List<Map<String, Object>> changes,
+                              boolean finalSnapshot, long createdAtEpochMs, List<Map<String, Object>> changes,
                               List<Map<String, Object>> jobDiagnostics) {
         this.organizationId = organizationId;
         this.jobId = jobId;
@@ -56,6 +57,7 @@ public final class StructuredSnapshot {
         this.phase = phase;
         this.sequence = sequence;
         this.finalSnapshot = finalSnapshot;
+        this.createdAtEpochMs = createdAtEpochMs;
         this.changes = changes;
         this.jobDiagnostics = jobDiagnostics;
     }
@@ -71,6 +73,7 @@ public final class StructuredSnapshot {
             List<Map<String, Object>> safeDiagnostics = objectMapper.convertValue(
                     jobDiagnostics == null ? List.of() : jobDiagnostics, LIST_OF_MAPS);
             return new StructuredSnapshot(organizationId, jobId, stepId, phase, sequence, finalSnapshot,
+                    System.currentTimeMillis(),
                     Collections.unmodifiableList(safeChanges), Collections.unmodifiableList(safeDiagnostics));
         } catch (IllegalArgumentException e) {
             throw new SnapshotSerializationException(e);

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/structured/StructuredSnapshotPersister.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/structured/StructuredSnapshotPersister.java
@@ -1,0 +1,15 @@
+package io.terrakube.executor.service.terraform.structured;
+
+/**
+ * Persists one coalesced {@link StructuredSnapshot} to the job context store. Called only from the
+ * {@link StructuredOutputPersistenceQueue} worker thread - never from a Terraform reader thread.
+ *
+ * <p>Implementations must never throw: a failure is reported by returning {@code false}, which lets
+ * the queue apply retry/backoff and, ultimately, a metric-and-warn without touching the Terraform
+ * result.
+ */
+public interface StructuredSnapshotPersister {
+
+    /** @return {@code true} only when the context write succeeded. */
+    boolean persist(StructuredSnapshot snapshot);
+}

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -78,8 +78,9 @@ io.terrakube.api.url=${TerrakubeApiUrl}
 ##########
 # HEALTH #
 ##########
-management.endpoints.web.exposure.include=health
+management.endpoints.web.exposure.include=health,prometheus
 management.endpoint.health.enabled=true
+management.endpoint.prometheus.enabled=true
 management.endpoints.enabled-by-default=false
 management.endpoint.health.probes.enabled=true
 management.health.livenessstate.enabled=true

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -16,6 +16,19 @@ io.terrakube.executor.flags.ephemeral=${EphemeralFlagBatch:false}
 io.terrakube.executor.flags.ephemeralJobData=${EphemeralJobData:}
 io.terrakube.executor.flags.disableAcknowledge=${ExecutorFlagDisableAcknowledge:false}
 
+## Structured plan/apply output: persist context via a bounded async queue off the terraform
+## process-output reader thread (set false for the previous synchronous behaviour).
+io.terrakube.executor.flags.asyncStructuredOutput=${ExecutorAsyncStructuredOutput:true}
+io.terrakube.executor.structured-output.queue-capacity=${ExecutorStructuredOutputQueueCapacity:256}
+io.terrakube.executor.structured-output.max-persist-attempts=${ExecutorStructuredOutputMaxPersistAttempts:4}
+io.terrakube.executor.structured-output.initial-backoff-ms=${ExecutorStructuredOutputInitialBackoffMs:250}
+io.terrakube.executor.structured-output.max-backoff-ms=${ExecutorStructuredOutputMaxBackoffMs:4000}
+io.terrakube.executor.structured-output.drain-timeout-ms=${ExecutorStructuredOutputDrainTimeoutMs:30000}
+
+## Executor -> API /context/v1 HTTP timeouts (separate from object-storage timeouts).
+io.terrakube.executor.context.connect-timeout-ms=${ExecutorContextConnectTimeoutMs:5000}
+io.terrakube.executor.context.read-timeout-ms=${ExecutorContextReadTimeoutMs:15000}
+
 ## Ceiling for a single job before the pod is marked unhealthy (watchdog for a wedged terraform/hook process)
 io.terrakube.executor.job.maxDurationMinutes=${ExecutorJobMaxDurationMinutes:360}
 

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -19,11 +19,16 @@ io.terrakube.executor.flags.disableAcknowledge=${ExecutorFlagDisableAcknowledge:
 ## Structured plan/apply output: persist context via a bounded async queue off the terraform
 ## process-output reader thread (set false for the previous synchronous behaviour).
 io.terrakube.executor.flags.asyncStructuredOutput=${ExecutorAsyncStructuredOutput:true}
+io.terrakube.executor.flags.structuredOutputRecovery=${ExecutorStructuredOutputRecovery:true}
 io.terrakube.executor.structured-output.queue-capacity=${ExecutorStructuredOutputQueueCapacity:256}
 io.terrakube.executor.structured-output.max-persist-attempts=${ExecutorStructuredOutputMaxPersistAttempts:4}
 io.terrakube.executor.structured-output.initial-backoff-ms=${ExecutorStructuredOutputInitialBackoffMs:250}
 io.terrakube.executor.structured-output.max-backoff-ms=${ExecutorStructuredOutputMaxBackoffMs:4000}
 io.terrakube.executor.structured-output.drain-timeout-ms=${ExecutorStructuredOutputDrainTimeoutMs:30000}
+io.terrakube.executor.structured-output.recovery-retention-ms=${ExecutorStructuredOutputRecoveryRetentionMs:600000}
+io.terrakube.executor.structured-output.recovery-initial-delay-ms=${ExecutorStructuredOutputRecoveryInitialDelayMs:15000}
+io.terrakube.executor.structured-output.recovery-max-delay-ms=${ExecutorStructuredOutputRecoveryMaxDelayMs:60000}
+io.terrakube.executor.structured-output.recovery-max-retained=${ExecutorStructuredOutputRecoveryMaxRetained:64}
 
 ## Executor -> API /context/v1 HTTP timeouts (separate from object-storage timeouts).
 io.terrakube.executor.context.connect-timeout-ms=${ExecutorContextConnectTimeoutMs:5000}

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/DefaultStructuredSnapshotPersisterTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/DefaultStructuredSnapshotPersisterTest.java
@@ -1,0 +1,82 @@
+package io.terrakube.executor.service.terraform;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.executor.service.logs.ProcessLogs;
+import io.terrakube.executor.service.terraform.structured.StructuredSnapshot;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DefaultStructuredSnapshotPersisterTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private StructuredSnapshot planSnapshot() {
+        return StructuredSnapshot.copyOf("o", "1", "step-1", StructuredSnapshot.Phase.PLAN, 1L, false,
+                List.of(Map.of("address", "aws_s3_bucket.a", "action", "create")), List.of(), mapper);
+    }
+
+    @Test
+    void persistDoesGetMergePostThenSseAndReportsSuccess() {
+        JobContextService ctx = mock(JobContextService.class);
+        when(ctx.getCurrentContext("o", "1")).thenReturn(new HashMap<>());
+        when(ctx.saveContextChecked(eq("o"), eq("1"), any())).thenReturn(true);
+        PlanStructuredOutputService plan = mock(PlanStructuredOutputService.class);
+        Map<String, Object> merged = new HashMap<>();
+        merged.put("planStructuredOutput", Map.of());
+        when(plan.updateContext(any(), eq("step-1"), any(), any())).thenReturn(merged);
+        ApplyStructuredOutputService apply = mock(ApplyStructuredOutputService.class);
+        ProcessLogs logs = mock(ProcessLogs.class);
+
+        DefaultStructuredSnapshotPersister persister =
+                new DefaultStructuredSnapshotPersister(ctx, plan, apply, logs, mapper);
+
+        boolean ok = persister.persist(planSnapshot());
+
+        assertTrue(ok);
+        verify(ctx).saveContextChecked(eq("o"), eq("1"), eq(merged));
+        verify(logs).sendStructuredUpdate(eq(1), eq("step-1"), contains("\"phase\":\"plan\""));
+    }
+
+    @Test
+    void persistReturnsFalseWhenSaveFailsAndDoesNotPushSse() {
+        JobContextService ctx = mock(JobContextService.class);
+        when(ctx.getCurrentContext(any(), any())).thenReturn(new HashMap<>());
+        when(ctx.saveContextChecked(any(), any(), any())).thenReturn(false);
+        PlanStructuredOutputService plan = mock(PlanStructuredOutputService.class);
+        when(plan.updateContext(any(), any(), any(), any())).thenReturn(new HashMap<>());
+        ApplyStructuredOutputService apply = mock(ApplyStructuredOutputService.class);
+        ProcessLogs logs = mock(ProcessLogs.class);
+
+        DefaultStructuredSnapshotPersister persister =
+                new DefaultStructuredSnapshotPersister(ctx, plan, apply, logs, mapper);
+
+        assertFalse(persister.persist(planSnapshot()));
+        verify(logs, never()).sendStructuredUpdate(anyInt(), any(), any());
+    }
+
+    @Test
+    void persistNeverThrowsWhenContextReadBlowsUp() {
+        JobContextService ctx = mock(JobContextService.class);
+        when(ctx.getCurrentContext(any(), any())).thenThrow(new RuntimeException("boom"));
+
+        DefaultStructuredSnapshotPersister persister = new DefaultStructuredSnapshotPersister(
+                ctx, mock(PlanStructuredOutputService.class), mock(ApplyStructuredOutputService.class),
+                mock(ProcessLogs.class), mapper);
+
+        assertFalse(persister.persist(planSnapshot()));
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/DefaultStructuredSnapshotPersisterTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/DefaultStructuredSnapshotPersisterTest.java
@@ -57,6 +57,46 @@ class DefaultStructuredSnapshotPersisterTest {
     }
 
     @Test
+    void finalEmptyPlanSnapshotWritesTheNoChangePlanMarker() {
+        JobContextService ctx = mock(JobContextService.class);
+        when(ctx.getCurrentContext("o", "1")).thenReturn(new HashMap<>());
+        when(ctx.saveContextChecked(eq("o"), eq("1"), any())).thenReturn(true);
+        PlanStructuredOutputService plan = mock(PlanStructuredOutputService.class);
+        Map<String, Object> merged = new HashMap<>();
+        when(plan.updateContext(any(), eq("step-1"), any(), any())).thenReturn(merged);
+        DefaultStructuredSnapshotPersister persister = new DefaultStructuredSnapshotPersister(
+                ctx, plan, mock(ApplyStructuredOutputService.class), mock(ProcessLogs.class), mapper);
+
+        StructuredSnapshot emptyFinalPlan = StructuredSnapshot.copyOf("o", "1", "step-1",
+                StructuredSnapshot.Phase.PLAN, 2L, true, List.of(), List.of(), mapper);
+        assertTrue(persister.persist(emptyFinalPlan));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> marker = (Map<String, Object>) merged.get("noChangePlan");
+        assertEquals("step-1", marker.get("planStepId"));
+    }
+
+    @Test
+    void finalNonEmptyPlanSnapshotClearsAnyStaleNoChangePlanMarker() {
+        JobContextService ctx = mock(JobContextService.class);
+        Map<String, Object> merged = new HashMap<>();
+        merged.put("noChangePlan", Map.of("planStepId", "step-1"));
+        when(ctx.getCurrentContext("o", "1")).thenReturn(new HashMap<>());
+        when(ctx.saveContextChecked(eq("o"), eq("1"), any())).thenReturn(true);
+        PlanStructuredOutputService plan = mock(PlanStructuredOutputService.class);
+        when(plan.updateContext(any(), eq("step-1"), any(), any())).thenReturn(merged);
+        DefaultStructuredSnapshotPersister persister = new DefaultStructuredSnapshotPersister(
+                ctx, plan, mock(ApplyStructuredOutputService.class), mock(ProcessLogs.class), mapper);
+
+        StructuredSnapshot nonEmptyFinalPlan = StructuredSnapshot.copyOf("o", "1", "step-1",
+                StructuredSnapshot.Phase.PLAN, 3L, true,
+                List.of(Map.of("address", "aws_s3_bucket.a", "action", "create")), List.of(), mapper);
+        assertTrue(persister.persist(nonEmptyFinalPlan));
+
+        assertFalse(merged.containsKey("noChangePlan"));
+    }
+
+    @Test
     void persistReturnsFalseWhenSaveFailsAndDoesNotPushSse() {
         JobContextService ctx = mock(JobContextService.class);
         when(ctx.getCurrentContext(any(), any())).thenReturn(new HashMap<>());

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/DefaultStructuredSnapshotPersisterTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/DefaultStructuredSnapshotPersisterTest.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -49,6 +50,10 @@ class DefaultStructuredSnapshotPersisterTest {
         assertTrue(ok);
         verify(ctx).saveContextChecked(eq("o"), eq("1"), eq(merged));
         verify(logs).sendStructuredUpdate(eq(1), eq("step-1"), contains("\"phase\":\"plan\""));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> status = (Map<String, Object>) merged.get("structuredOutputStatus");
+        assertEquals("PERSISTED", status.get("state"));
+        assertEquals("plan", status.get("phase"));
     }
 
     @Test

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/JobContextServiceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/JobContextServiceTest.java
@@ -9,12 +9,26 @@ import io.terrakube.executor.service.workspace.security.WorkspaceSecurity;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.net.HttpURLConnection;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JobContextServiceTest {
+
+    @Test
+    void connectAndReadTimeoutsComeFromConfiguredValues() throws Exception {
+        JobContextService service = new JobContextService(
+                Mockito.mock(WorkspaceSecurity.class), new ObjectMapper(),
+                "http://api.example", Mockito.mock(TerrakubeClient.class), 1234, 5678);
+
+        HttpURLConnection connection = service.buildConnection("http://api.example/context/v1/1", "GET");
+
+        assertEquals(1234, connection.getConnectTimeout());
+        assertEquals(5678, connection.getReadTimeout());
+    }
 
     @Test
     @SuppressWarnings("unchecked")

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/PlanStructuredOutputServiceTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/PlanStructuredOutputServiceTest.java
@@ -394,4 +394,40 @@ class PlanStructuredOutputServiceTest {
 
         assertNull(service.getPlanAsHumanText(job, new File("/tmp")));
     }
+
+    @Test
+    void publishPlanProgressEnqueuesInsteadOfBlockingWhenAsyncEnabled() {
+        io.terrakube.executor.service.terraform.structured.StructuredOutputPersistenceQueue queue =
+                Mockito.mock(io.terrakube.executor.service.terraform.structured.StructuredOutputPersistenceQueue.class);
+        Mockito.when(queue.nextSequence()).thenReturn(1L);
+        JobContextService jobContextService = Mockito.mock(JobContextService.class);
+        io.terrakube.executor.configuration.ExecutorFlagsProperties flags =
+                new io.terrakube.executor.configuration.ExecutorFlagsProperties();
+        flags.setAsyncStructuredOutput(true);
+        PlanStructuredOutputService service = new PlanStructuredOutputService(
+                jobContextService, new ObjectMapper(), Mockito.mock(TerraformClient.class), queue, flags);
+
+        service.publishPlanProgress("o", "1", "step-1", List.of(Map.of("address", "a")), List.of());
+
+        Mockito.verify(queue).submit(Mockito.argThat(s ->
+                s.key().stepId().equals("step-1") && !s.isFinalSnapshot()));
+        Mockito.verify(jobContextService, Mockito.never()).getCurrentContext(Mockito.any(), Mockito.any());
+        Mockito.verify(jobContextService, Mockito.never()).saveContext(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void publishFinalPlanSnapshotStaysSynchronousWhenAsyncDisabled() {
+        JobContextService jobContextService = Mockito.mock(JobContextService.class);
+        Mockito.when(jobContextService.getCurrentContext("o", "1")).thenReturn(new HashMap<>());
+        io.terrakube.executor.configuration.ExecutorFlagsProperties flags =
+                new io.terrakube.executor.configuration.ExecutorFlagsProperties();
+        flags.setAsyncStructuredOutput(false);
+        PlanStructuredOutputService service = new PlanStructuredOutputService(
+                jobContextService, new ObjectMapper(), Mockito.mock(TerraformClient.class), null, flags);
+
+        service.publishFinalPlanSnapshot("o", "1", "step-1", List.of(Map.of("address", "a")), List.of());
+
+        Mockito.verify(jobContextService).getCurrentContext("o", "1");
+        Mockito.verify(jobContextService).saveContext(Mockito.eq("o"), Mockito.eq("1"), Mockito.any());
+    }
 }

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
@@ -58,6 +58,7 @@ class TerraformExecutorServiceImplTest {
     private final StructuredOutputPersistenceQueue structuredOutputPersistenceQueue = Mockito.mock(StructuredOutputPersistenceQueue.class);
     private final ExecutorFlagsProperties executorFlagsProperties = new ExecutorFlagsProperties();
     private final StructuredOutputProperties structuredOutputProperties = new StructuredOutputProperties();
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
 
     private TerraformExecutorServiceImpl subject() {
         when(redisTemplate.opsForStream()).thenReturn(streamOperations);
@@ -81,7 +82,7 @@ class TerraformExecutorServiceImplTest {
                 structuredOutputPersistenceQueue,
                 executorFlagsProperties,
                 structuredOutputProperties,
-                new SimpleMeterRegistry());
+                meterRegistry);
     }
 
     private TerraformJob createJob() {
@@ -616,5 +617,21 @@ class TerraformExecutorServiceImplTest {
 
         assertEquals(2, result.getExitCode());
         assertTrue(result.getOutputLog().contains("aws_instance.example: Plan to create"), result.getOutputLog());
+    }
+
+    @Test
+    void streamDrainFailureKeepsTheTerraformDiagnosticPrimaryAndCountsIt() {
+        TerraformExecutorServiceImpl subject = subject();
+        String realDiagnostic = "Error: Reference to undeclared input variable\n\n  on main.tf line 3\n";
+
+        ExecutorJobResult result = subject.setError(
+                new RuntimeException("Failed to capture process output stream"), realDiagnostic);
+
+        int diagnosticIndex = result.getOutputLog().indexOf("undeclared input variable");
+        int captureIndex = result.getOutputLog().indexOf("Failed to capture process output stream");
+        assertTrue(diagnosticIndex >= 0, result.getOutputLog());
+        assertTrue(captureIndex > diagnosticIndex, "real diagnostic must precede the capture note: " + result.getOutputLog());
+        assertTrue(result.getOutputLog().contains("The Terraform/OpenTofu diagnostic above is the primary error."));
+        assertEquals(1.0, meterRegistry.get("terrakube.executor.process.stream.drain.timeouts").counter().count());
     }
 }

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
@@ -1,11 +1,15 @@
 package io.terrakube.executor.service.terraform;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.terrakube.executor.configuration.ExecutorFlagsProperties;
+import io.terrakube.executor.configuration.StructuredOutputProperties;
 import io.terrakube.executor.plugin.tfstate.TerraformState;
 import io.terrakube.executor.service.executor.ExecutorJobResult;
 import io.terrakube.executor.service.logs.ProcessLogs;
 import io.terrakube.executor.service.mode.TerraformJob;
 import io.terrakube.executor.service.scripts.ScriptEngineService;
+import io.terrakube.executor.service.terraform.structured.StructuredOutputPersistenceQueue;
 import io.terrakube.terraform.TerraformClient;
 import io.terrakube.terraform.TerraformProcessData;
 import org.junit.jupiter.api.Test;
@@ -51,11 +55,16 @@ class TerraformExecutorServiceImplTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final RedisTemplate redisTemplate = Mockito.mock(RedisTemplate.class);
     private final StreamOperations streamOperations = Mockito.mock(StreamOperations.class);
+    private final StructuredOutputPersistenceQueue structuredOutputPersistenceQueue = Mockito.mock(StructuredOutputPersistenceQueue.class);
+    private final ExecutorFlagsProperties executorFlagsProperties = new ExecutorFlagsProperties();
+    private final StructuredOutputProperties structuredOutputProperties = new StructuredOutputProperties();
 
     private TerraformExecutorServiceImpl subject() {
         when(redisTemplate.opsForStream()).thenReturn(streamOperations);
         when(streamOperations.size(anyString())).thenReturn(0L);
         when(terraformState.getBackendStateFile(anyString(), anyString(), any(File.class), anyString())).thenReturn("backend.tfvars");
+        when(structuredOutputPersistenceQueue.awaitDrain(any())).thenReturn(true);
+        structuredOutputProperties.setDrainTimeoutMs(1000);
 
         return new TerraformExecutorServiceImpl(
                 terraformClient,
@@ -68,7 +77,11 @@ class TerraformExecutorServiceImplTest {
                 objectMapper,
                 false,
                 redisTemplate,
-                1);
+                1,
+                structuredOutputPersistenceQueue,
+                executorFlagsProperties,
+                structuredOutputProperties,
+                new SimpleMeterRegistry());
     }
 
     private TerraformJob createJob() {
@@ -424,9 +437,8 @@ class TerraformExecutorServiceImplTest {
 
         subject.plan(terraformJob, tempDir.toFile(), false);
 
-        verify(planStructuredOutputService, Mockito.atLeastOnce()).publishPlanProgress(
+        verify(planStructuredOutputService, Mockito.atLeastOnce()).publishFinalPlanSnapshot(
                 eq("org"), eq("42"), eq("1"), any(), any());
-        verify(logsService, Mockito.atLeastOnce()).sendStructuredUpdate(eq(42), eq("1"), anyString());
     }
 
     // Regression test for the reported bug: running `tofu plan` from the CLI showed only a bare
@@ -585,7 +597,7 @@ class TerraformExecutorServiceImplTest {
                 .thenReturn(CompletableFuture.completedFuture(true));
 
         Mockito.doThrow(new RuntimeException("redis is unreachable"))
-                .when(logsService).sendStructuredUpdate(anyInt(), anyString(), anyString());
+                .when(planStructuredOutputService).publishPlanProgress(anyString(), anyString(), anyString(), any(), any());
 
         String plannedChangeLine = "{\"type\":\"planned_change\",\"change\":{\"resource\":"
                 + "{\"addr\":\"aws_instance.example\"},\"action\":\"create\"},"

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredOutputPersistenceQueueTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredOutputPersistenceQueueTest.java
@@ -1,0 +1,155 @@
+package io.terrakube.executor.service.terraform.structured;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.terrakube.executor.configuration.StructuredOutputProperties;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StructuredOutputPersistenceQueueTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private StructuredSnapshot snap(String step, long seq, String addr) {
+        Map<String, Object> row = new HashMap<>();
+        row.put("address", addr);
+        return StructuredSnapshot.copyOf("o", "1", step, StructuredSnapshot.Phase.PLAN, seq, false,
+                List.of(row), List.of(), mapper);
+    }
+
+    private StructuredOutputProperties props(int capacity) {
+        StructuredOutputProperties p = new StructuredOutputProperties();
+        p.setQueueCapacity(capacity);
+        p.setMaxPersistAttempts(2);
+        p.setInitialBackoffMs(1);
+        p.setMaxBackoffMs(2);
+        return p;
+    }
+
+    private StructuredOutputPersistenceQueue started(StructuredSnapshotPersister persister, SimpleMeterRegistry reg, int capacity) {
+        StructuredOutputPersistenceQueue queue = new StructuredOutputPersistenceQueue(props(capacity), reg, persister);
+        queue.start();
+        return queue;
+    }
+
+    @Test
+    void submitReturnsImmediatelyEvenWhenPersisterBlocks() throws Exception {
+        CountDownLatch release = new CountDownLatch(1);
+        StructuredSnapshotPersister slow = s -> {
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return true;
+        };
+        StructuredOutputPersistenceQueue queue = started(slow, new SimpleMeterRegistry(), 256);
+
+        long startNanos = System.nanoTime();
+        for (int i = 0; i < 200; i++) {
+            queue.submit(snap("step-1", i, "a" + i));
+        }
+        long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+
+        assertTrue(elapsedMs < 500, "200 submits blocked for " + elapsedMs + "ms");
+        release.countDown();
+        queue.stop();
+    }
+
+    @Test
+    void coalescesRepeatedUpdatesForTheSameKey() throws Exception {
+        List<StructuredSnapshot> persisted = Collections.synchronizedList(new java.util.ArrayList<>());
+        CountDownLatch gate = new CountDownLatch(1);
+        StructuredSnapshotPersister capture = s -> {
+            try {
+                gate.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            persisted.add(s);
+            return true;
+        };
+        StructuredOutputPersistenceQueue queue = started(capture, new SimpleMeterRegistry(), 256);
+
+        for (int i = 0; i < 20; i++) {
+            queue.submit(snap("step-1", i, "addr" + i));
+        }
+        gate.countDown();
+
+        assertTrue(queue.awaitDrain(Duration.ofSeconds(5)));
+        assertTrue(persisted.size() < 20, "expected coalescing, persisted " + persisted.size());
+        assertEquals("addr19", persisted.get(persisted.size() - 1).getChanges().get(0).get("address"));
+        queue.stop();
+    }
+
+    @Test
+    void dropsOldestWhenFullAndCountsIt() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        CountDownLatch block = new CountDownLatch(1);
+        StructuredSnapshotPersister stuck = s -> {
+            try {
+                block.await(2, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return true;
+        };
+        StructuredOutputPersistenceQueue queue = started(stuck, registry, 4);
+
+        for (int i = 0; i < 20; i++) {
+            queue.submit(snap("step-" + i, i, "a"));
+        }
+
+        assertTrue(queue.queueDepth() <= 5, "depth was " + queue.queueDepth());
+        assertTrue(registry.get("terrakube.executor.structured.output.dropped").counter().count() >= 10);
+        block.countDown();
+        queue.stop();
+    }
+
+    @Test
+    void persistFailureIsCountedAndNeverThrows() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        StructuredOutputPersistenceQueue queue = started(s -> false, registry, 64);
+
+        queue.submit(snap("step-1", 1, "a"));
+
+        assertTrue(queue.awaitDrain(Duration.ofSeconds(5)));
+        assertEquals(1.0, registry.get("terrakube.executor.structured.output.persist.failures")
+                .tag("phase", "plan").counter().count());
+        assertEquals(1.0, registry.get("terrakube.executor.structured.output.persist")
+                .tag("outcome", "failure").counter().count());
+        queue.stop();
+    }
+
+    @Test
+    void persisterThrowingIsSwallowedAndRetried() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        int[] calls = {0};
+        StructuredSnapshotPersister flaky = s -> {
+            calls[0]++;
+            if (calls[0] == 1) {
+                throw new RuntimeException("boom");
+            }
+            return true;
+        };
+        StructuredOutputPersistenceQueue queue = started(flaky, registry, 64);
+
+        queue.submit(snap("step-1", 1, "a"));
+
+        assertTrue(queue.awaitDrain(Duration.ofSeconds(5)));
+        assertEquals(2, calls[0]);
+        assertEquals(1.0, registry.get("terrakube.executor.structured.output.persist")
+                .tag("outcome", "success").counter().count());
+        queue.stop();
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredOutputPersistenceQueueTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredOutputPersistenceQueueTest.java
@@ -27,17 +27,41 @@ class StructuredOutputPersistenceQueueTest {
                 List.of(row), List.of(), mapper);
     }
 
+    private StructuredSnapshot finalSnap(String step, long seq, String addr) {
+        Map<String, Object> row = new HashMap<>();
+        row.put("address", addr);
+        return StructuredSnapshot.copyOf("o", "1", step, StructuredSnapshot.Phase.PLAN, seq, true,
+                List.of(row), List.of(), mapper);
+    }
+
     private StructuredOutputProperties props(int capacity) {
         StructuredOutputProperties p = new StructuredOutputProperties();
         p.setQueueCapacity(capacity);
         p.setMaxPersistAttempts(2);
         p.setInitialBackoffMs(1);
         p.setMaxBackoffMs(2);
+        p.setRecoveryInitialDelayMs(100);
+        p.setRecoveryMaxDelayMs(200);
+        p.setRecoveryRetentionMs(60_000);
+        p.setRecoveryMaxRetained(4);
         return p;
     }
 
+    private io.terrakube.executor.configuration.ExecutorFlagsProperties flags(boolean recovery) {
+        io.terrakube.executor.configuration.ExecutorFlagsProperties f =
+                new io.terrakube.executor.configuration.ExecutorFlagsProperties();
+        f.setStructuredOutputRecovery(recovery);
+        return f;
+    }
+
     private StructuredOutputPersistenceQueue started(StructuredSnapshotPersister persister, SimpleMeterRegistry reg, int capacity) {
-        StructuredOutputPersistenceQueue queue = new StructuredOutputPersistenceQueue(props(capacity), reg, persister);
+        return started(persister, reg, capacity, false);
+    }
+
+    private StructuredOutputPersistenceQueue started(StructuredSnapshotPersister persister, SimpleMeterRegistry reg,
+                                                     int capacity, boolean recovery) {
+        StructuredOutputPersistenceQueue queue =
+                new StructuredOutputPersistenceQueue(props(capacity), flags(recovery), reg, persister);
         queue.start();
         return queue;
     }
@@ -150,6 +174,128 @@ class StructuredOutputPersistenceQueueTest {
         assertEquals(2, calls[0]);
         assertEquals(1.0, registry.get("terrakube.executor.structured.output.persist")
                 .tag("outcome", "success").counter().count());
+        queue.stop();
+    }
+
+    // --- delayed recovery -------------------------------------------------------------------
+
+    @Test
+    void retainsNewestSnapshotAfterRetryExhaustion() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        StructuredOutputPersistenceQueue queue = started(s -> false, registry, 64, true);
+
+        queue.submit(finalSnap("step-1", 1, "a"));
+
+        assertTrue(queue.awaitDrain(Duration.ofSeconds(5)));
+        assertEquals(1, queue.retainedDepth());
+        assertEquals(1.0, registry.get("terrakube.executor.structured.output.recovery.pending").gauge().value());
+        queue.stop();
+    }
+
+    @Test
+    void recoverRetainedPersistsOnceStorageRecovers() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        java.util.concurrent.atomic.AtomicBoolean healthy = new java.util.concurrent.atomic.AtomicBoolean(false);
+        List<Long> persistedSequences = Collections.synchronizedList(new java.util.ArrayList<>());
+        StructuredSnapshotPersister persister = s -> {
+            if (!healthy.get()) {
+                return false;
+            }
+            persistedSequences.add(s.getSequence());
+            return true;
+        };
+        StructuredOutputPersistenceQueue queue = started(persister, registry, 64, true);
+
+        queue.submit(snap("step-1", 1, "a"));
+        queue.submit(finalSnap("step-1", 2, "b")); // newer supersedes the retained progress snapshot
+        assertTrue(queue.awaitDrain(Duration.ofSeconds(5)));
+        assertEquals(1, queue.retainedDepth());
+
+        healthy.set(true);
+        Thread.sleep(200); // let the retained entry become due (recovery-initial-delay = 100ms)
+        queue.recoverRetained();
+
+        assertEquals(0, queue.retainedDepth());
+        assertEquals(List.of(2L), persistedSequences);
+        assertTrue(registry.get("terrakube.executor.structured.output.recovery.attempts").counter().count() >= 1);
+        queue.stop();
+    }
+
+    @Test
+    void recoveryRetentionExpiryRemovesTheSnapshotAndCountsIt() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        StructuredOutputProperties p = props(64);
+        p.setRecoveryRetentionMs(1);
+        StructuredOutputPersistenceQueue queue =
+                new StructuredOutputPersistenceQueue(p, flags(true), registry, s -> false);
+        queue.start();
+
+        queue.submit(finalSnap("step-1", 1, "a"));
+        assertTrue(queue.awaitDrain(Duration.ofSeconds(5)));
+        Thread.sleep(150);
+        queue.recoverRetained();
+
+        assertEquals(0, queue.retainedDepth());
+        assertEquals(1.0, registry.get("terrakube.executor.structured.output.recovery.expired").counter().count());
+        queue.stop();
+    }
+
+    @Test
+    void retainedCapacityKeepsFinalSnapshotsOverProgress() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        // recoveryMaxRetained = 4 (see props)
+        java.util.concurrent.atomic.AtomicBoolean healthy = new java.util.concurrent.atomic.AtomicBoolean(false);
+        List<String> persistedSteps = Collections.synchronizedList(new java.util.ArrayList<>());
+        StructuredSnapshotPersister persister = s -> {
+            if (!healthy.get()) {
+                return false;
+            }
+            persistedSteps.add(s.getStepId());
+            return true;
+        };
+        StructuredOutputPersistenceQueue queue = started(persister, registry, 64, true);
+
+        queue.submit(finalSnap("final-step", 1, "a"));
+        for (int i = 0; i < 8; i++) {
+            queue.submit(snap("progress-" + i, 10 + i, "a"));
+        }
+        assertTrue(queue.awaitDrain(Duration.ofSeconds(5)));
+
+        assertEquals(4, queue.retainedDepth());
+        assertTrue(registry.get("terrakube.executor.structured.output.recovery.evictions").counter().count() >= 4);
+
+        healthy.set(true);
+        Thread.sleep(200);
+        queue.recoverRetained();
+        assertTrue(persistedSteps.contains("final-step"), "final snapshot must survive eviction: " + persistedSteps);
+        queue.stop();
+    }
+
+    @Test
+    void pendingCapacityEvictsProgressBeforeFinal() throws Exception {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        CountDownLatch block = new CountDownLatch(1);
+        List<String> persistedSteps = Collections.synchronizedList(new java.util.ArrayList<>());
+        StructuredSnapshotPersister persister = s -> {
+            try {
+                block.await(2, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            persistedSteps.add(s.getStepId());
+            return true;
+        };
+        StructuredOutputPersistenceQueue queue = started(persister, registry, 2, false);
+
+        queue.submit(finalSnap("final-step", 1, "a")); // worker picks this up and blocks on it
+        Thread.sleep(50);
+        queue.submit(snap("progress-a", 2, "a"));
+        queue.submit(snap("progress-b", 3, "a"));
+        queue.submit(snap("progress-c", 4, "a")); // forces an eviction among the pending progress rows
+
+        block.countDown();
+        assertTrue(queue.awaitDrain(Duration.ofSeconds(5)));
+        assertTrue(persistedSteps.contains("final-step"), "final snapshot must not be evicted: " + persistedSteps);
         queue.stop();
     }
 }

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredOutputResilienceIntegrationTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredOutputResilienceIntegrationTest.java
@@ -1,0 +1,64 @@
+package io.terrakube.executor.service.terraform.structured;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.terrakube.executor.configuration.ExecutorFlagsProperties;
+import io.terrakube.executor.configuration.StructuredOutputProperties;
+import io.terrakube.executor.service.terraform.JobContextService;
+import io.terrakube.terraform.TerraformClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.terrakube.executor.service.terraform.PlanStructuredOutputService;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end guard for spec acceptance criterion 2: a context store that is slower than any
+ * terraform-client stream-drain budget must never block or fail the -json line consumer.
+ */
+class StructuredOutputResilienceIntegrationTest {
+
+    @Test
+    void aGlacialContextStoreNeverBlocksTheLineConsumerAndNeverThrows() throws Exception {
+        StructuredSnapshotPersister glacial = snapshot -> {
+            try {
+                Thread.sleep(3_000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return true;
+        };
+
+        StructuredOutputProperties properties = new StructuredOutputProperties();
+        properties.setQueueCapacity(128);
+        StructuredOutputPersistenceQueue queue =
+                new StructuredOutputPersistenceQueue(properties, new SimpleMeterRegistry(), glacial);
+        queue.start();
+
+        ExecutorFlagsProperties flags = new ExecutorFlagsProperties();
+        flags.setAsyncStructuredOutput(true);
+        // A FailUnkownMethod-style strict mock: any synchronous HTTP call here fails the test.
+        JobContextService jobContextService = Mockito.mock(JobContextService.class, invocation -> {
+            throw new AssertionError("line consumer made a synchronous context call: " + invocation.getMethod());
+        });
+        PlanStructuredOutputService planService = new PlanStructuredOutputService(
+                jobContextService, new ObjectMapper(), Mockito.mock(TerraformClient.class), queue, flags);
+
+        long startNanos = System.nanoTime();
+        for (int i = 0; i < 500; i++) {
+            planService.publishFinalPlanSnapshot("o", "1", "step-1",
+                    List.of(Map.of("address", "resource_" + i)), List.of());
+        }
+        long elapsedMs = Duration.ofNanos(System.nanoTime() - startNanos).toMillis();
+
+        assertTrue(elapsedMs < 1_000, "500 progress publications blocked for " + elapsedMs + "ms");
+        assertTrue(queue.queueDepth() <= 1, "same-key snapshots should coalesce, depth=" + queue.queueDepth());
+
+        queue.stop();
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredOutputResilienceIntegrationTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredOutputResilienceIntegrationTest.java
@@ -36,12 +36,12 @@ class StructuredOutputResilienceIntegrationTest {
 
         StructuredOutputProperties properties = new StructuredOutputProperties();
         properties.setQueueCapacity(128);
-        StructuredOutputPersistenceQueue queue =
-                new StructuredOutputPersistenceQueue(properties, new SimpleMeterRegistry(), glacial);
-        queue.start();
-
         ExecutorFlagsProperties flags = new ExecutorFlagsProperties();
         flags.setAsyncStructuredOutput(true);
+        flags.setStructuredOutputRecovery(false);
+        StructuredOutputPersistenceQueue queue =
+                new StructuredOutputPersistenceQueue(properties, flags, new SimpleMeterRegistry(), glacial);
+        queue.start();
         // A FailUnkownMethod-style strict mock: any synchronous HTTP call here fails the test.
         JobContextService jobContextService = Mockito.mock(JobContextService.class, invocation -> {
             throw new AssertionError("line consumer made a synchronous context call: " + invocation.getMethod());

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredOutputResilienceIntegrationTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredOutputResilienceIntegrationTest.java
@@ -56,7 +56,10 @@ class StructuredOutputResilienceIntegrationTest {
         }
         long elapsedMs = Duration.ofNanos(System.nanoTime() - startNanos).toMillis();
 
-        assertTrue(elapsedMs < 1_000, "500 progress publications blocked for " + elapsedMs + "ms");
+        // The persister blocks 3s per call; 500 non-blocking enqueues must finish far quicker. The
+        // ceiling is generous (CPU-only deep copies, sensitive to CI load) but still orders of
+        // magnitude below a single blocked persist.
+        assertTrue(elapsedMs < 2_500, "500 progress publications blocked for " + elapsedMs + "ms");
         assertTrue(queue.queueDepth() <= 1, "same-key snapshots should coalesce, depth=" + queue.queueDepth());
 
         queue.stop();

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredOutputWiringTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredOutputWiringTest.java
@@ -1,0 +1,56 @@
+package io.terrakube.executor.service.terraform.structured;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.terrakube.client.TerrakubeClient;
+import io.terrakube.executor.configuration.ExecutorFlagsProperties;
+import io.terrakube.executor.configuration.StructuredOutputProperties;
+import io.terrakube.executor.service.logs.ProcessLogs;
+import io.terrakube.executor.service.terraform.ApplyStructuredOutputService;
+import io.terrakube.executor.service.terraform.DefaultStructuredSnapshotPersister;
+import io.terrakube.executor.service.terraform.JobContextService;
+import io.terrakube.executor.service.terraform.PlanStructuredOutputService;
+import io.terrakube.terraform.TerraformClient;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The structured-output beans form a construction cycle (services -> queue -> persister -> services)
+ * that {@code @Lazy} on the queue's persister dependency must break. No {@code @SpringBootTest}
+ * precedent in this module, so this drives just the relevant beans through the container.
+ */
+class StructuredOutputWiringTest {
+
+    @Configuration
+    static class Collaborators {
+        @Bean ObjectMapper objectMapper() { return new ObjectMapper(); }
+        @Bean MeterRegistry meterRegistry() { return new SimpleMeterRegistry(); }
+        @Bean StructuredOutputProperties structuredOutputProperties() { return new StructuredOutputProperties(); }
+        @Bean ExecutorFlagsProperties executorFlagsProperties() { return new ExecutorFlagsProperties(); }
+        @Bean JobContextService jobContextService() { return Mockito.mock(JobContextService.class); }
+        @Bean ProcessLogs processLogs() { return Mockito.mock(ProcessLogs.class); }
+        @Bean TerraformClient terraformClient() { return Mockito.mock(TerraformClient.class); }
+        @Bean TerrakubeClient terrakubeClient() { return Mockito.mock(TerrakubeClient.class); }
+    }
+
+    @Test
+    void theStructuredOutputBeanGraphStartsWithoutACircularDependency() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(Collaborators.class)
+                .withBean(StructuredOutputPersistenceQueue.class)
+                .withBean(DefaultStructuredSnapshotPersister.class)
+                .withBean(PlanStructuredOutputService.class)
+                .withBean(ApplyStructuredOutputService.class)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(StructuredOutputPersistenceQueue.class);
+                    assertThat(context).hasSingleBean(DefaultStructuredSnapshotPersister.class);
+                });
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredSnapshotTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredSnapshotTest.java
@@ -1,0 +1,54 @@
+package io.terrakube.executor.service.terraform.structured;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StructuredSnapshotTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void copyOfDeepCopiesSoLaterMutationDoesNotLeak() {
+        List<Map<String, Object>> changes = new ArrayList<>();
+        Map<String, Object> row = new HashMap<>();
+        row.put("address", "aws_s3_bucket.a");
+        changes.add(row);
+
+        StructuredSnapshot snapshot = StructuredSnapshot.copyOf(
+                "org", "42", "step-1", StructuredSnapshot.Phase.PLAN, 1L, false, changes, List.of(), mapper);
+
+        row.put("address", "MUTATED");
+        changes.add(new HashMap<>());
+
+        assertEquals(1, snapshot.getChanges().size());
+        assertEquals("aws_s3_bucket.a", snapshot.getChanges().get(0).get("address"));
+        assertEquals(new StructuredSnapshot.Key("42", "step-1", StructuredSnapshot.Phase.PLAN), snapshot.key());
+        assertTrue(snapshot.getJobDiagnostics().isEmpty());
+    }
+
+    @Test
+    void copyOfToleratesNullLists() {
+        StructuredSnapshot snapshot = StructuredSnapshot.copyOf(
+                "org", "42", "s", StructuredSnapshot.Phase.APPLY, 7L, true, null, null, mapper);
+
+        assertTrue(snapshot.getChanges().isEmpty());
+        assertTrue(snapshot.isFinalSnapshot());
+        assertEquals(7L, snapshot.getSequence());
+    }
+
+    @Test
+    void copyOfRejectsUnserializableContent() {
+        List<Map<String, Object>> changes = List.of(Map.of("bad", new Object()));
+        assertThrows(StructuredSnapshot.SnapshotSerializationException.class, () -> StructuredSnapshot.copyOf(
+                "org", "42", "s", StructuredSnapshot.Phase.PLAN, 1L, false, changes, List.of(), mapper));
+    }
+}

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredSnapshotTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/structured/StructuredSnapshotTest.java
@@ -36,6 +36,16 @@ class StructuredSnapshotTest {
     }
 
     @Test
+    void copyOfStampsCreatedAtTimestamp() {
+        long before = System.currentTimeMillis();
+        StructuredSnapshot snapshot = StructuredSnapshot.copyOf(
+                "org", "42", "s", StructuredSnapshot.Phase.PLAN, 1L, true, List.of(), List.of(), mapper);
+        long after = System.currentTimeMillis();
+
+        assertTrue(snapshot.getCreatedAtEpochMs() >= before && snapshot.getCreatedAtEpochMs() <= after);
+    }
+
+    @Test
     void copyOfToleratesNullLists() {
         StructuredSnapshot snapshot = StructuredSnapshot.copyOf(
                 "org", "42", "s", StructuredSnapshot.Phase.APPLY, 7L, true, null, null, mapper);

--- a/ui/src/config/__tests__/axiosConfig.test.ts
+++ b/ui/src/config/__tests__/axiosConfig.test.ts
@@ -1,4 +1,10 @@
 import { mgr } from "../authConfig";
+import { getBackendError, setBackendError } from "@/modules/api/backendStatus";
+import {
+  getAuxiliaryRequestFailureCounts,
+  getGlobalBackendErrorActivations,
+  resetRequestMetrics,
+} from "@/modules/api/requestMetrics";
 
 jest.mock("../authConfig", () => ({
   mgr: { removeUser: jest.fn() },
@@ -11,9 +17,25 @@ jest.mock("../authUser", () => ({
 
 const mockRemoveUser = mgr.removeUser as jest.Mock;
 
+const rejectWith =
+  (status: number | undefined, extra: Record<string, unknown> = {}) =>
+  (config: unknown) =>
+    Promise.reject({
+      isAxiosError: true,
+      config,
+      response:
+        status == null
+          ? undefined
+          : { status, data: {}, statusText: "", headers: {}, config },
+      toJSON: () => ({}),
+      ...extra,
+    });
+
 describe("axiosConfig response interceptor", () => {
   beforeEach(() => {
     mockRemoveUser.mockClear();
+    setBackendError(null);
+    resetRequestMetrics();
   });
 
   it("signs the user out when a request comes back 401", async () => {
@@ -46,5 +68,84 @@ describe("axiosConfig response interceptor", () => {
 
     await expect(axiosInstance.get("/organizations")).rejects.toBeTruthy();
     expect(mockRemoveUser).not.toHaveBeenCalled();
+  });
+
+  it("sets global backend-error state on a core 503 and records the activation", async () => {
+    const { default: axiosInstance } = await import("../axiosConfig");
+    axiosInstance.defaults.adapter = rejectWith(503);
+
+    await expect(axiosInstance.get("/organizations")).rejects.toBeTruthy();
+
+    expect(getBackendError()).toBe(503);
+    expect(getGlobalBackendErrorActivations()).toEqual({ core: 1 });
+  });
+});
+
+describe("axiosAuxiliary client", () => {
+  beforeEach(() => {
+    mockRemoveUser.mockClear();
+    setBackendError(null);
+    resetRequestMetrics();
+  });
+
+  it.each([404, 429, 500, 502, 503, 504])(
+    "keeps a %s failure local - no global backend-error activation",
+    async (status) => {
+      const { axiosAuxiliary } = await import("../axiosConfig");
+      axiosAuxiliary.defaults.adapter = rejectWith(status);
+
+      await expect(axiosAuxiliary.get("/context/v1/1", { auxClass: "context" })).rejects.toBeTruthy();
+
+      expect(getBackendError()).toBeNull();
+      expect(getGlobalBackendErrorActivations()).toEqual({});
+      expect(getAuxiliaryRequestFailureCounts()).toEqual({ [`context:${status}`]: 1 });
+    }
+  );
+
+  it("classifies a network error (no response) as network", async () => {
+    const { axiosAuxiliary } = await import("../axiosConfig");
+    axiosAuxiliary.defaults.adapter = rejectWith(undefined, { message: "Network Error" });
+
+    await expect(axiosAuxiliary.get("/tfoutput/v1/x", { auxClass: "step-log" })).rejects.toBeTruthy();
+
+    expect(getBackendError()).toBeNull();
+    expect(getAuxiliaryRequestFailureCounts()).toEqual({ "step-log:network": 1 });
+  });
+
+  it("still signs the user out on a 401", async () => {
+    const { axiosAuxiliary } = await import("../axiosConfig");
+    axiosAuxiliary.defaults.adapter = rejectWith(401);
+
+    await expect(axiosAuxiliary.get("/context/v1/1", { auxClass: "context" })).rejects.toBeTruthy();
+
+    expect(mockRemoveUser).toHaveBeenCalledTimes(1);
+    expect(getBackendError()).toBeNull();
+  });
+
+  it("still enriches a 403 with a permission message", async () => {
+    const { axiosAuxiliary } = await import("../axiosConfig");
+    axiosAuxiliary.defaults.adapter = rejectWith(403);
+
+    await expect(axiosAuxiliary.get("/context/v1/1", { auxClass: "context" })).rejects.toMatchObject({
+      permissionError: true,
+    });
+    expect(mockRemoveUser).not.toHaveBeenCalled();
+  });
+
+  it("a successful auxiliary response does not clear a genuine global outage", async () => {
+    const { axiosAuxiliary } = await import("../axiosConfig");
+    setBackendError(503);
+    axiosAuxiliary.defaults.adapter = () =>
+      Promise.resolve({
+        data: {},
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        config: {} as never,
+      });
+
+    await axiosAuxiliary.get("/context/v1/1", { auxClass: "context" });
+
+    expect(getBackendError()).toBe(503);
   });
 });

--- a/ui/src/config/axiosConfig.ts
+++ b/ui/src/config/axiosConfig.ts
@@ -2,6 +2,22 @@ import axios, { AxiosError, AxiosResponse } from "axios";
 import { mgr } from "./authConfig";
 import getUserFromStorage from "./authUser";
 import { setBackendError, FATAL_API_STATUSES } from "@/modules/api/backendStatus";
+import {
+  classifyRequestOutcome,
+  recordAuxiliaryRequestFailure,
+  recordGlobalBackendErrorActivation,
+} from "@/modules/api/requestMetrics";
+
+declare module "axios" {
+  interface AxiosRequestConfig {
+    /**
+     * Marks a request as auxiliary Job Details data (context read, archived log, reconciliation
+     * poll). Only used for metric labelling - the {@link axiosAuxiliary} client already prevents
+     * global backend-error mutation.
+     */
+    auxClass?: string;
+  }
+}
 
 type RuntimeEnv = Window["_env_"] & { REACT_APP_TERRAKUBE_SEND_COOKIES?: string };
 
@@ -29,6 +45,17 @@ export const axiosRegistry = axios.create({
   withCredentials: sendCookiesWithRequests,
 });
 
+/**
+ * Client for auxiliary Job Details data (structured context, archived step logs, reconciliation
+ * polls). Same auth as {@link axiosInstance}, but its 404/429/5xx/timeout/network failures are
+ * local to the calling component and never activate the application-wide backend-error screen.
+ * 401/403 handling is identical to the shared interceptor.
+ */
+export const axiosAuxiliary = axios.create({
+  baseURL: window._env_.REACT_APP_TERRAKUBE_API_URL,
+  withCredentials: sendCookiesWithRequests,
+});
+
 // Shared request interceptor that attaches the Bearer token
 function attachAuthToken(config: any) {
   const user = getUserFromStorage();
@@ -44,6 +71,7 @@ function rejectError(error: any) {
 axiosInstance.interceptors.request.use(attachAuthToken, rejectError);
 axiosGraphQL.interceptors.request.use(attachAuthToken, rejectError);
 axiosRegistry.interceptors.request.use(attachAuthToken, rejectError);
+axiosAuxiliary.interceptors.request.use(attachAuthToken, rejectError);
 
 // Shared response interceptor that enriches 403 errors with a clear message
 function handleResponseSuccess(response: AxiosResponse) {
@@ -51,10 +79,8 @@ function handleResponseSuccess(response: AxiosResponse) {
   return response;
 }
 
-function handleResponseError(error: AxiosError) {
-  if (error.response && FATAL_API_STATUSES.includes(error.response.status)) {
-    setBackendError(error.response.status);
-  }
+// 401/403 handling shared by the core and auxiliary interceptors - never duplicated.
+function applyAuthHandling(error: AxiosError) {
   if (error.response?.status === 401) {
     // Token rejected by the API - sign out so the user lands back on Login.
     mgr.removeUser();
@@ -66,12 +92,34 @@ function handleResponseError(error: AxiosError) {
     enriched.permissionMessage =
       "You do not have the required permissions to perform this action. Please contact your organization administrator.";
   }
+}
+
+function handleResponseError(error: AxiosError) {
+  if (error.response && FATAL_API_STATUSES.includes(error.response.status)) {
+    setBackendError(error.response.status);
+    recordGlobalBackendErrorActivation(error.config?.auxClass ?? "core");
+  }
+  applyAuthHandling(error);
+  return Promise.reject(error);
+}
+
+// Auxiliary requests: a transient failure stays local to the calling component. No backend-error
+// mutation (invariant 2), and a success must not clear a genuine global outage (invariant 6).
+function handleAuxiliaryResponseError(error: AxiosError) {
+  const requestClass = error.config?.auxClass ?? "auxiliary";
+  if (!error.response || !error.response.status || error.response.status < 400) {
+    recordAuxiliaryRequestFailure(requestClass, classifyRequestOutcome(error));
+  } else {
+    recordAuxiliaryRequestFailure(requestClass, String(error.response.status));
+  }
+  applyAuthHandling(error);
   return Promise.reject(error);
 }
 
 axiosInstance.interceptors.response.use(handleResponseSuccess, handleResponseError);
 axiosGraphQL.interceptors.response.use(handleResponseSuccess, handleResponseError);
 axiosRegistry.interceptors.response.use(handleResponseSuccess, handleResponseError);
+axiosAuxiliary.interceptors.response.use((response) => response, handleAuxiliaryResponseError);
 
 /**
  * Helper to extract a user-friendly error message from an axios error.

--- a/ui/src/domain/Jobs/Details.tsx
+++ b/ui/src/domain/Jobs/Details.tsx
@@ -258,6 +258,7 @@ export const DetailsJob = ({ jobId }: Props) => {
         guardMessage={isGuardStep ? item.outputLog : undefined}
         structured={getStepStructuredData(item)}
         uiType={uiType}
+        onRetryStructured={() => void loadContext()}
       />
     );
   };

--- a/ui/src/domain/Jobs/Details.tsx
+++ b/ui/src/domain/Jobs/Details.tsx
@@ -26,6 +26,7 @@ import { IncludedItem, Job, JobStep, Workspace } from "../types";
 import {
   ContextAvailability,
   parseContextAvailability,
+  parseNoChangePlanStepId,
   recordReconciliationResult,
 } from "./contextAvailability";
 import { getPublicApiOrigin } from "./outputUrl";
@@ -120,6 +121,10 @@ export const DetailsJob = ({ jobId }: Props) => {
   const [terraformOutputs, setTerraformOutputs] = useState<StructuredOutputsByStep>({});
   const [jobDiagnostics, setJobDiagnostics] = useState<JobDiagnosticsByStep>({});
   const [contextAvailability, setContextAvailability] = useState<ContextAvailability>("pending");
+  // Sticky: once a persisted context has been seen, a later transient 503 does not un-see it.
+  const [contextEverPersisted, setContextEverPersisted] = useState(false);
+  // Plan step id of an explicitly persisted no-change plan (sticky once observed).
+  const [noChangePlanStepId, setNoChangePlanStepId] = useState<string | undefined>(undefined);
   // Non-null while we keep polling context after a terminal job status (bounded reconciliation).
   const [reconcileUntil, setReconcileUntil] = useState<number | null>(null);
   const reconcileAttemptRef = useRef(0);
@@ -224,6 +229,22 @@ export const DetailsJob = ({ jobId }: Props) => {
     }
   };
 
+  // Phase/step-aware structured-output evidence, so a transient job-wide 503 does not turn a
+  // no-op apply (whose Plan was explicitly empty) into a false "temporarily unavailable".
+  const planEvidence = (() => {
+    const planEntries = Object.values(planStructuredOutput);
+    const anyPlanHasRows = planEntries.some((rows) => Array.isArray(rows) && rows.length > 0);
+    const markedNoChange =
+      noChangePlanStepId != null &&
+      !(Array.isArray(planStructuredOutput[noChangePlanStepId]) &&
+        planStructuredOutput[noChangePlanStepId].length > 0);
+    const inferredNoChange =
+      contextEverPersisted &&
+      planEntries.length > 0 &&
+      planEntries.every((rows) => Array.isArray(rows) && rows.length === 0);
+    return { anyPlanHasRows, associatedPlanIsNoChange: markedNoChange || inferredNoChange };
+  })();
+
   const getStepStructuredData = (item: JobStep) => {
     const template = uiTemplates[item.id] || uiTemplates[String(item.stepNumber)];
     const structuredChanges = planStructuredOutput[item.id] || planStructuredOutput[String(item.stepNumber)];
@@ -232,7 +253,17 @@ export const DetailsJob = ({ jobId }: Props) => {
     const stepJobDiagnostics = jobDiagnostics[item.id] || jobDiagnostics[String(item.stepNumber)];
     const hasStructuredView = Boolean(template) || Boolean(structuredChanges) || Boolean(structuredApplyChanges);
 
-    return { template, structuredChanges, structuredApplyChanges, stepOutputs, stepJobDiagnostics, hasStructuredView };
+    return {
+      template,
+      structuredChanges,
+      structuredApplyChanges,
+      stepOutputs,
+      stepJobDiagnostics,
+      hasStructuredView,
+      contextEverPersisted,
+      associatedPlanIsNoChange: planEvidence.associatedPlanIsNoChange,
+      anyPlanHasRows: planEvidence.anyPlanHasRows,
+    };
   };
 
   const renderStepExtra = (item: JobStep) => {
@@ -479,7 +510,15 @@ export const DetailsJob = ({ jobId }: Props) => {
       if (requestId !== contextRequestRef.current) {
         return;
       }
-      setContextAvailability(parseContextAvailability(response?.data, response?.status));
+      const availability = parseContextAvailability(response?.data, response?.status);
+      setContextAvailability(availability);
+      if (availability === "persisted") {
+        setContextEverPersisted(true);
+      }
+      const noChangeStepId = parseNoChangePlanStepId(response?.data);
+      if (noChangeStepId != null) {
+        setNoChangePlanStepId(noChangeStepId);
+      }
       setUITemplates(normalizeUITemplates(response?.data?.terrakubeUI));
       // Merge (not replace) plan/apply/diagnostics - this REST snapshot can lag behind the live
       // SSE stream (useStructuredOutputStream's effect below), which pushes per-step updates as

--- a/ui/src/domain/Jobs/Details.tsx
+++ b/ui/src/domain/Jobs/Details.tsx
@@ -23,6 +23,11 @@ import { statusColors } from "../../modules/workspaces/utils/workspaceStatusColo
 import { getWorkspaceStatusIcon } from "../../modules/workspaces/utils/workspaceStatusIcon";
 import { getWorkspaceStatusText } from "../../modules/workspaces/utils/workspaceStatusText";
 import { IncludedItem, Job, JobStep, Workspace } from "../types";
+import {
+  ContextAvailability,
+  parseContextAvailability,
+  recordReconciliationResult,
+} from "./contextAvailability";
 import { getPublicApiOrigin } from "./outputUrl";
 import { shouldStepBeCollapsible, shouldStepBeExpandedByDefault } from "./stepExpansion";
 import { isTerminalStatus } from "./stepStatus";
@@ -114,6 +119,11 @@ export const DetailsJob = ({ jobId }: Props) => {
   const [applyStructuredOutput, setApplyStructuredOutput] = useState<StructuredApplyOutputByStep>({});
   const [terraformOutputs, setTerraformOutputs] = useState<StructuredOutputsByStep>({});
   const [jobDiagnostics, setJobDiagnostics] = useState<JobDiagnosticsByStep>({});
+  const [contextAvailability, setContextAvailability] = useState<ContextAvailability>("pending");
+  // Non-null while we keep polling context after a terminal job status (bounded reconciliation).
+  const [reconcileUntil, setReconcileUntil] = useState<number | null>(null);
+  const reconcileAttemptRef = useRef(0);
+  const previousJobStatusRef = useRef<string | undefined>(undefined);
   const { getSignal: getJobSignal, abort: abortJobRequests } = useAbortController();
   const { getSignal: getContextSignal, abort: abortContextRequests } = useAbortController();
   const jobRequestRef = useRef(0);
@@ -258,6 +268,7 @@ export const DetailsJob = ({ jobId }: Props) => {
         guardMessage={isGuardStep ? item.outputLog : undefined}
         structured={getStepStructuredData(item)}
         uiType={uiType}
+        contextAvailability={contextAvailability}
         onRetryStructured={() => void loadContext()}
       />
     );
@@ -465,6 +476,7 @@ export const DetailsJob = ({ jobId }: Props) => {
       if (requestId !== contextRequestRef.current) {
         return;
       }
+      setContextAvailability(parseContextAvailability(response?.data, response?.status));
       setUITemplates(normalizeUITemplates(response?.data?.terrakubeUI));
       // Merge (not replace) plan/apply/diagnostics - this REST snapshot can lag behind the live
       // SSE stream (useStructuredOutputStream's effect below), which pushes per-step updates as
@@ -482,6 +494,11 @@ export const DetailsJob = ({ jobId }: Props) => {
       setJobDiagnostics((previous) => ({ ...previous, ...normalizeJobDiagnostics(response?.data?.jobDiagnostics) }));
     } catch (error) {
       if (isAbortError(error)) return;
+      if (requestId !== contextRequestRef.current) return;
+      // A failed/controlled context response must not clear already-loaded structured state and
+      // must never bounce the whole page back to its loading spinner.
+      const httpStatus = (error as { response?: { status?: number } })?.response?.status;
+      setContextAvailability(httpStatus != null && httpStatus >= 500 ? "unavailable" : "pending");
     }
   }, [getContextSignal, jobId]);
 
@@ -517,6 +534,52 @@ export const DetailsJob = ({ jobId }: Props) => {
     }
   );
 
+  // A terminal job status does not prove its final structured context is persisted yet. On the
+  // terminal transition (and on any status transition) re-fetch context, and keep a bounded,
+  // context-only reconciliation running - job metadata and console stay untouched by this.
+  useEffect(() => {
+    const status = job?.data?.attributes.status;
+    if (status === previousJobStatusRef.current) {
+      return;
+    }
+    const becameTerminal =
+      !isTerminalStatus(previousJobStatusRef.current) && isTerminalStatus(status);
+    previousJobStatusRef.current = status;
+
+    if (!jobId) {
+      return;
+    }
+    void loadContext();
+    if (becameTerminal && contextAvailability !== "persisted") {
+      reconcileAttemptRef.current = 0;
+      setReconcileUntil(Date.now() + 60_000);
+    }
+  }, [job?.data?.attributes.status, contextAvailability, jobId, loadContext]);
+
+  // Bounded exponential backoff while reconciling. Re-runs whenever loadContext updates
+  // contextAvailability, so it schedules the next retry or stops.
+  useEffect(() => {
+    if (reconcileUntil == null) {
+      return;
+    }
+    if (contextAvailability === "persisted") {
+      recordReconciliationResult("persisted");
+      setReconcileUntil(null);
+      return;
+    }
+    if (Date.now() >= reconcileUntil) {
+      recordReconciliationResult(contextAvailability === "unavailable" ? "unavailable" : "expired");
+      setReconcileUntil(null);
+      return;
+    }
+    const delay = Math.min(8000, 1000 * 2 ** reconcileAttemptRef.current);
+    const timer = setTimeout(() => {
+      reconcileAttemptRef.current += 1;
+      void loadContext();
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [reconcileUntil, contextAvailability, loadContext]);
+
   type LiveStructuredOutput = {
     phase: "plan" | "apply";
     changes: Record<string, unknown>;
@@ -526,7 +589,7 @@ export const DetailsJob = ({ jobId }: Props) => {
   const isJobRunning = job?.data?.attributes.status === "running";
   const liveStructuredOutput = useStructuredOutputStream<LiveStructuredOutput | null>({
     url: `${getPublicApiOrigin()}/context/v1/${jobId}/stream`,
-    enabled: Boolean(jobId) && isJobRunning,
+    enabled: Boolean(jobId) && (isJobRunning || reconcileUntil != null),
     initial: null,
   });
 
@@ -534,6 +597,9 @@ export const DetailsJob = ({ jobId }: Props) => {
     if (liveStructuredOutput == null) {
       return;
     }
+
+    // A live event means the executor just wrote context - re-fetch the authoritative snapshot too.
+    void loadContext();
 
     // Each push only carries the one step (plan or apply) that just changed, keyed by that
     // step's id - merge it into the existing per-step maps rather than replacing them wholesale,
@@ -551,7 +617,7 @@ export const DetailsJob = ({ jobId }: Props) => {
         ...normalizeStructuredApplyOutput(liveStructuredOutput.changes),
       }));
     }
-  }, [liveStructuredOutput]);
+  }, [liveStructuredOutput, loadContext]);
 
   return (
     <div style={{ marginTop: "14px" }}>

--- a/ui/src/domain/Jobs/Details.tsx
+++ b/ui/src/domain/Jobs/Details.tsx
@@ -16,7 +16,7 @@ import {
 import { AxiosResponse } from "axios";
 import { cloneElement, useCallback, useEffect, useRef, useState } from "react";
 import { ORGANIZATION_ARCHIVE } from "../../config/actionTypes";
-import axiosInstance from "../../config/axiosConfig";
+import axiosInstance, { axiosAuxiliary } from "../../config/axiosConfig";
 import { useAbortController, usePolling, useStructuredOutputStream } from "../../hooks";
 import WorkspaceStatusTag from "@/components/display/WorkspaceStatusTag";
 import { statusColors } from "../../modules/workspaces/utils/workspaceStatusColors";
@@ -472,7 +472,10 @@ export const DetailsJob = ({ jobId }: Props) => {
     const apiOrigin = getPublicApiOrigin();
 
     try {
-      const response = await axiosInstance.get(`${apiOrigin}/context/v1/${jobId}`, { signal });
+      const response = await axiosAuxiliary.get(`${apiOrigin}/context/v1/${jobId}`, {
+        signal,
+        auxClass: "context",
+      });
       if (requestId !== contextRequestRef.current) {
         return;
       }

--- a/ui/src/domain/Jobs/StepConsole.tsx
+++ b/ui/src/domain/Jobs/StepConsole.tsx
@@ -1,7 +1,8 @@
-import { Spin } from "antd";
+import { Alert, Button, Spin } from "antd";
 import parse from "html-react-parser";
 import { useStepLog } from "../../hooks";
 import { JobStep } from "../types";
+import { parseConsolePlanSummary } from "./consolePlanSummary";
 import { LiveTerminalOutput } from "./LiveTerminalOutput";
 import { isRunningStatus, isTerminalStatus } from "./stepStatus";
 import { StructuredPlanOutput } from "./StructuredPlanOutput";
@@ -30,6 +31,8 @@ type Props = {
   guardMessage?: string;
   structured: StructuredData;
   uiType: "structured" | "console";
+  /** Re-fetch the structured context (used by the "temporarily unavailable" retry control). */
+  onRetryStructured?: () => void;
 };
 
 /**
@@ -40,7 +43,15 @@ type Props = {
  * When a structured view exists it shares the same log text (for terraform-version extraction etc.)
  * and the console sits behind the Structured/Console toggle.
  */
-export const StepConsole = ({ item, jobId, organizationId, guardMessage, structured, uiType }: Props) => {
+export const StepConsole = ({
+  item,
+  jobId,
+  organizationId,
+  guardMessage,
+  structured,
+  uiType,
+  onRetryStructured,
+}: Props) => {
   const running = isRunningStatus(item.status);
   const terminal = isTerminalStatus(item.status);
 
@@ -83,6 +94,48 @@ export const StepConsole = ({ item, jobId, organizationId, guardMessage, structu
       />
     );
   };
+
+  // A completed plan/apply step whose console clearly shows changes but whose structured context
+  // is missing or empty: the structured write is stale or failed. Show an explicit "temporarily
+  // unavailable" state with the console as fallback and a retry - never a false "No changes".
+  const hasRealStructuredContent =
+    Boolean(structured.template) ||
+    (structured.structuredChanges != null && structured.structuredChanges.length > 0) ||
+    (structured.structuredApplyChanges != null && structured.structuredApplyChanges.length > 0);
+  const consolePlanSummary = parseConsolePlanSummary(logText);
+  const structuredUnavailable =
+    terminal &&
+    !hasRealStructuredContent &&
+    consolePlanSummary.hasPlan &&
+    consolePlanSummary.declaresChanges;
+
+  if (structuredUnavailable) {
+    return (
+      <>
+        <Alert
+          type="warning"
+          showIcon
+          style={{ marginBottom: 12 }}
+          message="Structured output temporarily unavailable"
+          description={
+            <>
+              This step produced changes, but the structured view could not be loaded. The full
+              output is shown below.
+              {onRetryStructured != null && (
+                <>
+                  {" "}
+                  <Button size="small" onClick={onRetryStructured}>
+                    Retry
+                  </Button>
+                </>
+              )}
+            </>
+          }
+        />
+        {renderConsole()}
+      </>
+    );
+  }
 
   if (!structured.hasStructuredView) {
     return renderConsole();

--- a/ui/src/domain/Jobs/StepConsole.tsx
+++ b/ui/src/domain/Jobs/StepConsole.tsx
@@ -1,3 +1,4 @@
+import { CheckCircleOutlined } from "@ant-design/icons";
 import { Alert, Button, Spin } from "antd";
 import parse from "html-react-parser";
 import { useStepLog } from "../../hooks";
@@ -22,6 +23,12 @@ type StructuredData = {
   stepOutputs?: StructuredOutputsByStep[string];
   stepJobDiagnostics?: JobDiagnosticsByStep[string];
   hasStructuredView: boolean;
+  /** A persisted context (with a real snapshot, even an empty one) has been seen at least once. */
+  contextEverPersisted?: boolean;
+  /** The associated plan is explicitly a no-change plan (marker or confirmed all-empty). */
+  associatedPlanIsNoChange?: boolean;
+  /** Some plan step has resource rows - a standard apply here is expected to produce apply rows. */
+  anyPlanHasRows?: boolean;
 };
 
 type Props = {
@@ -99,23 +106,65 @@ export const StepConsole = ({
     );
   };
 
-  // A completed plan/apply step with no real structured content whose context the API has not
-  // confirmed as persisted (pending / unavailable), or whose console clearly shows changes:
-  // show an explicit "temporarily unavailable" state with the console as fallback and a retry -
-  // never a false "No changes".
   const hasRealStructuredContent =
     Boolean(structured.template) ||
     (structured.structuredChanges != null && structured.structuredChanges.length > 0) ||
     (structured.structuredApplyChanges != null && structured.structuredApplyChanges.length > 0);
   const consolePlanSummary = parseConsolePlanSummary(logText);
-  const isPlanOrApplyStep = /\b(plan|apply|destroy)\b/.test(item.name.toLowerCase());
+
+  const stepNameLower = item.name.toLowerCase();
+  const isApplyStep = /\bapply\b/.test(stepNameLower);
+  const isPlanStep = /\bplan\b/.test(stepNameLower);
+  const isDestroyStep = /\bdestroy\b/.test(stepNameLower);
+  const isPlanOrApplyStep = isApplyStep || isPlanStep || isDestroyStep;
+  const stepFailed =
+    item.status === "failed" ||
+    item.status === "cancelled" ||
+    /(^|\n)\s*Error: /.test(logText);
+
+  // This phase's own snapshot has been loaded from a persisted context (even an explicit empty
+  // array is authoritative evidence, not a persistence failure).
+  const ownPhaseSnapshot = isApplyStep || isDestroyStep ? structured.structuredApplyChanges : structured.structuredChanges;
+  const ownSnapshotConfirmed = ownPhaseSnapshot != null && Boolean(structured.contextEverPersisted);
+
+  // A standard apply whose plan was explicitly empty is a valid no-op: absent applyStructuredOutput
+  // is expected there. Console/job status stays authoritative for a real execution error.
+  const applyIsNoOp =
+    isApplyStep &&
+    terminal &&
+    !stepFailed &&
+    !(structured.structuredApplyChanges != null && structured.structuredApplyChanges.length > 0) &&
+    Boolean(structured.associatedPlanIsNoChange) &&
+    !consolePlanSummary.declaresChanges;
+
+  // "Structured output temporarily unavailable" is now phase/step-specific: only when this phase
+  // expected structured output but we can neither confirm an explicit empty result nor load its
+  // snapshot. A confirmed snapshot, an explicit no-change plan, a console "no changes", or a real
+  // step failure all rule it out.
   const structuredUnavailable =
     terminal &&
-    !hasRealStructuredContent &&
     isPlanOrApplyStep &&
+    !hasRealStructuredContent &&
+    !applyIsNoOp &&
+    !stepFailed &&
+    !ownSnapshotConfirmed &&
     !consolePlanSummary.declaresNoChanges &&
-    (contextAvailability !== "persisted" ||
-      (consolePlanSummary.hasPlan && consolePlanSummary.declaresChanges));
+    !(isApplyStep && Boolean(structured.associatedPlanIsNoChange)) &&
+    ((consolePlanSummary.hasPlan && consolePlanSummary.declaresChanges) ||
+      (isApplyStep && Boolean(structured.anyPlanHasRows)) ||
+      contextAvailability !== "persisted");
+
+  if (applyIsNoOp) {
+    return (
+      <>
+        <div className="structured-plan-noChanges" style={{ marginBottom: 12 }}>
+          <CheckCircleOutlined className="structured-plan-noChangesIcon" />
+          <span>Apply completed with no changes.</span>
+        </div>
+        {renderConsole()}
+      </>
+    );
+  }
 
   if (structuredUnavailable) {
     return (

--- a/ui/src/domain/Jobs/StepConsole.tsx
+++ b/ui/src/domain/Jobs/StepConsole.tsx
@@ -2,6 +2,7 @@ import { Alert, Button, Spin } from "antd";
 import parse from "html-react-parser";
 import { useStepLog } from "../../hooks";
 import { JobStep } from "../types";
+import { ContextAvailability } from "./contextAvailability";
 import { parseConsolePlanSummary } from "./consolePlanSummary";
 import { LiveTerminalOutput } from "./LiveTerminalOutput";
 import { isRunningStatus, isTerminalStatus } from "./stepStatus";
@@ -31,6 +32,8 @@ type Props = {
   guardMessage?: string;
   structured: StructuredData;
   uiType: "structured" | "console";
+  /** How the API reports the structured context: persisted / pending / unavailable. */
+  contextAvailability?: ContextAvailability;
   /** Re-fetch the structured context (used by the "temporarily unavailable" retry control). */
   onRetryStructured?: () => void;
 };
@@ -50,6 +53,7 @@ export const StepConsole = ({
   guardMessage,
   structured,
   uiType,
+  contextAvailability = "persisted",
   onRetryStructured,
 }: Props) => {
   const running = isRunningStatus(item.status);
@@ -95,19 +99,23 @@ export const StepConsole = ({
     );
   };
 
-  // A completed plan/apply step whose console clearly shows changes but whose structured context
-  // is missing or empty: the structured write is stale or failed. Show an explicit "temporarily
-  // unavailable" state with the console as fallback and a retry - never a false "No changes".
+  // A completed plan/apply step with no real structured content whose context the API has not
+  // confirmed as persisted (pending / unavailable), or whose console clearly shows changes:
+  // show an explicit "temporarily unavailable" state with the console as fallback and a retry -
+  // never a false "No changes".
   const hasRealStructuredContent =
     Boolean(structured.template) ||
     (structured.structuredChanges != null && structured.structuredChanges.length > 0) ||
     (structured.structuredApplyChanges != null && structured.structuredApplyChanges.length > 0);
   const consolePlanSummary = parseConsolePlanSummary(logText);
+  const isPlanOrApplyStep = /\b(plan|apply|destroy)\b/.test(item.name.toLowerCase());
   const structuredUnavailable =
     terminal &&
     !hasRealStructuredContent &&
-    consolePlanSummary.hasPlan &&
-    consolePlanSummary.declaresChanges;
+    isPlanOrApplyStep &&
+    !consolePlanSummary.declaresNoChanges &&
+    (contextAvailability !== "persisted" ||
+      (consolePlanSummary.hasPlan && consolePlanSummary.declaresChanges));
 
   if (structuredUnavailable) {
     return (
@@ -119,8 +127,8 @@ export const StepConsole = ({
           message="Structured output temporarily unavailable"
           description={
             <>
-              This step produced changes, but the structured view could not be loaded. The full
-              output is shown below.
+              The structured view for this step could not be loaded yet. The full console output is
+              shown below and the page keeps retrying automatically.
               {onRetryStructured != null && (
                 <>
                   {" "}

--- a/ui/src/domain/Jobs/__tests__/Details.test.tsx
+++ b/ui/src/domain/Jobs/__tests__/Details.test.tsx
@@ -1,5 +1,12 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { DetailsJob } from "../Details";
+import { stepLogCache } from "../stepLogCache";
+
+// The step-log cache is module-level and would otherwise leak a fetched log from one test into the
+// next (they reuse step ids like "step-1").
+beforeEach(() => {
+  stepLogCache.clear();
+});
 
 window._env_ = {
   REACT_APP_AUTHORITY: "http://localhost/authority",
@@ -159,6 +166,45 @@ describe("DetailsJob apply structured output", () => {
     expect(
       screen.queryByText("Your infrastructure matches the configuration — no changes needed.")
     ).not.toBeInTheDocument();
+  });
+
+  it("shows 'temporarily unavailable' (never a false 'No changes') when structured context is missing after a plan with changes", async () => {
+    getMock.mockImplementation((url: string) => {
+      if (url.includes("/context/v1/")) {
+        return Promise.resolve({ data: {} });
+      }
+      if (url.includes("/step/")) {
+        return Promise.resolve({
+          data: "Terraform will perform the following actions:\n\nPlan: 1 to add, 0 to change, 0 to destroy.\n",
+        });
+      }
+
+      return Promise.resolve({
+        data: {
+          data: {
+            id: "1",
+            attributes: { status: "completed" },
+          },
+          included: [
+            {
+              id: "step-1",
+              type: "step",
+              attributes: { name: "Plan", status: "completed", stepNumber: "1" },
+            },
+          ],
+        },
+      });
+    });
+
+    render(<DetailsJob jobId="1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Structured output temporarily unavailable")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText("Your infrastructure matches the configuration — no changes needed.")
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
   });
 });
 

--- a/ui/src/domain/Jobs/__tests__/Details.test.tsx
+++ b/ui/src/domain/Jobs/__tests__/Details.test.tsx
@@ -208,6 +208,97 @@ describe("DetailsJob apply structured output", () => {
   });
 });
 
+describe("DetailsJob terminal-status context reconciliation", () => {
+  beforeEach(() => {
+    useStructuredOutputStreamMock.mockReturnValue(null);
+  });
+
+  it("loads the final structured diff after a terminal transition without a browser refresh", async () => {
+    let jobStatus: "running" | "completed" = "running";
+    let contextPersisted = false;
+
+    getMock.mockImplementation((url: string) => {
+      if (url.includes("/context/v1/")) {
+        return Promise.resolve(
+          contextPersisted
+            ? {
+                data: {
+                  structuredOutputStatus: { state: "PERSISTED" },
+                  applyStructuredOutput: {
+                    "step-2": [
+                      {
+                        address: "aws_instance.reconciled",
+                        action: "create",
+                        actions: ["create"],
+                        after: { id: "i-1" },
+                        status: "applied",
+                      },
+                    ],
+                  },
+                },
+              }
+            : { data: {} }
+        );
+      }
+      return Promise.resolve({
+        data: {
+          data: { id: "1", attributes: { status: jobStatus } },
+          included: [
+            { id: "step-2", type: "step", attributes: { name: "Apply", status: jobStatus, stepNumber: "2" } },
+          ],
+        },
+      });
+    });
+
+    render(<DetailsJob jobId="1" />);
+    await waitFor(() => expect(screen.getByText(/Apply/)).toBeInTheDocument());
+
+    jobStatus = "completed";
+    contextPersisted = true;
+
+    await waitFor(
+      () => expect(screen.getByRole("button", { name: /aws_instance\.reconciled/i })).toBeInTheDocument(),
+      { timeout: 8000 }
+    );
+    expect(screen.queryByText("Structured output temporarily unavailable")).not.toBeInTheDocument();
+  }, 12000);
+
+  it("keeps the page usable when context stays unavailable (503) - console shown, no spinner, never 'No changes'", async () => {
+    let jobStatus: "running" | "completed" = "running";
+
+    getMock.mockImplementation((url: string) => {
+      if (url.includes("/context/v1/")) {
+        return Promise.reject({ response: { status: 503 }, isAxiosError: true });
+      }
+      if (url.includes("/step/")) {
+        return Promise.resolve({ data: "Plan: 1 to add, 0 to change, 0 to destroy.\n" });
+      }
+      return Promise.resolve({
+        data: {
+          data: { id: "1", attributes: { status: jobStatus } },
+          included: [
+            { id: "step-1", type: "step", attributes: { name: "Plan", status: jobStatus, stepNumber: "1" } },
+          ],
+        },
+      });
+    });
+
+    render(<DetailsJob jobId="1" />);
+    await waitFor(() => expect(screen.getByText(/Plan/)).toBeInTheDocument());
+
+    jobStatus = "completed";
+
+    await waitFor(
+      () => expect(screen.getByText("Structured output temporarily unavailable")).toBeInTheDocument(),
+      { timeout: 8000 }
+    );
+    expect(
+      screen.queryByText("Your infrastructure matches the configuration — no changes needed.")
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Loading Job...")).not.toBeInTheDocument();
+  }, 12000);
+});
+
 describe("DetailsJob SSE reconnect behavior", () => {
   beforeEach(() => {
     useStructuredOutputStreamMock.mockReset();

--- a/ui/src/domain/Jobs/__tests__/Details.test.tsx
+++ b/ui/src/domain/Jobs/__tests__/Details.test.tsx
@@ -511,3 +511,141 @@ describe("DetailsJob progressive render", () => {
     });
   });
 });
+
+describe("DetailsJob no-change apply semantics", () => {
+  beforeEach(() => {
+    useStructuredOutputStreamMock.mockReturnValue(null);
+  });
+
+  const twoStepJob = (status: string) => ({
+    data: {
+      data: { id: "1", attributes: { status } },
+      included: [
+        { id: "plan-1", type: "step", attributes: { name: "Terraform Plan", status, stepNumber: "1" } },
+        { id: "apply-1", type: "step", attributes: { name: "Terraform Apply", status, stepNumber: "2" } },
+      ],
+    },
+  });
+
+  const noChangeContext = {
+    data: {
+      structuredOutputStatus: { state: "PERSISTED" },
+      noChangePlan: { planStepId: "plan-1" },
+      planStructuredOutput: { "plan-1": [] },
+    },
+  };
+
+  it("renders a no-op Apply state (not a warning) for a persisted empty plan with no apply rows", async () => {
+    getMock.mockImplementation((url: string) => {
+      if (url.includes("/context/v1/")) return Promise.resolve(noChangeContext);
+      if (url.includes("/step/")) return Promise.resolve({ data: "Apply complete! Resources: 0 added, 0 changed, 0 destroyed.", headers: {} });
+      return Promise.resolve(twoStepJob("completed"));
+    });
+
+    render(<DetailsJob jobId="1" />);
+
+    await waitFor(() => expect(screen.getByText(/Apply completed with no changes/)).toBeInTheDocument());
+    expect(
+      screen.getByText("Your infrastructure matches the configuration — no changes needed.")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Structured output temporarily unavailable")).not.toBeInTheDocument();
+  });
+
+  it("retains the no-change/no-op presentation when a later context read returns 503", async () => {
+    let jobStatus = "running";
+    let contextCalls = 0;
+    getMock.mockImplementation((url: string) => {
+      if (url.includes("/context/v1/")) {
+        contextCalls += 1;
+        return contextCalls === 1
+          ? Promise.resolve(noChangeContext)
+          : Promise.reject({ response: { status: 503 }, isAxiosError: true });
+      }
+      if (url.includes("/step/")) return Promise.resolve({ data: "Apply complete! Resources: 0 added, 0 changed, 0 destroyed.", headers: {} });
+      return Promise.resolve(twoStepJob(jobStatus));
+    });
+
+    render(<DetailsJob jobId="1" />);
+    await waitFor(() => expect(contextCalls).toBeGreaterThan(0));
+
+    jobStatus = "completed"; // the 5s poll re-fetches job (terminal) + context (now 503)
+
+    // Plan step reaching its terminal "no changes needed" proves the job transitioned AND a
+    // later 503 context read has already happened - the empty-plan evidence must have survived it.
+    await waitFor(
+      () =>
+        expect(
+          screen.getByText("Your infrastructure matches the configuration — no changes needed.")
+        ).toBeInTheDocument(),
+      { timeout: 10000 }
+    );
+    expect(contextCalls).toBeGreaterThan(1);
+    expect(screen.getByText(/Apply completed with no changes/)).toBeInTheDocument();
+    expect(screen.queryByText("Structured output temporarily unavailable")).not.toBeInTheDocument();
+  }, 15000);
+
+  it("still warns for Apply when the plan had changes but the apply snapshot is unavailable", async () => {
+    getMock.mockImplementation((url: string) => {
+      if (url.includes("/context/v1/")) {
+        return Promise.resolve({
+          data: {
+            structuredOutputStatus: { state: "PERSISTED" },
+            planStructuredOutput: {
+              "plan-1": [
+                { address: "aws_instance.x", action: "create", actions: ["create"], after: { id: "i-1" } },
+              ],
+            },
+          },
+        });
+      }
+      if (url.includes("/step/")) return Promise.resolve({ data: "Terraform will perform the following actions:", headers: {} });
+      return Promise.resolve(twoStepJob("completed"));
+    });
+
+    render(<DetailsJob jobId="1" />);
+
+    await waitFor(() => expect(screen.getByText("Structured output temporarily unavailable")).toBeInTheDocument());
+    expect(screen.queryByText(/Apply completed with no changes/)).not.toBeInTheDocument();
+  });
+
+  it("does not show 'No changes' for an unavailable context with no prior no-change evidence", async () => {
+    getMock.mockImplementation((url: string) => {
+      if (url.includes("/context/v1/")) return Promise.reject({ response: { status: 503 }, isAxiosError: true });
+      if (url.includes("/step/")) return Promise.resolve({ data: "Refreshing state...", headers: {} });
+      return Promise.resolve(twoStepJob("completed"));
+    });
+
+    render(<DetailsJob jobId="1" />);
+
+    await waitFor(() => expect(screen.getAllByText("Structured output temporarily unavailable").length).toBeGreaterThan(0));
+    expect(
+      screen.queryByText("Your infrastructure matches the configuration — no changes needed.")
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Apply completed with no changes/)).not.toBeInTheDocument();
+  });
+
+  it("shows the real console diagnostic for a genuinely failed apply even with a no-change plan marker", async () => {
+    getMock.mockImplementation((url: string) => {
+      if (url.includes("/context/v1/")) return Promise.resolve(noChangeContext);
+      if (url.includes("/step/apply-1"))
+        return Promise.resolve({ data: "Error: the Terrakube executor could not finish this operation", headers: {} });
+      if (url.includes("/step/")) return Promise.resolve({ data: "no changes", headers: {} });
+      return Promise.resolve({
+        data: {
+          data: { id: "1", attributes: { status: "failed" } },
+          included: [
+            { id: "plan-1", type: "step", attributes: { name: "Terraform Plan", status: "completed", stepNumber: "1" } },
+            { id: "apply-1", type: "step", attributes: { name: "Terraform Apply", status: "failed", stepNumber: "2" } },
+          ],
+        },
+      });
+    });
+
+    render(<DetailsJob jobId="1" />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/the Terrakube executor could not finish this operation/)).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/Apply completed with no changes/)).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/domain/Jobs/__tests__/Details.test.tsx
+++ b/ui/src/domain/Jobs/__tests__/Details.test.tsx
@@ -24,6 +24,10 @@ jest.mock("../../../config/axiosConfig", () => ({
   __esModule: true,
   default: { get: (...args: unknown[]) => getMock(...args) },
   axiosClient: { get: (...args: unknown[]) => getMock(...args) },
+  axiosAuxiliary: {
+    get: (...args: unknown[]) => getMock(...args),
+    head: (...args: unknown[]) => getMock(...args),
+  },
 }));
 
 const useStructuredOutputStreamMock = jest.fn();
@@ -263,6 +267,41 @@ describe("DetailsJob terminal-status context reconciliation", () => {
     expect(screen.queryByText("Structured output temporarily unavailable")).not.toBeInTheDocument();
   }, 12000);
 
+  it("keeps the page and other steps usable when one archived step log returns 503", async () => {
+    getMock.mockImplementation((url: string) => {
+      if (url.includes("/context/v1/")) {
+        return Promise.resolve({ data: { structuredOutputStatus: { state: "PERSISTED" } } });
+      }
+      if (url.includes("/step/step-1")) {
+        return Promise.reject({ response: { status: 503 }, isAxiosError: true });
+      }
+      if (url.includes("/step/step-2")) {
+        return Promise.resolve({ data: "step two log output", headers: {} });
+      }
+      return Promise.resolve({
+        data: {
+          data: { id: "1", attributes: { status: "completed" } },
+          included: [
+            { id: "step-1", type: "step", attributes: { name: "Terraform Plan", status: "completed", stepNumber: "1" } },
+            { id: "step-2", type: "step", attributes: { name: "Terraform Apply", status: "completed", stepNumber: "2" } },
+          ],
+        },
+      });
+    });
+
+    render(<DetailsJob jobId="1" />);
+
+    await waitFor(() => expect(screen.getByText(/Terraform Plan/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Could not load this step’s log.")).toBeInTheDocument(), {
+      timeout: 12000,
+    });
+
+    // The page shell and the healthy step's log are still there.
+    expect(screen.queryByText("Loading Job...")).not.toBeInTheDocument();
+    expect(screen.getByText(/Terraform Apply/)).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /retry/i }).length).toBeGreaterThan(0);
+  }, 20000);
+
   it("keeps the page usable when context stays unavailable (503) - console shown, no spinner, never 'No changes'", async () => {
     let jobStatus: "running" | "completed" = "running";
 
@@ -303,6 +342,57 @@ describe("DetailsJob SSE reconnect behavior", () => {
   beforeEach(() => {
     useStructuredOutputStreamMock.mockReset();
   });
+
+  it("keeps Job Details rendered and HTTP polling delivering structured output while SSE is disconnected", async () => {
+    // The SSE hook returns null the whole time (connection interrupted / never established).
+    useStructuredOutputStreamMock.mockReturnValue(null);
+    let contextHasData = false;
+
+    getMock.mockImplementation((url: string) => {
+      if (url.includes("/context/v1/")) {
+        return Promise.resolve(
+          contextHasData
+            ? {
+                data: {
+                  structuredOutputStatus: { state: "PERSISTED" },
+                  applyStructuredOutput: {
+                    "step-2": [
+                      {
+                        address: "aws_instance.via_poll",
+                        action: "create",
+                        actions: ["create"],
+                        after: { id: "i-9" },
+                        status: "applied",
+                      },
+                    ],
+                  },
+                },
+              }
+            : { data: {} }
+        );
+      }
+      return Promise.resolve({
+        data: {
+          data: { id: "1", attributes: { status: "running" } },
+          included: [
+            { id: "step-2", type: "step", attributes: { name: "Apply", status: "running", stepNumber: "2" } },
+          ],
+        },
+      });
+    });
+
+    render(<DetailsJob jobId="1" />);
+    await waitFor(() => expect(screen.getByText(/Apply/)).toBeInTheDocument());
+
+    contextHasData = true;
+
+    // No SSE event ever arrives; the 5s refreshJobDetails HTTP poll must still pick up the diff.
+    await waitFor(
+      () => expect(screen.getByRole("button", { name: /aws_instance\.via_poll/i })).toBeInTheDocument(),
+      { timeout: 8000 }
+    );
+    expect(screen.queryByText("Loading Job...")).not.toBeInTheDocument();
+  }, 12000);
 
   it(
     "keeps the last known structured output when the job leaves running and the live channel disables",

--- a/ui/src/domain/Jobs/__tests__/consolePlanSummary.test.ts
+++ b/ui/src/domain/Jobs/__tests__/consolePlanSummary.test.ts
@@ -1,0 +1,41 @@
+import { parseConsolePlanSummary } from "../consolePlanSummary";
+
+describe("parseConsolePlanSummary", () => {
+  it("detects a plan that produced changes", () => {
+    const summary = parseConsolePlanSummary("...\nPlan: 2 to add, 1 to change, 0 to destroy.\n");
+    expect(summary).toMatchObject({ hasPlan: true, declaresChanges: true, add: 2, change: 1, destroy: 0 });
+  });
+
+  it("detects an explicit no-changes plan", () => {
+    const summary = parseConsolePlanSummary("No changes. Your infrastructure matches the configuration.");
+    expect(summary).toMatchObject({ hasPlan: true, declaresNoChanges: true, declaresChanges: false });
+  });
+
+  it("treats a zero-count plan line as no changes", () => {
+    const summary = parseConsolePlanSummary("Plan: 0 to add, 0 to change, 0 to destroy.");
+    expect(summary).toMatchObject({ hasPlan: true, declaresChanges: false, declaresNoChanges: true });
+  });
+
+  it("tolerates ANSI colour codes", () => {
+    const summary = parseConsolePlanSummary("[1mPlan:[0m 1 to add, 0 to change, 0 to destroy.");
+    expect(summary.declaresChanges).toBe(true);
+  });
+
+  it("detects apply completion with resource counts", () => {
+    const summary = parseConsolePlanSummary("Apply complete! Resources: 3 added, 0 changed, 1 destroyed.");
+    expect(summary).toMatchObject({ hasPlan: true, declaresChanges: true });
+  });
+
+  it("returns all-false for unrelated output", () => {
+    expect(parseConsolePlanSummary("Initializing the backend...")).toMatchObject({
+      hasPlan: false,
+      declaresChanges: false,
+      declaresNoChanges: false,
+    });
+  });
+
+  it("handles empty / nullish input", () => {
+    expect(parseConsolePlanSummary(undefined).hasPlan).toBe(false);
+    expect(parseConsolePlanSummary("").hasPlan).toBe(false);
+  });
+});

--- a/ui/src/domain/Jobs/__tests__/contextAvailability.test.ts
+++ b/ui/src/domain/Jobs/__tests__/contextAvailability.test.ts
@@ -1,0 +1,44 @@
+import {
+  getReconciliationCounts,
+  parseContextAvailability,
+  recordReconciliationResult,
+  resetReconciliationCounts,
+} from "../contextAvailability";
+
+describe("parseContextAvailability", () => {
+  it("maps a 5xx status to unavailable regardless of body", () => {
+    expect(parseContextAvailability({ planStructuredOutput: {} }, 503)).toBe("unavailable");
+  });
+
+  it("reads an explicit structuredOutputStatus.state", () => {
+    expect(parseContextAvailability({ structuredOutputStatus: { state: "PERSISTED" } })).toBe("persisted");
+    expect(parseContextAvailability({ structuredOutputStatus: { state: "PENDING" } })).toBe("pending");
+    expect(parseContextAvailability({ structuredOutputStatus: { state: "UNAVAILABLE" } })).toBe("unavailable");
+  });
+
+  it("treats a bare {} as pending, not an empty plan", () => {
+    expect(parseContextAvailability({})).toBe("pending");
+  });
+
+  it("treats legacy content with no status marker as persisted", () => {
+    expect(parseContextAvailability({ planStructuredOutput: { "step-1": [] } })).toBe("persisted");
+    expect(parseContextAvailability({ applyStructuredOutput: { "step-1": [] } })).toBe("persisted");
+  });
+
+  it("handles nullish / non-object data", () => {
+    expect(parseContextAvailability(undefined)).toBe("pending");
+    expect(parseContextAvailability(null)).toBe("pending");
+    expect(parseContextAvailability("nope")).toBe("pending");
+  });
+});
+
+describe("reconciliation counters", () => {
+  beforeEach(() => resetReconciliationCounts());
+
+  it("records outcomes", () => {
+    recordReconciliationResult("persisted");
+    recordReconciliationResult("persisted");
+    recordReconciliationResult("expired");
+    expect(getReconciliationCounts()).toEqual({ persisted: 2, unavailable: 0, expired: 1 });
+  });
+});

--- a/ui/src/domain/Jobs/__tests__/contextAvailability.test.ts
+++ b/ui/src/domain/Jobs/__tests__/contextAvailability.test.ts
@@ -1,6 +1,7 @@
 import {
   getReconciliationCounts,
   parseContextAvailability,
+  parseNoChangePlanStepId,
   recordReconciliationResult,
   resetReconciliationCounts,
 } from "../contextAvailability";
@@ -29,6 +30,19 @@ describe("parseContextAvailability", () => {
     expect(parseContextAvailability(undefined)).toBe("pending");
     expect(parseContextAvailability(null)).toBe("pending");
     expect(parseContextAvailability("nope")).toBe("pending");
+  });
+});
+
+describe("parseNoChangePlanStepId", () => {
+  it("reads the plan step id from the noChangePlan marker", () => {
+    expect(parseNoChangePlanStepId({ noChangePlan: { planStepId: "step-1" } })).toBe("step-1");
+  });
+
+  it("returns undefined when the marker is absent or malformed", () => {
+    expect(parseNoChangePlanStepId({})).toBeUndefined();
+    expect(parseNoChangePlanStepId({ noChangePlan: {} })).toBeUndefined();
+    expect(parseNoChangePlanStepId({ noChangePlan: { planStepId: "" } })).toBeUndefined();
+    expect(parseNoChangePlanStepId(null)).toBeUndefined();
   });
 });
 

--- a/ui/src/domain/Jobs/__tests__/fetchStepLog.test.ts
+++ b/ui/src/domain/Jobs/__tests__/fetchStepLog.test.ts
@@ -4,6 +4,7 @@ jest.mock("../../../config/axiosConfig", () => ({
   __esModule: true,
   default: { get: jest.fn(), head: jest.fn() },
   axiosClient: { get: jest.fn(), head: jest.fn() },
+  axiosAuxiliary: { get: jest.fn(), head: jest.fn() },
 }));
 
 jest.mock("../outputUrl", () => ({
@@ -12,7 +13,7 @@ jest.mock("../outputUrl", () => ({
   isTerrakubeApiUrl: () => true,
 }));
 
-import axiosInstance from "../../../config/axiosConfig";
+import { axiosAuxiliary } from "../../../config/axiosConfig";
 
 const ac = () => new AbortController().signal;
 const base = {
@@ -26,8 +27,8 @@ describe("fetchStepLog", () => {
   beforeEach(() => jest.clearAllMocks());
 
   it("returns the body for a small completed-step log", async () => {
-    (axiosInstance.head as jest.Mock).mockResolvedValue({ headers: { "content-length": "12" } });
-    (axiosInstance.get as jest.Mock).mockResolvedValue({ status: 200, data: "hello world!", headers: {} });
+    (axiosAuxiliary.head as jest.Mock).mockResolvedValue({ headers: { "content-length": "12" } });
+    (axiosAuxiliary.get as jest.Mock).mockResolvedValue({ status: 200, data: "hello world!", headers: {} });
 
     const result = await fetchStepLog({ ...base, signal: ac() });
 
@@ -35,10 +36,10 @@ describe("fetchStepLog", () => {
   });
 
   it("tails a large log with a Range request and marks it truncated", async () => {
-    (axiosInstance.head as jest.Mock).mockResolvedValue({
+    (axiosAuxiliary.head as jest.Mock).mockResolvedValue({
       headers: { "content-length": String(5 * 1024 * 1024) },
     });
-    (axiosInstance.get as jest.Mock).mockResolvedValue({
+    (axiosAuxiliary.get as jest.Mock).mockResolvedValue({
       status: 206,
       data: "...tail...",
       headers: { "content-range": "bytes 5000000-5242879/5242880" },
@@ -47,27 +48,27 @@ describe("fetchStepLog", () => {
     const result = await fetchStepLog({ ...base, signal: ac(), tailBytes: 262144 });
 
     expect(result.truncated).toBe(true);
-    expect((axiosInstance.get as jest.Mock).mock.calls[0][1].headers.Range).toBe("bytes=-262144");
+    expect((axiosAuxiliary.get as jest.Mock).mock.calls[0][1].headers.Range).toBe("bytes=-262144");
   });
 
   it("does not tail when the object is under the threshold", async () => {
-    (axiosInstance.head as jest.Mock).mockResolvedValue({ headers: { "content-length": "1024" } });
-    (axiosInstance.get as jest.Mock).mockResolvedValue({ status: 200, data: "small", headers: {} });
+    (axiosAuxiliary.head as jest.Mock).mockResolvedValue({ headers: { "content-length": "1024" } });
+    (axiosAuxiliary.get as jest.Mock).mockResolvedValue({ status: 200, data: "small", headers: {} });
 
     await fetchStepLog({ ...base, signal: ac(), tailBytes: 262144 });
 
-    expect((axiosInstance.get as jest.Mock).mock.calls[0][1].headers).toBeUndefined();
+    expect((axiosAuxiliary.get as jest.Mock).mock.calls[0][1].headers).toBeUndefined();
   });
 
   it("throws StepLogNotFoundError on 404", async () => {
-    (axiosInstance.head as jest.Mock).mockRejectedValue({ response: { status: 404 } });
+    (axiosAuxiliary.head as jest.Mock).mockRejectedValue({ response: { status: 404 } });
 
     await expect(fetchStepLog({ ...base, signal: ac() })).rejects.toBeInstanceOf(StepLogNotFoundError);
   });
 
   it("throws StepLogFetchError with status on 502", async () => {
-    (axiosInstance.head as jest.Mock).mockResolvedValue({ headers: {} });
-    (axiosInstance.get as jest.Mock).mockRejectedValue({ response: { status: 502 } });
+    (axiosAuxiliary.head as jest.Mock).mockResolvedValue({ headers: {} });
+    (axiosAuxiliary.get as jest.Mock).mockRejectedValue({ response: { status: 502 } });
 
     await expect(fetchStepLog({ ...base, signal: ac() })).rejects.toMatchObject({
       name: "StepLogFetchError",
@@ -76,8 +77,8 @@ describe("fetchStepLog", () => {
   });
 
   it("falls through to GET when HEAD is rejected with a non-404", async () => {
-    (axiosInstance.head as jest.Mock).mockRejectedValue({ response: { status: 405 } });
-    (axiosInstance.get as jest.Mock).mockResolvedValue({ status: 200, data: "body", headers: {} });
+    (axiosAuxiliary.head as jest.Mock).mockRejectedValue({ response: { status: 405 } });
+    (axiosAuxiliary.get as jest.Mock).mockResolvedValue({ status: 200, data: "body", headers: {} });
 
     const result = await fetchStepLog({ ...base, signal: ac() });
 

--- a/ui/src/domain/Jobs/consolePlanSummary.ts
+++ b/ui/src/domain/Jobs/consolePlanSummary.ts
@@ -1,0 +1,55 @@
+/**
+ * Reads a Terraform/OpenTofu plan or apply summary line out of raw console output.
+ *
+ * The structured plan view must not fall back to "No changes" just because the structured context
+ * is missing or stale - if the console clearly shows a plan that *did* produce changes, the UI
+ * should say "structured output temporarily unavailable" instead. This parser provides that signal.
+ */
+export type ConsolePlanSummary = {
+  /** A plan/apply summary line was found at all. */
+  hasPlan: boolean;
+  /** The summary reports one or more resource changes. */
+  declaresChanges: boolean;
+  /** The summary explicitly reports no changes. */
+  declaresNoChanges: boolean;
+  add?: number;
+  change?: number;
+  destroy?: number;
+};
+
+// eslint-disable-next-line no-control-regex
+const ANSI = /\x1b\[[0-9;]*m/g;
+const PLAN_LINE = /Plan:\s+(\d+)\s+to add,\s+(\d+)\s+to change,\s+(\d+)\s+to destroy/i;
+const APPLY_LINE = /Apply complete!\s+Resources:\s+(\d+)\s+added,\s+(\d+)\s+changed,\s+(\d+)\s+destroyed/i;
+const NO_CHANGES = /No changes\.\s+Your infrastructure (?:still )?matches the configuration/i;
+
+const EMPTY: ConsolePlanSummary = { hasPlan: false, declaresChanges: false, declaresNoChanges: false };
+
+export const parseConsolePlanSummary = (consoleText: string | undefined | null): ConsolePlanSummary => {
+  if (!consoleText) {
+    return EMPTY;
+  }
+
+  const text = consoleText.replace(ANSI, "");
+  const counts = text.match(PLAN_LINE) ?? text.match(APPLY_LINE);
+  if (counts) {
+    const add = Number(counts[1]);
+    const change = Number(counts[2]);
+    const destroy = Number(counts[3]);
+    const total = add + change + destroy;
+    return {
+      hasPlan: true,
+      declaresChanges: total > 0,
+      declaresNoChanges: total === 0,
+      add,
+      change,
+      destroy,
+    };
+  }
+
+  if (NO_CHANGES.test(text)) {
+    return { hasPlan: true, declaresChanges: false, declaresNoChanges: true };
+  }
+
+  return EMPTY;
+};

--- a/ui/src/domain/Jobs/contextAvailability.ts
+++ b/ui/src/domain/Jobs/contextAvailability.ts
@@ -35,6 +35,18 @@ export const parseContextAvailability = (data: unknown, httpStatus?: number): Co
   return hasContent ? "persisted" : "pending";
 };
 
+/**
+ * The plan step id of an explicitly persisted no-change plan, if the executor wrote the marker.
+ * This is affirmative evidence that the associated standard apply is a valid no-op.
+ */
+export const parseNoChangePlanStepId = (data: unknown): string | undefined => {
+  if (!isRecord(data) || !isRecord(data.noChangePlan)) {
+    return undefined;
+  }
+  const planStepId = data.noChangePlan.planStepId;
+  return typeof planStepId === "string" && planStepId.length > 0 ? planStepId : undefined;
+};
+
 // No UI metrics backend exists yet; this module-level counter records reconciliation outcomes for
 // tests and future wiring of `terrakube_ui_structured_output_reconciliation_total`.
 export type ReconciliationResult = "persisted" | "unavailable" | "expired";

--- a/ui/src/domain/Jobs/contextAvailability.ts
+++ b/ui/src/domain/Jobs/contextAvailability.ts
@@ -1,0 +1,59 @@
+/**
+ * How the API's `/context/v1/{jobId}` response should be interpreted by the Job Details page.
+ *
+ * - `persisted`   — structured context is stored; an empty change set here genuinely means "No changes".
+ * - `pending`     — no context object yet (persistence still catching up); NOT an empty plan.
+ * - `unavailable` — the store returned a controlled `503`/timeout; retry, never infer "No changes".
+ */
+export type ContextAvailability = "persisted" | "pending" | "unavailable";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value != null && typeof value === "object";
+
+export const parseContextAvailability = (data: unknown, httpStatus?: number): ContextAvailability => {
+  if (httpStatus != null && httpStatus >= 500) {
+    return "unavailable";
+  }
+  if (!isRecord(data)) {
+    return "pending";
+  }
+
+  const status = data.structuredOutputStatus;
+  if (isRecord(status)) {
+    if (status.state === "UNAVAILABLE") return "unavailable";
+    if (status.state === "PENDING") return "pending";
+    if (status.state === "PERSISTED") return "persisted";
+  }
+
+  // Legacy executors persist no status marker: any structured content means it was persisted;
+  // a bare `{}` means nothing has been written yet.
+  const hasContent =
+    data.planStructuredOutput != null ||
+    data.applyStructuredOutput != null ||
+    data.terraformOutputs != null ||
+    data.terrakubeUI != null;
+  return hasContent ? "persisted" : "pending";
+};
+
+// No UI metrics backend exists yet; this module-level counter records reconciliation outcomes for
+// tests and future wiring of `terrakube_ui_structured_output_reconciliation_total`.
+export type ReconciliationResult = "persisted" | "unavailable" | "expired";
+const reconciliationCounts: Record<ReconciliationResult, number> = {
+  persisted: 0,
+  unavailable: 0,
+  expired: 0,
+};
+
+export const recordReconciliationResult = (result: ReconciliationResult): void => {
+  reconciliationCounts[result] += 1;
+};
+
+export const getReconciliationCounts = (): Record<ReconciliationResult, number> => ({
+  ...reconciliationCounts,
+});
+
+export const resetReconciliationCounts = (): void => {
+  reconciliationCounts.persisted = 0;
+  reconciliationCounts.unavailable = 0;
+  reconciliationCounts.expired = 0;
+};

--- a/ui/src/domain/Jobs/fetchStepLog.ts
+++ b/ui/src/domain/Jobs/fetchStepLog.ts
@@ -1,4 +1,4 @@
-import axiosInstance, { axiosClient } from "../../config/axiosConfig";
+import { axiosAuxiliary, axiosClient } from "../../config/axiosConfig";
 import { getJobOutputRequestUrl, getPublicApiOrigin, isTerrakubeApiUrl } from "./outputUrl";
 
 /** Objects at or above this size are fetched tail-first via a Range request. */
@@ -88,11 +88,13 @@ export async function fetchStepLog(params: FetchStepLogParams): Promise<FetchSte
 
 async function fetchStepLogInner(params: FetchStepLogParams): Promise<FetchStepLogResult> {
   const { url, terrakubeApi } = resolveUrl(params);
-  const client = terrakubeApi ? axiosInstance : axiosClient;
+  // Archived step logs are auxiliary Job Details data: a transient storage failure must stay local
+  // to the step, never the application-wide backend-error screen.
+  const client = terrakubeApi ? axiosAuxiliary : axiosClient;
 
   let contentLength: number | undefined;
   try {
-    const head = await client.head(url, { signal: params.signal });
+    const head = await client.head(url, { signal: params.signal, auxClass: "step-log" });
     const raw = head.headers?.["content-length"];
     contentLength = raw != null ? Number(raw) : undefined;
   } catch (error) {
@@ -115,11 +117,13 @@ async function fetchStepLogInner(params: FetchStepLogParams): Promise<FetchStepL
           headers: { Range: `bytes=-${params.tailBytes}` },
           responseType: "text",
           transformResponse: (d) => d,
+          auxClass: "step-log",
         })
       : await client.get(url, {
           signal: params.signal,
           responseType: "text",
           transformResponse: (d) => d,
+          auxClass: "step-log",
         });
 
     const text = typeof response.data === "string" ? response.data : String(response.data ?? "");

--- a/ui/src/hooks/__tests__/useEventStream.test.ts
+++ b/ui/src/hooks/__tests__/useEventStream.test.ts
@@ -30,6 +30,76 @@ describe("useEventStream", () => {
     await waitFor(() => expect(result.current).toEqual(["a", "b"]));
   });
 
+  it("reconnects after a dropped connection and keeps folding messages", async () => {
+    jest.useFakeTimers();
+    let attempt = 0;
+    (readEventStream as jest.Mock).mockImplementation(async (_url, { onMessage }) => {
+      attempt += 1;
+      if (attempt === 1) {
+        onMessage("a", "1");
+        throw new Error("connection dropped"); // not an AbortError
+      }
+      onMessage("b", "2");
+      return new Promise(() => {});
+    });
+
+    const { result } = renderHook(() =>
+      useEventStream<string[]>({
+        url: "http://localhost/stream",
+        enabled: true,
+        initial: [],
+        reduce: (previous, data) => [...previous, data],
+      })
+    );
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current).toEqual(["a"]);
+
+    // First reconnect is scheduled at the initial 1s backoff.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(1000);
+    });
+
+    await waitFor(() => expect(result.current).toEqual(["a", "b"]));
+    expect(attempt).toBe(2);
+    jest.useRealTimers();
+  });
+
+  it("reports failed status once reconnect backoff reaches its ceiling, then recovers", async () => {
+    jest.useFakeTimers();
+    const statuses: boolean[] = [];
+    let attempt = 0;
+    (readEventStream as jest.Mock).mockImplementation(async (_url, { onMessage }) => {
+      attempt += 1;
+      if (attempt <= 6) {
+        throw new Error("still down");
+      }
+      onMessage("recovered", "9");
+      return new Promise(() => {});
+    });
+
+    renderHook(() =>
+      useEventStream<string[]>({
+        url: "http://localhost/stream",
+        enabled: true,
+        initial: [],
+        reduce: (previous, data) => [...previous, data],
+        onStatus: ({ failed }) => statuses.push(failed),
+      })
+    );
+
+    // Drive well past the 30s ceiling of doubling backoff (1+2+4+8+16+32 ≈ 63s).
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(120000);
+    });
+
+    expect(statuses).toContain(true);
+    await waitFor(() => expect(statuses[statuses.length - 1]).toBe(false));
+    jest.useRealTimers();
+  });
+
   it("resets to initial when disabled, and never connects", () => {
     const { result } = renderHook(() =>
       useEventStream<string[]>({

--- a/ui/src/modules/api/requestMetrics.ts
+++ b/ui/src/modules/api/requestMetrics.ts
@@ -1,0 +1,49 @@
+/**
+ * Lightweight in-memory counters for request-failure classification. There is no UI metrics
+ * backend yet; these are exposed for tests and for future wiring of:
+ *  - `terrakube_ui_auxiliary_request_failures_total` (labeled by request class + HTTP/network outcome)
+ *  - `terrakube_ui_global_backend_error_activations_total` (labeled by request class; must stay 0
+ *    for auxiliary requests)
+ */
+
+const auxiliaryFailures: Record<string, number> = {};
+const globalBackendErrorActivations: Record<string, number> = {};
+
+const bump = (map: Record<string, number>, key: string): void => {
+  map[key] = (map[key] ?? 0) + 1;
+};
+
+export const recordAuxiliaryRequestFailure = (requestClass: string, outcome: string): void => {
+  bump(auxiliaryFailures, `${requestClass}:${outcome}`);
+};
+
+export const recordGlobalBackendErrorActivation = (requestClass: string): void => {
+  bump(globalBackendErrorActivations, requestClass);
+};
+
+export const getAuxiliaryRequestFailureCounts = (): Record<string, number> => ({ ...auxiliaryFailures });
+
+export const getGlobalBackendErrorActivations = (): Record<string, number> => ({
+  ...globalBackendErrorActivations,
+});
+
+export const resetRequestMetrics = (): void => {
+  for (const key of Object.keys(auxiliaryFailures)) delete auxiliaryFailures[key];
+  for (const key of Object.keys(globalBackendErrorActivations)) delete globalBackendErrorActivations[key];
+};
+
+/** Classify an Axios error into a stable metric-safe outcome label. */
+export const classifyRequestOutcome = (error: {
+  response?: { status?: number };
+  code?: string;
+  message?: string;
+}): string => {
+  const status = error?.response?.status;
+  if (status != null) {
+    return String(status);
+  }
+  if (error?.code === "ECONNABORTED" || /timeout/i.test(error?.message ?? "")) {
+    return "timeout";
+  }
+  return "network";
+};


### PR DESCRIPTION
## Why

When object storage (S3/MinIO) or the `/context/v1` read path is briefly slow or returns errors, the Job Details page degrades even though the Terraform/OpenTofu run itself is fine:

- A persistent-executor job could be marked **failed** because the API tried to deserialize the `202` acknowledgement body instead of just treating `202` as "accepted".
- A slow S3-backed context write could block a Terraform output-reader thread until the stream-drain watchdog fired `Failed to capture process output stream`, **masking the real Terraform diagnostic** (e.g. an unset required variable).
- After the async context write exhausted its retry budget, the newest structured snapshot was **dropped and never recovered**, even once storage came back.
- A single transient context `GET 503` was treated as a fatal backend outage and **replaced the whole application with the global error page** — for an optional Job Details request.
- A no-change plan's Apply step showed *"Structured output temporarily unavailable"* (a false positive — a no-op apply has no structured rows by design).
- Users had to refresh the browser to see final status/structured output, and completed jobs opened slowly under concurrent storage latency.

Root theme: auxiliary Job Details data (structured plan/apply context, archived logs, live streams) is treated as critical, blocks Terraform threads, and doesn't recover on its own.

## What

Job outcome and console output become authoritative; auxiliary data fails **locally** and heals without a refresh. No change to Terraform job semantics; no REST contract break (additive JSON keys only).

**Executor**
- `202` is treated as a bodyless acknowledgement.
- Structured-output persistence is moved off the Terraform output-reader threads onto a bounded, coalescing, retrying async queue keyed by `(jobId, stepId, phase)`.
- On retry-budget exhaustion the newest snapshot is retained and retried on a slow jittered cadence (defaults 15s → 60s, 10 min retention); final snapshots are kept ahead of progress snapshots under capacity pressure; shutdown stays bounded.
- The real Terraform/OpenTofu diagnostic stays primary when the stream-drain watchdog fires.
- A zero-change plan writes an explicit `noChangePlan` marker plus `structuredOutputStatus` metadata into context.
- `/actuator/prometheus` is exposed.

**API**
- `ContextReadService` — per-pod TTL cache + **single-flight** coalescing of concurrent misses. Its lifecycle is tied to the backing storage read, not to the first HTTP caller: a caller whose budget expires gets `503` while the read keeps running and later callers coalesce onto it, and a late success still populates the cache. Failures are never negative-cached. Bounded worker pool.
- `/context/v1` returns machine-readable states: `200` with `structuredOutputStatus.state=PENDING` when the object is absent, `503` + `Retry-After` + `state=UNAVAILABLE` on timeout/failure — never an unhandled `500`. A successful write refreshes the cache.
- Archived step-log storage failures map to a controlled `503`, not a servlet `500`.

**UI**
- A dedicated auxiliary Axios client: context/log `404/429/5xx/timeout/network` failures stay local to the component and **never activate the application-wide backend-error screen**. `401` (sign-out) and `403` (permission) handling is unchanged and not duplicated.
- After a job goes terminal, the UI keeps reconciling context with bounded exponential backoff (~60s budget), re-fetches on every live-stream event and status transition, and never reverts the page to the loading spinner on a context failure — no browser refresh needed to recover.
- *"No changes"* is shown only with a persisted (or console-confirmed) empty result. A standard apply whose plan is explicitly empty renders *"Apply completed with no changes."* The *"temporarily unavailable"* warning still shows for a non-empty plan with a missing apply snapshot, and previously loaded structured evidence is retained across a later `503`.

New Prometheus metrics accompany each area (queue depth / drops / persist / recovery; context cache hit/miss/coalesced; single-flight completions; stream-drain timeouts; step-log storage failures).

## How / design notes

- **Feature-flagged**: `io.terrakube.executor.flags.asyncStructuredOutput` (default `true`) and `structuredOutputRecovery` (default `true`) — the previous synchronous persistence path is retained.
- `noChangePlan` / `structuredOutputStatus` are additive keys; the context sanitizer already round-trips unknown keys and explicit empty arrays.
- SSE stays on native `fetch`, deliberately outside Axios, so a stream failure can't reach the global error handler.
- Timeout defaults are unchanged; the PR documents tuning them from the new `terrakube_api_context_storage_duration` histogram.
- New config knobs are added with `${EnvVar:default}` placeholders.

## Testing

| Suite | Result |
| --- | --- |
| `mvn -pl api test` | 980 passed |
| `mvn -pl executor test` | 219 passed |
| `ui` jest (config / modules / hooks / jobs) + `tsc --noEmit` | 369 passed, typecheck clean |

New tests cover the bodyless-`202` regression; controlled context `503` + metrics; queue coalescing / capacity eviction / retry / delayed recovery / supersession / expiry / bounded shutdown; single-flight owner-timeout coalescing (exactly one storage read) and cache-on-late-success; worker-pool saturation; step-log `503`; auxiliary Axios classification; live-stream reconnect; terminal-status reconciliation; and the no-op-apply / `noChangePlan` matrix.

**Manual testing completed** against a local stack with injected storage latency / `503`:

- [x] Context `503` while a job page is open → metadata, status, controls and console stay visible; only structured output is unavailable/retryable; the app shell is not replaced by the global error page.
- [x] `503` / timeout on one archived step log → the page and other step logs stay usable; the affected step offers a local retry.
- [x] Live stream interrupted during a running job → the page stays rendered, reconnects with backoff, HTTP polling continues.
- [x] `401` / `403` behave as before; a genuine core API outage still shows the global error state.
- [x] No-change plan → successful no-op apply, then force a context `503` → both steps keep the correct no-change / no-op copy without a refresh.
- [x] Non-empty plan → apply whose structured snapshot is unavailable → Apply still shows the warning with console fallback and retry.
- [x] Delayed context read: the initiating caller times out and a second request arrives before storage responds → exactly one object-store read, the second coalesces, the late result is cached.
- [x] Restore the context store before recovery retention expires → the latest snapshot persists without re-running OpenTofu and replaces obsolete progress snapshots.
- [x] Submit a plan with an unset required variable while the context store is slow → the run fails with the original OpenTofu diagnostic, with no stream-capture error masking it and a usable console log.

## Backwards compatibility

Existing plan/apply/destroy/approval/console-only and `No changes` behaviour is unchanged; the synchronous persistence path is retained behind a flag; only additive JSON keys and a controlled `503` body where the endpoint previously returned `500`.