### PR TITLE
fix: allow users with project write and org read access to link VCS to workspaces (#3530)

### DIFF
--- a/api/src/main/java/io/terrakube/api/rs/checks/vcs/TeamViewVcs.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/vcs/TeamViewVcs.java
@@ -41,7 +41,8 @@ public class TeamViewVcs extends OperationCheck<Vcs> {
             if (isMember)
                 return true;
             else
-                return groupService.isMemberWithLimitedAccessV2(requestScope.getUser(), vcs.getOrganization());
+                return groupService.isMemberWithLimitedAccessV2(requestScope.getUser(), vcs.getOrganization())
+                        || groupService.isMemberWithProjectAccess(requestScope.getUser(), vcs.getOrganization());
         }
     }
 }

--- a/api/src/main/java/io/terrakube/api/rs/vcs/Vcs.java
+++ b/api/src/main/java/io/terrakube/api/rs/vcs/Vcs.java
@@ -99,6 +99,7 @@ public class Vcs extends GenericAuditFields {
     @ManyToOne
     private Organization organization;
 
+    @UpdatePermission(expression = "team manage vcs OR team view vcs")
     @OneToMany(mappedBy = "vcs")
     private List<Workspace> workspace;
 }

--- a/api/src/test/java/io/terrakube/api/ProjectAccessTests.java
+++ b/api/src/test/java/io/terrakube/api/ProjectAccessTests.java
@@ -1425,4 +1425,227 @@ public class ProjectAccessTests extends ServerApplicationTests {
                 .assertThat()
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
+
+    @Test
+    void createWorkspaceWithProjectWriteRole() {
+        String projectId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"createWorkspaceWithProjectWriteRole\",\n" +
+                        "      \"description\": \"Integration test project\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        String accessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"PROJECT_WRITE_MEMBER\",\n" +
+                        "      \"role\": \"write\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        String workspaceId = given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_WRITE_MEMBER"),
+                        "Content-Type", "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic\"",
+                        "Accept", "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic\"")
+                .body("{\n" +
+                        "  \"atomic:operations\": [\n" +
+                        "    {\n" +
+                        "      \"op\": \"add\",\n" +
+                        "      \"href\": \"/organization/" + ORG_ID + "/workspace\",\n" +
+                        "      \"data\": {\n" +
+                        "        \"type\": \"workspace\",\n" +
+                        "        \"lid\": \"" + UUID.randomUUID() + "\",\n" +
+                        "        \"attributes\": {\n" +
+                        "          \"name\": \"wsCreatedByProjectWrite\",\n" +
+                        "          \"source\": \"https://github.com/AzBuilder/terraform-azurerm-terrakube-app-registration.git\",\n" +
+                        "          \"branch\": \"main\",\n" +
+                        "          \"terraformVersion\": \"1.0.11\"\n" +
+                        "        },\n" +
+                        "        \"relationships\": {\n" +
+                        "          \"project\": {\n" +
+                        "            \"data\": {\n" +
+                        "              \"type\": \"project\",\n" +
+                        "              \"id\": \"" + projectId + "\"\n" +
+                        "            }\n" +
+                        "          }\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  ]\n" +
+                        "}")
+                .when()
+                .post("/api/v1/operations")
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().path("'atomic:results'[0].data.id");
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + accessId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    @Test
+    void createWorkspaceWithVcsAndProjectWriteRole() {
+        io.terrakube.api.rs.vcs.Vcs vcs = new io.terrakube.api.rs.vcs.Vcs();
+        vcs.setAccessToken("1234567890");
+        vcs.setClientId("123");
+        vcs.setClientSecret("123");
+        vcs.setName("testVcsProjectWrite");
+        vcs.setDescription("test VCS");
+        vcs.setVcsType(io.terrakube.api.rs.vcs.VcsType.GITHUB);
+        vcs.setOrganization(organizationRepository.findById(UUID.fromString(ORG_ID)).get());
+        vcs = vcsRepository.save(vcs);
+
+        Team orgTeam = new Team();
+        orgTeam.setName("PROJECT_WRITE_ORG_READ_TEAM");
+        orgTeam.setRole("read");
+        orgTeam.setOrganization(organizationRepository.findById(UUID.fromString(ORG_ID)).get());
+        orgTeam = teamRepository.save(orgTeam);
+
+        String projectId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"createWorkspaceWithVcsAndProjectWriteRole\",\n" +
+                        "      \"description\": \"Integration test project\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        String accessId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"), "Content-Type", "application/vnd.api+json")
+                .body("{\n" +
+                        "  \"data\": {\n" +
+                        "    \"type\": \"project_access\",\n" +
+                        "    \"attributes\": {\n" +
+                        "      \"name\": \"PROJECT_WRITE_ORG_READ_TEAM\",\n" +
+                        "      \"role\": \"write\"\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}")
+                .when()
+                .post("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value()).extract().path("data.id");
+
+        String workspaceId = given()
+                .headers("Authorization", "Bearer " + generatePAT("PROJECT_WRITE_ORG_READ_TEAM"),
+                        "Content-Type", "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic\"",
+                        "Accept", "application/vnd.api+json;ext=\"https://jsonapi.org/ext/atomic\"")
+                .body("{\n" +
+                        "  \"atomic:operations\": [\n" +
+                        "    {\n" +
+                        "      \"op\": \"add\",\n" +
+                        "      \"href\": \"/organization/" + ORG_ID + "/workspace\",\n" +
+                        "      \"data\": {\n" +
+                        "        \"type\": \"workspace\",\n" +
+                        "        \"lid\": \"" + UUID.randomUUID() + "\",\n" +
+                        "        \"attributes\": {\n" +
+                        "          \"name\": \"wsVcsProjectWrite\",\n" +
+                        "          \"source\": \"https://github.com/AzBuilder/terraform-azurerm-terrakube-app-registration.git\",\n" +
+                        "          \"branch\": \"main\",\n" +
+                        "          \"terraformVersion\": \"1.0.11\"\n" +
+                        "        },\n" +
+                        "        \"relationships\": {\n" +
+                        "          \"project\": {\n" +
+                        "            \"data\": {\n" +
+                        "              \"type\": \"project\",\n" +
+                        "              \"id\": \"" + projectId + "\"\n" +
+                        "            }\n" +
+                        "          },\n" +
+                        "          \"vcs\": {\n" +
+                        "            \"data\": {\n" +
+                        "              \"type\": \"vcs\",\n" +
+                        "              \"id\": \"" + vcs.getId() + "\"\n" +
+                        "            }\n" +
+                        "          }\n" +
+                        "        }\n" +
+                        "      }\n" +
+                        "    }\n" +
+                        "  ]\n" +
+                        "}")
+                .when()
+                .post("/api/v1/operations")
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value())
+                .extract().path("'atomic:results'[0].data.id");
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/workspace/" + workspaceId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId + "/projectAccess/" + accessId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .delete("/api/v1/organization/" + ORG_ID + "/project/" + projectId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        teamRepository.delete(orgTeam);
+        vcsRepository.delete(vcs);
+    }
 }


### PR DESCRIPTION
Closes #3530

## Summary
When users with `read` permission at the organization level and `write` permission at the project level create a workspace connected to a VCS provider via JSON:API / Atomic Operations, Elide returned `403 UpdatePermission Denied`.

This PR fixes the permission barrier on the VCS relationship and extends `TeamViewVcs` to recognize users with project-level access, allowing project write members to link organization VCS instances to workspaces without requiring organization-wide `manage_vcs` rights.

---

## Root Cause Analysis

### 1. The Reported Hypothesis vs Reality
In issue #3530, the reporter hypothesized that `TeamProjectLimitedCreateWorkspace` was failing because it called `project.getProjectAccess()` which was allegedly blocked by Elide's `@ReadPermission` on `ProjectAccess` for non-admin users.

**Our analysis and integration tests proved this hypothesis incorrect:**
- Elide security permission checks (`@ReadPermission`) apply to incoming JSON:API / GraphQL queries and relationship traversals performed by clients through Elide's engine.
- Elide does **not** intercept internal Java method invocations (such as direct JPA getter calls like `project.getProjectAccess()`) executed inside backend security check classes.
- An integration test confirming workspace creation with project `write` role **without** a VCS relationship succeeded without errors (`createWorkspaceWithProjectWriteRole`).

### 2. The Actual Root Cause: Inverse Collection Update on VCS
When a workspace is created with a VCS relationship:
```json
"relationships": {
  "vcs": {
    "data": {
      "type": "vcs",
      "id": "<vcs-id>"
    }
  }
}
```
Elide automatically updates the bidirectional relationship: `Workspace.vcs` (Many-to-One) and `Vcs.workspace` (One-to-Many).
In `Vcs.java`, the inverse collection was:
```java
@OneToMany(mappedBy = "vcs")
private List<Workspace> workspace;
```
Because `workspace` did not specify a field-level `@UpdatePermission`, Elide defaulted to the class-level annotation on `Vcs`:
```java
@UpdatePermission(expression = "team manage vcs")
```
Users with `read` access at the organization level lack `manage_vcs` permissions (or org admin rights). When Elide attempted to update the inverse collection `vcs.getWorkspace().add(workspace)`, Elide checked `team manage vcs` on `Vcs` and denied the request with `403 UpdatePermission Denied`.

### 3. VCS Visibility for Project Members
In `TeamViewVcs.java`, VCS visibility was restricted to direct organization members and limited access V2 members (`isMemberWithLimitedAccessV2`), but did not account for members whose access is granted via project-level assignments (`isMemberWithProjectAccess`).

---

## Proposed Changes

### 1. `io.terrakube.api.rs.vcs.Vcs`
- Added explicit `@UpdatePermission(expression = "team manage vcs OR team view vcs")` on the `List<Workspace> workspace` field.
- **Rationale**: Anyone permitted to view a VCS connection (including project writers within the organization) should be allowed to associate a new workspace with that VCS connection, without granting them rights to edit the VCS provider credentials (`clientId`, `clientSecret`, `accessToken`, etc.).

### 2. `io.terrakube.api.rs.checks.vcs.TeamViewVcs`
- Updated `TeamViewVcs` check to include `groupService.isMemberWithProjectAccess(requestScope.getUser(), vcs.getOrganization())`.
- **Rationale**: Users who only have project-level assignments within an organization can view and use the organization's VCS providers when creating workspaces in their projects.

### 3. `io.terrakube.api.ProjectAccessTests`
Added automated integration tests covering both scenarios:
1. `createWorkspaceWithProjectWriteRole`:
   - Validates that a user with project `write` role can create a workspace in that project without VCS.
2. `createWorkspaceWithVcsAndProjectWriteRole`:
   - Configures an organization team with role `read`.
   - Grants the team `write` access on a project via `projectAccess`.
   - Creates a VCS connection in the organization.
   - User belonging only to the `read` org team issues an atomic operation `POST /api/v1/operations` to create a workspace linking both the `project` and the `vcs`.
   - Asserts `HTTP 200 OK` (previously returned `403 Forbidden`).
   - Verifies clean teardown of all entities.

---

## Verification Results

### Automated Integration Tests
Ran integration test suite using JDK 25 (`sdk use java 25.0.4-librca`):

```bash
mvn test -Dtest=ProjectAccessTests
```

**Results:**
```text
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 26.94 s -- in io.terrakube.api.ProjectAccessTests
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
```
All 14 tests in `ProjectAccessTests` passed successfully.

---

## Security Considerations
- **No privilege escalation**: The VCS configuration attributes (`accessToken`, `clientSecret`, `clientId`, `connectionType`) remain strictly protected by class-level and field-level permissions (`team manage vcs`).
- Only the `workspace` relationship list on `Vcs` allows linking by users with `team view vcs`.
