### PR TITLE
fix: read job log stream with a single offset in RemoteTfeService

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/state/RemoteTfeService.java
@@ -1611,8 +1611,7 @@ public class RemoteTfeService {
                         try {
                             @SuppressWarnings("unchecked")
                             List<MapRecord<String, String, String>> messagesPlan = redisTemplate.opsForStream()
-                                    .read(StreamOffset.fromStart(String.valueOf(job.get().getId())),
-                                            StreamOffset.latest(String.valueOf(job.get().getId())));
+                                    .read(StreamOffset.fromStart(String.valueOf(job.get().getId())));
 
                             for (MapRecord<String, String, String> mapRecord : messagesPlan) {
                                 Map<String, String> streamData = (Map<String, String>) mapRecord.getValue();
@@ -1626,7 +1625,7 @@ public class RemoteTfeService {
                             logs = logsOutputString.substring(offset, endIndex).getBytes(StandardCharsets.UTF_8);
                             log.debug("{}", logs);
                         } catch (Exception ex) {
-                            log.debug(ex.getMessage());
+                            log.error("Could not read plan logs for job {}: {}", job.get().getId(), ex.getMessage());
                         }
                     }
                 }
@@ -1651,8 +1650,7 @@ public class RemoteTfeService {
                         try {
                             @SuppressWarnings("unchecked")
                             List<MapRecord<String, String, String>> messagesApply = redisTemplate.opsForStream().read(
-                                    StreamOffset.fromStart(String.valueOf(job.get().getId())),
-                                    StreamOffset.latest(String.valueOf(job.get().getId())));
+                                    StreamOffset.fromStart(String.valueOf(job.get().getId())));
 
                             for (MapRecord<String, String, String> mapRecord : messagesApply) {
                                 Map<String, String> streamData = (Map<String, String>) mapRecord.getValue();
@@ -1666,7 +1664,7 @@ public class RemoteTfeService {
                             logs = logsOutputString.substring(offset, endIndex).getBytes(StandardCharsets.UTF_8);
                             log.debug("{}", logs);
                         } catch (Exception ex) {
-                            log.debug(ex.getMessage());
+                            log.error("Could not read apply logs for job {}: {}", job.get().getId(), ex.getMessage());
                         }
                     }
                 }

--- a/api/src/test/java/io/terrakube/api/plugin/state/RemoteTfeServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/state/RemoteTfeServiceTest.java
@@ -32,6 +32,7 @@ import io.terrakube.api.rs.team.Team;
 import io.terrakube.api.rs.workspace.Workspace;
 import io.terrakube.api.rs.workspace.tag.WorkspaceTag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.StreamOffset;
@@ -235,7 +236,7 @@ class RemoteTfeServiceTest {
 
         StreamOperations<String, String, String> streamOperations = Mockito.mock(StreamOperations.class);
         when(redisTemplate.opsForStream()).thenReturn(streamOperations);
-        when(streamOperations.read(any(StreamOffset.class), any(StreamOffset.class)))
+        when(streamOperations.read(any(StreamOffset.class)))
                 .thenReturn(List.of(MapRecord.create("123", Map.of("output", executorConsole))));
 
         String logs = new String(service.getPlanLogs("encrypted-plan-id", 0, 500_000), StandardCharsets.UTF_8);
@@ -244,6 +245,71 @@ class RemoteTfeServiceTest {
         assertTrue(logs.contains("12:   subnet = aws_subnet.main.identifier"), logs);
         assertTrue(logs.contains(
                 "This object has no argument, nested block, or exported attribute named \"identifier\"."), logs);
+    }
+
+    // getPlanLogs/getApplyLogs must pass exactly one StreamOffset for the job id. The second
+    // offset they used to pass was StreamOffset.latest(), i.e. "$", which contributes nothing to
+    // a historical read and only duplicates the stream key in the XREAD. Redis and Valkey tolerate
+    // the repeated key; other Redis-protocol servers reject it outright, and the resulting
+    // exception left the caller with empty logs. Regression coverage: a test only asserting the
+    // returned log text would still pass against the old two-offset call under a lenient mock,
+    // so this pins the call shape instead.
+    @Test
+    @SuppressWarnings("unchecked")
+    void getPlanLogsReadsWithExactlyOneStreamOffsetForTheJobId() {
+        RemoteTfeService service = remoteTfeService();
+
+        Job job = new Job();
+        job.setId(456);
+        Step planStep = new Step();
+        planStep.setId(UUID.randomUUID());
+        planStep.setStepNumber(100);
+        job.setStep(List.of(planStep));
+
+        when(encryptionService.decrypt("encrypted-plan-id")).thenReturn("456");
+        when(jobRepository.findById(456)).thenReturn(Optional.of(job));
+
+        StreamOperations<String, String, String> streamOperations = Mockito.mock(StreamOperations.class);
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        ArgumentCaptor<StreamOffset[]> offsetsCaptor = ArgumentCaptor.forClass(StreamOffset[].class);
+        when(streamOperations.read(offsetsCaptor.capture()))
+                .thenReturn(List.of(MapRecord.create("456", Map.of("output", "line 1"))));
+
+        service.getPlanLogs("encrypted-plan-id", 0, 500);
+
+        StreamOffset[] offsets = offsetsCaptor.getValue();
+        assertEquals(1, offsets.length);
+        assertEquals("456", offsets[0].getKey());
+    }
+
+    // Same bug, same fix, in the sibling method: getApplyLogs must also pass exactly one
+    // StreamOffset for the job id.
+    @Test
+    @SuppressWarnings("unchecked")
+    void getApplyLogsReadsWithExactlyOneStreamOffsetForTheJobId() {
+        RemoteTfeService service = remoteTfeService();
+
+        Job job = new Job();
+        job.setId(789);
+        Step applyStep = new Step();
+        applyStep.setId(UUID.randomUUID());
+        applyStep.setStepNumber(100);
+        job.setStep(List.of(applyStep));
+
+        when(encryptionService.decrypt("encrypted-apply-id")).thenReturn("789");
+        when(jobRepository.findById(789)).thenReturn(Optional.of(job));
+
+        StreamOperations<String, String, String> streamOperations = Mockito.mock(StreamOperations.class);
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        ArgumentCaptor<StreamOffset[]> offsetsCaptor = ArgumentCaptor.forClass(StreamOffset[].class);
+        when(streamOperations.read(offsetsCaptor.capture()))
+                .thenReturn(List.of(MapRecord.create("789", Map.of("output", "line 1"))));
+
+        service.getApplyLogs("encrypted-apply-id", 0, 500);
+
+        StreamOffset[] offsets = offsetsCaptor.getValue();
+        assertEquals(1, offsets.length);
+        assertEquals("789", offsets[0].getKey());
     }
 
     private RemoteTfeService remoteTfeService() {


### PR DESCRIPTION
Fixes #3540

`getPlanLogs()` and `getApplyLogs()` each passed the same Redis stream key twice to a single `XREAD`:

```java
.read(StreamOffset.fromStart(String.valueOf(job.get().getId())),
        StreamOffset.latest(String.valueOf(job.get().getId())));
```

`StreamOffset.latest()` is `$`, which in a non-blocking `XREAD` means "entries added after this call" and so contributes nothing to a historical read. `fromStart` alone already returns the whole stream, which is what the surrounding code expects — it accumulates everything into a `TextStringBuilder` and then slices by the `offset`/`limit` query parameters. The second offset therefore only duplicated the stream key.

Redis and Valkey accept the repeated key, so this was latent for them. Servers that validate the `STREAMS` clause reject it, and the exception was swallowed at `log.debug`, leaving the CLI's `log-read-url` returning an empty body with nothing logged.

## Changes

- Drop the second `StreamOffset` in both methods.
- Raise the swallowed `log.debug(ex.getMessage())` to `log.error(...)` with the job id, in both catch blocks, so a future failure here is diagnosable rather than silent.

## Verification

Measured against real servers with Testcontainers, using this project's own Spring Data Redis / Lettuce stack:

| Backend | before | after |
|---|---|---|
| Redis 6.2 / 7.0 / 7.2 / 7.4 / 8.x | full history returned | full history returned |
| Valkey 7.2 / 8 / 9 | full history returned | full history returned |
| DragonflyDB | `RedisCommandExecutionException: ERR Same stream specified multiple time` | full history returned |

Driving the real `getPlanLogs` against DragonflyDB: empty string before the change, the plan output after it.

On the logging change specifically — reading a stream that does not exist returns empty rather than erroring on both Redis and DragonflyDB, so this catch is not on the routine polling path and raising the level does not make normal operation noisy.

## Tests

`RemoteTfeServiceTest` gains a regression test per method asserting exactly one `StreamOffset` is passed and that its key is the job id. Asserting on the returned text alone would still pass against the old call under a lenient mock, so these pin the call shape instead.

I also wrote two Testcontainers integration tests covering the table above, including one that drives `getPlanLogs` end to end against DragonflyDB. They are not included here because this module's tests are currently mock-based and they would add container pulls to CI — happy to add them if you would like them.
