### PR TITLE
fix: display correct job via source for webhook runs (#3535)

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
@@ -43,6 +43,7 @@ import io.terrakube.api.rs.Organization;
 import io.terrakube.api.rs.globalvar.Globalvar;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.JobVia;
 import io.terrakube.api.rs.job.address.Address;
 import io.terrakube.api.rs.job.address.AddressType;
 import io.terrakube.api.rs.job.step.Step;
@@ -1205,7 +1206,7 @@ public class RemoteTfeService {
         job.setStatus(JobStatus.pending);
         job.setAutoApply(autoApply);
         job.setComments("terraform-cli");
-        job.setVia("CLI");
+        job.setVia(JobVia.CLI.getValue());
         job.setTemplateReference(template.getId().toString());
         // if the vcs connection is not null, we need to override the value inside the
         // job

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/RepoWebhookService.java
@@ -32,6 +32,7 @@ import io.terrakube.api.repository.WebhookEventRepository;
 import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.JobVia;
 import io.terrakube.api.rs.vcs.VcsType;
 import io.terrakube.api.rs.webhook.RepoWebhook;
 import io.terrakube.api.rs.webhook.WebhookEvent;
@@ -433,7 +434,7 @@ public class RepoWebhookService {
         Date triggerDate = new Date(System.currentTimeMillis());
         job.setCreatedDate(triggerDate);
         job.setUpdatedDate(triggerDate);
-        job.setVia(webhookResult.getVia());
+        job.setVia(webhookResult.getVia() != null ? webhookResult.getVia() : JobVia.UI.getValue());
         job.setCommitId(webhookResult.getCommit());
         return job;
     }

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/WebhookService.java
@@ -17,6 +17,7 @@ import io.terrakube.api.repository.WebhookRepository;
 import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.JobVia;
 import io.terrakube.api.rs.vcs.Vcs;
 import io.terrakube.api.rs.webhook.Webhook;
 import io.terrakube.api.rs.webhook.WebhookEventType;
@@ -202,7 +203,7 @@ public class WebhookService {
         Date triggerDate = new Date(System.currentTimeMillis());
         job.setCreatedDate(triggerDate);
         job.setUpdatedDate(triggerDate);
-        job.setVia(webhookResult.getVia());
+        job.setVia(webhookResult.getVia() != null ? webhookResult.getVia() : JobVia.UI.getValue());
         job.setCommitId(webhookResult.getCommit());
         Job savedJob = jobRepository.save(job);
         scheduleJobService.createJobContext(savedJob);

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/bitbucket/BitBucketWebhookService.java
@@ -2,6 +2,7 @@ package io.terrakube.api.plugin.vcs.provider.bitbucket;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobVia;
 import io.terrakube.api.rs.webhook.Webhook;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -45,7 +46,7 @@ public class BitBucketWebhookService extends WebhookServiceBase {
     }
 
     public WebhookResult processWebhook(String jsonPayload, Map<String, String> headers, String token) {
-        return handleWebhook(jsonPayload, headers, token, "x-hub-signature", "Bitbucket", this::handleEvent);
+        return handleWebhook(jsonPayload, headers, token, "x-hub-signature", JobVia.BITBUCKET.getValue(), this::handleEvent);
     }
 
     public WebhookResult handleEvent(String jsonPayload, WebhookResult result, Map<String, String> headers) {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/provider/gitlab/GitLabWebhookService.java
@@ -65,7 +65,7 @@ public class GitLabWebhookService extends WebhookServiceBase {
     public WebhookResult processWebhook(String jsonPayload, Map<String, String> headers, String token, Workspace workspace) {
         WebhookResult result = new WebhookResult();
         result.setBranch("");
-        result.setVia("GitLab");
+        result.setVia(JobVia.GITLAB.getValue());
         try {
             // Verify the GitLab token
             String tokenHeader = headers.get("x-gitlab-token");

--- a/api/src/main/java/io/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/Job.java
@@ -95,7 +95,7 @@ public class Job extends GenericAuditFields {
     private String templateReference;
 
     @Column(name = "via")
-    private String via = "UI";
+    private String via = JobVia.UI.getValue();
 
     @Column(name = "refresh")
     private boolean refresh = true;

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/RepoWebhookServiceTest.java
@@ -44,6 +44,7 @@ import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.rs.Organization;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.JobVia;
 import io.terrakube.api.rs.vcs.Vcs;
 import io.terrakube.api.rs.vcs.VcsType;
 import io.terrakube.api.rs.webhook.RepoWebhook;
@@ -1107,7 +1108,7 @@ class RepoWebhookServiceTest {
             pushResult.setValid(true);
             pushResult.setBranch("main");
             pushResult.setCreatedBy("user@test.com");
-            pushResult.setVia("Github");
+            pushResult.setVia(JobVia.GITHUB.getValue());
             pushResult.setCommit("abc123");
             pushResult.setFileChanges(List.of("main.tf"));
             when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(pushResult);
@@ -1147,7 +1148,9 @@ class RepoWebhookServiceTest {
 
             subject.processClaimedDelivery(rw, payload, headers);
 
-            verify(jobRepository, times(2)).save(any(Job.class));
+            ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
+            verify(jobRepository, times(2)).save(jobCaptor.capture());
+            assertThat(jobCaptor.getAllValues()).allMatch(job -> JobVia.GITHUB.getValue().equals(job.getVia()));
         }
 
         @Test
@@ -1162,7 +1165,7 @@ class RepoWebhookServiceTest {
             pushResult.setValid(true);
             pushResult.setBranch("main");
             pushResult.setCreatedBy("user@test.com");
-            pushResult.setVia("Github");
+            pushResult.setVia(JobVia.GITHUB.getValue());
             pushResult.setCommit("abc123");
             pushResult.setFileChanges(List.of("main.tf"));
             when(gitHubWebhookService.parseGitHubPayload(eq(payload), any())).thenReturn(pushResult);
@@ -1726,7 +1729,7 @@ class RepoWebhookServiceTest {
             pushResult.setBranch("main");
             pushResult.setCommit("abc123");
             pushResult.setCreatedBy("user@test.com");
-            pushResult.setVia("Azure DevOps");
+            pushResult.setVia(JobVia.AZURE_DEVOPS.getValue());
             pushResult.setFileChanges(new java.util.ArrayList<>());
             pushResult.setRawPayload(payload);
             when(azDevOpsWebhookService.parseAzDevOpsPayload(eq(payload), any())).thenReturn(pushResult);

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/WebhookServiceTest.java
@@ -29,6 +29,7 @@ import io.terrakube.api.repository.WebhookEventRepository;
 import io.terrakube.api.repository.WebhookRepository;
 import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobVia;
 import io.terrakube.api.rs.vcs.Vcs;
 import io.terrakube.api.rs.vcs.VcsType;
 import io.terrakube.api.rs.webhook.Webhook;
@@ -282,5 +283,37 @@ public class WebhookServiceTest {
 
         verify(jobRepository, never()).save(any());
         verify(scheduleJobService, never()).createJobContext(any());
+    }
+
+    @Test
+    public void planCommentSetsViaOntoJob() throws Exception {
+        pullRequestEvent.setPrWorkflowEnabled(true);
+        WebhookResult result = createCommentResult("plan", 5);
+        result.setVia(JobVia.GITHUB.getValue());
+
+        org.mockito.ArgumentCaptor<Job> captor = org.mockito.ArgumentCaptor.forClass(Job.class);
+        Job savedJob = new Job();
+        savedJob.setWorkspace(workspace);
+        doReturn(savedJob).when(jobRepository).save(captor.capture());
+
+        subject.handlePrCommentCommand(result, webhook, workspace);
+
+        assertEquals(JobVia.GITHUB.getValue(), captor.getAllValues().get(0).getVia());
+    }
+
+    @Test
+    public void jobCreationFallsBackToUiWhenViaIsNull() throws Exception {
+        pullRequestEvent.setPrWorkflowEnabled(true);
+        WebhookResult result = createCommentResult("plan", 5);
+        result.setVia(null);
+
+        org.mockito.ArgumentCaptor<Job> captor = org.mockito.ArgumentCaptor.forClass(Job.class);
+        Job savedJob = new Job();
+        savedJob.setWorkspace(workspace);
+        doReturn(savedJob).when(jobRepository).save(captor.capture());
+
+        subject.handlePrCommentCommand(result, webhook, workspace);
+
+        assertEquals(JobVia.UI.getValue(), captor.getAllValues().get(0).getVia());
     }
 }

--- a/ui/src/domain/Jobs/Details.tsx
+++ b/ui/src/domain/Jobs/Details.tsx
@@ -22,7 +22,7 @@ import WorkspaceStatusTag from "@/components/display/WorkspaceStatusTag";
 import { statusColors } from "../../modules/workspaces/utils/workspaceStatusColors";
 import { getWorkspaceStatusIcon } from "../../modules/workspaces/utils/workspaceStatusIcon";
 import { getWorkspaceStatusText } from "../../modules/workspaces/utils/workspaceStatusText";
-import { IncludedItem, Job, JobStep, Workspace } from "../types";
+import { formatJobVia, IncludedItem, Job, JobStep, Workspace } from "../types";
 import {
   ContextAvailability,
   parseContextAvailability,
@@ -683,7 +683,7 @@ export const DetailsJob = ({ jobId }: Props) => {
             : null}
           <div>
             <WorkspaceStatusTag status={job.data.attributes.status} />{" "}
-            <h2 style={{ display: "inline" }}>Triggered via UI</h2>
+            <h2 style={{ display: "inline" }}>Triggered via {formatJobVia(job.data.attributes.via)}</h2>
           </div>
 
           <Collapse
@@ -693,7 +693,7 @@ export const DetailsJob = ({ jobId }: Props) => {
                 label: (
                   <span>
                     <Avatar size="small" shape="square" icon={<UserOutlined />} />{" "}
-                    <b>{job.data.attributes.createdBy}</b> triggered a run from {job.data.attributes.via || "UI"}{" "}
+                    <b>{job.data.attributes.createdBy}</b> triggered a run from {formatJobVia(job.data.attributes.via)}{" "}
                     {job.data.attributes.createdDate ? relativeTime(job.data.attributes.createdDate) : ""}
                   </span>
                 ),

--- a/ui/src/domain/Workspaces/__tests__/workspaceDataUtils.test.ts
+++ b/ui/src/domain/Workspaces/__tests__/workspaceDataUtils.test.ts
@@ -1,4 +1,4 @@
-import { buildResourceOptions, getResourceAddress, parseState, parseOldState } from "../workspaceDataUtils";
+import { buildResourceOptions, getResourceAddress, parseState, parseOldState, setupWorkspaceIncludes } from "../workspaceDataUtils";
 import { Resource } from "../../types";
 
 const baseResource: Resource = {
@@ -141,6 +141,87 @@ describe("parseState", () => {
       type: "terraform_data",
       index: "name.surname",
     });
+  });
+});
+
+describe("setupWorkspaceIncludes job and history titles", () => {
+  const createPayload = (jobVia?: string, historyVia?: string) => ({
+    data: {
+      attributes: {
+        iacType: "terraform",
+      },
+    },
+    included: [
+      {
+        id: "job-1",
+        type: "job",
+        attributes: {
+          via: jobVia,
+          commitId: "abcdef123456",
+          createdDate: "2026-09-08T12:00:00Z",
+          updatedDate: "2026-09-08T12:05:00Z",
+        },
+      },
+      {
+        id: "hist-1",
+        type: "history",
+        attributes: {
+          via: historyVia,
+          createdDate: "2026-09-08T11:00:00Z",
+        },
+      },
+    ],
+  });
+
+  const runSetup = async (payload: any) => {
+    let capturedJobs: any[] = [];
+    let capturedHistory: any[] = [];
+    await setupWorkspaceIncludes(
+      payload,
+      () => {},
+      (jobs) => {
+        capturedJobs = jobs;
+      },
+      () => {},
+      (history) => {
+        capturedHistory = history;
+      },
+      () => {},
+      [],
+      () => {},
+      () => {},
+      () => {},
+      "",
+      { get: () => Promise.resolve({ data: {} }) },
+      () => {},
+      () => {},
+      () => {},
+      false,
+      () => {},
+      () => {},
+      () => {},
+      () => {},
+      () => {}
+    );
+    return { jobs: capturedJobs, history: capturedHistory };
+  };
+
+  it("generates dynamic Triggered via <Source> titles for non-UI webhook runs", async () => {
+    const { jobs, history } = await runSetup(createPayload("Github", "Gitlab"));
+    expect(jobs[0].title).toBe("Triggered via GitHub");
+    expect(history[0].title).toBe("Triggered via GitLab");
+  });
+
+  it("formats Azure DevOps and CLI titles properly", async () => {
+    const { jobs, history } = await runSetup(createPayload("AzureDevops", "CLI"));
+    expect(jobs[0].title).toBe("Triggered via Azure DevOps");
+    expect(history[0].title).toBe("Triggered via CLI");
+  });
+
+  it("keeps 'Queue manually using Terraform' for UI runs or undefined via", async () => {
+    const { jobs, history } = await runSetup(createPayload("UI", undefined));
+    expect(jobs[0].title).toBe("Queue manually using Terraform");
+    expect(history[0].title).toBe("Queue manually using Terraform");
   });
 });
 

--- a/ui/src/domain/Workspaces/workspaceDataUtils.ts
+++ b/ui/src/domain/Workspaces/workspaceDataUtils.ts
@@ -4,11 +4,13 @@ import {
   FlatJob,
   FlatJobHistory,
   FlatVariable,
+  JobVia,
   Resource,
   Schedule,
   Template,
   VcsType,
   StateOutputValue,
+  formatJobVia,
 } from "../types";
 import { getIaCNameById } from "./Workspaces";
 import { relativeTime } from "@/modules/utils/dates";
@@ -113,10 +115,14 @@ export async function setupWorkspaceIncludes(
           })
         );
         break;
-      case include.JOB:
+      case include.JOB: {
+        const jobVia = element.attributes?.via;
+        const isNonUi = jobVia && jobVia !== JobVia.Ui && jobVia !== "UI";
         jobs.push({
           id: element.id,
-          title: "Queue manually using " + getIaCNameById(data?.data?.attributes?.iacType),
+          title: isNonUi
+            ? "Triggered via " + formatJobVia(jobVia)
+            : "Queue manually using " + getIaCNameById(data?.data?.attributes?.iacType),
           commitId: element.attributes.commitId,
           stepNumber: element.attributes.stepNumber,
           latestChange: relativeTime(element.attributes.createdDate),
@@ -124,16 +130,22 @@ export async function setupWorkspaceIncludes(
         });
         setLastRun(element.attributes.updatedDate);
         break;
-      case include.HISTORY:
+      }
+      case include.HISTORY: {
         console.log(element);
+        const historyVia = element.attributes?.via;
+        const isNonUi = historyVia && historyVia !== JobVia.Ui && historyVia !== "UI";
         history.push({
           id: element.id,
-          title: "Queue manually using " + getIaCNameById(data?.data?.attributes?.iacType),
+          title: isNonUi
+            ? "Triggered via " + formatJobVia(historyVia)
+            : "Queue manually using " + getIaCNameById(data?.data?.attributes?.iacType),
           relativeDate: relativeTime(element.attributes.createdDate),
           createdDate: element.attributes.createdDate,
           ...element.attributes,
         });
         break;
+      }
 
       case include.SCHEDULE:
         schedule.push({

--- a/ui/src/domain/__tests__/types.test.ts
+++ b/ui/src/domain/__tests__/types.test.ts
@@ -1,0 +1,31 @@
+import { formatJobVia, JobVia } from "../types";
+
+describe("formatJobVia", () => {
+  it("formats known VCS providers and run sources properly", () => {
+    expect(formatJobVia(JobVia.Github)).toBe("GitHub");
+    expect(formatJobVia("Github")).toBe("GitHub");
+    expect(formatJobVia(JobVia.Gitlab)).toBe("GitLab");
+    expect(formatJobVia("Gitlab")).toBe("GitLab");
+    expect(formatJobVia("GitLab")).toBe("GitLab");
+    expect(formatJobVia(JobVia.Bitbucket)).toBe("Bitbucket");
+    expect(formatJobVia("Bitbucket")).toBe("Bitbucket");
+    expect(formatJobVia(JobVia.AzureDevops)).toBe("Azure DevOps");
+    expect(formatJobVia("AzureDevops")).toBe("Azure DevOps");
+    expect(formatJobVia("Azure DevOps")).toBe("Azure DevOps");
+    expect(formatJobVia(JobVia.Cli)).toBe("CLI");
+    expect(formatJobVia("CLI")).toBe("CLI");
+    expect(formatJobVia(JobVia.Schedule)).toBe("Schedule");
+    expect(formatJobVia("Schedule")).toBe("Schedule");
+    expect(formatJobVia(JobVia.Ui)).toBe("UI");
+    expect(formatJobVia("UI")).toBe("UI");
+  });
+
+  it("falls back to UI when input is undefined or empty", () => {
+    expect(formatJobVia(undefined)).toBe("UI");
+    expect(formatJobVia("")).toBe("UI");
+  });
+
+  it("passes through unknown strings", () => {
+    expect(formatJobVia("CustomSource")).toBe("CustomSource");
+  });
+});

--- a/ui/src/domain/types.ts
+++ b/ui/src/domain/types.ts
@@ -126,8 +126,42 @@ export enum JobVia {
   Github = "Github",
   Gitlab = "Gitlab",
   Bitbucket = "Bitbucket",
+  AzureDevops = "AzureDevops",
   Schedule = "Schedule",
 }
+
+export const formatJobVia = (via?: JobVia | string): string => {
+  if (!via) {
+    return "UI";
+  }
+  switch (via) {
+    case JobVia.Github:
+    case "Github":
+      return "GitHub";
+    case JobVia.Gitlab:
+    case "Gitlab":
+    case "GitLab":
+      return "GitLab";
+    case JobVia.Bitbucket:
+    case "Bitbucket":
+      return "Bitbucket";
+    case JobVia.AzureDevops:
+    case "AzureDevops":
+    case "Azure DevOps":
+      return "Azure DevOps";
+    case JobVia.Cli:
+    case "CLI":
+      return "CLI";
+    case JobVia.Schedule:
+    case "Schedule":
+      return "Schedule";
+    case JobVia.Ui:
+    case "UI":
+      return "UI";
+    default:
+      return via;
+  }
+};
 
 export type JobAttributes = {
   status: JobStatus;

--- a/ui/src/modules/workspaces/components/RunList.tsx
+++ b/ui/src/modules/workspaces/components/RunList.tsx
@@ -1,7 +1,7 @@
 import { List, Avatar, Tag, Pagination, Tooltip, Button } from "antd";
 import { UserOutlined, WarningOutlined } from "@ant-design/icons";
 import { Link } from "react-router-dom";
-import { FlatJob } from "../../../domain/types";
+import { FlatJob, formatJobVia } from "../../../domain/types";
 import { useState, useEffect, useCallback } from "react";
 import axiosInstance from "../../../config/axiosConfig";
 import { ORGANIZATION_ARCHIVE } from "../../../config/actionTypes";
@@ -159,7 +159,7 @@ export default function RunList({ jobs, onRunClick, runLink }: Props) {
               description={
                 <span>
                   #job-{item.id} &nbsp;&nbsp;|&nbsp;&nbsp; <b>{item.createdBy}</b> triggered via{" "}
-                  <b>{item.via || "UI"}</b> using template <b>{getTemplateName(item)}</b> &nbsp;&nbsp;|&nbsp;&nbsp;{" "}
+                  <b>{formatJobVia(item.via)}</b> using template <b>{getTemplateName(item)}</b> &nbsp;&nbsp;|&nbsp;&nbsp;{" "}
                   <Button type="link" style={{ padding: 0 }}>
                     #{item.commitId?.substring(0, 6)}
                   </Button>

--- a/ui/src/modules/workspaces/components/RunList.tsx
+++ b/ui/src/modules/workspaces/components/RunList.tsx
@@ -1,7 +1,7 @@
 import { List, Avatar, Tag, Pagination, Tooltip, Button } from "antd";
 import { UserOutlined, WarningOutlined } from "@ant-design/icons";
 import { Link } from "react-router-dom";
-import { FlatJob } from "../../../domain/types";
+import { FlatJob, formatJobVia } from "../../../domain/types";
 import { useState, useEffect, useCallback } from "react";
 import axiosInstance from "../../../config/axiosConfig";
 import { ORGANIZATION_ARCHIVE } from "../../../config/actionTypes";
@@ -159,7 +159,8 @@ export default function RunList({ jobs, onRunClick, runLink }: Props) {
               description={
                 <span>
                   #job-{item.id} &nbsp;&nbsp;|&nbsp;&nbsp; <b>{item.createdBy}</b> triggered via{" "}
-                  <b>{item.via || "UI"}</b> using template <b>{getTemplateName(item)}</b> &nbsp;&nbsp;|&nbsp;&nbsp;{" "}
+                  <b>{formatJobVia(item.via)}</b> using template <b>{getTemplateName(item)}</b>{" "}
+                  &nbsp;&nbsp;|&nbsp;&nbsp;{" "}
                   <Button type="link" style={{ padding: 0 }}>
                     #{item.commitId?.substring(0, 6)}
                   </Button>


### PR DESCRIPTION
Closes #3535

### Description

When a workspace run is triggered via a VCS webhook (e.g. GitHub, GitLab, Bitbucket, Azure DevOps), the run details page in the Web Console previously displayed a hardcoded title `Triggered via UI`, and the workspace run list showed a static title `Queue manually using Terraform`.

This PR fixes the issue by:
1. Standardizing backend `JobVia` enum usage across all VCS webhook handlers, remote CLI runs, and default values.
2. Dynamically displaying the trigger source in the Web UI Run Details page (`Triggered via <Source>`) using a display formatter (`formatJobVia`).
3. Updating workspace run and history list titles to show `"Triggered via <Source>"` for non-UI runs while preserving `"Queue manually using <IaC>"` for UI-queued runs.
4. Adding missing `AzureDevops` to the UI `JobVia` enum.

---

### Key Changes

#### Backend (`terrakube/api`)
- **`Job.java`**: Set default `via` to `JobVia.UI.getValue()`.
- **`GitLabWebhookService.java`**: Changed `"GitLab"` string literal to `JobVia.GITLAB.getValue()` (`"Gitlab"`).
- **`BitBucketWebhookService.java`**: Replaced `"Bitbucket"` string literal with `JobVia.BITBUCKET.getValue()`.
- **`RemoteTfeService.java`**: Replaced `"CLI"` string literal with `JobVia.CLI.getValue()`.
- **`WebhookService.java` & `RepoWebhookService.java`**: Added defensive fallback to `JobVia.UI.getValue()` if `webhookResult.getVia()` is null.
- **`WebhookServiceTest.java` & `RepoWebhookServiceTest.java`**: Added assertions and unit tests verifying `job.getVia()` assignment.

#### Frontend (`terrakube/ui`)
- **`types.ts`**: Added `AzureDevops = "AzureDevops"` to `JobVia` enum and exported `formatJobVia(via?: JobVia | string): string` to format display names ("GitHub", "GitLab", "Azure DevOps", "Bitbucket", "CLI", "Schedule", "UI").
- **`Details.tsx`**: Updated the header from static `<h2>Triggered via UI</h2>` to `<h2>Triggered via {formatJobVia(job.data.attributes.via)}</h2>` and updated the collapse header.
- **`RunList.tsx`**: Formatted `item.via` using `formatJobVia(item.via)`.
- **`workspaceDataUtils.ts`**: Generated dynamic titles (`"Triggered via " + formatJobVia(via)`) for non-UI runs.
- **`types.test.ts` & `workspaceDataUtils.test.ts`**: Added unit test coverage for formatting and title generation.

---

### Verification

- **API Tests**: `mvn test -Dtest=RepoWebhookServiceTest,WebhookServiceTest,GitLabWebhookServiceTest,AzDevOpsWebhookServiceTest,GitHubWebhookServiceTest -pl api` passed (101 tests, 0 failures).
- **UI Tests**: Jest test suites passed (`types.test.ts`, `workspaceDataUtils.test.ts`, `Details.test.tsx`).
- **UI Build**: `yarn build` completed with zero errors.
