### PR TITLE
fix: improve job reliability by ensuring immediate heartbeat writes in JobExecutionWatchdog and relaxing reconciliation sweep grace periods.

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationSweep.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationSweep.java
@@ -16,6 +16,8 @@ import org.quartz.JobKey;
 import org.quartz.ObjectAlreadyExistsException;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -40,7 +42,6 @@ import static io.terrakube.api.plugin.scheduler.ScheduleJobService.PREFIX_JOB_CO
  *    FIFO isn't blocked on a callback that will never arrive.
  */
 @Slf4j
-@AllArgsConstructor
 @Component
 public class JobReconciliationSweep implements org.quartz.Job {
 
@@ -51,7 +52,6 @@ public class JobReconciliationSweep implements org.quartz.Job {
     // Duplicated as a literal in executor's JobExecutionWatchdog - separate Spring Boot apps, no
     // shared module for this constant.
     private static final String HEARTBEAT_PREFIX = "executor-job-heartbeat:";
-    private static final Duration HEARTBEAT_GRACE_PERIOD = Duration.ofSeconds(60);
 
     // Redis here has no persistent volume, so a restart comes back completely empty - every
     // heartbeat gone at once. Give executors a full refresh cycle (15s) plus margin to
@@ -72,6 +72,44 @@ public class JobReconciliationSweep implements org.quartz.Job {
     ReconciliationProperties properties;
     JobReconciliationService reconciliationService;
     JobReconciliationMetrics metrics;
+    Duration heartbeatGracePeriod;
+
+    @Autowired
+    public JobReconciliationSweep(
+            JobRepository jobRepository,
+            StepRepository stepRepository,
+            WorkspaceRepository workspaceRepository,
+            Scheduler scheduler,
+            ScheduleJobService scheduleJobService,
+            RedisTemplate<String, Object> redisTemplate,
+            ReconciliationProperties properties,
+            JobReconciliationService reconciliationService,
+            JobReconciliationMetrics metrics,
+            @Value("${io.terrakube.scheduler.reconciliation.heartbeat-grace-period-seconds:${ReconciliationHeartbeatGracePeriodSeconds:300}}") long heartbeatGracePeriodSeconds) {
+        this.jobRepository = jobRepository;
+        this.stepRepository = stepRepository;
+        this.workspaceRepository = workspaceRepository;
+        this.scheduler = scheduler;
+        this.scheduleJobService = scheduleJobService;
+        this.redisTemplate = redisTemplate;
+        this.properties = properties;
+        this.reconciliationService = reconciliationService;
+        this.metrics = metrics;
+        this.heartbeatGracePeriod = Duration.ofSeconds(heartbeatGracePeriodSeconds);
+    }
+
+    public JobReconciliationSweep(
+            JobRepository jobRepository,
+            StepRepository stepRepository,
+            WorkspaceRepository workspaceRepository,
+            Scheduler scheduler,
+            ScheduleJobService scheduleJobService,
+            RedisTemplate<String, Object> redisTemplate,
+            ReconciliationProperties properties,
+            JobReconciliationService reconciliationService,
+            JobReconciliationMetrics metrics) {
+        this(jobRepository, stepRepository, workspaceRepository, scheduler, scheduleJobService, redisTemplate, properties, reconciliationService, metrics, 300);
+    }
 
     @Transactional
     @Override
@@ -186,7 +224,7 @@ public class JobReconciliationSweep implements org.quartz.Job {
     }
 
     // Fails a job whose executor heartbeat has expired. Skips jobs younger than
-    // HEARTBEAT_GRACE_PERIOD so a freshly-dispatched job gets a full refresh cycle first. Unlike
+    // heartbeatGracePeriod so a freshly-dispatched job gets a full refresh cycle first. Unlike
     // most Redis errors elsewhere in this codebase, an unreachable Redis here does nothing rather
     // than assuming the job is dead - presuming a live job dead risks failing it mid-apply.
     private void failIfExecutorHeartbeatExpired(Job job, boolean redisRecentlyRestarted) {
@@ -194,7 +232,7 @@ public class JobReconciliationSweep implements org.quartz.Job {
             return;
         }
         Duration age = Duration.between(job.getUpdatedDate().toInstant(), Instant.now());
-        if (age.compareTo(HEARTBEAT_GRACE_PERIOD) < 0) {
+        if (age.compareTo(heartbeatGracePeriod) < 0) {
             return;
         }
         if (redisRecentlyRestarted) {

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -106,6 +106,7 @@ spring.quartz.properties.org.quartz.jobStore.clusterCheckinInterval=20000
 # io.terrakube.api.plugin.datasource.poolSize) for webhook ingestion and other DB consumers -
 # SchedulerThreadPoolValidation fails startup if this is ever raised to or above the pool size.
 spring.quartz.properties.org.quartz.threadPool.threadCount=${io.terrakube.scheduler.thread-count:8}
+io.terrakube.scheduler.reconciliation.heartbeat-grace-period-seconds=${ReconciliationHeartbeatGracePeriodSeconds:300}
 
 ####################
 #NOTIFICATION SETUP#

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationSweepTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationSweepTest.java
@@ -154,7 +154,7 @@ class JobReconciliationSweepTest {
     @Test
     void failsARunningJobPastTheGracePeriodWithNoHeartbeat() throws Exception {
         Job running = job(21, JobStatus.running);
-        running.setUpdatedDate(new Date(System.currentTimeMillis() - 90_000)); // 90s old
+        running.setUpdatedDate(new Date(System.currentTimeMillis() - 350_000)); // 350s old (> 300s grace period)
         doReturn(List.of(running)).when(jobRepository)
                 .findAllByStatusInOrderByIdAsc(JobReconciliationSweep.ACTIVE_STATUSES);
         doReturn(true).when(scheduler).checkExists(new JobKey("TerrakubeV2_Job_21"));
@@ -175,9 +175,43 @@ class JobReconciliationSweepTest {
     }
 
     @Test
+    void leavesARunningJobAloneWhenWithinExtendedGracePeriodWithNoHeartbeat() throws Exception {
+        // Issue #3521: a cold-start ephemeral pod reaches ~70-90s before writing its first heartbeat.
+        // With the 300s default grace period, the sweep must not fail it.
+        Job running = job(21, JobStatus.running);
+        running.setUpdatedDate(new Date(System.currentTimeMillis() - 90_000)); // 90s old (< 300s)
+        doReturn(List.of(running)).when(jobRepository)
+                .findAllByStatusInOrderByIdAsc(JobReconciliationSweep.ACTIVE_STATUSES);
+        doReturn(true).when(scheduler).checkExists(new JobKey("TerrakubeV2_Job_21"));
+        doReturn(false).when(redisTemplate).hasKey("executor-job-heartbeat:21");
+
+        subject().execute(null);
+
+        verify(jobRepository, times(0)).updateStatusByIdAndStatusIn(eq(JobStatus.failed), eq(21), any());
+    }
+
+    @Test
+    void respectsCustomConfiguredHeartbeatGracePeriod() throws Exception {
+        JobReconciliationSweep customSweep = new JobReconciliationSweep(
+                jobRepository, stepRepository, workspaceRepository, scheduler, scheduleJobService, redisTemplate,
+                properties, reconciliationService, metrics, 600);
+
+        Job running = job(30, JobStatus.running);
+        running.setUpdatedDate(new Date(System.currentTimeMillis() - 450_000)); // 450s old (< 600s)
+        doReturn(List.of(running)).when(jobRepository)
+                .findAllByStatusInOrderByIdAsc(JobReconciliationSweep.ACTIVE_STATUSES);
+        doReturn(true).when(scheduler).checkExists(new JobKey("TerrakubeV2_Job_30"));
+        doReturn(false).when(redisTemplate).hasKey("executor-job-heartbeat:30");
+
+        customSweep.execute(null);
+
+        verify(jobRepository, times(0)).updateStatusByIdAndStatusIn(eq(JobStatus.failed), eq(30), any());
+    }
+
+    @Test
     void leavesARunningJobAloneWhenItsHeartbeatIsStillAlive() throws Exception {
         Job running = job(22, JobStatus.running);
-        running.setUpdatedDate(new Date(System.currentTimeMillis() - 90_000));
+        running.setUpdatedDate(new Date(System.currentTimeMillis() - 350_000));
         doReturn(List.of(running)).when(jobRepository)
                 .findAllByStatusInOrderByIdAsc(JobReconciliationSweep.ACTIVE_STATUSES);
         doReturn(true).when(scheduler).checkExists(new JobKey("TerrakubeV2_Job_22"));
@@ -191,7 +225,7 @@ class JobReconciliationSweepTest {
     @Test
     void doesNotFailAJobWhenRedisIsUnreachableDuringTheHeartbeatCheck() throws Exception {
         Job running = job(23, JobStatus.running);
-        running.setUpdatedDate(new Date(System.currentTimeMillis() - 90_000));
+        running.setUpdatedDate(new Date(System.currentTimeMillis() - 350_000));
         doReturn(List.of(running)).when(jobRepository)
                 .findAllByStatusInOrderByIdAsc(JobReconciliationSweep.ACTIVE_STATUSES);
         doReturn(true).when(scheduler).checkExists(new JobKey("TerrakubeV2_Job_23"));
@@ -213,7 +247,7 @@ class JobReconciliationSweepTest {
         // would fail this test outright (FailUnkownMethod), proving the warm-up check short-
         // circuits before ever asking Redis about the heartbeat itself.
         Job running = job(25, JobStatus.running);
-        running.setUpdatedDate(new Date(System.currentTimeMillis() - 90_000));
+        running.setUpdatedDate(new Date(System.currentTimeMillis() - 350_000));
         doReturn(List.of(running)).when(jobRepository)
                 .findAllByStatusInOrderByIdAsc(JobReconciliationSweep.ACTIVE_STATUSES);
         doReturn(true).when(scheduler).checkExists(new JobKey("TerrakubeV2_Job_25"));
@@ -227,7 +261,7 @@ class JobReconciliationSweepTest {
     @Test
     void treatsAnUndeterminableRedisUptimeAsRecentlyRestarted() throws Exception {
         Job running = job(26, JobStatus.running);
-        running.setUpdatedDate(new Date(System.currentTimeMillis() - 90_000));
+        running.setUpdatedDate(new Date(System.currentTimeMillis() - 350_000));
         doReturn(List.of(running)).when(jobRepository)
                 .findAllByStatusInOrderByIdAsc(JobReconciliationSweep.ACTIVE_STATUSES);
         doReturn(true).when(scheduler).checkExists(new JobKey("TerrakubeV2_Job_26"));
@@ -242,7 +276,7 @@ class JobReconciliationSweepTest {
     @Test
     void doesNotCheckHeartbeatForNonExecutorStatuses() throws Exception {
         Job pending = job(24, JobStatus.pending);
-        pending.setUpdatedDate(new Date(System.currentTimeMillis() - 90_000));
+        pending.setUpdatedDate(new Date(System.currentTimeMillis() - 350_000));
         doReturn(List.of(pending)).when(jobRepository)
                 .findAllByStatusInOrderByIdAsc(JobReconciliationSweep.ACTIVE_STATUSES);
         doReturn(true).when(scheduler).checkExists(new JobKey("TerrakubeV2_Job_24"));
@@ -348,7 +382,7 @@ class JobReconciliationSweepTest {
     @Test
     void sweepDoesNotOverwriteJobWhenItIsNoLongerInExecutorOwnedStatus() throws Exception {
         Job running = job(42, JobStatus.running);
-        running.setUpdatedDate(new Date(System.currentTimeMillis() - 90_000));
+        running.setUpdatedDate(new Date(System.currentTimeMillis() - 350_000));
         doReturn(List.of(running)).when(jobRepository)
                 .findAllByStatusInOrderByIdAsc(JobReconciliationSweep.ACTIVE_STATUSES);
         doReturn(true).when(scheduler).checkExists(new JobKey("TerrakubeV2_Job_42"));

--- a/executor/src/main/java/io/terrakube/executor/service/executor/JobExecutionWatchdog.java
+++ b/executor/src/main/java/io/terrakube/executor/service/executor/JobExecutionWatchdog.java
@@ -55,6 +55,7 @@ public class JobExecutionWatchdog {
     void markBusy(TerraformJob job) {
         busySince.set(Instant.now());
         currentJob.set(job);
+        refreshHeartbeat();
     }
 
     void markFree() {
@@ -83,7 +84,9 @@ public class JobExecutionWatchdog {
             return;
         }
         try {
-            redisTemplate.opsForValue().set(HEARTBEAT_PREFIX + job.getJobId(), "1", HEARTBEAT_TTL);
+            if (redisTemplate != null && redisTemplate.opsForValue() != null) {
+                redisTemplate.opsForValue().set(HEARTBEAT_PREFIX + job.getJobId(), "1", HEARTBEAT_TTL);
+            }
         } catch (DataAccessException e) {
             log.warn("Could not refresh heartbeat for Job {}: {}", job.getJobId(), e.getMessage());
         }

--- a/executor/src/test/java/io/terrakube/executor/service/executor/JobExecutionWatchdogTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/executor/JobExecutionWatchdogTest.java
@@ -1,5 +1,6 @@
 package io.terrakube.executor.service.executor;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.availability.AvailabilityChangeEvent;
@@ -32,8 +33,12 @@ class JobExecutionWatchdogTest {
     private final ValueOperations<String, Object> valueOperations = Mockito.mock(ValueOperations.class);
     private final UpdateJobStatus updateJobStatus = Mockito.mock(UpdateJobStatus.class);
 
-    private JobExecutionWatchdog subject() {
+    @BeforeEach
+    void setup() {
         doReturn(valueOperations).when(redisTemplate).opsForValue();
+    }
+
+    private JobExecutionWatchdog subject() {
         return new JobExecutionWatchdog(eventPublisher, 360, redisTemplate, updateJobStatus);
     }
 
@@ -87,13 +92,22 @@ class JobExecutionWatchdogTest {
     }
 
     @Test
+    void markBusyImmediatelyWritesHeartbeatKey() {
+        JobExecutionWatchdog watchdog = subject();
+
+        watchdog.markBusy(job("42"));
+
+        verify(valueOperations, times(1)).set("executor-job-heartbeat:42", "1", Duration.ofSeconds(45));
+    }
+
+    @Test
     void refreshesTheHeartbeatKeyWhileBusy() {
         JobExecutionWatchdog watchdog = subject();
 
         watchdog.markBusy(job("42"));
         watchdog.refreshHeartbeat();
 
-        verify(valueOperations, times(1)).set("executor-job-heartbeat:42", "1", Duration.ofSeconds(45));
+        verify(valueOperations, times(2)).set("executor-job-heartbeat:42", "1", Duration.ofSeconds(45));
     }
 
     @Test


### PR DESCRIPTION
Closes #3521

---

### Summary

Resolves an issue where `JobReconciliationSweep` prematurely fails healthy jobs when running ephemeral executors (`api.ephemeralExecution.enabled: true`) on autoscaled Kubernetes clusters (e.g. Karpenter with scale-to-zero). 

The failure occurred because `JobReconciliationSweep` used an unconfigurable, hardcoded 60-second grace period measured from `job.updatedDate` (the dispatch timestamp). In cold-start environments, node provisioning, image pull, and Spring Boot startup routinely exceed 60 seconds before the executor can publish its first Redis heartbeat. Additionally, the executor previously waited up to 15 seconds for its `@Scheduled` loop before writing the heartbeat to Redis.

This change:
1. **Makes the reconciliation heartbeat grace period configurable** via `io.terrakube.scheduler.reconciliation.heartbeat-grace-period-seconds` (or environment variable `ReconciliationHeartbeatGracePeriodSeconds`), and raises the default from 60s to **300s (5 minutes)**.
2. **Eliminates executor startup jitter** by immediately publishing the heartbeat key to Redis inside `JobExecutionWatchdog.markBusy()` upon job pickup, rather than waiting for the first 15-second timer tick.
3. **Adds comprehensive test coverage** in both `api` and `executor` modules to validate extended grace periods and immediate heartbeat initialization.

---

### Root Cause Analysis

#### 1. Cold-Start Latency on Ephemeral Agents
When ephemeral execution is enabled on a cluster scaling from zero (e.g., EKS with Karpenter, AKS, or GKE auto-provisioning):
1. **Node Provisioning:** Karpenter / Cluster Autoscaler launches and provisions a new node: **~25–35s**.
2. **Image Pull:** Kubelet pulls the executor image (`azbuilder/executor:2.33.1`, uncompressed ~388 MB): **~10–25s** (longer during concurrent bursts).
3. **Application Boot:** Container starts, JVM initializes, and Spring Boot reaches `ContextRefreshedEvent`: **~15–20s**.
4. **Heartbeat Schedule Jitter:** `JobExecutionWatchdog.refreshHeartbeat()` ran strictly on `@Scheduled(fixedDelay = 15_000)`, adding up to **15s** before the first Redis key write.

**Total cold-start duration before first heartbeat:** **50–95+ seconds**.

#### 2. Premature Judgment by `JobReconciliationSweep`
`JobReconciliationSweep` runs every 30 seconds (`*/30 * * ? * *`). During each tick:
- It measures `job.updatedDate` (set when status becomes `queue` at dispatch).
- If `age >= HEARTBEAT_GRACE_PERIOD` (hardcoded to `Duration.ofSeconds(60)`) and Redis key `executor-job-heartbeat:<jobId>` is absent, the sweep concludes the executor is dead and fails the job.
- At the first tick in the `[60s, 90s)` window, cold-starting pods were killed before their first heartbeat could be registered.

#### 3. Cascading Step Failures (Destroying Still-Pending Steps)
When failing the job, the sweep iterates through all steps and marks any step with status `pending` or `running` as `failed`, then deletes the Quartz job context.
- For a multi-step job (Plan -> Apply), the plan pod was still cold-starting while the apply step was `pending`.
- The sweep failed the still-pending apply step with empty output logs and deleted the scheduler context.
- Even when the cold-starting pod later came online and completed the plan step successfully, the apply step had already been destroyed administratively.

---

### Solution & Changes

#### 1. Configurable Grace Period with Safe Default (`terrakube/api`)
- In `JobReconciliationSweep.java`:
  - Replaced the static literal `Duration HEARTBEAT_GRACE_PERIOD = Duration.ofSeconds(60)` with an injected `heartbeatGracePeriod`.
  - Injected `@Value("${io.terrakube.scheduler.reconciliation.heartbeat-grace-period-seconds:${ReconciliationHeartbeatGracePeriodSeconds:300}}") long heartbeatGracePeriodSeconds`.
  - Provided a backward-compatible overloaded constructor defaulting to 300s.
- In `application.properties`:
  - Added `io.terrakube.scheduler.reconciliation.heartbeat-grace-period-seconds=${ReconciliationHeartbeatGracePeriodSeconds:300}`.

#### 2. Immediate Heartbeat on Job Pickup (`terrakube/executor`)
- In `JobExecutionWatchdog.java`:
  - Updated `markBusy(TerraformJob job)` to immediately trigger `refreshHeartbeat()` upon job receipt, with null-safe handling.
  - Removes the 0–15s delay so the heartbeat key is published to Redis as soon as the container begins execution.

---

### Configuration Reference

Operators can tune the grace period according to their cluster's cold-start provisioning SLAs:

#### Via Environment Variable:
```bash
ReconciliationHeartbeatGracePeriodSeconds=300
```

#### Via Spring Property (`application.properties` / `JAVA_TOOL_OPTIONS`):
```properties
io.terrakube.scheduler.reconciliation.heartbeat-grace-period-seconds=300
```

#### Via Helm Chart (`values.yaml`):
```yaml
api:
  properties:
    # Optional override if default (300s) needs adjustment for slower storage/network
    heartbeatGracePeriodSeconds: "300"
```

---

### Testing & Verification

1. **API Module Tests (`JobReconciliationSweepTest`):**
   - Verified that a job at 90s age (which previously failed under the 60s hardcoded limit) is safely left alone under the 300s default grace period.
   - Verified that jobs exceeding the grace period without a heartbeat are correctly failed.
   - Verified that custom grace periods (e.g. 600s) are respected.
   ```bash
   mvn test -pl api -Dtest=JobReconciliationSweepTest
   # Tests run: 19, Failures: 0, Errors: 0, Skipped: 0
   ```

2. **Reconciliation Suite Tests (`*Reconciliation*`):**
   ```bash
   mvn test -pl api -Dtest="*Reconciliation*"
   # Tests run: 34, Failures: 0, Errors: 0, Skipped: 0
   ```

3. **Executor Module Tests (`JobExecutionWatchdogTest`):**
   - Verified that `markBusy()` immediately writes the heartbeat key to Redis.
   - Verified that periodic refreshes continue as scheduled.
   ```bash
   mvn test -pl executor -Dtest=JobExecutionWatchdogTest
   # Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
   ```
