### PR TITLE
fix(scheduler): prevent trigger churn, in-flight step anomaly flagging, and stale status overwrites in the reconciliation sweep process.

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationService.java
@@ -65,8 +65,10 @@ public class JobReconciliationService {
                 .map(s -> new StepEvidence(s.getStepNumber(), s.getStatus()))
                 .toList();
 
-        long pendingSteps = steps.stream().filter(s -> s.getStatus() == JobStatus.pending).count();
-        if (pendingSteps > 0) {
+        boolean hasActiveWork = steps.stream().anyMatch(s -> s.getStatus() == JobStatus.pending
+                || s.getStatus() == JobStatus.running
+                || s.getStatus() == JobStatus.queue);
+        if (hasActiveWork) {
             return new ReconciliationResult(jobId, job.getStatus(), null, null,
                     ReconciliationDisposition.SKIPPED_HAS_WORK, evidence);
         }
@@ -113,7 +115,10 @@ public class JobReconciliationService {
         return jobRepository.findAllByStatusInOrderByIdAsc(JobReconciliationSweep.ACTIVE_STATUSES).stream()
                 .map(job -> {
                     List<Step> steps = stepRepository.findByJobId(job.getId());
-                    if (steps.isEmpty() || steps.stream().anyMatch(s -> s.getStatus() == JobStatus.pending)) {
+                    boolean hasActiveWork = steps.stream().anyMatch(s -> s.getStatus() == JobStatus.pending
+                            || s.getStatus() == JobStatus.running
+                            || s.getStatus() == JobStatus.queue);
+                    if (steps.isEmpty() || hasActiveWork) {
                         return null;
                     }
                     DerivedOutcome outcome = deriver.derive(job, steps);

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationSweep.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationSweep.java
@@ -79,7 +79,16 @@ public class JobReconciliationSweep implements org.quartz.Job {
         boolean redisRecentlyRestarted = isRedisWithinWarmupPeriod();
         for (Job job : jobRepository.findAllByStatusInOrderByIdAsc(ACTIVE_STATUSES)) {
             if (properties.isSweepEnabled()) {
-                reconcileZeroPendingJob(job);
+                ReconciliationResult result = reconcileZeroPendingJob(job);
+                if (result != null) {
+                    if (result.disposition() == ReconciliationResult.ReconciliationDisposition.APPLIED && result.targetStatus() != null) {
+                        job.setStatus(result.targetStatus());
+                    }
+                    if (result.disposition() == ReconciliationResult.ReconciliationDisposition.APPLIED
+                            || result.disposition() == ReconciliationResult.ReconciliationDisposition.ALREADY_TERMINAL) {
+                        continue;
+                    }
+                }
             }
             reconcileTrigger(job);
             if (isExecutorOwnedStatus(job.getStatus())) {
@@ -88,22 +97,26 @@ public class JobReconciliationSweep implements org.quartz.Job {
         }
     }
 
-    // Hands a job that is non-terminal with >=1 step and no pending step to the shared
-    // reconciliation routine (dry-run when auto-remediate is off). Jobs with no steps yet keep
+    // Hands a job that is non-terminal with >=1 step and no active work (pending, running, or queue)
+    // to the shared reconciliation routine (dry-run when auto-remediate is off). Jobs with no steps yet keep
     // today's trigger-only reconciliation - they're just uninitialised, not stuck.
-    private void reconcileZeroPendingJob(Job job) {
+    private ReconciliationResult reconcileZeroPendingJob(Job job) {
         List<Step> steps = stepRepository.findByJobId(job.getId());
-        if (steps.isEmpty() || steps.stream().anyMatch(s -> s.getStatus() == JobStatus.pending)) {
-            return;
+        boolean hasActiveWork = steps.stream().anyMatch(s -> s.getStatus() == JobStatus.pending
+                || s.getStatus() == JobStatus.running
+                || s.getStatus() == JobStatus.queue);
+        if (steps.isEmpty() || hasActiveWork) {
+            return null;
         }
         if (!acquirePerJobLock(job.getId())) {
-            return; // a live ScheduleJob firing (or another replica's sweep) owns this job now
+            return null; // a live ScheduleJob firing (or another replica's sweep) owns this job now
         }
         try {
-            reconciliationService.reconcile(job.getId(), !properties.isAutoRemediate());
+            return reconciliationService.reconcile(job.getId(), !properties.isAutoRemediate());
         } catch (RuntimeException e) {
             log.warn("Reconciliation of zero-pending job {} failed this sweep, will retry: {}",
                     job.getId(), e.getMessage());
+            return null;
         } finally {
             releasePerJobLock(job.getId());
         }
@@ -154,6 +167,9 @@ public class JobReconciliationSweep implements org.quartz.Job {
     }
 
     private void reconcileTrigger(Job job) {
+        if (!ACTIVE_STATUSES.contains(job.getStatus())) {
+            return;
+        }
         try {
             JobKey key = new JobKey(PREFIX_JOB_CONTEXT + job.getId());
             if (!scheduler.checkExists(key)) {
@@ -198,7 +214,13 @@ public class JobReconciliationSweep implements org.quartz.Job {
         }
 
         log.warn("Job {} has no executor heartbeat after {}, the executor that had it is gone - failing it", job.getId(), age);
-        jobRepository.updateStatusById(JobStatus.failed, job.getId());
+        int rowsUpdated = jobRepository.updateStatusByIdAndStatusIn(
+                JobStatus.failed, job.getId(), List.of(JobStatus.queue, JobStatus.running));
+        if (rowsUpdated == 0) {
+            log.info("Job {} is no longer in queue or running status in DB, skipping heartbeat failure", job.getId());
+            return;
+        }
+        job.setStatus(JobStatus.failed);
         for (Step step : stepRepository.findByJobId(job.getId())) {
             if (step.getStatus().equals(JobStatus.pending) || step.getStatus().equals(JobStatus.running)) {
                 step.setStatus(JobStatus.failed);

--- a/api/src/main/java/io/terrakube/api/repository/JobRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/JobRepository.java
@@ -48,6 +48,10 @@ public interface JobRepository extends JpaRepository<Job, Integer> {
     @Query("update job j set j.status = :status where j.id = :jobId")
     int updateStatusById(@Param("status") JobStatus status, @Param("jobId") int jobId);
 
+    @Modifying(flushAutomatically = true)
+    @Query("update job j set j.status = :newStatus where j.id = :jobId and j.status in :currentStatuses")
+    int updateStatusByIdAndStatusIn(@Param("newStatus") JobStatus newStatus, @Param("jobId") int jobId, @Param("currentStatuses") List<JobStatus> currentStatuses);
+
     @Query(value = "SELECT id FROM job WHERE workspace_id = :workspaceId", nativeQuery = true)
     List<Integer> findAllJobIdsByWorkspaceIncludingDeleted(@Param("workspaceId") String workspaceId);
 

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationServiceTest.java
@@ -130,6 +130,19 @@ class JobReconciliationServiceTest {
     }
 
     @Test
+    void runningOrQueueStepsFoundAfterLockMeansSkippedHasWork() {
+        Job j = job(755, JobStatus.running);
+        doReturn(j).when(jobRepository).lockForUpdate(755);
+        doReturn(List.of(step(JobStatus.completed, 100), step(JobStatus.running, 200)))
+                .when(stepRepository).findByJobId(755);
+
+        ReconciliationResult result = subject.reconcile(755, false);
+
+        assertThat(result.disposition()).isEqualTo(ReconciliationDisposition.SKIPPED_HAS_WORK);
+        verify(jobRepository, never()).save(any());
+    }
+
+    @Test
     void anomalyIsHeldNotTransitioned() {
         Job j = job(755, JobStatus.approved);
         doReturn(j).when(jobRepository).lockForUpdate(755);

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationSweepTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationSweepTest.java
@@ -148,7 +148,7 @@ class JobReconciliationSweepTest {
 
         subject().execute(null);
 
-        verify(jobRepository, times(0)).updateStatusById(eq(JobStatus.failed), eq(20));
+        verify(jobRepository, times(0)).updateStatusByIdAndStatusIn(eq(JobStatus.failed), eq(20), any());
     }
 
     @Test
@@ -160,12 +160,12 @@ class JobReconciliationSweepTest {
         doReturn(true).when(scheduler).checkExists(new JobKey("TerrakubeV2_Job_21"));
         doReturn(false).when(redisTemplate).hasKey("executor-job-heartbeat:21");
         doReturn(List.of()).when(stepRepository).findByJobId(21);
-        doReturn(1).when(jobRepository).updateStatusById(JobStatus.failed, 21);
+        doReturn(1).when(jobRepository).updateStatusByIdAndStatusIn(JobStatus.failed, 21, List.of(JobStatus.queue, JobStatus.running));
         doReturn(true).when(scheduler).deleteJob(new JobKey("TerrakubeV2_Job_21"));
 
         subject().execute(null);
 
-        verify(jobRepository, times(1)).updateStatusById(JobStatus.failed, 21);
+        verify(jobRepository, times(1)).updateStatusByIdAndStatusIn(JobStatus.failed, 21, List.of(JobStatus.queue, JobStatus.running));
         verify(scheduler, times(1)).deleteJob(new JobKey("TerrakubeV2_Job_21"));
         // updateStatusById is a bulk update that bypasses Elide's JobManageHook, which normally
         // keeps workspace.lastJobStatus in sync - without this explicit save the workspace list
@@ -185,7 +185,7 @@ class JobReconciliationSweepTest {
 
         subject().execute(null);
 
-        verify(jobRepository, times(0)).updateStatusById(eq(JobStatus.failed), eq(22));
+        verify(jobRepository, times(0)).updateStatusByIdAndStatusIn(eq(JobStatus.failed), eq(22), any());
     }
 
     @Test
@@ -202,7 +202,7 @@ class JobReconciliationSweepTest {
 
         // A Redis outage must never be treated as "the job is dead" - that would fail every
         // in-flight job on a transient blip, which is far worse than a delayed detection.
-        verify(jobRepository, times(0)).updateStatusById(eq(JobStatus.failed), eq(23));
+        verify(jobRepository, times(0)).updateStatusByIdAndStatusIn(eq(JobStatus.failed), eq(23), any());
     }
 
     @Test
@@ -221,7 +221,7 @@ class JobReconciliationSweepTest {
 
         subject().execute(null);
 
-        verify(jobRepository, times(0)).updateStatusById(eq(JobStatus.failed), eq(25));
+        verify(jobRepository, times(0)).updateStatusByIdAndStatusIn(eq(JobStatus.failed), eq(25), any());
     }
 
     @Test
@@ -236,7 +236,7 @@ class JobReconciliationSweepTest {
 
         subject().execute(null);
 
-        verify(jobRepository, times(0)).updateStatusById(eq(JobStatus.failed), eq(26));
+        verify(jobRepository, times(0)).updateStatusByIdAndStatusIn(eq(JobStatus.failed), eq(26), any());
     }
 
     @Test
@@ -309,5 +309,60 @@ class JobReconciliationSweepTest {
         subject().execute(null);
 
         verify(reconciliationService, never()).reconcile(anyInt(), anyBoolean());
+    }
+
+    @Test
+    void sweepDoesNotRecreateTriggerAfterReconcilingToTerminal() throws Exception {
+        Job zombie = job(40, JobStatus.approved);
+        doReturn(List.of(zombie)).when(jobRepository)
+                .findAllByStatusInOrderByIdAsc(JobReconciliationSweep.ACTIVE_STATUSES);
+        doReturn(List.of(step(JobStatus.completed))).when(stepRepository).findByJobId(40);
+        doReturn(false).when(scheduler).checkExists(new JobKey("TerrakubeV2_Job_40"));
+        doReturn(new ReconciliationResult(40, JobStatus.approved, DerivedOutcome.COMPLETED,
+                JobStatus.completed, ReconciliationResult.ReconciliationDisposition.APPLIED, List.of()))
+                .when(reconciliationService).reconcile(40, false);
+
+        subject().execute(null);
+
+        verify(reconciliationService, times(1)).reconcile(40, false);
+        verify(scheduleJobService, never()).createJobContext(any());
+    }
+
+    @Test
+    void sweepDoesNotFlagInFlightJobOnFinalStepAsAnomaly() throws Exception {
+        Job running = job(41, JobStatus.running);
+        doReturn(List.of(running)).when(jobRepository)
+                .findAllByStatusInOrderByIdAsc(JobReconciliationSweep.ACTIVE_STATUSES);
+        // Step 1 completed, Step 2 running (in flight)
+        doReturn(List.of(step(JobStatus.completed), step(JobStatus.running)))
+                .when(stepRepository).findByJobId(41);
+        doReturn(true).when(scheduler).checkExists(new JobKey("TerrakubeV2_Job_41"));
+        doReturn(true).when(redisTemplate).hasKey("executor-job-heartbeat:41");
+
+        subject().execute(null);
+
+        // Active work in progress: must never call reconcile
+        verify(reconciliationService, never()).reconcile(anyInt(), anyBoolean());
+    }
+
+    @Test
+    void sweepDoesNotOverwriteJobWhenItIsNoLongerInExecutorOwnedStatus() throws Exception {
+        Job running = job(42, JobStatus.running);
+        running.setUpdatedDate(new Date(System.currentTimeMillis() - 90_000));
+        doReturn(List.of(running)).when(jobRepository)
+                .findAllByStatusInOrderByIdAsc(JobReconciliationSweep.ACTIVE_STATUSES);
+        doReturn(true).when(scheduler).checkExists(new JobKey("TerrakubeV2_Job_42"));
+        doReturn(false).when(redisTemplate).hasKey("executor-job-heartbeat:42");
+        // Simulated race: by the time heartbeat check executes, job was completed in DB (rows updated = 0)
+        doReturn(0).when(jobRepository).updateStatusByIdAndStatusIn(
+                JobStatus.failed, 42, List.of(JobStatus.queue, JobStatus.running));
+
+        subject().execute(null);
+
+        verify(jobRepository, times(1)).updateStatusByIdAndStatusIn(
+                JobStatus.failed, 42, List.of(JobStatus.queue, JobStatus.running));
+        verify(stepRepository, never()).save(any());
+        verify(workspaceRepository, never()).save(any());
+        verify(scheduler, never()).deleteJob(any());
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses three high-severity defects identified in the zero-pending job reconciliation feature introduced in #3509 (`jakegroves/zero-pending-job-reconciliation`).

These fixes prevent:
1. **Trigger Recreation Churn:** `JobReconciliationSweep` from immediately recreating Quartz triggers for jobs that were just reconciled to a terminal status.
2. **False ANOMALY Flags on Active Runs:** In-flight jobs on their final step (where the final step is `running` or `queue` with zero `pending` steps) from being misclassified as zero-pending and flagged as `ANOMALY`.
3. **Overwriting Completed Runs to Failed:** Stale in-memory job state in the 30-second sweep loop from blindly overwriting a recently finished/completed job to `failed` during executor heartbeat expiration checks.

---

## Background & Problem Description

PR #3509 added a pure terminal-state deriver (`JobTerminalStateDeriver`) and a periodic sweep (`JobReconciliationSweep`) to detect and repair jobs stranded with zero pending steps. During edge-case analysis under concurrency, three critical bugs were identified in the sweep execution:

### 1. Trigger Recreated Immediately After Terminal Reconciliation (High Severity)
In `JobReconciliationSweep.execute()`, the sweep loops over all active jobs:
```java
if (properties.isSweepEnabled()) {
    reconcileZeroPendingJob(job);
}
reconcileTrigger(job);
```
When `reconcileZeroPendingJob(job)` successfully reconciles a zombie job to a terminal status (e.g., `completed`), `JobReconciliationService.reconcile()` commits the status change and deletes the Quartz trigger. 

However, `reconcileZeroPendingJob()` previously had a `void` return type and did not update the loop's in-memory `job` object or skip downstream actions. The loop immediately continued to `reconcileTrigger(job)`:
- `scheduler.checkExists(key)` was `false` (since the trigger was just deleted).
- `job.getStatus()` in memory was still `approved` / `pending`.
- As a result, `reconcileTrigger` immediately recreated the Quartz trigger for the newly completed job, defeating the cleanup and restarting trigger churn.

### 2. Normal In-Flight Jobs on Final Step Flagged as ANOMALY (High Severity)
In multi-step jobs (e.g. `terraformPlan` -> `approval` -> `terraformApply`), when the final step transitions to `running` (or `queue`), there are **zero `pending` steps remaining**. 
Because `reconcileZeroPendingJob` and `reconciliationService.reconcile()` only checked for `step.status == JobStatus.pending`, they considered the job to have "no pending work":
- The in-flight job was handed to `JobTerminalStateDeriver`.
- Because the final step was `running` (not in `STEP_DONE_OK = {completed, notExecuted}`), the deriver could not match a terminal outcome and fell through to `DerivedOutcome.ANOMALY`.
- This incremented `terrakube_scheduler_reconciliation_anomalies_total` and produced spurious anomaly warnings for completely healthy, in-flight jobs.

### 3. Risk of Stale In-Memory Status Overwriting Completed Jobs to FAILED (High Severity)
`JobReconciliationSweep.execute()` queries `findAllByStatusInOrderByIdAsc(ACTIVE_STATUSES)` at the beginning of its tick. If a job was in `queue` or `running` when the tick began, but completed execution while the sweep was running (or was transitioned by `reconcileZeroPendingJob`), the in-memory `job` object still held the old status.
When the loop reached `failIfExecutorHeartbeatExpired(job)`:
- The executor had already finished and cleaned up its Redis heartbeat key (`alive == false`).
- The method called `jobRepository.updateStatusById(JobStatus.failed, job.getId())`—an unconditional JPQL bulk update.
- This blindly overwrote the job in the database to `failed` and marked all steps and the workspace as `failed`, turning successful runs into failed runs.

---

## Detailed Changes

### 1. Atomic Status Check on Heartbeat Expiration
* **`JobRepository.java`**: Added an atomic conditional update query:
  ```java
  @Modifying(flushAutomatically = true)
  @Query("update job j set j.status = :newStatus where j.id = :jobId and j.status in :currentStatuses")
  int updateStatusByIdAndStatusIn(@Param("newStatus") JobStatus newStatus, @Param("jobId") int jobId, @Param("currentStatuses") List<JobStatus> currentStatuses);
  ```
* **`JobReconciliationSweep.java` (`failIfExecutorHeartbeatExpired`)**: Replaced `updateStatusById` with `updateStatusByIdAndStatusIn(JobStatus.failed, job.getId(), List.of(JobStatus.queue, JobStatus.running))`. If `0` rows are updated, the job is no longer in an executor-owned status in the database (e.g., it completed concurrently); the method aborts immediately without touching steps, workspace, or Quartz state.

### 2. Recognize In-Flight Steps as Active Work (`SKIPPED_HAS_WORK`)
* **`JobReconciliationService.java`**: Updated `reconcile()` and `report()` to check for `pending`, `running`, or `queue` statuses:
  ```java
  boolean hasActiveWork = steps.stream().anyMatch(s -> s.getStatus() == JobStatus.pending
          || s.getStatus() == JobStatus.running
          || s.getStatus() == JobStatus.queue);
  if (hasActiveWork) {
      return new ReconciliationResult(jobId, job.getStatus(), null, null,
              ReconciliationDisposition.SKIPPED_HAS_WORK, evidence);
  }
  ```
* **`JobReconciliationSweep.java` (`reconcileZeroPendingJob`)**: Updated the discovery filter so that any job with active work in progress (`pending`, `running`, or `queue` steps) is skipped before acquiring locks or calling the service.

### 3. Prevent Trigger Recreation After Terminal Reconciliation
* **`JobReconciliationSweep.java` (`execute`)**:
  - `reconcileZeroPendingJob` now returns `ReconciliationResult`.
  - When a job transitions to a terminal state (`APPLIED`) or was already terminal (`ALREADY_TERMINAL`), the in-memory entity status is synchronized (`job.setStatus(result.targetStatus())`) and downstream operations (`reconcileTrigger` and `failIfExecutorHeartbeatExpired`) are bypassed via `continue;`.
* **`JobReconciliationSweep.java` (`reconcileTrigger`)**:
  - Added a status guard checking `!ACTIVE_STATUSES.contains(job.getStatus())` to ensure triggers are never recreated for jobs in a terminal state.

---

## Invariants Maintained

1. **Terminal Invariance**: A job reconciled to `completed`, `failed`, `cancelled`, or `rejected` permanently stays terminal and has its Quartz context deleted without trigger resurrection.
2. **In-Flight Safety**: Actively running executor jobs are never evaluated by `JobTerminalStateDeriver` or reported as `ANOMALY`.
3. **Heartbeat Concurrency Safety**: A job cannot be failed by the heartbeat watchdog if its database status is no longer `queue` or `running`.
4. **FIFO Queue Liveness**: Guarded FIFO admission and trigger cleanup continue to ensure zero-pending jobs never block the executor queue.

---

## Verification & Automated Tests

All tests executed with Maven on Java 25 against PostgreSQL and Redis:

### Unit Tests (`79 passed, 0 failures`):
```bash
mvn test -Dtest=JobReconciliationSweepTest,JobReconciliationServiceTest,JobTerminalStateDeriverTest,ScheduleJobTest,SchedulerQueueMetricsTest -pl api
```
Added targeted unit tests:
- `JobReconciliationSweepTest.sweepDoesNotRecreateTriggerAfterReconcilingToTerminal`: Verifies that `scheduleJobService.createJobContext()` is not invoked after a zero-pending job reconciles to terminal.
- `JobReconciliationSweepTest.sweepDoesNotFlagInFlightJobOnFinalStepAsAnomaly`: Verifies that an in-flight job on its final step (`running`) is skipped and not sent to reconciliation.
- `JobReconciliationSweepTest.sweepDoesNotOverwriteJobWhenItIsNoLongerInExecutorOwnedStatus`: Verifies that `failIfExecutorHeartbeatExpired` does not fail a job if its DB status transitioned away from `queue`/`running`.
- `JobReconciliationServiceTest.runningOrQueueStepsFoundAfterLockMeansSkippedHasWork`: Verifies `reconcile()` returns `SKIPPED_HAS_WORK` when a step is in `running` status.

### Integration Tests (Testcontainers, `18 passed, 0 failures`):
```bash
mvn test -Dtest=JobReconciliationSweepIntegrationTest,SchedulerReconciliationControllerTest,JobDispatchOrderRepositoryIntegrationTest,JobReconciliationConcurrencyIntegrationTest -pl api
```
- Verified container-backed end-to-end reconciliation sweeps, concurrent transitions, protected admin API endpoints, and FIFO dispatch order queries.
```
