### PR TITLE
feat: make S3 path-style access configurable

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/storage/aws/AwsStorageTypeProperties.java
+++ b/api/src/main/java/io/terrakube/api/plugin/storage/aws/AwsStorageTypeProperties.java
@@ -32,4 +32,9 @@ public class AwsStorageTypeProperties {
     private String endpointRegion = "auto";
     private boolean chunkedEncodingEnabled = true;
     private boolean checksumValidationEnabled = true;
+
+    // Some S3-compatible object stores reject path-style addressing outright.
+    // Alibaba OSS answers "Please use virtual hosted style to access" with HTTP
+    // 403 / SecondLevelDomainForbidden. Default true keeps existing behaviour.
+    private boolean pathStyleAccessEnabled = true;
 }

--- a/api/src/main/java/io/terrakube/api/plugin/storage/configuration/StorageTypeAutoConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/storage/configuration/StorageTypeAutoConfiguration.java
@@ -59,7 +59,7 @@ public class StorageTypeAutoConfiguration {
 
     static S3Configuration s3ServiceConfiguration(AwsStorageTypeProperties props) {
         return S3Configuration.builder()
-                .pathStyleAccessEnabled(true)
+                .pathStyleAccessEnabled(props.isPathStyleAccessEnabled())
                 .chunkedEncodingEnabled(props.isChunkedEncodingEnabled())
                 .checksumValidationEnabled(props.isChecksumValidationEnabled())
                 .build();

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -206,6 +206,7 @@ io.terrakube.storage.aws.endpoint=${AwsEndpoint}
 io.terrakube.storage.aws.enableRoleAuthentication=${AwsEnableRoleAuth:false}
 # S3-compatible backends (Qumulo, MinIO, ...) that need a real signing region or no chunked/checksum support
 io.terrakube.storage.aws.endpointRegion=${AwsEndpointRegion:auto}
+io.terrakube.storage.aws.pathStyleAccessEnabled=${AwsPathStyleAccess:true}
 io.terrakube.storage.aws.chunkedEncodingEnabled=${AwsChunkedEncodingEnabled:true}
 io.terrakube.storage.aws.checksumValidationEnabled=${AwsChecksumValidationEnabled:true}
 # Storage read resilience - a hung object read fails within apiCallTimeout instead of the SDK's

--- a/api/src/test/java/io/terrakube/api/plugin/storage/configuration/StorageClientResilienceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/storage/configuration/StorageClientResilienceTest.java
@@ -64,4 +64,14 @@ class StorageClientResilienceTest {
         assertFalse(config.checksumValidationEnabled());
         assertTrue(config.pathStyleAccessEnabled());
     }
+
+    @Test
+    void s3ServiceConfigurationHonorsDisabledPathStyleAccess() {
+        AwsStorageTypeProperties props = new AwsStorageTypeProperties();
+        props.setPathStyleAccessEnabled(false);
+
+        S3Configuration config = StorageTypeAutoConfiguration.s3ServiceConfiguration(props);
+
+        assertFalse(config.pathStyleAccessEnabled());
+    }
 }

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImpl.java
@@ -63,6 +63,17 @@ public class AwsTerraformStateImpl implements TerraformState {
 
     private boolean useLockfile;
 
+    // Written into the generated backend as use_path_style. Must follow the same
+    // setting as the S3 client: an object store that rejects path-style rejects
+    // it for the backend too, and that failure surfaces as a client-side
+    // OpenTofu error rather than a server one.
+    //
+    // @Builder.Default is load-bearing. Without it an unset builder field is the
+    // primitive default false, which would silently turn path-style OFF for every
+    // existing custom-endpoint deployment.
+    @Builder.Default
+    private boolean pathStyleAccessEnabled = true;
+
     @NonNull
     TerraformOutputPathService terraformOutputPathService;
 
@@ -137,7 +148,7 @@ public class AwsTerraformStateImpl implements TerraformState {
                     awsBackendHcl.appendln("    }");
                     awsBackendHcl.appendln("    skip_requesting_account_id = true");
                     awsBackendHcl.appendln("    skip_s3_checksum = true");
-                    awsBackendHcl.appendln("    use_path_style = true");
+                    awsBackendHcl.appendln("    use_path_style = " + pathStyleAccessEnabled);
                 }
 
                 awsBackendHcl.appendln("    skip_credentials_validation  = true");

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateProperties.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateProperties.java
@@ -29,4 +29,9 @@ public class AwsTerraformStateProperties {
     private String endpointRegion = "auto";
     private boolean chunkedEncodingEnabled = true;
     private boolean checksumValidationEnabled = true;
+
+    // Some S3-compatible object stores reject path-style addressing outright.
+    // Alibaba OSS answers "Please use virtual hosted style to access" with HTTP
+    // 403 / SecondLevelDomainForbidden. Default true keeps existing behaviour.
+    private boolean pathStyleAccessEnabled = true;
 }

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
@@ -86,7 +86,7 @@ public class TerraformStateAutoConfiguration {
                         log.info("Creating AWS with custom endpoint and custom credentials");
 
                         S3Configuration serviceConfiguration = S3Configuration.builder()
-                                .pathStyleAccessEnabled(true)
+                                .pathStyleAccessEnabled(awsTerraformStateProperties.isPathStyleAccessEnabled())
                                 .chunkedEncodingEnabled(awsTerraformStateProperties.isChunkedEncodingEnabled())
                                 .checksumValidationEnabled(awsTerraformStateProperties.isChecksumValidationEnabled())
                                 .build();
@@ -116,6 +116,7 @@ public class TerraformStateAutoConfiguration {
                             .region(Region.of(awsTerraformStateProperties.getRegion()))
                             .includeBackendKeys(awsTerraformStateProperties.isIncludeBackendKeys())
                             .useLockfile(awsTerraformStateProperties.isUseLockfile())
+                            .pathStyleAccessEnabled(awsTerraformStateProperties.isPathStyleAccessEnabled())
                             .terrakubeClient(terrakubeClient)
                             .terraformStatePathService(terraformStatePathService)
                             .terraformOutputPathService(terraformOutputPathService)

--- a/executor/src/main/resources/application.properties
+++ b/executor/src/main/resources/application.properties
@@ -63,6 +63,7 @@ io.terrakube.executor.plugin.tfstate.aws.enableRoleAuthentication=${AwsEnableRol
 io.terrakube.executor.plugin.tfstate.aws.useLockfile=${AwsUseLockfile:false}
 # S3-compatible backends (Qumulo, MinIO, ...) that need a real signing region or no chunked/checksum support
 io.terrakube.executor.plugin.tfstate.aws.endpointRegion=${AwsEndpointRegion:auto}
+io.terrakube.executor.plugin.tfstate.aws.pathStyleAccessEnabled=${AwsPathStyleAccess:true}
 io.terrakube.executor.plugin.tfstate.aws.chunkedEncodingEnabled=${AwsChunkedEncodingEnabled:true}
 io.terrakube.executor.plugin.tfstate.aws.checksumValidationEnabled=${AwsChecksumValidationEnabled:true}
 

--- a/executor/src/test/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/plugin/tfstate/aws/AwsTerraformStateImplTest.java
@@ -119,6 +119,28 @@ class AwsTerraformStateImplTest {
     }
 
     @Test
+    void testGetBackendStateFile_PathStyleOnByDefaultWithEndpoint(@TempDir Path tempDir) throws IOException {
+        awsTerraformState.setEndpoint("http://minio:9000");
+
+        awsTerraformState.getBackendStateFile("org1", "ws1", tempDir.toFile(), "1.13.0");
+
+        String content = FileUtils.readFileToString(new File(tempDir.toFile(), "aws_backend_override.tf"), Charset.defaultCharset());
+        assertTrue(content.contains("use_path_style = true"), "Path style stays on unless explicitly disabled");
+    }
+
+    @Test
+    void testGetBackendStateFile_PathStyleCanBeDisabled(@TempDir Path tempDir) throws IOException {
+        awsTerraformState.setEndpoint("https://oss-me-central-1.aliyuncs.com");
+        awsTerraformState.setPathStyleAccessEnabled(false);
+
+        awsTerraformState.getBackendStateFile("org1", "ws1", tempDir.toFile(), "1.13.0");
+
+        String content = FileUtils.readFileToString(new File(tempDir.toFile(), "aws_backend_override.tf"), Charset.defaultCharset());
+        assertTrue(content.contains("use_path_style = false"),
+                "Stores that reject path style, such as Alibaba OSS, need virtual hosted style here too");
+    }
+
+    @Test
     void testGetBackendStateFile_PessimisticConstraintWithEndpoint(@TempDir Path tempDir) throws IOException {
         awsTerraformState.setEndpoint("http://minio:9000");
 

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/aws/AwsStorageServiceProperties.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/aws/AwsStorageServiceProperties.java
@@ -42,4 +42,9 @@ public class AwsStorageServiceProperties {
     private String endpointRegion = "auto";
     private boolean chunkedEncodingEnabled = true;
     private boolean checksumValidationEnabled = true;
+
+    // Some S3-compatible object stores reject path-style addressing outright.
+    // Alibaba OSS answers "Please use virtual hosted style to access" with HTTP
+    // 403 / SecondLevelDomainForbidden. Default true keeps existing behaviour.
+    private boolean pathStyleAccessEnabled = true;
 }

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfiguration.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfiguration.java
@@ -108,7 +108,7 @@ public class StorageAutoConfiguration {
                     log.info("Creating AWS SDK with custom endpoint and custom credentials");
 
                     S3Configuration serviceConfiguration = S3Configuration.builder()
-                            .pathStyleAccessEnabled(true)
+                            .pathStyleAccessEnabled(awsStorageServiceProperties.isPathStyleAccessEnabled())
                             .chunkedEncodingEnabled(awsStorageServiceProperties.isChunkedEncodingEnabled())
                             .checksumValidationEnabled(awsStorageServiceProperties.isChecksumValidationEnabled())
                             .build();

--- a/registry/src/main/resources/application.properties
+++ b/registry/src/main/resources/application.properties
@@ -44,6 +44,7 @@ io.terrakube.registry.plugin.storage.aws.endpoint=${AwsEndpoint}
 io.terrakube.registry.plugin.storage.aws.enableRoleAuthentication=${AwsEnableRoleAuth:false}
 # S3-compatible backends (Qumulo, MinIO, ...) that need a real signing region or no chunked/checksum support
 io.terrakube.registry.plugin.storage.aws.endpointRegion=${AwsEndpointRegion:auto}
+io.terrakube.registry.plugin.storage.aws.pathStyleAccessEnabled=${AwsPathStyleAccess:true}
 io.terrakube.registry.plugin.storage.aws.chunkedEncodingEnabled=${AwsChunkedEncodingEnabled:true}
 io.terrakube.registry.plugin.storage.aws.checksumValidationEnabled=${AwsChecksumValidationEnabled:true}
 # S3Client/S3Presigner HTTP client bounds - fail fast rather than queue request threads against a


### PR DESCRIPTION
Closes #3523.

Path-style addressing is forced whenever a custom S3 endpoint is configured, which makes object stores that only accept virtual-hosted style unusable. Alibaba OSS refuses path-style requests with `Please use virtual hosted style to access` (HTTP 403 / `SecondLevelDomainForbidden`).

## Change

Adds `pathStyleAccessEnabled` to the AWS storage properties of the **api**, **executor** and **registry** modules, bound to `AwsPathStyleAccess` and **defaulting to `true`** — existing deployments are unaffected. It follows the shape of the existing `endpointRegion`, `chunkedEncodingEnabled` and `checksumValidationEnabled` properties added for S3-compatible backends.

The same setting is threaded into the backend the executor generates for each job, where `use_path_style` was also hardcoded.

## Two things worth a reviewer's eye

**The generated backend is the one that hides.** With only the three S3 clients made configurable, every service starts cleanly and every job still fails — and it fails as a *client-side* OpenTofu error on `ListObjectsV2`, which points at local configuration rather than the server:

```
Error: Failed to get existing workspaces: operation error S3: ListObjectsV2,
https response error StatusCode: 403, api error SecondLevelDomainForbidden
```

**`@Builder.Default` is load-bearing.** `AwsTerraformStateImpl` uses Lombok `@Builder`, so an unset builder field would be the primitive default `false` — silently turning path style *off* for every existing custom-endpoint deployment. The annotation is what keeps the default `true`.

## Tests

| Suite | Result |
|---|---|
| `StorageClientResilienceTest` | 5/5 (4 pre-existing + 1 new) |
| `AwsTerraformStateImplTest` | 30/30 (28 pre-existing + 2 new) |

New cases cover the api service configuration honouring the property, and the generated backend emitting `use_path_style` both `true` by default and `false` when disabled.

## Note on scope

Only path style. The related signing-region problem — OSS also rejects `auto` in the SigV4 credential scope — is already solved by `endpointRegion` on `main`.

Path style presumably became the default for MinIO (cf. #580); keeping the default at `true` preserves that.