### PR TITLE
 fix(executor): restore full diagnostic text in CLI-driven plan/apply outputFix/executor cli plan diagnostic output (#3483)

### DIFF
--- a/api/src/test/java/io/terrakube/api/plugin/state/RemoteTfeServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/state/RemoteTfeServiceTest.java
@@ -25,16 +25,22 @@ import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.repository.WorkspaceTagRepository;
 import io.terrakube.api.rs.ExecutionMode;
 import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.step.Step;
 import io.terrakube.api.rs.tag.Tag;
 import io.terrakube.api.rs.team.Team;
 import io.terrakube.api.rs.workspace.Workspace;
 import io.terrakube.api.rs.workspace.tag.WorkspaceTag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StreamOperations;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -195,6 +201,49 @@ class RemoteTfeServiceTest {
         WorkspaceList result = service.listWorkspace("sample-org", Optional.empty(), Optional.of("exact"), currentUser);
 
         assertEquals("1.6.0", result.getData().get(0).getAttributes().get("terraform-version"));
+    }
+
+    // The CLI renders `tofu plan` output straight from the bytes this returns. The executor now
+    // writes a diagnostic's full rendering (header + `on <file> line <n>` + snippet + detail) to
+    // the job's step-100 log stream as several lines; getPlanLogs must hand all of them back, not
+    // drop everything after the "Error:" header, and the offset/limit slice must not chop the
+    // block when a page big enough to hold it is requested.
+    @Test
+    @SuppressWarnings("unchecked")
+    void planLogsReturnTheFullMultiLineDiagnosticBlock() {
+        RemoteTfeService service = remoteTfeService();
+
+        Job job = new Job();
+        job.setId(123);
+        Step planStep = new Step();
+        planStep.setId(UUID.randomUUID());
+        planStep.setStepNumber(100);
+        job.setStep(List.of(planStep));
+
+        when(encryptionService.decrypt("encrypted-plan-id")).thenReturn("123");
+        when(jobRepository.findById(123)).thenReturn(Optional.of(job));
+
+        String executorConsole = String.join("\n",
+                "Plan: 0 to add, 0 to change, 0 to destroy.",
+                "",
+                "Error: Unsupported attribute",
+                "",
+                "  on main.tf line 12, in resource \"aws_instance\" \"web\":",
+                "  12:   subnet = aws_subnet.main.identifier",
+                "",
+                "This object has no argument, nested block, or exported attribute named \"identifier\".");
+
+        StreamOperations<String, String, String> streamOperations = Mockito.mock(StreamOperations.class);
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.read(any(StreamOffset.class), any(StreamOffset.class)))
+                .thenReturn(List.of(MapRecord.create("123", Map.of("output", executorConsole))));
+
+        String logs = new String(service.getPlanLogs("encrypted-plan-id", 0, 500_000), StandardCharsets.UTF_8);
+
+        assertTrue(logs.contains("on main.tf line 12, in resource \"aws_instance\" \"web\":"), logs);
+        assertTrue(logs.contains("12:   subnet = aws_subnet.main.identifier"), logs);
+        assertTrue(logs.contains(
+                "This object has no argument, nested block, or exported attribute named \"identifier\"."), logs);
     }
 
     private RemoteTfeService remoteTfeService() {

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -183,7 +183,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     Consumer<String> jsonLineConsumer = (line) -> {
                         String humanMessage = eventParser.parseLine(line, liveChanges, jobDiagnostics);
                         if (humanMessage != null) {
-                            planOutput.accept(humanMessage);
+                            acceptConsoleLines(planOutput, humanMessage);
                         }
 
                         long now = System.currentTimeMillis();
@@ -381,7 +381,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         Consumer<String> jsonLineConsumer = (line) -> {
             String humanMessage = eventParser.parseLine(line, changes, jobDiagnostics);
             if (humanMessage != null) {
-                applyOutput.accept(humanMessage);
+                acceptConsoleLines(applyOutput, humanMessage);
             }
 
             long now = System.currentTimeMillis();
@@ -425,7 +425,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         Consumer<String> jsonLineConsumer = (line) -> {
             String humanMessage = eventParser.parseLine(line, changes, jobDiagnostics);
             if (humanMessage != null) {
-                destroyOutput.accept(humanMessage);
+                acceptConsoleLines(destroyOutput, humanMessage);
             }
 
             long now = System.currentTimeMillis();
@@ -450,6 +450,15 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         pushLiveStructuredUpdate("apply", terraformJob, changes, jobDiagnostics);
 
         return execution;
+    }
+
+    // The json event stream is one event per line, but a single diagnostic event renders as a
+    // multi-line block (header, source snippet, explanatory detail). Split it so every line gets
+    // its own log record and line number, instead of one record carrying embedded newlines.
+    private static void acceptConsoleLines(Consumer<String> output, String message) {
+        for (String line : message.split("\n", -1)) {
+            output.accept(line);
+        }
     }
 
     // Best-effort live push over the new structured-output SSE channel - never lets a

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformJsonEventParser.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformJsonEventParser.java
@@ -51,7 +51,10 @@ public class TerraformJsonEventParser {
                 updateStatus(changes, resourceAddress(event), "errored");
                 updateElapsedSeconds(changes, resourceAddress(event), event);
             }
-            case "diagnostic" -> attachDiagnostic(changes, jobDiagnostics, event);
+            case "diagnostic" -> {
+                attachDiagnostic(changes, jobDiagnostics, event);
+                return renderDiagnostic(event, message instanceof String text ? text : null);
+            }
             case "provision_start" -> updateCurrentProvisioner(changes, resourceAddress(event), provisionerName(event));
             case "provision_progress" -> appendProvisionerOutput(changes, resourceAddress(event), event);
             case "provision_complete", "provision_errored" -> updateCurrentProvisioner(changes, resourceAddress(event), null);
@@ -201,6 +204,80 @@ public class TerraformJsonEventParser {
         }
 
         jobDiagnostics.add(diagnosticEntry);
+    }
+
+    // Under `-json` a diagnostic's own @message is only the one-line "Error: <summary>" /
+    // "Warning: <summary>" header - the file/line, the source snippet and the explanatory detail
+    // all live in the structured "diagnostic" object and would otherwise never reach the console
+    // stream. That stream is what `terraform`/`tofu` prints back to a CLI-driven plan, what the
+    // raw-log download serves, and what PrCommentService posts, so rebuild the full multi-line
+    // rendering here, close to what plain (non-json) terraform would have printed. Falls back to
+    // the raw @message if the structured object is missing or malformed.
+    private String renderDiagnostic(Map<String, Object> event, String fallbackMessage) {
+        Object diagnosticRaw = event.get("diagnostic");
+        if (!(diagnosticRaw instanceof Map<?, ?> diagnostic)) {
+            return fallbackMessage;
+        }
+
+        String severity = severityOrNull(diagnostic.get("severity"));
+        if (severity == null || !(diagnostic.get("summary") instanceof String summary)) {
+            return fallbackMessage;
+        }
+
+        StringBuilder rendered = new StringBuilder();
+        rendered.append('\n')
+                .append("error".equals(severity) ? "Error: " : "Warning: ")
+                .append(summary)
+                .append('\n');
+
+        String location = renderDiagnosticSource(diagnostic);
+        if (location != null) {
+            rendered.append('\n').append(location).append('\n');
+        }
+
+        if (diagnostic.get("detail") instanceof String detail && !detail.isBlank()) {
+            rendered.append('\n').append(detail).append('\n');
+        }
+
+        return rendered.toString();
+    }
+
+    // "  on main.tf line 12, in resource "aws_instance" "web":" followed by the numbered source
+    // lines - the same layout terraform's own console renderer uses. Degrades to just the
+    // "  on <file> line <n>:" header when the event carries a range but no code snippet, and to
+    // null when the diagnostic has no source location at all (a config-wide problem).
+    private String renderDiagnosticSource(Map<?, ?> diagnostic) {
+        if (!(diagnostic.get("range") instanceof Map<?, ?> range)
+                || !(range.get("filename") instanceof String filename)) {
+            return null;
+        }
+
+        Integer line = null;
+        if (range.get("start") instanceof Map<?, ?> start && start.get("line") instanceof Number lineNumber) {
+            line = lineNumber.intValue();
+        }
+
+        StringBuilder source = new StringBuilder("  on ").append(filename);
+        if (line != null) {
+            source.append(" line ").append(line);
+        }
+
+        Map<?, ?> snippet = diagnostic.get("snippet") instanceof Map<?, ?> s ? s : null;
+        if (snippet != null && snippet.get("context") instanceof String context && !context.isBlank()) {
+            source.append(", in ").append(context);
+        }
+        source.append(':');
+
+        if (snippet != null && snippet.get("code") instanceof String code) {
+            int startLine = snippet.get("start_line") instanceof Number n ? n.intValue()
+                    : (line != null ? line : 1);
+            String[] codeLines = code.split("\n", -1);
+            for (int i = 0; i < codeLines.length; i++) {
+                source.append('\n').append(String.format("%4d: %s", startLine + i, codeLines[i]));
+            }
+        }
+
+        return source.toString();
     }
 
     // Diagnostics that carry no resource address at all (a deprecated variable/output, which can

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -426,5 +427,112 @@ class TerraformExecutorServiceImplTest {
         verify(planStructuredOutputService, Mockito.atLeastOnce()).publishPlanProgress(
                 eq("org"), eq("42"), eq("1"), any(), any());
         verify(logsService, Mockito.atLeastOnce()).sendStructuredUpdate(eq(42), eq("1"), anyString());
+    }
+
+    // Regression test for the reported bug: running `tofu plan` from the CLI showed only a bare
+    // "Error: Unsupported attribute" header with no file, line or explanation. Under `-json` the
+    // diagnostic's detail lives in the structured event, not in @message - the executor must
+    // reconstruct the full rendering into the console stream the CLI reads.
+    @Test
+    void planForwardsTheFullDiagnosticRenderingToTheConsoleStream() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        String diagnosticLine = "{\"@message\":\"Error: Unsupported attribute\",\"type\":\"diagnostic\","
+                + "\"diagnostic\":{\"severity\":\"error\",\"summary\":\"Unsupported attribute\","
+                + "\"detail\":\"This object has no argument, nested block, or exported attribute named \\\"identifier\\\".\","
+                + "\"range\":{\"filename\":\"main.tf\",\"start\":{\"line\":12,\"column\":12}}}}";
+
+        TerraformClient jsonPlanClient = Mockito.mock(TerraformClient.class);
+        when(jsonPlanClient.planDetailExitCode(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenAnswer(invocation -> {
+                    Consumer<String> lineConsumer = invocation.getArgument(1);
+                    lineConsumer.accept(diagnosticLine);
+                    return CompletableFuture.completedFuture(1);
+                });
+        doReturn(jsonPlanClient).when(subject).buildJsonEnabledPlanClient();
+
+        subject.plan(terraformJob, tempDir.toFile(), false);
+
+        verify(logsService, Mockito.atLeastOnce()).sendLogs(eq(42), eq("1"), anyInt(),
+                argThat(line -> line != null && line.contains("no argument, nested block")));
+        verify(logsService, Mockito.atLeastOnce()).sendLogs(eq(42), eq("1"), anyInt(),
+                argThat(line -> line != null && line.contains("on main.tf line 12")));
+    }
+
+    // Same regression as the plan case, on the apply path: apply -json's diagnostic events must
+    // land in the console stream with their detail and location, not just the "Error:" header.
+    @Test
+    void applyForwardsTheFullDiagnosticRenderingToTheConsoleStream() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+
+        Map<String, Object> seededChange = new HashMap<>();
+        seededChange.put("address", "null_resource.fails");
+        seededChange.put("status", "pending");
+        when(applyStructuredOutputService.seedFromPlan("org", "42")).thenReturn(List.of(seededChange));
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.show(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+        when(terraformClient.statePull(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+
+        String diagnosticLine = "{\"@message\":\"Error: Missing required argument\",\"type\":\"diagnostic\","
+                + "\"diagnostic\":{\"severity\":\"error\",\"summary\":\"Missing required argument\","
+                + "\"detail\":\"The argument \\\"triggers\\\" is required, but no definition was found.\","
+                + "\"range\":{\"filename\":\"main.tf\",\"start\":{\"line\":5,\"column\":1}}}}";
+
+        TerraformClient jsonApplyClient = Mockito.mock(TerraformClient.class);
+        when(jsonApplyClient.apply(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenAnswer(invocation -> {
+                    Consumer<String> lineConsumer = invocation.getArgument(1);
+                    lineConsumer.accept(diagnosticLine);
+                    return CompletableFuture.completedFuture(false);
+                });
+        doReturn(jsonApplyClient).when(subject).buildJsonEnabledApplyClient();
+
+        ExecutorJobResult result = subject.apply(terraformJob, tempDir.toFile());
+
+        assertTrue(result.getOutputLog().contains("The argument \"triggers\" is required, but no definition was found."),
+                result.getOutputLog());
+        assertTrue(result.getOutputLog().contains("on main.tf line 5"), result.getOutputLog());
+    }
+
+    // Same regression on the destroy path.
+    @Test
+    void destroyForwardsTheFullDiagnosticRenderingToTheConsoleStream() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.show(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+        when(terraformClient.statePull(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+
+        String diagnosticLine = "{\"@message\":\"Error: Provider configuration not present\",\"type\":\"diagnostic\","
+                + "\"diagnostic\":{\"severity\":\"error\",\"summary\":\"Provider configuration not present\","
+                + "\"detail\":\"To work with null_resource.fails its original provider configuration is required.\"}}";
+
+        TerraformClient jsonDestroyClient = Mockito.mock(TerraformClient.class);
+        when(jsonDestroyClient.destroy(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenAnswer(invocation -> {
+                    Consumer<String> lineConsumer = invocation.getArgument(1);
+                    lineConsumer.accept(diagnosticLine);
+                    return CompletableFuture.completedFuture(false);
+                });
+        doReturn(jsonDestroyClient).when(subject).buildJsonEnabledDestroyClient();
+
+        ExecutorJobResult result = subject.destroy(terraformJob, tempDir.toFile());
+
+        assertTrue(result.getOutputLog().contains(
+                "To work with null_resource.fails its original provider configuration is required."),
+                result.getOutputLog());
     }
 }

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformJsonEventParserTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformJsonEventParserTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -71,6 +72,47 @@ class TerraformJsonEventParserTest {
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> diagnostics = (List<Map<String, Object>>) changes.get(0).get("diagnostics");
         assertEquals("local-exec provisioner error", diagnostics.get(0).get("summary"));
+    }
+
+    // Under `-json` a diagnostic's own `@message` is only the one-line "Error: <summary>" header -
+    // the file, line, source snippet and explanation live in the structured `diagnostic` object.
+    // parseLine must hand the caller the full multi-line rendering that plain `tofu plan` prints,
+    // otherwise the CLI (and raw-log download, and PR comment) show a bare "Error: Unsupported
+    // attribute" with nothing else.
+    @Test
+    void returnsFullHumanReadableDiagnosticRenderingForTheConsole() {
+        List<Map<String, Object>> changes = new ArrayList<>();
+        List<Map<String, Object>> jobDiagnostics = new ArrayList<>();
+
+        String consoleText = subject().parseLine(
+                "{\"@message\":\"Error: Unsupported attribute\",\"@level\":\"error\",\"type\":\"diagnostic\","
+                        + "\"diagnostic\":{\"severity\":\"error\",\"summary\":\"Unsupported attribute\","
+                        + "\"detail\":\"This object has no argument, nested block, or exported attribute named \\\"identifier\\\".\","
+                        + "\"range\":{\"filename\":\"main.tf\",\"start\":{\"line\":12,\"column\":12},\"end\":{\"line\":12,\"column\":30}},"
+                        + "\"snippet\":{\"context\":\"resource \\\"aws_instance\\\" \\\"web\\\"\",\"code\":\"  subnet = aws_subnet.main.identifier\",\"start_line\":12}}}",
+                changes, jobDiagnostics);
+
+        assertTrue(consoleText.contains("Error: Unsupported attribute"), consoleText);
+        assertTrue(consoleText.contains("on main.tf line 12, in resource \"aws_instance\" \"web\""), consoleText);
+        assertTrue(consoleText.contains("12:   subnet = aws_subnet.main.identifier"), consoleText);
+        assertTrue(consoleText.contains(
+                "This object has no argument, nested block, or exported attribute named \"identifier\"."), consoleText);
+    }
+
+    @Test
+    void rendersADiagnosticWithNoSourceLocationAsJustSummaryAndDetail() {
+        List<Map<String, Object>> changes = new ArrayList<>();
+        List<Map<String, Object>> jobDiagnostics = new ArrayList<>();
+
+        String consoleText = subject().parseLine(
+                "{\"@message\":\"Warning: Deprecated attribute\",\"type\":\"diagnostic\","
+                        + "\"diagnostic\":{\"severity\":\"warning\",\"summary\":\"Deprecated attribute\","
+                        + "\"detail\":\"The attribute \\\"foo\\\" is deprecated. Use \\\"bar\\\" instead.\"}}",
+                changes, jobDiagnostics);
+
+        assertTrue(consoleText.contains("Warning: Deprecated attribute"), consoleText);
+        assertTrue(consoleText.contains("The attribute \"foo\" is deprecated. Use \"bar\" instead."), consoleText);
+        assertFalse(consoleText.contains("  on "), consoleText);
     }
 
     @Test


### PR DESCRIPTION
* fix(executor): restore full diagnostic text in CLI-driven plan/apply output

* test: cover diagnostic console rendering on apply/destroy and the plan-logs API

Follow-up coverage for the CLI diagnostic fix:

- TerraformExecutorServiceImplTest: assert apply -json and destroy -json diagnostic events reach the console stream with their detail and location, matching the existing plan-path test (all three verified failing with the parser change reverted).
- RemoteTfeServiceTest: getPlanLogs returns the full multi-line diagnostic block from the step-100 stream and the offset/limit slice doesn't chop it when a large-enough page is requested - this is the path the CLI renders `tofu plan` output from.