### PR TITLE
ci(workflows): skip builds for draft pull requests from forks [skip ci]

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -13,6 +13,7 @@ permissions:
 jobs:
   build-jammy:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -43,5 +44,5 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       - name: Build Terrakube from Fork
-        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && !github.event.pull_request.draft }}
         run: mvn clean install -Dspring-boot.build-image.skip=true

--- a/.github/workflows/pull_request_ui.yml
+++ b/.github/workflows/pull_request_ui.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'ui/**'
 
@@ -15,6 +15,7 @@ permissions:
 jobs:
   buildui:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository || !github.event.pull_request.draft }}
     defaults:
       run:
         working-directory: ./ui


### PR DESCRIPTION
- Add condition to build-jammy and buildui jobs to ignore draft PRs from forks
- Update step 'Build Terrakube from Fork' in pull_request.yml to ignore draft PRs
- Add ready_for_review trigger to pull_request events so builds trigger when draft PRs are marked ready