### PR TITLE
fix(ui): prevent invalid workspace sources from crashing the UI

### DIFF
--- a/ui/src/modules/workspaces/utils/getVcsNameFromUrl.spec.ts
+++ b/ui/src/modules/workspaces/utils/getVcsNameFromUrl.spec.ts
@@ -1,6 +1,17 @@
 import getVcsNameFromUrl from "./getVcsNameFromUrl";
 
 describe("getVcsNameFromUrl", () => {
+  test.each(["myorg/myrepo", "empty", "", "https://", "https://host:invalid/repo.git"])(
+    "invalid source %j is displayed unchanged",
+    (source) => {
+      expect(getVcsNameFromUrl(source)).toBe(source);
+    }
+  );
+
+  test("SSH source returns the repository name", () => {
+    expect(getVcsNameFromUrl("git@github.com:myorg/myrepo.git")).toBe("myorg/myrepo");
+  });
+
   test("DevOps url returns correct", async () => {
     const result = getVcsNameFromUrl("https://dev.azure.com/org-name/project-name/repo-name");
     expect(result).toBe("org-name/project-name/repo-name");

--- a/ui/src/modules/workspaces/utils/getVcsNameFromUrl.ts
+++ b/ui/src/modules/workspaces/utils/getVcsNameFromUrl.ts
@@ -3,7 +3,9 @@ import formatSshUrl from "./formatSshUrl";
 export default function (normalizedUrl: string): string {
   // Let's just be safe in case the wrong url was passed
   const fixedUrl = formatSshUrl(normalizedUrl);
-  const urlObj = new URL(fixedUrl);
-  const pathname = urlObj.pathname;
-  return pathname.substring(1);
+  try {
+    return new URL(fixedUrl).pathname.substring(1);
+  } catch {
+    return normalizedUrl;
+  }
 }

--- a/ui/src/modules/workspaces/utils/getVcsTypeFromUrl.spec.ts
+++ b/ui/src/modules/workspaces/utils/getVcsTypeFromUrl.spec.ts
@@ -2,6 +2,17 @@ import { VcsType } from "../../../domain/types";
 import getVcsTypeFromUrl from "./getVcsTypeFromUrl";
 
 describe("getVcsTypeFromUrl", () => {
+  test.each(["myorg/myrepo", "empty", "", "https://", "https://host:invalid/repo.git"])(
+    "invalid source %j returns UNKNOWN",
+    (source) => {
+      expect(getVcsTypeFromUrl(source)).toBe(VcsType.UNKNOWN);
+    }
+  );
+
+  test("SSH source returns the provider", () => {
+    expect(getVcsTypeFromUrl("git@github.com:myorg/myrepo.git")).toBe(VcsType.GITHUB);
+  });
+
   test("dev.azure.com returns correct", async () => {
     const result = getVcsTypeFromUrl("https://dev.azure.com/org-name/project-name/repo-name");
     expect(result).toBe(VcsType.AZURE_DEVOPS);

--- a/ui/src/modules/workspaces/utils/getVcsTypeFromUrl.ts
+++ b/ui/src/modules/workspaces/utils/getVcsTypeFromUrl.ts
@@ -8,7 +8,12 @@ export default function (normalizedSource: string): VcsType {
   const bitbucketEndpoints = ["bitbucket.org"];
   // Let's just be safe in case the wrong url was passed
   const fixedUrl = formatSshUrl(normalizedSource);
-  const hostname = new URL(fixedUrl).hostname;
+  let hostname: string;
+  try {
+    hostname = new URL(fixedUrl).hostname;
+  } catch {
+    return VcsType.UNKNOWN;
+  }
   // ghe.com uses subdomain
   if (githubEndpoints.includes(hostname) || githubEndpoints.some((h) => hostname.endsWith(h))) return VcsType.GITHUB;
   // visualstudio.com uses subdomin


### PR DESCRIPTION
A workspace source such as `myorg/myrepo` caused URL parsing to throw while rendering workspace cards or the table, taking down the organization page. The shared VCS helpers now preserve the original source as the display name and return `UNKNOWN` for the provider when parsing fails.

Adds regression coverage for relative, empty, and malformed sources, plus valid SSH URLs.

Validation: 98 workspace utility tests passed on this branch; ESLint passed for the four changed files; `git diff --check` passed.

Fixes #3517
