### PR TITLE
fix(storage): configure S3 checksum behavior on the client only

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/storage/configuration/StorageTypeAutoConfiguration.java
+++ b/api/src/main/java/io/terrakube/api/plugin/storage/configuration/StorageTypeAutoConfiguration.java
@@ -25,6 +25,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.retry.RetryPolicy;
@@ -58,10 +59,25 @@ public class StorageTypeAutoConfiguration {
     }
 
     static S3Configuration s3ServiceConfiguration(AwsStorageTypeProperties props) {
+        // Checksum behavior is configured on the client below; setting it here as well makes the
+        // SDK throw "Checksum behavior has been configured on both S3Configuration and the client".
         return S3Configuration.builder()
                 .pathStyleAccessEnabled(props.isPathStyleAccessEnabled())
                 .chunkedEncodingEnabled(props.isChunkedEncodingEnabled())
-                .checksumValidationEnabled(props.isChecksumValidationEnabled())
+                .build();
+    }
+
+    static S3Client s3CompatibleClient(AwsStorageTypeProperties props, ClientOverrideConfiguration override) {
+        return S3Client.builder()
+                .region(Region.of(props.getEndpointRegion()))
+                .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(props)))
+                .endpointOverride(URI.create(props.getEndpoint()))
+                .serviceConfiguration(s3ServiceConfiguration(props))
+                .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+                .responseChecksumValidation(props.isChecksumValidationEnabled()
+                        ? ResponseChecksumValidation.WHEN_SUPPORTED
+                        : ResponseChecksumValidation.WHEN_REQUIRED)
+                .overrideConfiguration(override)
                 .build();
     }
 
@@ -94,18 +110,7 @@ public class StorageTypeAutoConfiguration {
                             .build();
                 } else if (awsStorageTypeProperties.getEndpoint() != null && !awsStorageTypeProperties.getEndpoint().isEmpty()) {
                     log.info("Creating AWS SDK with custom endpoint and custom credentials");
-
-                    S3Configuration serviceConfiguration = s3ServiceConfiguration(awsStorageTypeProperties);
-
-                    s3client = S3Client.builder()
-                            .region(Region.of(awsStorageTypeProperties.getEndpointRegion()))
-                            .credentialsProvider(StaticCredentialsProvider.create(getAwsBasicCredentials(awsStorageTypeProperties)))
-                            .endpointOverride(URI.create(awsStorageTypeProperties.getEndpoint()))
-                            .serviceConfiguration(serviceConfiguration)
-                            .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
-                            .overrideConfiguration(s3Override)
-                            .build();
-
+                    s3client = s3CompatibleClient(awsStorageTypeProperties, s3Override);
                 } else {
                     log.info("Creating AWS SDK with custom credentials");
                     s3client = S3Client.builder()
@@ -150,7 +155,7 @@ public class StorageTypeAutoConfiguration {
         return storageTypeService;
     }
 
-    private AwsBasicCredentials getAwsBasicCredentials(AwsStorageTypeProperties awsStorageTypeProperties) {
+    private static AwsBasicCredentials getAwsBasicCredentials(AwsStorageTypeProperties awsStorageTypeProperties) {
         AwsBasicCredentials awsCreds = AwsBasicCredentials.create(awsStorageTypeProperties.getAccessKey(), awsStorageTypeProperties.getSecretKey());
         return awsCreds;
     }

--- a/api/src/test/java/io/terrakube/api/plugin/storage/configuration/StorageClientResilienceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/storage/configuration/StorageClientResilienceTest.java
@@ -120,6 +120,7 @@ class StorageClientResilienceTest {
         props.setEndpoint("http://localhost:9000");
         props.setAccessKey("minio");
         props.setSecretKey("minio123");
+        props.setChecksumValidationEnabled(true);
         return props;
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/storage/configuration/StorageClientResilienceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/storage/configuration/StorageClientResilienceTest.java
@@ -2,14 +2,18 @@ package io.terrakube.api.plugin.storage.configuration;
 
 import io.terrakube.api.plugin.storage.aws.AwsStorageTypeProperties;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
 
 import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StorageClientResilienceTest {
@@ -47,7 +51,6 @@ class StorageClientResilienceTest {
         assertEquals("auto", props.getEndpointRegion());
         assertTrue(config.pathStyleAccessEnabled());
         assertTrue(config.chunkedEncodingEnabled());
-        assertTrue(config.checksumValidationEnabled());
     }
 
     @Test
@@ -55,13 +58,11 @@ class StorageClientResilienceTest {
         AwsStorageTypeProperties props = new AwsStorageTypeProperties();
         props.setEndpointRegion("us-east-1");
         props.setChunkedEncodingEnabled(false);
-        props.setChecksumValidationEnabled(false);
 
         S3Configuration config = StorageTypeAutoConfiguration.s3ServiceConfiguration(props);
 
         assertEquals("us-east-1", props.getEndpointRegion());
         assertFalse(config.chunkedEncodingEnabled());
-        assertFalse(config.checksumValidationEnabled());
         assertTrue(config.pathStyleAccessEnabled());
     }
 
@@ -73,5 +74,52 @@ class StorageClientResilienceTest {
         S3Configuration config = StorageTypeAutoConfiguration.s3ServiceConfiguration(props);
 
         assertFalse(config.pathStyleAccessEnabled());
+    }
+
+    @Test
+    void s3ServiceConfigurationLeavesChecksumBehaviorToClient() {
+        AwsStorageTypeProperties props = new AwsStorageTypeProperties();
+        props.setChecksumValidationEnabled(false);
+
+        S3Configuration config = StorageTypeAutoConfiguration.s3ServiceConfiguration(props);
+
+        // The SDK refuses to build a client when checksum behavior is set on both S3Configuration
+        // and the client (#3528), so it must stay unset here.
+        assertNull(config.toBuilder().checksumValidationEnabled());
+    }
+
+    @Test
+    void s3CompatibleClientBuildsWithChecksumValidationEnabled() {
+        AwsStorageTypeProperties props = s3CompatibleProps();
+
+        try (S3Client client = StorageTypeAutoConfiguration.s3CompatibleClient(props,
+                StorageTypeAutoConfiguration.storageClientOverride(props))) {
+            assertEquals(RequestChecksumCalculation.WHEN_REQUIRED,
+                    client.serviceClientConfiguration().requestChecksumCalculation());
+            assertEquals(ResponseChecksumValidation.WHEN_SUPPORTED,
+                    client.serviceClientConfiguration().responseChecksumValidation());
+        }
+    }
+
+    @Test
+    void s3CompatibleClientBuildsWithChecksumValidationDisabled() {
+        AwsStorageTypeProperties props = s3CompatibleProps();
+        props.setChecksumValidationEnabled(false);
+
+        try (S3Client client = StorageTypeAutoConfiguration.s3CompatibleClient(props,
+                StorageTypeAutoConfiguration.storageClientOverride(props))) {
+            assertEquals(RequestChecksumCalculation.WHEN_REQUIRED,
+                    client.serviceClientConfiguration().requestChecksumCalculation());
+            assertEquals(ResponseChecksumValidation.WHEN_REQUIRED,
+                    client.serviceClientConfiguration().responseChecksumValidation());
+        }
+    }
+
+    private static AwsStorageTypeProperties s3CompatibleProps() {
+        AwsStorageTypeProperties props = new AwsStorageTypeProperties();
+        props.setEndpoint("http://localhost:9000");
+        props.setAccessKey("minio");
+        props.setSecretKey("minio123");
+        return props;
     }
 }

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
@@ -99,9 +99,7 @@ public class TerraformStateAutoConfiguration {
                                 .endpointOverride(URI.create(awsTerraformStateProperties.getEndpoint()))
                                 .serviceConfiguration(serviceConfiguration)
                                 .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
-                                .responseChecksumValidation(awsTerraformStateProperties.isChecksumValidationEnabled()
-                                        ? ResponseChecksumValidation.WHEN_SUPPORTED
-                                        : ResponseChecksumValidation.WHEN_REQUIRED)
+                                .responseChecksumValidation(responseChecksumValidation(awsTerraformStateProperties.isChecksumValidationEnabled()))
                                 .build();
                     } else {
                         log.info("Creating AWS SDK with custom credentials");
@@ -165,6 +163,12 @@ public class TerraformStateAutoConfiguration {
                     .terraformStatePathService(terraformStatePathService)
                     .build();
         return terraformState;
+    }
+
+    static ResponseChecksumValidation responseChecksumValidation(boolean checksumValidationEnabled) {
+        return checksumValidationEnabled
+                ? ResponseChecksumValidation.WHEN_SUPPORTED
+                : ResponseChecksumValidation.WHEN_REQUIRED;
     }
 
     private AwsBasicCredentials getAwsBasicCredentials(AwsTerraformStateProperties awsTerraformStateProperties) {

--- a/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
+++ b/executor/src/main/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfiguration.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -85,10 +86,11 @@ public class TerraformStateAutoConfiguration {
                     } else if (awsTerraformStateProperties.getEndpoint() != null && !awsTerraformStateProperties.getEndpoint().isEmpty()) {
                         log.info("Creating AWS with custom endpoint and custom credentials");
 
+                        // Checksum behavior must be configured on the client only; setting it on
+                        // S3Configuration as well makes the SDK throw at build time (#3528).
                         S3Configuration serviceConfiguration = S3Configuration.builder()
                                 .pathStyleAccessEnabled(awsTerraformStateProperties.isPathStyleAccessEnabled())
                                 .chunkedEncodingEnabled(awsTerraformStateProperties.isChunkedEncodingEnabled())
-                                .checksumValidationEnabled(awsTerraformStateProperties.isChecksumValidationEnabled())
                                 .build();
 
                         s3client = S3Client.builder()
@@ -97,6 +99,9 @@ public class TerraformStateAutoConfiguration {
                                 .endpointOverride(URI.create(awsTerraformStateProperties.getEndpoint()))
                                 .serviceConfiguration(serviceConfiguration)
                                 .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+                                .responseChecksumValidation(awsTerraformStateProperties.isChecksumValidationEnabled()
+                                        ? ResponseChecksumValidation.WHEN_SUPPORTED
+                                        : ResponseChecksumValidation.WHEN_REQUIRED)
                                 .build();
                     } else {
                         log.info("Creating AWS SDK with custom credentials");

--- a/executor/src/test/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfigurationTest.java
+++ b/executor/src/test/java/io/terrakube/executor/plugin/tfstate/configuration/TerraformStateAutoConfigurationTest.java
@@ -1,0 +1,17 @@
+package io.terrakube.executor.plugin.tfstate.configuration;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TerraformStateAutoConfigurationTest {
+
+    @Test
+    void responseChecksumValidationMapsFlagToSdkMode() {
+        assertEquals(ResponseChecksumValidation.WHEN_SUPPORTED,
+                TerraformStateAutoConfiguration.responseChecksumValidation(true));
+        assertEquals(ResponseChecksumValidation.WHEN_REQUIRED,
+                TerraformStateAutoConfiguration.responseChecksumValidation(false));
+    }
+}

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfiguration.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfiguration.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryMode;
 import software.amazon.awssdk.core.retry.RetryPolicy;
@@ -107,17 +108,21 @@ public class StorageAutoConfiguration {
                         && !awsStorageServiceProperties.isEnableRoleAuthentication()) {
                     log.info("Creating AWS SDK with custom endpoint and custom credentials");
 
+                    // Checksum behavior must be configured on the client only; setting it on
+                    // S3Configuration as well makes the SDK throw at build time (#3528).
                     S3Configuration serviceConfiguration = S3Configuration.builder()
                             .pathStyleAccessEnabled(awsStorageServiceProperties.isPathStyleAccessEnabled())
                             .chunkedEncodingEnabled(awsStorageServiceProperties.isChunkedEncodingEnabled())
-                            .checksumValidationEnabled(awsStorageServiceProperties.isChecksumValidationEnabled())
                             .build();
 
                     s3ClientBuilder
                             .region(Region.of(awsStorageServiceProperties.getEndpointRegion()))
                             .endpointOverride(URI.create(awsStorageServiceProperties.getEndpoint()))
                             .serviceConfiguration(serviceConfiguration)
-                            .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+                            .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+                            .responseChecksumValidation(awsStorageServiceProperties.isChecksumValidationEnabled()
+                                    ? ResponseChecksumValidation.WHEN_SUPPORTED
+                                    : ResponseChecksumValidation.WHEN_REQUIRED);
                     s3PresignerBuilder
                             .region(Region.of(awsStorageServiceProperties.getEndpointRegion()))
                             .endpointOverride(URI.create(awsStorageServiceProperties.getEndpoint()))

--- a/registry/src/main/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfiguration.java
+++ b/registry/src/main/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfiguration.java
@@ -120,9 +120,7 @@ public class StorageAutoConfiguration {
                             .endpointOverride(URI.create(awsStorageServiceProperties.getEndpoint()))
                             .serviceConfiguration(serviceConfiguration)
                             .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
-                            .responseChecksumValidation(awsStorageServiceProperties.isChecksumValidationEnabled()
-                                    ? ResponseChecksumValidation.WHEN_SUPPORTED
-                                    : ResponseChecksumValidation.WHEN_REQUIRED);
+                            .responseChecksumValidation(responseChecksumValidation(awsStorageServiceProperties.isChecksumValidationEnabled()));
                     s3PresignerBuilder
                             .region(Region.of(awsStorageServiceProperties.getEndpointRegion()))
                             .endpointOverride(URI.create(awsStorageServiceProperties.getEndpoint()))
@@ -186,6 +184,12 @@ public class StorageAutoConfiguration {
                 storageService = null;
         }
         return storageService;
+    }
+
+    static ResponseChecksumValidation responseChecksumValidation(boolean checksumValidationEnabled) {
+        return checksumValidationEnabled
+                ? ResponseChecksumValidation.WHEN_SUPPORTED
+                : ResponseChecksumValidation.WHEN_REQUIRED;
     }
 
     private static AwsBasicCredentials getAwsBasicCredentials(AwsStorageServiceProperties

--- a/registry/src/test/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfigurationTest.java
+++ b/registry/src/test/java/io/terrakube/registry/plugin/storage/configuration/StorageAutoConfigurationTest.java
@@ -1,0 +1,17 @@
+package io.terrakube.registry.plugin.storage.configuration;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StorageAutoConfigurationTest {
+
+    @Test
+    void responseChecksumValidationMapsFlagToSdkMode() {
+        assertEquals(ResponseChecksumValidation.WHEN_SUPPORTED,
+                StorageAutoConfiguration.responseChecksumValidation(true));
+        assertEquals(ResponseChecksumValidation.WHEN_REQUIRED,
+                StorageAutoConfiguration.responseChecksumValidation(false));
+    }
+}


### PR DESCRIPTION
Fixes #3528

Since #3473 the custom-endpoint branch of the S3 client setup in `api`, `executor` and `registry` sets `checksumValidationEnabled(...)` on `S3Configuration` while the same builder chain also sets `requestChecksumCalculation(WHEN_REQUIRED)` on the client. AWS SDK v2 (`DefaultS3BaseClientBuilder.finalizeServiceConfiguration`) rejects that combination when the client is built:

```
java.lang.IllegalStateException: Checksum behavior has been configured on both S3Configuration and the client/global level. Please limit checksum behavior configuration to one location.
```

The property is a primitive `boolean`, so the `S3Configuration` setter is always called and the failure is unconditional for anyone using `io.terrakube.storage.aws.endpoint` (MinIO, Ceph, R2, ...), whatever `checksumValidationEnabled` is set to. Reproduced on SDK 2.54.7 with both `true` and `false`.

### Change

- Drop `checksumValidationEnabled` from `S3Configuration` in all three components.
- Map the property to the client-level `responseChecksumValidation` instead (`true` -> `WHEN_SUPPORTED`, the SDK default; `false` -> `WHEN_REQUIRED`). This is the same mapping the SDK applies internally for the legacy flag. Request checksums stay `WHEN_REQUIRED`, as they were before #3473, so the default configuration behaves exactly like 2.33.1.
- `api`: extract the custom-endpoint client build into `StorageTypeAutoConfiguration.s3CompatibleClient(...)` (same static-helper pattern as `storageClientOverride` / `s3ServiceConfiguration`) so the test can build the real client.

### Tests

`StorageClientResilienceTest`:
- `s3ServiceConfigurationLeavesChecksumBehaviorToClient`: `S3Configuration.checksumValidationEnabled` stays unset.
- `s3CompatibleClientBuildsWithChecksumValidationEnabled` / `...Disabled`: build the custom-endpoint `S3Client` and assert the resolved request/response checksum settings.

All three new tests fail against `main` (2 x `IllegalStateException`, 1 assertion) and pass with this change. `executor` and `registry` compile; their change is the same two lines inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
