### PR TITLE
fix: NullPointerException for Workspace/Project Scoped Workloads using federated credentials

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/security/federated/FederatedLookupService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/federated/FederatedLookupService.java
@@ -44,20 +44,28 @@ public class FederatedLookupService {
     }
 
     /**
-     * Resolves and authorizes a federated credential from decoded token claims.
+     * Resolves and authorizes all federated credentials that match decoded token claims.
      *
      * <p>Every audience is considered because OIDC tokens may contain more than one intended
      * recipient. Claim conditions remain part of this method so a caller cannot accidentally treat
      * an issuer/audience match as authorization.
      */
-    public Optional<Federated> findAuthorized(Map<String, Object> tokenAttributes) {
+    public List<Federated> findAllAuthorized(Map<String, Object> tokenAttributes) {
         String issuer = FederatedTokenClaims.issuer(tokenAttributes);
         if (issuer.isEmpty()) {
-            return Optional.empty();
+            return List.of();
         }
         return FederatedTokenClaims.audiences(tokenAttributes).stream()
                 .flatMap(audience -> findAllByIssuerUrlAndAudience(issuer, audience).stream())
                 .filter(federated -> FederatedClaimMatcher.matchesClaims(federated, tokenAttributes))
-                .findFirst();
+                .distinct()
+                .toList();
+    }
+
+    /**
+     * Resolves and authorizes a federated credential from decoded token claims.
+     */
+    public Optional<Federated> findAuthorized(Map<String, Object> tokenAttributes) {
+        return findAllAuthorized(tokenAttributes).stream().findFirst();
     }
 }

--- a/api/src/main/java/io/terrakube/api/plugin/security/groups/dex/DexGroupServiceImpl.java
+++ b/api/src/main/java/io/terrakube/api/plugin/security/groups/dex/DexGroupServiceImpl.java
@@ -17,8 +17,14 @@ import io.terrakube.api.rs.project.access.ProjectAccess;
 import io.terrakube.api.rs.workspace.Workspace;
 import io.terrakube.api.rs.workspace.access.Access;
 
+import io.terrakube.api.rs.federated.Federated;
+
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -46,9 +52,14 @@ public class DexGroupServiceImpl implements GroupService {
     public boolean isMember(User user, String group) {
         JwtAuthenticationToken principal = ((JwtAuthenticationToken) user.getPrincipal());
         boolean isMember = false;
-        for (String groupName : toStringArray((java.util.ArrayList) principal.getTokenAttributes().get("groups"))) {
-            if (groupName.equals(group))
-                isMember = true;
+        Object tokenGroups = principal.getTokenAttributes().get("groups");
+        if (tokenGroups instanceof Collection<?> values) {
+            for (Object groupName : values) {
+                if (groupName != null && groupName.toString().equals(group)) {
+                    isMember = true;
+                    break;
+                }
+            }
         }
         log.debug("{} is member {} {}", principal.getTokenAttributes().get("name"), group, isMember);
         return isMember;
@@ -65,9 +76,14 @@ public class DexGroupServiceImpl implements GroupService {
             if (isFederated && isFederatedMember(user, group))
                 isMember = true;
 
-            for (String groupName : toStringArray((java.util.ArrayList) principal.getTokenAttributes().get("groups"))) {
-                if (groupName.equals(group))
-                    isMember = true;
+            Object tokenGroups = principal.getTokenAttributes().get("groups");
+            if (tokenGroups instanceof Collection<?> values) {
+                for (Object groupName : values) {
+                    if (groupName != null && groupName.toString().equals(group)) {
+                        isMember = true;
+                        break;
+                    }
+                }
             }
             log.debug("{} is member {} {}", principal.getTokenAttributes().get("name"), group, isMember);
         }else{
@@ -78,26 +94,42 @@ public class DexGroupServiceImpl implements GroupService {
 
     private boolean isFederatedAccount(User user) {
         JwtAuthenticationToken principal = ((JwtAuthenticationToken) user.getPrincipal());
-        return federatedLookupService.findAuthorized(principal.getTokenAttributes()).isPresent();
+        return !federatedLookupService.findAllAuthorized(principal.getTokenAttributes()).isEmpty();
     }
 
     @Override
     public boolean isFederatedMember(User user, String group) {
         JwtAuthenticationToken principal = ((JwtAuthenticationToken) user.getPrincipal());
-        return federatedLookupService.findAuthorized(principal.getTokenAttributes())
-                .map(federated -> federated.getName().equals(group))
-                .orElse(false);
+        return federatedLookupService.findAllAuthorized(principal.getTokenAttributes()).stream()
+                .anyMatch(federated -> federated.getName().equals(group));
     }
 
-    private String[] toStringArray(java.util.ArrayList array) {
-        if (array == null)
-            return new String[0];
+    private List<String> getEffectiveGroups(User user) {
+        JwtAuthenticationToken principal = (JwtAuthenticationToken) user.getPrincipal();
+        Map<String, Object> tokenAttributes = principal.getTokenAttributes();
+        List<String> groups = new ArrayList<>();
 
-        String[] arr = new String[array.size()];
-        for (int i = 0; i < arr.length; i++) {
-            arr[i] = (String) array.get(i);
+        Object tokenGroups = tokenAttributes.get("groups");
+        if (tokenGroups instanceof Collection<?> values) {
+            values.stream()
+                    .filter(Objects::nonNull)
+                    .map(Object::toString)
+                    .forEach(groups::add);
         }
-        return arr;
+
+        federatedLookupService.findAllAuthorized(tokenAttributes).stream()
+                .map(Federated::getName)
+                .filter(Objects::nonNull)
+                .forEach(groups::add);
+
+        return groups.stream().distinct().toList();
+    }
+
+    private String[] toStringArray(Object array) {
+        if (array instanceof Collection<?> values) {
+            return values.stream().filter(Objects::nonNull).map(Object::toString).toArray(String[]::new);
+        }
+        return new String[0];
     }
 
     @Override
@@ -135,19 +167,27 @@ public class DexGroupServiceImpl implements GroupService {
     @Override
     @SuppressWarnings("unchecked")
     public boolean isMemberWithLimitedAccessV2(User user, Organization organization){
-        List<String> groups = (List<String>)((JwtAuthenticationToken) user.getPrincipal()).getTokenAttributes().get("groups");
+        List<String> groups = getEffectiveGroups(user);
+        if (groups.isEmpty()) {
+            log.debug("No groups found for user in workspace limited access check");
+            return false;
+        }
         Optional<List<Access>> accessList = RequestScopedMemo.memoize(
                 WORKSPACE_ACCESS_MEMO,
                 Arrays.asList(organization.getId(), groups),
                 () -> accessRepository.findAllByWorkspaceOrganizationIdAndNameIn(organization.getId(), groups));
-        log.debug("Groups Size: {}, IsPresent: {},  Group Access {}", groups.size(), accessList.isPresent(), accessList.get().isEmpty());
-        return !accessList.get().isEmpty();
+        log.debug("Groups Size: {}, IsPresent: {}, Group Access {}", groups.size(), accessList.isPresent(), accessList.map(l -> !l.isEmpty()).orElse(false));
+        return accessList.map(l -> !l.isEmpty()).orElse(false);
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public boolean isMemberWithProjectAccess(User user, Organization organization){
-        List<String> groups = (List<String>)((JwtAuthenticationToken) user.getPrincipal()).getTokenAttributes().get("groups");
+        List<String> groups = getEffectiveGroups(user);
+        if (groups.isEmpty()) {
+            log.debug("No groups found for user in project access check");
+            return false;
+        }
         Optional<List<ProjectAccess>> accessList = RequestScopedMemo.memoize(
                 PROJECT_ACCESS_MEMO,
                 Arrays.asList(organization.getId(), groups),

--- a/api/src/main/java/io/terrakube/api/plugin/token/team/TeamTokenService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/token/team/TeamTokenService.java
@@ -134,9 +134,9 @@ public class TeamTokenService {
     }
 
     public List<String> getCurrentGroups(JwtAuthenticationToken principalJwt) {
-        Optional<Federated> federated = federatedLookupService.findAuthorized(principalJwt.getTokenAttributes());
-        if (federated.isPresent()) {
-            return List.of(federated.get().getName());
+        List<Federated> federatedList = federatedLookupService.findAllAuthorized(principalJwt.getTokenAttributes());
+        if (!federatedList.isEmpty()) {
+            return federatedList.stream().map(Federated::getName).filter(Objects::nonNull).distinct().toList();
         }
 
         Object groups = principalJwt.getTokenAttributes().get("groups");

--- a/api/src/test/java/io/terrakube/api/DexGroupServiceTests.java
+++ b/api/src/test/java/io/terrakube/api/DexGroupServiceTests.java
@@ -3,20 +3,31 @@ package io.terrakube.api;
 import com.yahoo.elide.core.security.User;
 import io.terrakube.api.plugin.security.federated.FederatedLookupService;
 import io.terrakube.api.plugin.security.groups.dex.DexGroupServiceImpl;
+import io.terrakube.api.repository.AccessRepository;
 import io.terrakube.api.repository.FederatedRepository;
+import io.terrakube.api.repository.ProjectAccessRepository;
+import io.terrakube.api.rs.Organization;
 import io.terrakube.api.rs.federated.Federated;
 import io.terrakube.api.rs.federated.claim.FederatedClaim;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+import io.terrakube.api.rs.workspace.access.Access;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class DexGroupServiceTests {
@@ -75,6 +86,190 @@ class DexGroupServiceTests {
 
         assertTrue(groupService.isServiceMember(user, "TERRAKUBE_ADMIN"));
         assertFalse(groupService.isServiceMember(user, "other-group"));
+    }
+
+    @Test
+    void isMemberWithLimitedAccessV2_federatedToken_hasWorkspaceAccess() {
+        Federated federated = federated(GROUP, Map.of("repository", "acme/infra"));
+        FederatedRepository federatedRepository = mock(FederatedRepository.class);
+        when(federatedRepository.findAllByIssuerUrlAndAudience(ISSUER, AUDIENCE)).thenReturn(List.of(federated));
+
+        AccessRepository accessRepository = mock(AccessRepository.class);
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+
+        when(accessRepository.findAllByWorkspaceOrganizationIdAndNameIn(eq(organization.getId()), eq(List.of(GROUP))))
+                .thenReturn(Optional.of(List.of(mock(Access.class))));
+
+        DexGroupServiceImpl groupService =
+                new DexGroupServiceImpl(null, accessRepository, null, new FederatedLookupService(federatedRepository));
+
+        User user = userWith(Map.of(
+                "iss", ISSUER,
+                "aud", AUDIENCE,
+                "repository", "acme/infra"));
+
+        assertTrue(groupService.isMemberWithLimitedAccessV2(user, organization));
+    }
+
+    @Test
+    void isMemberWithLimitedAccessV2_federatedToken_noWorkspaceAccess() {
+        Federated federated = federated(GROUP, Map.of("repository", "acme/infra"));
+        FederatedRepository federatedRepository = mock(FederatedRepository.class);
+        when(federatedRepository.findAllByIssuerUrlAndAudience(ISSUER, AUDIENCE)).thenReturn(List.of(federated));
+
+        AccessRepository accessRepository = mock(AccessRepository.class);
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+
+        when(accessRepository.findAllByWorkspaceOrganizationIdAndNameIn(eq(organization.getId()), eq(List.of(GROUP))))
+                .thenReturn(Optional.of(List.of()));
+
+        DexGroupServiceImpl groupService =
+                new DexGroupServiceImpl(null, accessRepository, null, new FederatedLookupService(federatedRepository));
+
+        User user = userWith(Map.of(
+                "iss", ISSUER,
+                "aud", AUDIENCE,
+                "repository", "acme/infra"));
+
+        assertFalse(groupService.isMemberWithLimitedAccessV2(user, organization));
+    }
+
+    @Test
+    void isMemberWithLimitedAccessV2_tokenWithoutGroups_andNotFederated_doesNotThrowNpe() {
+        FederatedRepository federatedRepository = mock(FederatedRepository.class);
+        when(federatedRepository.findAllByIssuerUrlAndAudience(anyString(), anyString())).thenReturn(List.of());
+        AccessRepository accessRepository = mock(AccessRepository.class);
+
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+
+        DexGroupServiceImpl groupService =
+                new DexGroupServiceImpl(null, accessRepository, null, new FederatedLookupService(federatedRepository));
+
+        User user = userWith(Map.of(
+                "iss", "https://dex.example.com",
+                "aud", "terrakube"));
+
+        assertDoesNotThrow(() -> {
+            boolean result = groupService.isMemberWithLimitedAccessV2(user, organization);
+            assertFalse(result);
+        });
+        verifyNoInteractions(accessRepository);
+    }
+
+    @Test
+    void isMemberWithProjectAccess_federatedToken_hasProjectAccess() {
+        Federated federated = federated(GROUP, Map.of("repository", "acme/infra"));
+        FederatedRepository federatedRepository = mock(FederatedRepository.class);
+        when(federatedRepository.findAllByIssuerUrlAndAudience(ISSUER, AUDIENCE)).thenReturn(List.of(federated));
+
+        ProjectAccessRepository projectAccessRepository = mock(ProjectAccessRepository.class);
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+
+        when(projectAccessRepository.findAllByProjectOrganizationIdAndNameIn(eq(organization.getId()), eq(List.of(GROUP))))
+                .thenReturn(Optional.of(List.of(mock(ProjectAccess.class))));
+
+        DexGroupServiceImpl groupService =
+                new DexGroupServiceImpl(null, null, projectAccessRepository, new FederatedLookupService(federatedRepository));
+
+        User user = userWith(Map.of(
+                "iss", ISSUER,
+                "aud", AUDIENCE,
+                "repository", "acme/infra"));
+
+        assertTrue(groupService.isMemberWithProjectAccess(user, organization));
+    }
+
+    @Test
+    void isMemberWithProjectAccess_federatedToken_noProjectAccess() {
+        Federated federated = federated(GROUP, Map.of("repository", "acme/infra"));
+        FederatedRepository federatedRepository = mock(FederatedRepository.class);
+        when(federatedRepository.findAllByIssuerUrlAndAudience(ISSUER, AUDIENCE)).thenReturn(List.of(federated));
+
+        ProjectAccessRepository projectAccessRepository = mock(ProjectAccessRepository.class);
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+
+        when(projectAccessRepository.findAllByProjectOrganizationIdAndNameIn(eq(organization.getId()), eq(List.of(GROUP))))
+                .thenReturn(Optional.of(List.of()));
+
+        DexGroupServiceImpl groupService =
+                new DexGroupServiceImpl(null, null, projectAccessRepository, new FederatedLookupService(federatedRepository));
+
+        User user = userWith(Map.of(
+                "iss", ISSUER,
+                "aud", AUDIENCE,
+                "repository", "acme/infra"));
+
+        assertFalse(groupService.isMemberWithProjectAccess(user, organization));
+    }
+
+    @Test
+    void isMemberWithProjectAccess_tokenWithoutGroups_andNotFederated_doesNotThrowNpe() {
+        FederatedRepository federatedRepository = mock(FederatedRepository.class);
+        when(federatedRepository.findAllByIssuerUrlAndAudience(anyString(), anyString())).thenReturn(List.of());
+        ProjectAccessRepository projectAccessRepository = mock(ProjectAccessRepository.class);
+
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+
+        DexGroupServiceImpl groupService =
+                new DexGroupServiceImpl(null, null, projectAccessRepository, new FederatedLookupService(federatedRepository));
+
+        User user = userWith(Map.of(
+                "iss", "https://dex.example.com",
+                "aud", "terrakube"));
+
+        assertDoesNotThrow(() -> {
+            boolean result = groupService.isMemberWithProjectAccess(user, organization);
+            assertFalse(result);
+        });
+        verifyNoInteractions(projectAccessRepository);
+    }
+
+    @Test
+    void isFederatedMember_multipleCredentials_matchesAny() {
+        Federated cred1 = federated("TEAM_A", Map.of("repository", "acme/infra"));
+        Federated cred2 = federated("TEAM_B", Map.of("repository", "acme/infra"));
+
+        FederatedRepository federatedRepository = mock(FederatedRepository.class);
+        when(federatedRepository.findAllByIssuerUrlAndAudience(ISSUER, AUDIENCE)).thenReturn(List.of(cred1, cred2));
+
+        DexGroupServiceImpl groupService =
+                new DexGroupServiceImpl(null, null, null, new FederatedLookupService(federatedRepository));
+
+        User user = userWith(Map.of(
+                "iss", ISSUER,
+                "aud", AUDIENCE,
+                "repository", "acme/infra"));
+
+        assertTrue(groupService.isFederatedMember(user, "TEAM_A"));
+        assertTrue(groupService.isFederatedMember(user, "TEAM_B"));
+        assertFalse(groupService.isFederatedMember(user, "TEAM_C"));
+    }
+
+    @Test
+    void tokenWithNonArrayListGroups_doesNotThrowClassCastException() {
+        FederatedRepository federatedRepository = mock(FederatedRepository.class);
+        when(federatedRepository.findAllByIssuerUrlAndAudience(anyString(), anyString())).thenReturn(List.of());
+
+        DexGroupServiceImpl groupService =
+                new DexGroupServiceImpl(null, null, null, new FederatedLookupService(federatedRepository));
+
+        // Use List.of which returns an immutable list that is NOT java.util.ArrayList
+        User user = userWith(Map.of(
+                "iss", "https://dex.example.com",
+                "aud", "terrakube",
+                "groups", List.of("TEAM_CUSTOM")));
+
+        assertDoesNotThrow(() -> {
+            assertTrue(groupService.isMember(user, "TEAM_CUSTOM"));
+            assertTrue(groupService.isServiceMember(user, "TEAM_CUSTOM"));
+            assertFalse(groupService.isMember(user, "OTHER"));
+        });
     }
 
     private DexGroupServiceImpl groupServiceWith(Federated federated) {

--- a/api/src/test/java/io/terrakube/api/FederatedLookupServiceTests.java
+++ b/api/src/test/java/io/terrakube/api/FederatedLookupServiceTests.java
@@ -187,6 +187,27 @@ class FederatedLookupServiceTests {
         assertFalse(service.findAuthorized(Map.of("iss", ISSUER, "aud", AUDIENCE)).isPresent());
     }
 
+    @Test
+    void findAllAuthorizedReturnsAllMatchingCredentials() {
+        Federated cred1 = federated("team-a", Map.of("repository", "acme/shared"));
+        Federated cred2 = federated("team-b", Map.of("repository", "acme/shared"));
+        Federated cred3 = federated("team-c", Map.of("repository", "acme/other"));
+
+        FederatedRepository repository = mock(FederatedRepository.class);
+        when(repository.findAllByIssuerUrlAndAudience(ISSUER, AUDIENCE))
+                .thenReturn(List.of(cred1, cred2, cred3));
+        FederatedLookupService service = new FederatedLookupService(repository);
+
+        List<Federated> authorized = service.findAllAuthorized(Map.of(
+                "iss", ISSUER,
+                "aud", AUDIENCE,
+                "repository", "acme/shared"));
+
+        assertEquals(2, authorized.size());
+        assertTrue(authorized.stream().anyMatch(c -> "team-a".equals(c.getName())));
+        assertTrue(authorized.stream().anyMatch(c -> "team-b".equals(c.getName())));
+    }
+
     private void bindRequest() {
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(new MockHttpServletRequest()));
     }


### PR DESCRIPTION
## Description

This PR resolves an unhandled `NullPointerException` (HTTP 500) that occurs when external OIDC federated workloads (e.g., GitHub Actions, Kubernetes ServiceAccounts, GitLab CI) attempt to access workspaces or projects where permissions are scoped to specific workspaces or projects rather than granted organization-wide.
It also enables federated workloads to properly inherit and exercise workspace-level and project-level role-based access control (RBAC).


## Problem & Root Cause
1. **Missing `"groups"` Claim in External OIDC Tokens**:
   Unlike internal tokens or IdP user logins, external OIDC tokens issued by GitHub Actions, Kubernetes, or GitLab do not carry a `"groups"` claim. As a result, `tokenAttributes.get("groups")` returns `null`.
2. **Unhandled `NullPointerException` in Scoped RBAC Checks**:
   When a workload's mapped federated team is granted access only to specific workspaces or projects (rather than being an organization-wide team in `organization.getTeam()`):
   - `UserBelongsOrganization` evaluates `groupService.isMemberWithLimitedAccessV2()` and `groupService.isMemberWithProjectAccess()`.
   - In `DexGroupServiceImpl`:
     ```java
     List<String> groups = (List<String>)((JwtAuthenticationToken) user.getPrincipal()).getTokenAttributes().get("groups");
     ...
     log.debug("Groups Size: {}, ...", groups.size(), ...); // <--- Throws NullPointerException!
     ```
   - Calling `groups.size()` on a `null` reference causes an HTTP 500 crash, blocking the request.
3. **Inability to Use Scoped Permissions**:
   Even if the `null` was avoided, `DexGroupServiceImpl` previously only inspected the JWT token's `"groups"` claim and never resolved the federated team identity (`federated.getName()`) for workspace or project access. Workloads were completely locked out of scoped RBAC.
4. **Multi-Credential Blind Spot & Fragile Casting**:
   - Workloads satisfying multiple federated credentials only recognized the first credential returned by Hibernate (`.findFirst()`).
   - Casting `(java.util.ArrayList)` on the `"groups"` claim risked throwing `ClassCastException` on immutable or unmodifiable collections (`List.of(...)`, Nimbus collections).
---
## Solution
* **Safe & Unified Group Extraction (`getEffectiveGroups`)**:
  - Safely extracts groups from the JWT `"groups"` claim, supporting any `Collection<?>` without casting to `ArrayList` and handling `null` safely.
  - Merges in team names from all matching federated credentials via `federatedLookupService.findAllAuthorized(...)`.
* **NPE Fix & Early Return**:
  - `isMemberWithLimitedAccessV2` and `isMemberWithProjectAccess` now return `false` early if `groups.isEmpty()`, preventing NPEs and avoiding unnecessary `IN ()` database queries.
  - Safely extracts query results using `accessList.map(l -> !l.isEmpty()).orElse(false)`.
* **Multi-Credential Resolution**:
  - Added `findAllAuthorized` in `FederatedLookupService` and updated `TeamTokenService.getCurrentGroups` and `isFederatedMember` to evaluate all matching credentials for a workload.
---
## Changes Summary
- `DexGroupServiceImpl.java`: Safe group extraction, NPE elimination, and federated team resolution in limited/project access checks.
- `FederatedLookupService.java`: Added `findAllAuthorized` for discovering all matching credentials.
- `TeamTokenService.java`: Supports multi-team resolution for federated tokens in `getCurrentGroups`.
- `DexGroupServiceTests.java`: Added 8 comprehensive test cases covering workspace access, project access, null groups safety, and multi-credential matching.
- `FederatedLookupServiceTests.java`: Added unit test for `findAllAuthorized`.
---
## Verification
- **Targeted Tests**:
  ```bash
  mvn test -Dtest=DexGroupServiceTests,FederatedLookupServiceTests,FederatedLookupTests,DexAuthenticationManagerResolverTest