### PR TITLE
fix: complete stale approved jobs

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/logs/StepOutputReader.java
+++ b/api/src/main/java/io/terrakube/api/plugin/logs/StepOutputReader.java
@@ -1,0 +1,63 @@
+package io.terrakube.api.plugin.logs;
+
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Service;
+
+import io.terrakube.api.plugin.storage.StorageTypeService;
+import io.terrakube.api.plugin.streaming.StreamingService;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.step.Step;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Reads a step's console output as plain text - live logs while the step is still streaming,
+ * the persisted object afterwards - with terminal colour codes stripped. Shared by every caller
+ * that needs the human-readable run text rather than the raw log stream (PR/MR comments,
+ * failure-notification summaries, ...).
+ */
+@Slf4j
+@Service
+public class StepOutputReader {
+
+    private static final Pattern ANSI_PATTERN = Pattern.compile(
+            "[\\u001b\\u009b][\\[()#;?]*(?:\\d{1,4}(?:;\\d{1,4})*)?[0-9A-ORZcf-nq-uy=><~]");
+
+    private final StorageTypeService storageTypeService;
+    private final StreamingService streamingService;
+
+    public StepOutputReader(StorageTypeService storageTypeService, StreamingService streamingService) {
+        this.storageTypeService = storageTypeService;
+        this.streamingService = streamingService;
+    }
+
+    /**
+     * ANSI-stripped console text for one step, or {@code null} when there is nothing to show or
+     * the lookup fails - reading run output is always a best-effort side concern and must never
+     * propagate an exception to its caller.
+     */
+    public String read(Job job, Step step) {
+        try {
+            String stepId = step.getId().toString();
+            String liveLogs = streamingService.getCurrentLogs(stepId, "");
+            if (liveLogs != null && !liveLogs.isEmpty()) {
+                return stripAnsi(liveLogs);
+            }
+            byte[] storedOutput = storageTypeService.getStepOutput(
+                    job.getOrganization().getId().toString(), String.valueOf(job.getId()), stepId);
+            if (storedOutput == null || storedOutput.length == 0) {
+                return null;
+            }
+            return stripAnsi(new String(storedOutput, StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            log.error("Error fetching step output for job {}: {}", job.getId(), e.getMessage());
+            return null;
+        }
+    }
+
+    public String stripAnsi(String text) {
+        return text == null ? null : ANSI_PATTERN.matcher(text).replaceAll("");
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/JobFailureSummaryService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/JobFailureSummaryService.java
@@ -1,0 +1,68 @@
+package io.terrakube.api.plugin.notification;
+
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import io.terrakube.api.plugin.logs.StepOutputReader;
+import io.terrakube.api.repository.StepRepository;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.step.Step;
+
+import lombok.extern.slf4j.Slf4j;
+
+// Builds the short "why did this run fail" blurb for a failure notification. There is no
+// failure-reason field on Job (job.output only ever holds vestigial "Step <id> completed"
+// markers - see the executor's UpdateJobStatusImpl), so this reads the console output of the
+// step that actually failed - the same source the job-details UI and PrCommentService use - and
+// returns a trimmed tail of it.
+@Slf4j
+@Service
+public class JobFailureSummaryService {
+
+    private static final int MAX_LENGTH = 500;
+
+    private final StepRepository stepRepository;
+    private final StepOutputReader stepOutputReader;
+
+    public JobFailureSummaryService(StepRepository stepRepository, StepOutputReader stepOutputReader) {
+        this.stepRepository = stepRepository;
+        this.stepOutputReader = stepOutputReader;
+    }
+
+    // Never throws: a failure notification must still go out even when the run output can't be
+    // read back. Returns null when there is nothing useful to show.
+    public String describeFailure(Job job) {
+        try {
+            Step failedStep = pickFailedStep(stepRepository.findByJobId(job.getId()));
+            if (failedStep == null) {
+                return null;
+            }
+            String output = stepOutputReader.read(job, failedStep);
+            if (output == null || output.isBlank()) {
+                return null;
+            }
+            output = output.strip();
+            return output.length() > MAX_LENGTH
+                    ? output.substring(output.length() - MAX_LENGTH).strip()
+                    : output;
+        } catch (Exception e) {
+            log.warn("Could not build failure summary for job {}: {}", job.getId(), e.getMessage());
+            return null;
+        }
+    }
+
+    // The step actually marked failed, if any; otherwise the last step that ran. A job can reach
+    // "failed" before any step is marked failed (e.g. a dispatch error), and a custom TCL
+    // template can append steps after the terraform step - so "highest step number" is the best
+    // fallback, not a guaranteed terraform step.
+    private Step pickFailedStep(List<Step> steps) {
+        return steps.stream()
+                .filter(step -> step.getStatus() == JobStatus.failed)
+                .max(Comparator.comparingInt(Step::getStepNumber))
+                .or(() -> steps.stream().max(Comparator.comparingInt(Step::getStepNumber)))
+                .orElse(null);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/notification/JobNotificationTrigger.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/JobNotificationTrigger.java
@@ -1,7 +1,9 @@
 package io.terrakube.api.plugin.notification;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -12,6 +14,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import io.terrakube.api.plugin.notification.payload.NotificationContext;
 import io.terrakube.api.plugin.notification.payload.NotificationPayloadRenderer;
 import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.notification.NotificationConfiguration;
 import io.terrakube.api.rs.notification.NotificationOutbox;
 import io.terrakube.api.rs.notification.NotificationOutboxStatus;
@@ -40,30 +43,55 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 public class JobNotificationTrigger {
 
+    // Statuses a run can still leave for a non-error status afterwards. A job briefly flips to
+    // "failed" when the API↔executor dispatch call throws (see ScheduleJob.errorJobAtStep) even
+    // though the executor often accepted the job and is running it - its next status callback
+    // (setRunningStatus / setCompletedStatus) then moves the job back off "failed" and the run
+    // completes normally. A notification for such a status is held back briefly and re-validated
+    // against the job's live status before it is actually delivered (see
+    // NotificationOutboxTransactions.claim), so these transient flips never reach the channel.
+    private static final Set<JobStatus> RECOVERABLE_STATUSES = Set.of(JobStatus.failed);
+
     private final NotificationConfigResolver notificationConfigResolver;
     private final NotificationPayloadRenderer notificationPayloadRenderer;
     private final NotificationOutboxRepository notificationOutboxRepository;
     private final NotificationDispatchService notificationDispatchService;
+    private final JobFailureSummaryService jobFailureSummaryService;
 
     @Value("${io.terrakube.ui.url:}")
     private String uiUrl;
 
+    // How long to hold a notification for a potentially-transient status (RECOVERABLE_STATUSES)
+    // before the poller may deliver it, giving the executor's own status callback time to
+    // correct a dispatch-error flip. Only delays the delivery of these rows; every other status
+    // is still dispatched immediately.
+    @Value("${io.terrakube.notification.recoverableStatusGraceSeconds:90}")
+    private long recoverableStatusGraceSeconds;
+
     public JobNotificationTrigger(NotificationConfigResolver notificationConfigResolver,
             NotificationPayloadRenderer notificationPayloadRenderer,
             NotificationOutboxRepository notificationOutboxRepository,
-            NotificationDispatchService notificationDispatchService) {
+            NotificationDispatchService notificationDispatchService,
+            JobFailureSummaryService jobFailureSummaryService) {
         this.notificationConfigResolver = notificationConfigResolver;
         this.notificationPayloadRenderer = notificationPayloadRenderer;
         this.notificationOutboxRepository = notificationOutboxRepository;
         this.notificationDispatchService = notificationDispatchService;
+        this.jobFailureSummaryService = jobFailureSummaryService;
     }
 
+    // Returns the ids of rows that are due for immediate dispatch. A row rendered for a
+    // potentially-transient status (RECOVERABLE_STATUSES) is still inserted, but with a short
+    // nextAttemptAt in the future and its id withheld from the result - only the outbox poller
+    // picks it up, after the grace window, and only if the job's live status still matches by
+    // then. Callers dispatch exactly what is returned; the poller covers the rest.
     public List<UUID> enqueue(Job job) {
         if (job.getWorkspace() == null) {
             return List.of();
         }
         List<UUID> insertedIds = new ArrayList<>();
         try {
+            boolean deferDispatch = RECOVERABLE_STATUSES.contains(job.getStatus());
             List<NotificationConfiguration> configs = notificationConfigResolver.resolve(job.getWorkspace());
             for (NotificationConfiguration configuration : configs) {
                 boolean statusMatches = configuration.getTriggers() != null && configuration.getTriggers().stream()
@@ -71,23 +99,37 @@ public class JobNotificationTrigger {
                 if (!statusMatches || !templateMatches(configuration, job)) {
                     continue;
                 }
-                String payload = notificationPayloadRenderer.render(configuration.getChannelType(),
-                        buildContext(job, configuration));
-
-                NotificationOutbox outbox = new NotificationOutbox();
-                outbox.setId(UUID.randomUUID());
-                outbox.setJob(job);
-                outbox.setConfiguration(configuration);
-                outbox.setPayload(payload);
-                outbox.setStatus(NotificationOutboxStatus.PENDING);
-                notificationOutboxRepository.save(outbox);
-                insertedIds.add(outbox.getId());
+                UUID outboxId = saveOutboxRow(job, configuration, deferDispatch);
+                if (!deferDispatch) {
+                    insertedIds.add(outboxId);
+                }
             }
         } catch (Exception e) {
             // Never let a resolution/render failure fail the job status update itself.
             log.error("Failed to resolve/enqueue notifications for job {}", job.getId(), e);
         }
         return insertedIds;
+    }
+
+    // Renders and persists one PENDING outbox row. A deferred row (job in a RECOVERABLE_STATUS)
+    // gets a nextAttemptAt in the future so only the poller picks it up, after the grace window.
+    private UUID saveOutboxRow(Job job, NotificationConfiguration configuration, boolean deferred) {
+        String payload = notificationPayloadRenderer.render(configuration.getChannelType(),
+                buildContext(job, configuration));
+
+        NotificationOutbox outbox = new NotificationOutbox();
+        outbox.setId(UUID.randomUUID());
+        outbox.setJob(job);
+        outbox.setConfiguration(configuration);
+        outbox.setPayload(payload);
+        outbox.setStatus(NotificationOutboxStatus.PENDING);
+        outbox.setJobStatus(job.getStatus());
+        if (deferred) {
+            outbox.setNextAttemptAt(
+                    new Date(System.currentTimeMillis() + recoverableStatusGraceSeconds * 1000L));
+        }
+        notificationOutboxRepository.save(outbox);
+        return outbox.getId();
     }
 
     // Empty/null templates means "applies to every template" - this only ever narrows which
@@ -122,14 +164,13 @@ public class JobNotificationTrigger {
         String workspaceUrl = String.format("%s/organizations/%s/workspaces/%s", uiUrl,
                 job.getOrganization().getId(), job.getWorkspace().getId());
         String runUrl = workspaceUrl + "/runs/" + job.getId();
-        // job.output is the raw Terraform/OpenTofu run output; there is no dedicated
-        // failure-reason field on Job, so this trims the tail of that log as a
-        // best-effort summary rather than shipping the whole (possibly huge) output.
-        String failureReason = null;
-        if (job.getOutput() != null && !job.getOutput().isBlank()) {
-            String output = job.getOutput();
-            failureReason = output.length() > 500 ? output.substring(output.length() - 500) : output;
-        }
+        // Only a genuinely failed job carries a failure reason; for any other status there is
+        // nothing to explain. The text is the tail of the failing step's console output (see
+        // JobFailureSummaryService) - job.output itself only holds "Step <id> completed"
+        // markers and is useless here.
+        String failureReason = job.getStatus() == JobStatus.failed
+                ? jobFailureSummaryService.describeFailure(job)
+                : null;
         return new NotificationContext(
                 job.getOrganization().getName(),
                 job.getWorkspace().getName(),

--- a/api/src/main/java/io/terrakube/api/plugin/notification/NotificationOutboxTransactions.java
+++ b/api/src/main/java/io/terrakube/api/plugin/notification/NotificationOutboxTransactions.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import io.terrakube.api.repository.NotificationOutboxRepository;
+import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.notification.NotificationOutbox;
 import io.terrakube.api.rs.notification.NotificationOutboxStatus;
 
@@ -49,6 +50,9 @@ public class NotificationOutboxTransactions {
         if (outbox == null) {
             return null;
         }
+        if (skipSupersededRow(outbox, now)) {
+            return null;
+        }
         // The delivery call happens after this transaction (and its Hibernate session) has
         // closed, so a still-lazy configuration proxy would blow up with a
         // LazyInitializationException the moment the sender reads a field off it. Force it to
@@ -56,6 +60,31 @@ public class NotificationOutboxTransactions {
         Hibernate.initialize(outbox.getConfiguration());
         return new ClaimedOutbox(outbox.getConfiguration(), outbox.getPayload(), outbox.getAttemptCount(),
                 outbox.getLastAttemptAt());
+    }
+
+    // False-alarm guard for a row that has just been claimed (PENDING -> SENDING). The payload
+    // was rendered for outbox.jobStatus; if the job has since moved to a different status that
+    // state no longer holds - the common case being a transient "failed" from a lost
+    // API->executor dispatch response (ScheduleJob.errorJobAtStep) that the executor's own
+    // status callback then corrected. Marks the row SKIPPED (terminal) and returns true so
+    // nothing is delivered and the poller never retries it. Rows written before the jobStatus
+    // column existed have null here and are always delivered, exactly as before.
+    private boolean skipSupersededRow(NotificationOutbox outbox, Date now) {
+        JobStatus renderedFor = outbox.getJobStatus();
+        JobStatus liveStatus = renderedFor == null ? null : outbox.getJob().getStatus();
+        if (renderedFor == null || liveStatus == renderedFor) {
+            return false;
+        }
+        // Same conditional-update discipline as the rest of this class - keyed on SENDING and
+        // the lastAttemptAt claimForDelivery just wrote - rather than a read-then-write.
+        notificationOutboxRepository.recordDeliveryResult(outbox.getId(), NotificationOutboxStatus.SENDING,
+                outbox.getLastAttemptAt(), NotificationOutboxStatus.SKIPPED,
+                "Job status changed from " + renderedFor + " to " + liveStatus
+                        + " before delivery; suppressed as a false alarm",
+                null, now);
+        log.info("Skipping notification outbox {} - job {} status moved from {} to {} before delivery",
+                outbox.getId(), outbox.getJob().getId(), renderedFor, liveStatus);
+        return true;
     }
 
     @Transactional
@@ -103,13 +132,15 @@ public class NotificationOutboxTransactions {
         }
     }
 
-    // Housekeeping: without this, notification_outbox grows forever - every SENT/FAILED row from
-    // every job status change with a matching trigger sits around indefinitely. Public for the
-    // same cross-package reason as sweepStuckSendingRows.
+    // Housekeeping: without this, notification_outbox grows forever - every SENT/FAILED/SKIPPED
+    // row from every job status change with a matching trigger sits around indefinitely. Public
+    // for the same cross-package reason as sweepStuckSendingRows.
     @Transactional
     public int pruneTerminalRowsOlderThan(Date cutoff) {
         int deleted = notificationOutboxRepository.deleteTerminalRowsCreatedBefore(
-                List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED), cutoff);
+                List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED,
+                        NotificationOutboxStatus.SKIPPED),
+                cutoff);
         if (deleted > 0) {
             log.info("Notification outbox retention sweep deleted {} row(s) older than {}", deleted, cutoff);
         }

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/ScheduleJob.java
@@ -592,6 +592,9 @@ public class ScheduleJob implements org.quartz.Job {
             } catch (ExecutionException e) {
                 errorJobAtStep(job, stepId, e);
             }
+        } else {
+            completeJob(job);
+            deleteOldJobs(job);
         }
         return true;
     }

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorService.java
@@ -13,6 +13,7 @@ import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
@@ -102,12 +103,17 @@ public class PersistentExecutorService {
                         executorUrlForRequest);
                 throw new ExecutorUnavailableException(new Throwable(ex.getMessage() + hint, ex));
             }
-            if (ex instanceof WebClientResponseException wcre
-                    && wcre.getStatusCode().equals(HttpStatus.SERVICE_UNAVAILABLE)) {
-                // The executor pod's per-pod capacity gate was already held by another job
-                // (persistent-executor-admission-control) - retryable, not a job failure.
+            if (ex instanceof WebClientResponseException wcre && isRetryableGatewayStatus(wcre.getStatusCode())) {
+                // 503: the executor pod's per-pod capacity gate was already held by another job
+                // (persistent-executor-admission-control). 502/504: a proxy/ingress between the
+                // API and the executor dropped or timed out the upstream connection - which can
+                // happen *after* the executor already accepted the job (its response, not the
+                // request, was lost). None of these mean the job is broken, and failing it here
+                // fires a spurious "failed" notification for a run the executor goes on to
+                // finish - so treat them all as retryable capacity/transport problems.
                 throw new ExecutorUnavailableException(new Throwable(
-                        "Executor at " + executorUrlForRequest + " is busy (503), will retry", ex));
+                        "Executor at " + executorUrlForRequest + " returned " + wcre.getStatusCode().value()
+                                + ", will retry", ex));
             }
             throw new ExecutionException(new Throwable(ex.getMessage(), ex));
         }
@@ -125,6 +131,15 @@ public class PersistentExecutorService {
                     response.getBody());
             throw new ExecutionException(new Throwable(message));
         }
+    }
+
+    // 503 (per-pod admission control) plus the two proxy/ingress statuses that show up when the
+    // hop between the API and the executor fails rather than the executor itself - retryable
+    // capacity/transport problems, not a broken job.
+    private static boolean isRetryableGatewayStatus(HttpStatusCode status) {
+        return status.equals(HttpStatus.SERVICE_UNAVAILABLE)
+                || status.equals(HttpStatus.BAD_GATEWAY)
+                || status.equals(HttpStatus.GATEWAY_TIMEOUT);
     }
 
     private String getExecutorUrl(Job job) throws URISyntaxException {

--- a/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/vcs/PrCommentService.java
@@ -2,8 +2,8 @@ package io.terrakube.api.plugin.vcs;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.terrakube.api.plugin.logs.StepOutputReader;
 import io.terrakube.api.plugin.storage.StorageTypeService;
-import io.terrakube.api.plugin.streaming.StreamingService;
 import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
 import io.terrakube.api.plugin.vcs.provider.github.GitHubWebhookService;
 import io.terrakube.api.plugin.vcs.provider.gitlab.GitLabWebhookService;
@@ -19,7 +19,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
@@ -44,16 +43,13 @@ public class PrCommentService {
             "(Plan: (?:\\d+ to import, )?\\d+ to add, \\d+ to change, \\d+ to destroy\\."
             + "|No changes\\. Your infrastructure matches the configuration\\."
             + "|Apply complete! Resources: \\d+ added, \\d+ changed, \\d+ destroyed\\.)");
-    private static final Pattern ANSI_PATTERN = Pattern.compile(
-            "[\\u001b\\u009b][\\[()#;?]*(?:\\d{1,4}(?:;\\d{1,4})*)?[0-9A-ORZcf-nq-uy=><~]");
-
     GitHubWebhookService gitHubWebhookService;
     GitLabWebhookService gitLabWebhookService;
     BitBucketWebhookService bitBucketWebhookService;
     JobRepository jobRepository;
     StepRepository stepRepository;
     StorageTypeService storageTypeService;
-    StreamingService streamingService;
+    StepOutputReader stepOutputReader;
     ObjectMapper objectMapper;
 
     @Value("${io.terrakube.ui.url:}")
@@ -61,14 +57,14 @@ public class PrCommentService {
 
     public PrCommentService(GitHubWebhookService gitHubWebhookService, GitLabWebhookService gitLabWebhookService,
             BitBucketWebhookService bitBucketWebhookService, JobRepository jobRepository, StepRepository stepRepository,
-            StorageTypeService storageTypeService, StreamingService streamingService, ObjectMapper objectMapper) {
+            StorageTypeService storageTypeService, StepOutputReader stepOutputReader, ObjectMapper objectMapper) {
         this.gitHubWebhookService = gitHubWebhookService;
         this.gitLabWebhookService = gitLabWebhookService;
         this.bitBucketWebhookService = bitBucketWebhookService;
         this.jobRepository = jobRepository;
         this.stepRepository = stepRepository;
         this.storageTypeService = storageTypeService;
-        this.streamingService = streamingService;
+        this.stepOutputReader = stepOutputReader;
         this.objectMapper = objectMapper;
     }
 
@@ -191,7 +187,7 @@ public class PrCommentService {
 
         String lastStepOutput = null;
         for (Step step : stepsNewestFirst) {
-            String output = readStepOutputText(job, step);
+            String output = stepOutputReader.read(job, step);
             if (lastStepOutput == null) {
                 lastStepOutput = output;
             }
@@ -201,30 +197,6 @@ public class PrCommentService {
         }
 
         return lastStepOutput;
-    }
-
-    private String readStepOutputText(Job job, Step step) {
-        try {
-            String stepId = step.getId().toString();
-            String liveLogs = streamingService.getCurrentLogs(stepId, "");
-            if (liveLogs != null && !liveLogs.isEmpty()) {
-                return stripAnsi(liveLogs);
-            }
-
-            byte[] storedOutput = storageTypeService.getStepOutput(
-                    job.getOrganization().getId().toString(), String.valueOf(job.getId()), stepId);
-            if (storedOutput == null || storedOutput.length == 0) {
-                return null;
-            }
-            return stripAnsi(new String(storedOutput, StandardCharsets.UTF_8));
-        } catch (Exception e) {
-            log.error("Error fetching step output for job {}: {}", job.getId(), e.getMessage());
-            return null;
-        }
-    }
-
-    private String stripAnsi(String text) {
-        return ANSI_PATTERN.matcher(text).replaceAll("");
     }
 
     private String matchRunSummary(String output) {

--- a/api/src/main/java/io/terrakube/api/repository/NotificationOutboxRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/NotificationOutboxRepository.java
@@ -88,9 +88,9 @@ public interface NotificationOutboxRepository extends JpaRepository<Notification
     int rearmFailedForRetry(@Param("id") UUID id, @Param("failed") NotificationOutboxStatus failed,
             @Param("pending") NotificationOutboxStatus pending, @Param("now") Date now);
 
-    // Retention sweep: only ever targets rows in a terminal state (SENT/FAILED) older than the
-    // cutoff - a row still PENDING/SENDING is mid-flight regardless of age and must never be
-    // deleted out from under the dispatch pipeline.
+    // Retention sweep: only ever targets rows in a terminal state (SENT/FAILED/SKIPPED) older
+    // than the cutoff - a row still PENDING/SENDING is mid-flight regardless of age and must
+    // never be deleted out from under the dispatch pipeline.
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM notification_outbox o WHERE o.status IN :terminalStatuses AND o.createdDate < :cutoff")
     int deleteTerminalRowsCreatedBefore(@Param("terminalStatuses") List<NotificationOutboxStatus> terminalStatuses,

--- a/api/src/main/java/io/terrakube/api/rs/checks/job/TeamApproveJobRbac.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/job/TeamApproveJobRbac.java
@@ -10,6 +10,7 @@ import io.terrakube.api.plugin.security.groups.GroupService;
 import io.terrakube.api.plugin.security.rbac.RbacService;
 import io.terrakube.api.plugin.security.user.AuthenticatedUser;
 import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.team.Team;
 
 import java.util.List;
@@ -43,6 +44,9 @@ public class TeamApproveJobRbac extends OperationCheck<Job> {
     @Override
     public boolean ok(Job job, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.debug("team approve job rbac {}", job.getId());
+        if (!isApprovalTransition(optional)) {
+            return false;
+        }
         List<Team> teamList = job.getOrganization().getTeam();
         boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         for (Team team : teamList) {
@@ -56,5 +60,14 @@ public class TeamApproveJobRbac extends OperationCheck<Job> {
             }
         }
         return false;
+    }
+
+    private boolean isApprovalTransition(Optional<ChangeSpec> optional) {
+        return optional
+                .filter(change -> "status".equals(change.getFieldName()))
+                .filter(change -> JobStatus.waitingApproval.equals(change.getOriginal()))
+                .filter(change -> change.getModified().equals(JobStatus.approved)
+                        || change.getModified().equals(JobStatus.rejected))
+                .isPresent();
     }
 }

--- a/api/src/main/java/io/terrakube/api/rs/checks/job/TeamLimitedApproveJob.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/job/TeamLimitedApproveJob.java
@@ -10,6 +10,7 @@ import io.terrakube.api.plugin.security.groups.GroupService;
 import io.terrakube.api.plugin.security.rbac.RbacService;
 import io.terrakube.api.plugin.security.user.AuthenticatedUser;
 import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.workspace.access.Access;
 
 import java.util.List;
@@ -38,6 +39,9 @@ public class TeamLimitedApproveJob extends OperationCheck<Job> {
     @Override
     public boolean ok(Job job, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.debug("team limited approve job {}", job.getId());
+        if (!isApprovalTransition(optional)) {
+            return false;
+        }
         List<Access> teamList = job.getWorkspace().getAccess();
         boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         if (!teamList.isEmpty())
@@ -52,5 +56,14 @@ public class TeamLimitedApproveJob extends OperationCheck<Job> {
                 }
             }
         return false;
+    }
+
+    private boolean isApprovalTransition(Optional<ChangeSpec> optional) {
+        return optional
+                .filter(change -> "status".equals(change.getFieldName()))
+                .filter(change -> JobStatus.waitingApproval.equals(change.getOriginal()))
+                .filter(change -> change.getModified().equals(JobStatus.approved)
+                        || change.getModified().equals(JobStatus.rejected))
+                .isPresent();
     }
 }

--- a/api/src/main/java/io/terrakube/api/rs/checks/job/TeamProjectLimitedApproveJob.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/job/TeamProjectLimitedApproveJob.java
@@ -10,6 +10,7 @@ import io.terrakube.api.plugin.security.rbac.RbacService;
 import io.terrakube.api.plugin.security.user.AuthenticatedUser;
 import io.terrakube.api.rs.checks.membership.MembershipService;
 import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
 import io.terrakube.api.rs.project.Project;
 import io.terrakube.api.rs.project.access.ProjectAccess;
 
@@ -33,11 +34,23 @@ public class TeamProjectLimitedApproveJob extends OperationCheck<Job> {
     @Override
     public boolean ok(Job job, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.debug("team project limited approve job {}", job.getId());
+        if (!isApprovalTransition(optional)) {
+            return false;
+        }
         Project project = job.getWorkspace().getProject();
         if (project == null) return false;
         List<ProjectAccess> accessList = project.getProjectAccess();
         if (accessList == null || accessList.isEmpty()) return false;
         return membershipService.checkProjectMembership(
                 requestScope.getUser(), accessList, pa -> rbacService.canApproveJob(pa));
+    }
+
+    private boolean isApprovalTransition(Optional<ChangeSpec> optional) {
+        return optional
+                .filter(change -> "status".equals(change.getFieldName()))
+                .filter(change -> JobStatus.waitingApproval.equals(change.getOriginal()))
+                .filter(change -> change.getModified().equals(JobStatus.approved)
+                        || change.getModified().equals(JobStatus.rejected))
+                .isPresent();
     }
 }

--- a/api/src/main/java/io/terrakube/api/rs/notification/NotificationOutbox.java
+++ b/api/src/main/java/io/terrakube/api/rs/notification/NotificationOutbox.java
@@ -8,6 +8,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import io.terrakube.api.plugin.security.audit.GenericAuditFields;
 import io.terrakube.api.rs.IdConverter;
 import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
@@ -49,6 +50,16 @@ public class NotificationOutbox extends GenericAuditFields {
 
     @Enumerated(EnumType.STRING)
     private NotificationOutboxStatus status = NotificationOutboxStatus.PENDING;
+
+    // The job status this row's payload was rendered for. Re-checked against the job's live
+    // status when the row is claimed for delivery: if the job has since moved to a different
+    // status, this notification described a state that no longer holds (e.g. a transient
+    // "failed" from a lost executor-dispatch response that the executor callback then undid)
+    // and the row is marked SKIPPED instead of sent. Null on rows created before this column
+    // existed - those are always sent, exactly as before.
+    @Enumerated(EnumType.STRING)
+    @Column(name = "job_status")
+    private JobStatus jobStatus;
 
     @Column(name = "attempt_count")
     private int attemptCount = 0;

--- a/api/src/main/java/io/terrakube/api/rs/notification/NotificationOutboxStatus.java
+++ b/api/src/main/java/io/terrakube/api/rs/notification/NotificationOutboxStatus.java
@@ -4,5 +4,10 @@ public enum NotificationOutboxStatus {
     PENDING,
     SENDING,
     SENT,
-    FAILED
+    FAILED,
+    // Terminal, like SENT/FAILED, but nothing was ever delivered: by the time this row was
+    // claimed for dispatch the job had already moved past the status the payload was rendered
+    // for (typically a transient "failed" that a lost executor-dispatch response caused, which
+    // the executor's own status callback then corrected). Sending it would be a false alarm.
+    SKIPPED
 }

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -122,4 +122,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-job-target-replace-addrs.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-provider-trust-signature.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-repo-webhook-delivery.xml" />
+    <include file="/db/changelog/local/changelog-2.33.1-notification-outbox-job-status.xml" />
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.33.1-notification-outbox-job-status.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.33.1-notification-outbox-job-status.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <!-- Follow-up to changelog-2.33.0-notification.xml (that file's changesets have shipped and
+         must not be edited). Adds the job status each outbox row's payload was rendered for, so
+         the dispatcher can re-check it against the job's live status at delivery time and drop a
+         row that no longer describes reality - typically a transient "failed" from a lost
+         API->executor dispatch response that the executor's own status callback then corrected.
+         Nullable: rows written before this column exists have null and are always delivered,
+         exactly as before. -->
+    <changeSet id="2-33-1-notification-outbox-job-status" author="jake">
+        <addColumn tableName="notification_outbox">
+            <column name="job_status" type="varchar(20)" />
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/test/java/io/terrakube/api/plugin/logs/StepOutputReaderTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/logs/StepOutputReaderTest.java
@@ -1,0 +1,94 @@
+package io.terrakube.api.plugin.logs;
+
+import io.terrakube.api.plugin.storage.StorageTypeService;
+import io.terrakube.api.plugin.streaming.StreamingService;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.step.Step;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StepOutputReaderTest {
+
+    @Mock
+    StorageTypeService storageTypeService;
+    @Mock
+    StreamingService streamingService;
+
+    @InjectMocks
+    StepOutputReader subject;
+
+    private Job job() {
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+        Job job = new Job();
+        job.setId(721);
+        job.setOrganization(organization);
+        return job;
+    }
+
+    private Step step() {
+        Step step = new Step();
+        step.setId(UUID.randomUUID());
+        return step;
+    }
+
+    @Test
+    void prefersLiveLogsAndStripsAnsi() {
+        Job job = job();
+        Step step = step();
+        when(streamingService.getCurrentLogs(step.getId().toString(), ""))
+                .thenReturn("[31mError: quota exceeded[0m");
+
+        assertThat(subject.read(job, step)).isEqualTo("Error: quota exceeded");
+        verify(storageTypeService, never()).getStepOutput(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void fallsBackToStoredOutputWhenLiveLogsAreEmpty() {
+        Job job = job();
+        Step step = step();
+        when(streamingService.getCurrentLogs(anyString(), anyString())).thenReturn("");
+        when(storageTypeService.getStepOutput(job.getOrganization().getId().toString(), "721",
+                step.getId().toString())).thenReturn("stored output".getBytes(StandardCharsets.UTF_8));
+
+        assertThat(subject.read(job, step)).isEqualTo("stored output");
+    }
+
+    @Test
+    void returnsNullWhenNeitherSourceHasContent() {
+        Job job = job();
+        Step step = step();
+        when(streamingService.getCurrentLogs(anyString(), anyString())).thenReturn(null);
+        when(storageTypeService.getStepOutput(anyString(), anyString(), anyString())).thenReturn(new byte[0]);
+
+        assertThat(subject.read(job, step)).isNull();
+    }
+
+    @Test
+    void returnsNullInsteadOfPropagatingAnException() {
+        Job job = job();
+        Step step = step();
+        when(streamingService.getCurrentLogs(anyString(), anyString())).thenThrow(new RuntimeException("boom"));
+
+        assertThat(subject.read(job, step)).isNull();
+    }
+
+    @Test
+    void stripAnsiToleratesNull() {
+        assertThat(subject.stripAnsi(null)).isNull();
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/JobFailureSummaryServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/JobFailureSummaryServiceTest.java
@@ -1,0 +1,118 @@
+package io.terrakube.api.plugin.notification;
+
+import io.terrakube.api.plugin.logs.StepOutputReader;
+import io.terrakube.api.repository.StepRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.step.Step;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JobFailureSummaryServiceTest {
+
+    @Mock
+    StepRepository stepRepository;
+    @Mock
+    StepOutputReader stepOutputReader;
+
+    @InjectMocks
+    JobFailureSummaryService subject;
+
+    private Job job() {
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+        Job job = new Job();
+        job.setId(721);
+        job.setStatus(JobStatus.failed);
+        job.setOrganization(organization);
+        return job;
+    }
+
+    private Step step(int number, JobStatus status) {
+        Step step = new Step();
+        step.setId(UUID.randomUUID());
+        step.setStepNumber(number);
+        step.setStatus(status);
+        return step;
+    }
+
+    @Test
+    void readsTheFailedStepsOutputAndTrimsTheTail() {
+        Job job = job();
+        Step planStep = step(100, JobStatus.completed);
+        Step applyStep = step(200, JobStatus.failed);
+        when(stepRepository.findByJobId(721)).thenReturn(List.of(planStep, applyStep));
+        String longOutput = "x".repeat(900) + "\nError: creating instance: quota exceeded\n";
+        when(stepOutputReader.read(job, applyStep)).thenReturn(longOutput);
+
+        String reason = subject.describeFailure(job);
+
+        assertThat(reason).endsWith("Error: creating instance: quota exceeded");
+        assertThat(reason.length()).isLessThanOrEqualTo(500);
+    }
+
+    @Test
+    void picksTheFailedStepNotTheHighestNumbered() {
+        Job job = job();
+        Step failed = step(100, JobStatus.failed);
+        Step laterCancelled = step(200, JobStatus.cancelled);
+        when(stepRepository.findByJobId(721)).thenReturn(List.of(failed, laterCancelled));
+        when(stepOutputReader.read(any(), any())).thenReturn("boom");
+
+        subject.describeFailure(job);
+
+        ArgumentCaptor<Step> captor = ArgumentCaptor.forClass(Step.class);
+        verify(stepOutputReader).read(eq(job), captor.capture());
+        assertThat(captor.getValue()).isSameAs(failed);
+    }
+
+    @Test
+    void fallsBackToTheLastStepWhenNoStepIsMarkedFailed() {
+        Job job = job();
+        Step first = step(100, JobStatus.completed);
+        Step last = step(200, JobStatus.running);
+        when(stepRepository.findByJobId(721)).thenReturn(List.of(first, last));
+        when(stepOutputReader.read(job, last)).thenReturn("dispatch error");
+
+        assertThat(subject.describeFailure(job)).isEqualTo("dispatch error");
+    }
+
+    @Test
+    void returnsNullWhenThereAreNoSteps() {
+        when(stepRepository.findByJobId(721)).thenReturn(List.of());
+
+        assertThat(subject.describeFailure(job())).isNull();
+    }
+
+    @Test
+    void returnsNullWhenTheStepHasNoOutput() {
+        Job job = job();
+        Step applyStep = step(200, JobStatus.failed);
+        when(stepRepository.findByJobId(721)).thenReturn(List.of(applyStep));
+        when(stepOutputReader.read(job, applyStep)).thenReturn("   ");
+
+        assertThat(subject.describeFailure(job)).isNull();
+    }
+
+    @Test
+    void neverThrows() {
+        when(stepRepository.findByJobId(721)).thenThrow(new RuntimeException("db down"));
+
+        assertThat(subject.describeFailure(job())).isNull();
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/notification/JobNotificationTriggerTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/JobNotificationTriggerTest.java
@@ -12,7 +12,9 @@ import io.terrakube.api.rs.notification.NotificationTrigger;
 import io.terrakube.api.rs.template.Template;
 import io.terrakube.api.rs.workspace.Workspace;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -39,9 +41,16 @@ class JobNotificationTriggerTest {
     NotificationOutboxRepository notificationOutboxRepository;
     @Mock
     NotificationDispatchService notificationDispatchService;
+    @Mock
+    JobFailureSummaryService jobFailureSummaryService;
 
     @InjectMocks
     JobNotificationTrigger subject;
+
+    @BeforeEach
+    void setGraceWindow() {
+        ReflectionTestUtils.setField(subject, "recoverableStatusGraceSeconds", 90L);
+    }
 
     @AfterEach
     void clearTransactionSynchronization() {
@@ -78,9 +87,9 @@ class JobNotificationTriggerTest {
 
     @Test
     void enqueue_matchingConfigInsertsExactlyOneOutboxRow() {
-        Job job = jobWithStatus(JobStatus.failed);
-        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
-        NotificationConfiguration nonMatching = configWithTrigger(NotificationChannelType.WEBHOOK, JobStatus.completed);
+        Job job = jobWithStatus(JobStatus.completed);
+        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.completed);
+        NotificationConfiguration nonMatching = configWithTrigger(NotificationChannelType.WEBHOOK, JobStatus.failed);
         when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(matching, nonMatching));
         when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");
 
@@ -90,7 +99,29 @@ class JobNotificationTriggerTest {
         verify(notificationOutboxRepository, times(1)).save(captor.capture());
         assertThat(captor.getValue().getConfiguration()).isEqualTo(matching);
         assertThat(captor.getValue().getJob()).isEqualTo(job);
+        assertThat(captor.getValue().getJobStatus()).isEqualTo(JobStatus.completed);
+        assertThat(captor.getValue().getNextAttemptAt()).isNull();
         assertThat(ids).containsExactly(captor.getValue().getId());
+    }
+
+    @Test
+    void enqueue_recoverableStatusRowIsInsertedButDeferredNotDispatchedImmediately() {
+        // A job briefly flips to "failed" when the API->executor dispatch call throws even
+        // though the executor is running it; the row is held back (nextAttemptAt in the future,
+        // id withheld from the result) so the poller can re-validate it against the job's live
+        // status before delivering - see JobNotificationTrigger.RECOVERABLE_STATUSES.
+        Job job = jobWithStatus(JobStatus.failed);
+        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(matching));
+        when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");
+
+        List<UUID> ids = subject.enqueue(job);
+
+        ArgumentCaptor<NotificationOutbox> captor = ArgumentCaptor.forClass(NotificationOutbox.class);
+        verify(notificationOutboxRepository, times(1)).save(captor.capture());
+        assertThat(captor.getValue().getJobStatus()).isEqualTo(JobStatus.failed);
+        assertThat(captor.getValue().getNextAttemptAt()).isAfter(new java.util.Date());
+        assertThat(ids).isEmpty();
     }
 
     @Test
@@ -129,8 +160,8 @@ class JobNotificationTriggerTest {
 
     @Test
     void notifyStatusChanged_dispatchesEveryEnqueuedOutboxRowImmediately() {
-        Job job = jobWithStatus(JobStatus.failed);
-        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        Job job = jobWithStatus(JobStatus.completed);
+        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.completed);
         when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(matching));
         when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");
 
@@ -143,8 +174,8 @@ class JobNotificationTriggerTest {
 
     @Test
     void notifyStatusChanged_defersDispatchUntilAfterCommitWhenATransactionIsActive() {
-        Job job = jobWithStatus(JobStatus.failed);
-        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        Job job = jobWithStatus(JobStatus.completed);
+        NotificationConfiguration matching = configWithTrigger(NotificationChannelType.SLACK, JobStatus.completed);
         when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(matching));
         when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");
 
@@ -178,10 +209,10 @@ class JobNotificationTriggerTest {
 
     @Test
     void enqueue_configScopedToTheJobsTemplateMatches() {
-        Job job = jobWithStatus(JobStatus.failed);
+        Job job = jobWithStatus(JobStatus.completed);
         UUID templateId = UUID.randomUUID();
         job.setTemplateReference(templateId.toString());
-        NotificationConfiguration configuration = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        NotificationConfiguration configuration = configWithTrigger(NotificationChannelType.SLACK, JobStatus.completed);
         Template matchingTemplate = new Template();
         matchingTemplate.setId(templateId);
         configuration.setTemplates(List.of(matchingTemplate));
@@ -196,9 +227,9 @@ class JobNotificationTriggerTest {
 
     @Test
     void enqueue_configWithNoTemplatesSelectedMatchesEveryTemplate() {
-        Job job = jobWithStatus(JobStatus.failed);
+        Job job = jobWithStatus(JobStatus.completed);
         job.setTemplateReference(UUID.randomUUID().toString());
-        NotificationConfiguration configuration = configWithTrigger(NotificationChannelType.SLACK, JobStatus.failed);
+        NotificationConfiguration configuration = configWithTrigger(NotificationChannelType.SLACK, JobStatus.completed);
         // templates left null/unset - see NotificationConfiguration.templates javadoc.
         when(notificationConfigResolver.resolve(job.getWorkspace())).thenReturn(List.of(configuration));
         when(notificationPayloadRenderer.render(eq(NotificationChannelType.SLACK), any())).thenReturn("{}");

--- a/api/src/test/java/io/terrakube/api/plugin/notification/NotificationOutboxTransactionsTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/notification/NotificationOutboxTransactionsTest.java
@@ -59,6 +59,50 @@ class NotificationOutboxTransactionsTest {
     }
 
     @Test
+    void claimSkipsTheRowWhenTheJobHasMovedPastTheRenderedStatus() {
+        UUID id = UUID.randomUUID();
+        Date lastAttemptAt = new Date();
+        io.terrakube.api.rs.job.Job job = new io.terrakube.api.rs.job.Job();
+        job.setId(721);
+        job.setStatus(io.terrakube.api.rs.job.JobStatus.completed);
+        NotificationOutbox row = new NotificationOutbox();
+        row.setId(id);
+        row.setPayload("{}");
+        row.setLastAttemptAt(lastAttemptAt);
+        row.setJob(job);
+        row.setJobStatus(io.terrakube.api.rs.job.JobStatus.failed);
+        when(notificationOutboxRepository.claimForDelivery(eq(id), eq(NotificationOutboxStatus.PENDING),
+                eq(NotificationOutboxStatus.SENDING), any())).thenReturn(1);
+        when(notificationOutboxRepository.findById(id)).thenReturn(Optional.of(row));
+
+        assertThat(subject.claim(id)).isNull();
+
+        verify(notificationOutboxRepository).recordDeliveryResult(eq(id), eq(NotificationOutboxStatus.SENDING),
+                eq(lastAttemptAt), eq(NotificationOutboxStatus.SKIPPED), any(), isNull(), any());
+    }
+
+    @Test
+    void claimDeliversTheRowWhenTheJobStillMatchesTheRenderedStatus() {
+        UUID id = UUID.randomUUID();
+        io.terrakube.api.rs.job.Job job = new io.terrakube.api.rs.job.Job();
+        job.setId(721);
+        job.setStatus(io.terrakube.api.rs.job.JobStatus.failed);
+        NotificationOutbox row = new NotificationOutbox();
+        row.setId(id);
+        row.setPayload("{}");
+        row.setLastAttemptAt(new Date());
+        row.setJob(job);
+        row.setJobStatus(io.terrakube.api.rs.job.JobStatus.failed);
+        when(notificationOutboxRepository.claimForDelivery(eq(id), eq(NotificationOutboxStatus.PENDING),
+                eq(NotificationOutboxStatus.SENDING), any())).thenReturn(1);
+        when(notificationOutboxRepository.findById(id)).thenReturn(Optional.of(row));
+
+        assertThat(subject.claim(id)).isNotNull();
+        verify(notificationOutboxRepository, never()).recordDeliveryResult(any(), any(), any(),
+                eq(NotificationOutboxStatus.SKIPPED), any(), any(), any());
+    }
+
+    @Test
     void recordResultDelegatesToTheConditionalUpdate() {
         UUID id = UUID.randomUUID();
         Date lastAttemptAt = new Date();
@@ -89,13 +133,15 @@ class NotificationOutboxTransactionsTest {
     void pruneTerminalRowsOlderThanDelegatesToTheDeleteQuery() {
         Date cutoff = new Date();
         when(notificationOutboxRepository.deleteTerminalRowsCreatedBefore(
-                eq(java.util.List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED)), eq(cutoff)))
+                eq(java.util.List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED,
+                        NotificationOutboxStatus.SKIPPED)), eq(cutoff)))
                 .thenReturn(5);
 
         int deleted = subject.pruneTerminalRowsOlderThan(cutoff);
 
         assertThat(deleted).isEqualTo(5);
         verify(notificationOutboxRepository).deleteTerminalRowsCreatedBefore(
-                eq(java.util.List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED)), eq(cutoff));
+                eq(java.util.List.of(NotificationOutboxStatus.SENT, NotificationOutboxStatus.FAILED,
+                        NotificationOutboxStatus.SKIPPED)), eq(cutoff));
     }
 }

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/ScheduleJobTest.java
@@ -753,6 +753,30 @@ public class ScheduleJobTest {
     }
 
     @Test
+    public void approvedJobWithNoMoreStepsCompletes() {
+        Job job = job(JobStatus.approved);
+
+        doReturn(Collections.emptyList()).when(globalVarRepository).findByOrganization(any());
+        doReturn(Optional.of(Collections.emptyList())).when(variableRepository).findByWorkspace(any());
+        doReturn(false).when(tclService).isTemplatePlanOnly(any());
+        doReturn(Optional.of(Collections.emptyList()))
+                .when(jobRepository)
+                .findByWorkspaceAndStatusNotInAndIdLessThan(
+                        any(Workspace.class), anyList(), anyInt());
+        doReturn(job).when(tclService).initJobConfiguration(any(Job.class));
+        doReturn(null).when(tclService).getNextFlow(any());
+        doReturn(job.getWorkspace()).when(workspaceRepository).save(any());
+        doReturn(job).when(jobRepository).save(any());
+        doNothing().when(gitLabWebhookService).sendCommitStatus(any(), any(), any());
+
+        Assertions.assertTrue(subject().runExecution(job));
+
+        Assertions.assertEquals(JobStatus.completed, job.getStatus());
+        verify(jobRepository, times(1)).save(job);
+        verify(jobNotificationTrigger, times(1)).notifyStatusChanged(job);
+    }
+
+    @Test
     public void approvedJobFailsOnExecutionError() throws Exception {
         Job job = job(JobStatus.approved);
 

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/job/tcl/executor/persistent/PersistentExecutorServiceTest.java
@@ -169,6 +169,38 @@ public class PersistentExecutorServiceTest {
     }
 
     @Test
+    public void badGatewayResponseBecomesExecutorUnavailableException() {
+        // A proxy/ingress between the API and the executor dropped the upstream connection -
+        // possibly after the executor already accepted the job. Retryable, not a job failure.
+        WebClientResponseException badGateway = WebClientResponseException.create(
+                502, "Bad Gateway", HttpHeaders.EMPTY, new byte[0], null);
+        doReturn(Mono.error(badGateway)).when(responseSpec).toEntity(ExecutorContext.class);
+
+        assertThrows(ExecutorUnavailableException.class, () -> subject().send(jobOnDefaultExecutor(), context()));
+    }
+
+    @Test
+    public void gatewayTimeoutResponseBecomesExecutorUnavailableException() {
+        WebClientResponseException gatewayTimeout = WebClientResponseException.create(
+                504, "Gateway Timeout", HttpHeaders.EMPTY, new byte[0], null);
+        doReturn(Mono.error(gatewayTimeout)).when(responseSpec).toEntity(ExecutorContext.class);
+
+        assertThrows(ExecutorUnavailableException.class, () -> subject().send(jobOnDefaultExecutor(), context()));
+    }
+
+    @Test
+    public void otherHttpErrorResponseStaysAHardExecutionException() {
+        WebClientResponseException serverError = WebClientResponseException.create(
+                500, "Internal Server Error", HttpHeaders.EMPTY, new byte[0], null);
+        doReturn(Mono.error(serverError)).when(responseSpec).toEntity(ExecutorContext.class);
+
+        ExecutionException thrown = assertThrows(ExecutionException.class,
+                () -> subject().send(jobOnDefaultExecutor(), context()));
+        // not the retryable subclass
+        org.junit.jupiter.api.Assertions.assertFalse(thrown instanceof ExecutorUnavailableException);
+    }
+
+    @Test
     public void postsToConfiguredExecutor() throws ExecutionException, URISyntaxException {
         Globalvar executorUrl = new Globalvar();
         executorUrl.setValue("http://ze-executor/");

--- a/api/src/test/java/io/terrakube/api/plugin/state/RemoteTfeServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/state/RemoteTfeServiceTest.java
@@ -25,16 +25,22 @@ import io.terrakube.api.repository.WorkspaceRepository;
 import io.terrakube.api.repository.WorkspaceTagRepository;
 import io.terrakube.api.rs.ExecutionMode;
 import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.step.Step;
 import io.terrakube.api.rs.tag.Tag;
 import io.terrakube.api.rs.team.Team;
 import io.terrakube.api.rs.workspace.Workspace;
 import io.terrakube.api.rs.workspace.tag.WorkspaceTag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.StreamOffset;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StreamOperations;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -195,6 +201,49 @@ class RemoteTfeServiceTest {
         WorkspaceList result = service.listWorkspace("sample-org", Optional.empty(), Optional.of("exact"), currentUser);
 
         assertEquals("1.6.0", result.getData().get(0).getAttributes().get("terraform-version"));
+    }
+
+    // The CLI renders `tofu plan` output straight from the bytes this returns. The executor now
+    // writes a diagnostic's full rendering (header + `on <file> line <n>` + snippet + detail) to
+    // the job's step-100 log stream as several lines; getPlanLogs must hand all of them back, not
+    // drop everything after the "Error:" header, and the offset/limit slice must not chop the
+    // block when a page big enough to hold it is requested.
+    @Test
+    @SuppressWarnings("unchecked")
+    void planLogsReturnTheFullMultiLineDiagnosticBlock() {
+        RemoteTfeService service = remoteTfeService();
+
+        Job job = new Job();
+        job.setId(123);
+        Step planStep = new Step();
+        planStep.setId(UUID.randomUUID());
+        planStep.setStepNumber(100);
+        job.setStep(List.of(planStep));
+
+        when(encryptionService.decrypt("encrypted-plan-id")).thenReturn("123");
+        when(jobRepository.findById(123)).thenReturn(Optional.of(job));
+
+        String executorConsole = String.join("\n",
+                "Plan: 0 to add, 0 to change, 0 to destroy.",
+                "",
+                "Error: Unsupported attribute",
+                "",
+                "  on main.tf line 12, in resource \"aws_instance\" \"web\":",
+                "  12:   subnet = aws_subnet.main.identifier",
+                "",
+                "This object has no argument, nested block, or exported attribute named \"identifier\".");
+
+        StreamOperations<String, String, String> streamOperations = Mockito.mock(StreamOperations.class);
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.read(any(StreamOffset.class), any(StreamOffset.class)))
+                .thenReturn(List.of(MapRecord.create("123", Map.of("output", executorConsole))));
+
+        String logs = new String(service.getPlanLogs("encrypted-plan-id", 0, 500_000), StandardCharsets.UTF_8);
+
+        assertTrue(logs.contains("on main.tf line 12, in resource \"aws_instance\" \"web\":"), logs);
+        assertTrue(logs.contains("12:   subnet = aws_subnet.main.identifier"), logs);
+        assertTrue(logs.contains(
+                "This object has no argument, nested block, or exported attribute named \"identifier\"."), logs);
     }
 
     private RemoteTfeService remoteTfeService() {

--- a/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/vcs/PrCommentServiceTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.terrakube.api.plugin.logs.StepOutputReader;
 import io.terrakube.api.plugin.storage.StorageTypeService;
 import io.terrakube.api.plugin.streaming.StreamingService;
 import io.terrakube.api.plugin.vcs.provider.bitbucket.BitBucketWebhookService;
@@ -55,6 +56,7 @@ public class PrCommentServiceTest {
     StepRepository stepRepository;
     StorageTypeService storageTypeService;
     StreamingService streamingService;
+    StepOutputReader stepOutputReader;
     ObjectMapper objectMapper;
 
     PrCommentService subject;
@@ -68,6 +70,10 @@ public class PrCommentServiceTest {
         stepRepository = mock(StepRepository.class);
         storageTypeService = mock(StorageTypeService.class);
         streamingService = mock(StreamingService.class);
+        // Real reader over the mocked storage/streaming beans, so the existing getCurrentLogs /
+        // getStepOutput stubs below keep exercising the same read-then-fallback behaviour that
+        // now lives in StepOutputReader.
+        stepOutputReader = new StepOutputReader(storageTypeService, streamingService);
         objectMapper = new ObjectMapper();
 
         subject = new PrCommentService(
@@ -77,7 +83,7 @@ public class PrCommentServiceTest {
                 jobRepository,
                 stepRepository,
                 storageTypeService,
-                streamingService,
+                stepOutputReader,
                 objectMapper);
     }
 

--- a/executor/src/main/java/io/terrakube/executor/service/status/UpdateJobStatusImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/status/UpdateJobStatusImpl.java
@@ -115,9 +115,11 @@ public class UpdateJobStatusImpl implements UpdateJobStatus {
         log.info("output: {}", jobOutput.length());
         log.info("outputError: {}", jobErrorOutput.length());
 
-        job.getAttributes().setOutput(
-                job.getAttributes().getOutput() == null ? "" : job.getAttributes().getOutput() + " Step " + stepId + " completed\n"
-        );
+        // Append-only per-step marker. The null check guards the first step (no prior output),
+        // it must not also swallow the marker itself - the parenthesised ternary is the base
+        // string, the marker is always appended.
+        String existingOutput = job.getAttributes().getOutput() == null ? "" : job.getAttributes().getOutput();
+        job.getAttributes().setOutput(existingOutput + " Step " + stepId + " completed\n");
         job.getAttributes().setTerraformPlan(jobPlan);
         job.getAttributes().setCommitId(commitId);
 

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -183,7 +183,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     Consumer<String> jsonLineConsumer = (line) -> {
                         String humanMessage = eventParser.parseLine(line, liveChanges, jobDiagnostics);
                         if (humanMessage != null) {
-                            planOutput.accept(humanMessage);
+                            acceptConsoleLines(planOutput, humanMessage);
                         }
 
                         long now = System.currentTimeMillis();
@@ -381,7 +381,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         Consumer<String> jsonLineConsumer = (line) -> {
             String humanMessage = eventParser.parseLine(line, changes, jobDiagnostics);
             if (humanMessage != null) {
-                applyOutput.accept(humanMessage);
+                acceptConsoleLines(applyOutput, humanMessage);
             }
 
             long now = System.currentTimeMillis();
@@ -425,7 +425,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         Consumer<String> jsonLineConsumer = (line) -> {
             String humanMessage = eventParser.parseLine(line, changes, jobDiagnostics);
             if (humanMessage != null) {
-                destroyOutput.accept(humanMessage);
+                acceptConsoleLines(destroyOutput, humanMessage);
             }
 
             long now = System.currentTimeMillis();
@@ -450,6 +450,15 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
         pushLiveStructuredUpdate("apply", terraformJob, changes, jobDiagnostics);
 
         return execution;
+    }
+
+    // The json event stream is one event per line, but a single diagnostic event renders as a
+    // multi-line block (header, source snippet, explanatory detail). Split it so every line gets
+    // its own log record and line number, instead of one record carrying embedded newlines.
+    private static void acceptConsoleLines(Consumer<String> output, String message) {
+        for (String line : message.split("\n", -1)) {
+            output.accept(line);
+        }
     }
 
     // Best-effort live push over the new structured-output SSE channel - never lets a

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImpl.java
@@ -196,17 +196,18 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
                     };
 
                     TerraformClient jsonPlanClient = buildJsonEnabledPlanClient();
+                    Consumer<String> guardedJsonLineConsumer = guardConsumer(jsonLineConsumer);
 
                     if (isDestroy) {
                         log.warn("Executor running a plan to destroy resources...");
                         exitCode = jsonPlanClient.planDestroyDetailExitCode(
                                 getTerraformProcessData(terraformJob, terraformWorkingDir, executorTempDirectory),
-                                jsonLineConsumer,
+                                guardedJsonLineConsumer,
                                 null).get();
                     } else {
                         exitCode = jsonPlanClient.planDetailExitCode(
                                 getTerraformProcessData(terraformJob, terraformWorkingDir, executorTempDirectory),
-                                jsonLineConsumer,
+                                guardedJsonLineConsumer,
                                 null).get();
                     }
 
@@ -271,7 +272,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             result.setPlan(true);
             result.setExitCode(exitCode);
         } catch (IOException | ExecutionException | InterruptedException exception) {
-            result = setError(exception);
+            result = setError(exception, jobOutput.toString());
+            result.setPlan(true);
             result.setExitCode(1);
         }
         return result;
@@ -351,7 +353,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             waitForStreamCompletion(terraformJob.getJobId(), 300);
             result = generateJobResult(scriptAfterSuccess, terraformOutput.toString(), terraformErrorOutput.toString());
         } catch (IOException | ExecutionException | InterruptedException exception) {
-            result = setError(exception);
+            result = setError(exception, terraformOutput.toString());
+            result.setExitCode(1);
         }
         return result;
     }
@@ -365,7 +368,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             // No plan structured output to seed from (custom TCL with 0/2+ plan steps, or plan
             // publishing failed) — fall back to a plain apply through the shared client, exactly
             // as before this feature existed.
-            return terraformClient.apply(terraformProcessData, applyOutput, null).get();
+            return terraformClient.apply(terraformProcessData, guardConsumer(applyOutput), null).get();
         }
 
         List<Map<String, Object>> jobDiagnostics = new ArrayList<>();
@@ -395,7 +398,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
         TerraformClient jsonApplyClient = buildJsonEnabledApplyClient();
 
-        boolean execution = jsonApplyClient.apply(terraformProcessData, jsonLineConsumer, null).get();
+        boolean execution = jsonApplyClient.apply(terraformProcessData, guardConsumer(jsonLineConsumer), null).get();
 
         String stateJson = getCurrentStateJson(terraformJob, terraformProcessData);
         if (stateJson != null) {
@@ -443,7 +446,7 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
 
         TerraformClient jsonDestroyClient = buildJsonEnabledDestroyClient();
 
-        boolean execution = jsonDestroyClient.destroy(terraformProcessData, jsonLineConsumer, null).get();
+        boolean execution = jsonDestroyClient.destroy(terraformProcessData, guardConsumer(jsonLineConsumer), null).get();
 
         applyStructuredOutputService.publishApplyProgress(
                 terraformJob.getOrganizationId(), terraformJob.getJobId(), terraformJob.getStepId(), changes, jobDiagnostics);
@@ -476,7 +479,11 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             payload.put("jobDiagnostics", Map.of(terraformJob.getStepId(), jobDiagnostics));
             logsService.sendStructuredUpdate(Integer.valueOf(terraformJob.getJobId()), terraformJob.getStepId(),
                     objectMapper.writeValueAsString(payload));
-        } catch (JsonProcessingException e) {
+        } catch (Exception e) {
+            // Best-effort: a serialization error, a null stepId in Map.of, or a transport failure
+            // in sendStructuredUpdate must never abort the plan/apply - some of these call sites
+            // run on terraform-spring-boot's output-reader thread, where an uncaught exception
+            // kills stream capture entirely.
             log.warn("Unable to push live structured update for job {} step {}", terraformJob.getJobId(), terraformJob.getStepId(), e);
         }
     }
@@ -579,7 +586,8 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
             waitForStreamCompletion(terraformJob.getJobId(), 300);
             result = generateJobResult(scriptAfterSuccess, jobOutput.toString(), jobErrorOutput.toString());
         } catch (IOException | ExecutionException | InterruptedException exception) {
-            result = setError(exception);
+            result = setError(exception, jobOutput.toString());
+            result.setExitCode(1);
         }
         return result;
     }
@@ -771,13 +779,54 @@ public class TerraformExecutorServiceImpl implements TerraformExecutor {
     }
 
     private ExecutorJobResult setError(Exception exception) {
-        ExecutorJobResult error = generateJobResult(false, "", exception.getMessage());
-        log.error(exception.getMessage());
+        return setError(exception, "");
+    }
+
+    // Keep everything Terraform/OpenTofu already streamed to the console before the failure. The
+    // previous behaviour replaced it all with just exception.getMessage(), so an operation that
+    // failed late - a data source erroring after the plan diff was already printed, or the
+    // terraform-spring-boot client's stream-drain watchdog firing on a large burst of output -
+    // reached the UI and CLI as a bare "java.lang.RuntimeException: Failed to capture process
+    // output stream" with none of the real Terraform output, and none of the real error (the
+    // "Error: External Program Lookup Failed" / missing-python diagnostic, in the reported case)
+    // that actually caused it.
+    private ExecutorJobResult setError(Exception exception, String partialConsoleOutput) {
+        String message = exception.getMessage() != null ? exception.getMessage() : exception.toString();
+        log.error("Terraform operation failed: {}", message, exception);
+
+        TextStringBuilder consoleOutput = new TextStringBuilder();
+        if (partialConsoleOutput != null && !partialConsoleOutput.isBlank()) {
+            consoleOutput.append(partialConsoleOutput);
+            if (!partialConsoleOutput.endsWith("\n")) {
+                consoleOutput.appendNewLine();
+            }
+            consoleOutput.appendNewLine();
+        }
+        consoleOutput.appendln("Error: the Terrakube executor could not finish this operation");
+        consoleOutput.appendln(message);
+
+        ExecutorJobResult error = generateJobResult(false, consoleOutput.toString(), message);
 
         if (exception instanceof InterruptedException) {
             Thread.currentThread().interrupt();
         }
         return error;
+    }
+
+    // terraform-spring-boot invokes the -json line consumer from inside its process-output reader
+    // loop; any exception thrown out of the consumer propagates back into that loop, kills the
+    // reader thread and fails the whole run with "Failed to capture process output stream",
+    // discarding every line already read. A dropped structured-progress update is recoverable; a
+    // killed reader is not. (LogsServiceRedis.sendLogs guards the plain-log consumer for the same
+    // reason.)
+    private Consumer<String> guardConsumer(Consumer<String> lineConsumer) {
+        return line -> {
+            try {
+                lineConsumer.accept(line);
+            } catch (Exception e) {
+                log.warn("Skipping a terraform output line that could not be processed: {}", e.getMessage(), e);
+            }
+        };
     }
 
     private boolean prepareTerraformOperation(TerraformJob terraformJob, File executorTempDirectory, File terraformWorkingDirectory, Consumer<String> output)

--- a/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformJsonEventParser.java
+++ b/executor/src/main/java/io/terrakube/executor/service/terraform/TerraformJsonEventParser.java
@@ -51,7 +51,10 @@ public class TerraformJsonEventParser {
                 updateStatus(changes, resourceAddress(event), "errored");
                 updateElapsedSeconds(changes, resourceAddress(event), event);
             }
-            case "diagnostic" -> attachDiagnostic(changes, jobDiagnostics, event);
+            case "diagnostic" -> {
+                attachDiagnostic(changes, jobDiagnostics, event);
+                return renderDiagnostic(event, message instanceof String text ? text : null);
+            }
             case "provision_start" -> updateCurrentProvisioner(changes, resourceAddress(event), provisionerName(event));
             case "provision_progress" -> appendProvisionerOutput(changes, resourceAddress(event), event);
             case "provision_complete", "provision_errored" -> updateCurrentProvisioner(changes, resourceAddress(event), null);
@@ -201,6 +204,80 @@ public class TerraformJsonEventParser {
         }
 
         jobDiagnostics.add(diagnosticEntry);
+    }
+
+    // Under `-json` a diagnostic's own @message is only the one-line "Error: <summary>" /
+    // "Warning: <summary>" header - the file/line, the source snippet and the explanatory detail
+    // all live in the structured "diagnostic" object and would otherwise never reach the console
+    // stream. That stream is what `terraform`/`tofu` prints back to a CLI-driven plan, what the
+    // raw-log download serves, and what PrCommentService posts, so rebuild the full multi-line
+    // rendering here, close to what plain (non-json) terraform would have printed. Falls back to
+    // the raw @message if the structured object is missing or malformed.
+    private String renderDiagnostic(Map<String, Object> event, String fallbackMessage) {
+        Object diagnosticRaw = event.get("diagnostic");
+        if (!(diagnosticRaw instanceof Map<?, ?> diagnostic)) {
+            return fallbackMessage;
+        }
+
+        String severity = severityOrNull(diagnostic.get("severity"));
+        if (severity == null || !(diagnostic.get("summary") instanceof String summary)) {
+            return fallbackMessage;
+        }
+
+        StringBuilder rendered = new StringBuilder();
+        rendered.append('\n')
+                .append("error".equals(severity) ? "Error: " : "Warning: ")
+                .append(summary)
+                .append('\n');
+
+        String location = renderDiagnosticSource(diagnostic);
+        if (location != null) {
+            rendered.append('\n').append(location).append('\n');
+        }
+
+        if (diagnostic.get("detail") instanceof String detail && !detail.isBlank()) {
+            rendered.append('\n').append(detail).append('\n');
+        }
+
+        return rendered.toString();
+    }
+
+    // "  on main.tf line 12, in resource "aws_instance" "web":" followed by the numbered source
+    // lines - the same layout terraform's own console renderer uses. Degrades to just the
+    // "  on <file> line <n>:" header when the event carries a range but no code snippet, and to
+    // null when the diagnostic has no source location at all (a config-wide problem).
+    private String renderDiagnosticSource(Map<?, ?> diagnostic) {
+        if (!(diagnostic.get("range") instanceof Map<?, ?> range)
+                || !(range.get("filename") instanceof String filename)) {
+            return null;
+        }
+
+        Integer line = null;
+        if (range.get("start") instanceof Map<?, ?> start && start.get("line") instanceof Number lineNumber) {
+            line = lineNumber.intValue();
+        }
+
+        StringBuilder source = new StringBuilder("  on ").append(filename);
+        if (line != null) {
+            source.append(" line ").append(line);
+        }
+
+        Map<?, ?> snippet = diagnostic.get("snippet") instanceof Map<?, ?> s ? s : null;
+        if (snippet != null && snippet.get("context") instanceof String context && !context.isBlank()) {
+            source.append(", in ").append(context);
+        }
+        source.append(':');
+
+        if (snippet != null && snippet.get("code") instanceof String code) {
+            int startLine = snippet.get("start_line") instanceof Number n ? n.intValue()
+                    : (line != null ? line : 1);
+            String[] codeLines = code.split("\n", -1);
+            for (int i = 0; i < codeLines.length; i++) {
+                source.append('\n').append(String.format("%4d: %s", startLine + i, codeLines[i]));
+            }
+        }
+
+        return source.toString();
     }
 
     // Diagnostics that carry no resource address at all (a deprecated variable/output, which can

--- a/executor/src/test/java/io/terrakube/executor/service/executor/AdmissionControlIntegrationTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/executor/AdmissionControlIntegrationTest.java
@@ -101,13 +101,19 @@ class AdmissionControlIntegrationTest {
         ResponseEntity<TerraformJob> secondResponse = controller.terraformJob(secondJob);
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE, secondResponse.getStatusCode());
 
-        // Let the first job finish, which releases the gate.
+        // Let the first job finish. ExecutorJobImpl releases the gate in its finally block
+        // *before* publishReadiness/publishExecutorAvailable and before the pool Runnable
+        // returns - so waiting only for the gate to free up races the pool thread still being
+        // busy, and the third submit below would then hit the queue-capacity-0 pool and be
+        // rejected (503) even though capacity is logically available. Wait for the pool thread
+        // to actually go idle instead.
         releaseFirstJob.countDown();
         long deadline = System.currentTimeMillis() + 5000;
-        while (gate.tryAcquire() == false && System.currentTimeMillis() < deadline) {
+        while (pool.getThreadPoolExecutor().getActiveCount() > 0 && System.currentTimeMillis() < deadline) {
             Thread.sleep(20);
         }
-        gate.release();
+        assertEquals(0, pool.getThreadPoolExecutor().getActiveCount(),
+                "first job's pool task did not finish within the timeout");
 
         // Third request after completion: pod accepts again.
         TerraformJob thirdJob = new TerraformJob();

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -426,5 +427,112 @@ class TerraformExecutorServiceImplTest {
         verify(planStructuredOutputService, Mockito.atLeastOnce()).publishPlanProgress(
                 eq("org"), eq("42"), eq("1"), any(), any());
         verify(logsService, Mockito.atLeastOnce()).sendStructuredUpdate(eq(42), eq("1"), anyString());
+    }
+
+    // Regression test for the reported bug: running `tofu plan` from the CLI showed only a bare
+    // "Error: Unsupported attribute" header with no file, line or explanation. Under `-json` the
+    // diagnostic's detail lives in the structured event, not in @message - the executor must
+    // reconstruct the full rendering into the console stream the CLI reads.
+    @Test
+    void planForwardsTheFullDiagnosticRenderingToTheConsoleStream() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        String diagnosticLine = "{\"@message\":\"Error: Unsupported attribute\",\"type\":\"diagnostic\","
+                + "\"diagnostic\":{\"severity\":\"error\",\"summary\":\"Unsupported attribute\","
+                + "\"detail\":\"This object has no argument, nested block, or exported attribute named \\\"identifier\\\".\","
+                + "\"range\":{\"filename\":\"main.tf\",\"start\":{\"line\":12,\"column\":12}}}}";
+
+        TerraformClient jsonPlanClient = Mockito.mock(TerraformClient.class);
+        when(jsonPlanClient.planDetailExitCode(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenAnswer(invocation -> {
+                    Consumer<String> lineConsumer = invocation.getArgument(1);
+                    lineConsumer.accept(diagnosticLine);
+                    return CompletableFuture.completedFuture(1);
+                });
+        doReturn(jsonPlanClient).when(subject).buildJsonEnabledPlanClient();
+
+        subject.plan(terraformJob, tempDir.toFile(), false);
+
+        verify(logsService, Mockito.atLeastOnce()).sendLogs(eq(42), eq("1"), anyInt(),
+                argThat(line -> line != null && line.contains("no argument, nested block")));
+        verify(logsService, Mockito.atLeastOnce()).sendLogs(eq(42), eq("1"), anyInt(),
+                argThat(line -> line != null && line.contains("on main.tf line 12")));
+    }
+
+    // Same regression as the plan case, on the apply path: apply -json's diagnostic events must
+    // land in the console stream with their detail and location, not just the "Error:" header.
+    @Test
+    void applyForwardsTheFullDiagnosticRenderingToTheConsoleStream() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+
+        Map<String, Object> seededChange = new HashMap<>();
+        seededChange.put("address", "null_resource.fails");
+        seededChange.put("status", "pending");
+        when(applyStructuredOutputService.seedFromPlan("org", "42")).thenReturn(List.of(seededChange));
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.show(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+        when(terraformClient.statePull(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+
+        String diagnosticLine = "{\"@message\":\"Error: Missing required argument\",\"type\":\"diagnostic\","
+                + "\"diagnostic\":{\"severity\":\"error\",\"summary\":\"Missing required argument\","
+                + "\"detail\":\"The argument \\\"triggers\\\" is required, but no definition was found.\","
+                + "\"range\":{\"filename\":\"main.tf\",\"start\":{\"line\":5,\"column\":1}}}}";
+
+        TerraformClient jsonApplyClient = Mockito.mock(TerraformClient.class);
+        when(jsonApplyClient.apply(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenAnswer(invocation -> {
+                    Consumer<String> lineConsumer = invocation.getArgument(1);
+                    lineConsumer.accept(diagnosticLine);
+                    return CompletableFuture.completedFuture(false);
+                });
+        doReturn(jsonApplyClient).when(subject).buildJsonEnabledApplyClient();
+
+        ExecutorJobResult result = subject.apply(terraformJob, tempDir.toFile());
+
+        assertTrue(result.getOutputLog().contains("The argument \"triggers\" is required, but no definition was found."),
+                result.getOutputLog());
+        assertTrue(result.getOutputLog().contains("on main.tf line 5"), result.getOutputLog());
+    }
+
+    // Same regression on the destroy path.
+    @Test
+    void destroyForwardsTheFullDiagnosticRenderingToTheConsoleStream() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+        when(terraformClient.show(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+        when(terraformClient.statePull(any(TerraformProcessData.class), any(Consumer.class), any(Consumer.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+
+        String diagnosticLine = "{\"@message\":\"Error: Provider configuration not present\",\"type\":\"diagnostic\","
+                + "\"diagnostic\":{\"severity\":\"error\",\"summary\":\"Provider configuration not present\","
+                + "\"detail\":\"To work with null_resource.fails its original provider configuration is required.\"}}";
+
+        TerraformClient jsonDestroyClient = Mockito.mock(TerraformClient.class);
+        when(jsonDestroyClient.destroy(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenAnswer(invocation -> {
+                    Consumer<String> lineConsumer = invocation.getArgument(1);
+                    lineConsumer.accept(diagnosticLine);
+                    return CompletableFuture.completedFuture(false);
+                });
+        doReturn(jsonDestroyClient).when(subject).buildJsonEnabledDestroyClient();
+
+        ExecutorJobResult result = subject.destroy(terraformJob, tempDir.toFile());
+
+        assertTrue(result.getOutputLog().contains(
+                "To work with null_resource.fails its original provider configuration is required."),
+                result.getOutputLog());
     }
 }

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformExecutorServiceImplTest.java
@@ -535,4 +535,74 @@ class TerraformExecutorServiceImplTest {
                 "To work with null_resource.fails its original provider configuration is required."),
                 result.getOutputLog());
     }
+
+    // Regression test for the reported bug: a plan that fails late (a data source erroring after
+    // the diff was already streamed) surfaced in the UI/CLI as a bare
+    // "java.lang.RuntimeException: Failed to capture process output stream" - the executor's
+    // catch block replaced every line Terraform had already printed with just the exception
+    // message. The console output that was already collected must be preserved.
+    @Test
+    void planKeepsAlreadyStreamedOutputWhenTheClientFutureFails() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        String plannedChangeLine = "{\"type\":\"planned_change\",\"change\":{\"resource\":"
+                + "{\"addr\":\"aws_instance.example\"},\"action\":\"create\"},"
+                + "\"@message\":\"aws_instance.example: Plan to create\"}";
+
+        TerraformClient jsonPlanClient = Mockito.mock(TerraformClient.class);
+        when(jsonPlanClient.planDetailExitCode(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenAnswer(invocation -> {
+                    Consumer<String> lineConsumer = invocation.getArgument(1);
+                    lineConsumer.accept(plannedChangeLine);
+                    return CompletableFuture.failedFuture(
+                            new RuntimeException("Failed to capture process output stream"));
+                });
+        doReturn(jsonPlanClient).when(subject).buildJsonEnabledPlanClient();
+
+        ExecutorJobResult result = subject.plan(terraformJob, tempDir.toFile(), false);
+
+        assertFalse(result.isSuccessfulExecution());
+        assertEquals(1, result.getExitCode());
+        assertTrue(result.getOutputLog().contains("aws_instance.example: Plan to create"), result.getOutputLog());
+        assertTrue(result.getOutputLog().contains("Failed to capture process output stream"), result.getOutputLog());
+        assertTrue(result.getOutputErrorLog().contains("Failed to capture process output stream"));
+    }
+
+    // A failure inside the -json line consumer (here: the live structured-update push blowing up)
+    // must not propagate into terraform-spring-boot's process-output reader loop - that kills the
+    // reader and fails the whole run with "Failed to capture process output stream", losing the
+    // console output that had already been read.
+    @Test
+    void planSurvivesAFailureRaisedFromInsideTheJsonLineConsumer() throws Exception {
+        TerraformExecutorServiceImpl subject = spy(subject());
+        TerraformJob terraformJob = createJob();
+
+        when(terraformClient.init(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenReturn(CompletableFuture.completedFuture(true));
+
+        Mockito.doThrow(new RuntimeException("redis is unreachable"))
+                .when(logsService).sendStructuredUpdate(anyInt(), anyString(), anyString());
+
+        String plannedChangeLine = "{\"type\":\"planned_change\",\"change\":{\"resource\":"
+                + "{\"addr\":\"aws_instance.example\"},\"action\":\"create\"},"
+                + "\"@message\":\"aws_instance.example: Plan to create\"}";
+
+        TerraformClient jsonPlanClient = Mockito.mock(TerraformClient.class);
+        when(jsonPlanClient.planDetailExitCode(any(TerraformProcessData.class), any(Consumer.class), any()))
+                .thenAnswer(invocation -> {
+                    Consumer<String> lineConsumer = invocation.getArgument(1);
+                    lineConsumer.accept(plannedChangeLine);
+                    return CompletableFuture.completedFuture(2);
+                });
+        doReturn(jsonPlanClient).when(subject).buildJsonEnabledPlanClient();
+
+        ExecutorJobResult result = subject.plan(terraformJob, tempDir.toFile(), false);
+
+        assertEquals(2, result.getExitCode());
+        assertTrue(result.getOutputLog().contains("aws_instance.example: Plan to create"), result.getOutputLog());
+    }
 }

--- a/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformJsonEventParserTest.java
+++ b/executor/src/test/java/io/terrakube/executor/service/terraform/TerraformJsonEventParserTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -71,6 +72,47 @@ class TerraformJsonEventParserTest {
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> diagnostics = (List<Map<String, Object>>) changes.get(0).get("diagnostics");
         assertEquals("local-exec provisioner error", diagnostics.get(0).get("summary"));
+    }
+
+    // Under `-json` a diagnostic's own `@message` is only the one-line "Error: <summary>" header -
+    // the file, line, source snippet and explanation live in the structured `diagnostic` object.
+    // parseLine must hand the caller the full multi-line rendering that plain `tofu plan` prints,
+    // otherwise the CLI (and raw-log download, and PR comment) show a bare "Error: Unsupported
+    // attribute" with nothing else.
+    @Test
+    void returnsFullHumanReadableDiagnosticRenderingForTheConsole() {
+        List<Map<String, Object>> changes = new ArrayList<>();
+        List<Map<String, Object>> jobDiagnostics = new ArrayList<>();
+
+        String consoleText = subject().parseLine(
+                "{\"@message\":\"Error: Unsupported attribute\",\"@level\":\"error\",\"type\":\"diagnostic\","
+                        + "\"diagnostic\":{\"severity\":\"error\",\"summary\":\"Unsupported attribute\","
+                        + "\"detail\":\"This object has no argument, nested block, or exported attribute named \\\"identifier\\\".\","
+                        + "\"range\":{\"filename\":\"main.tf\",\"start\":{\"line\":12,\"column\":12},\"end\":{\"line\":12,\"column\":30}},"
+                        + "\"snippet\":{\"context\":\"resource \\\"aws_instance\\\" \\\"web\\\"\",\"code\":\"  subnet = aws_subnet.main.identifier\",\"start_line\":12}}}",
+                changes, jobDiagnostics);
+
+        assertTrue(consoleText.contains("Error: Unsupported attribute"), consoleText);
+        assertTrue(consoleText.contains("on main.tf line 12, in resource \"aws_instance\" \"web\""), consoleText);
+        assertTrue(consoleText.contains("12:   subnet = aws_subnet.main.identifier"), consoleText);
+        assertTrue(consoleText.contains(
+                "This object has no argument, nested block, or exported attribute named \"identifier\"."), consoleText);
+    }
+
+    @Test
+    void rendersADiagnosticWithNoSourceLocationAsJustSummaryAndDetail() {
+        List<Map<String, Object>> changes = new ArrayList<>();
+        List<Map<String, Object>> jobDiagnostics = new ArrayList<>();
+
+        String consoleText = subject().parseLine(
+                "{\"@message\":\"Warning: Deprecated attribute\",\"type\":\"diagnostic\","
+                        + "\"diagnostic\":{\"severity\":\"warning\",\"summary\":\"Deprecated attribute\","
+                        + "\"detail\":\"The attribute \\\"foo\\\" is deprecated. Use \\\"bar\\\" instead.\"}}",
+                changes, jobDiagnostics);
+
+        assertTrue(consoleText.contains("Warning: Deprecated attribute"), consoleText);
+        assertTrue(consoleText.contains("The attribute \"foo\" is deprecated. Use \"bar\" instead."), consoleText);
+        assertFalse(consoleText.contains("  on "), consoleText);
     }
 
     @Test

--- a/registry/src/main/java/io/terrakube/registry/service/module/ModuleServiceImpl.java
+++ b/registry/src/main/java/io/terrakube/registry/service/module/ModuleServiceImpl.java
@@ -10,6 +10,7 @@ import io.terrakube.client.model.organization.module.ModuleRequest;
 import io.terrakube.client.model.organization.ssh.Ssh;
 import io.terrakube.client.model.organization.vcs.Vcs;
 import io.terrakube.client.model.organization.vcs.github_app_token.GitHubAppToken;
+import io.terrakube.client.model.response.Response;
 import io.terrakube.registry.plugin.storage.StorageService;
 import io.terrakube.registry.service.git.ModuleVersionDownload;
 import io.terrakube.registry.service.search.CommonSearchService;
@@ -20,7 +21,9 @@ import org.springframework.stereotype.Service;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @AllArgsConstructor
@@ -103,12 +106,13 @@ public class ModuleServiceImpl implements ModuleService {
         String folder = module.getAttributes().getFolder();
         String tagPrefix = module.getAttributes().getTagPrefix();
 
-        String gitTag = terrakubeClient.getAllVersionsByOrganizationIdAndModuleId(organizationId, module.getId())
-                .getData()
+        String gitTag = Optional.ofNullable(terrakubeClient.getAllVersionsByOrganizationIdAndModuleId(organizationId, module.getId()))
+                .map(Response::getData)
+                .orElseGet(Collections::emptyList)
                 .stream()
                 .filter(moduleVersion -> version.equals(moduleVersion.getAttributes().getVersion()))
-                .map(moduleVersion -> moduleVersion.getAttributes().getGitTag())
                 .findFirst()
+                .map(moduleVersion -> moduleVersion.getAttributes().getGitTag())
                 .orElse(null);
 
         if (module.getRelationships().getVcs().getData() != null) {

--- a/registry/src/test/java/io/terrakube/registry/service/module/ModuleServiceImplCacheTest.java
+++ b/registry/src/test/java/io/terrakube/registry/service/module/ModuleServiceImplCacheTest.java
@@ -1,0 +1,208 @@
+package io.terrakube.registry.service.module;
+
+import io.terrakube.client.TerrakubeClient;
+import io.terrakube.client.model.organization.module.Module;
+import io.terrakube.client.model.organization.module.ModuleAttributes;
+import io.terrakube.client.model.organization.module.Relationships;
+import io.terrakube.client.model.organization.module.SshData;
+import io.terrakube.client.model.organization.module.version.ModuleVersion;
+import io.terrakube.client.model.organization.module.version.ModuleVersionAttributes;
+import io.terrakube.client.model.organization.workspace.VcsData;
+import io.terrakube.client.model.response.Response;
+import io.terrakube.registry.configuration.CacheConfig;
+import io.terrakube.registry.plugin.storage.StorageService;
+import io.terrakube.registry.service.search.CommonSearchService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ModuleServiceImplCacheTest {
+
+    private AnnotationConfigApplicationContext context;
+
+    @AfterEach
+    void tearDown() {
+        if (context != null) {
+            context.close();
+        }
+    }
+
+    @Configuration
+    @EnableCaching
+    static class TestConfig {
+        @Bean
+        CacheConfig cacheConfig() {
+            return new CacheConfig();
+        }
+
+        @Bean
+        org.springframework.cache.CacheManager cacheManager(CacheConfig cacheConfig) {
+            return cacheConfig.cacheManager();
+        }
+
+        @Bean
+        TerrakubeClient terrakubeClient() {
+            return mock(TerrakubeClient.class);
+        }
+
+        @Bean
+        CommonSearchService commonSearchService() {
+            return mock(CommonSearchService.class);
+        }
+
+        @Bean
+        StorageService storageService() {
+            return mock(StorageService.class);
+        }
+
+        @Bean
+        ModuleServiceImpl moduleService(TerrakubeClient terrakubeClient, StorageService storageService,
+                CommonSearchService commonSearchService) {
+            return new ModuleServiceImpl(terrakubeClient, storageService, commonSearchService);
+        }
+    }
+
+    @Test
+    void cacheHitMakesNoFurtherCalls() throws Exception {
+        context = new AnnotationConfigApplicationContext(TestConfig.class);
+        TerrakubeClient terrakubeClient = context.getBean(TerrakubeClient.class);
+        CommonSearchService commonSearchService = context.getBean(CommonSearchService.class);
+        StorageService storageService = context.getBean(StorageService.class);
+        ModuleService moduleService = context.getBean(ModuleService.class);
+
+        when(commonSearchService.getOrganizationId("org")).thenReturn("org-id");
+
+        Module module = new Module();
+        module.setId("module-id");
+        ModuleAttributes attributes = new ModuleAttributes();
+        attributes.setSource("git::https://example.com/org/module.git");
+        module.setAttributes(attributes);
+        Relationships relationships = new Relationships();
+        relationships.setVcs(new VcsData());
+        relationships.setSsh(new SshData());
+        module.setRelationships(relationships);
+
+        Response<List<Module>> moduleResponse = new Response<>();
+        moduleResponse.setData(List.of(module));
+        when(terrakubeClient.getModuleByNameAndProvider("org-id", "module", "aws")).thenReturn(moduleResponse);
+
+        ModuleVersion moduleVersion = new ModuleVersion();
+        ModuleVersionAttributes versionAttributes = new ModuleVersionAttributes();
+        versionAttributes.setVersion("1.0.0");
+        versionAttributes.setGitTag("v1.0.0");
+        moduleVersion.setAttributes(versionAttributes);
+
+        Response<List<ModuleVersion>> versionResponse = new Response<>();
+        versionResponse.setData(List.of(moduleVersion));
+        when(terrakubeClient.getAllVersionsByOrganizationIdAndModuleId("org-id", "module-id"))
+                .thenReturn(versionResponse);
+
+        when(storageService.searchModule(anyString(), anyString(), anyString(), any()))
+                .thenReturn("https://registry.example.com/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip");
+
+        String first = moduleService.getModuleVersionPath("org", "module", "aws", "1.0.0");
+        String second = moduleService.getModuleVersionPath("org", "module", "aws", "1.0.0");
+
+        assertEquals(first, second);
+        verify(commonSearchService, times(1)).getOrganizationId("org");
+        verify(terrakubeClient, times(1)).getModuleByNameAndProvider(anyString(), anyString(), anyString());
+        verify(storageService, times(1)).searchModule(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    void getModuleVersionPathWithNullGitTagDoesNotThrowException() {
+        context = new AnnotationConfigApplicationContext(TestConfig.class);
+        TerrakubeClient terrakubeClient = context.getBean(TerrakubeClient.class);
+        CommonSearchService commonSearchService = context.getBean(CommonSearchService.class);
+        StorageService storageService = context.getBean(StorageService.class);
+        ModuleService moduleService = context.getBean(ModuleService.class);
+
+        when(commonSearchService.getOrganizationId("org")).thenReturn("org-id");
+
+        Module module = new Module();
+        module.setId("module-id");
+        ModuleAttributes attributes = new ModuleAttributes();
+        attributes.setSource("git::https://example.com/org/module.git");
+        module.setAttributes(attributes);
+        Relationships relationships = new Relationships();
+        relationships.setVcs(new VcsData());
+        relationships.setSsh(new SshData());
+        module.setRelationships(relationships);
+
+        Response<List<Module>> moduleResponse = new Response<>();
+        moduleResponse.setData(List.of(module));
+        when(terrakubeClient.getModuleByNameAndProvider("org-id", "module", "aws")).thenReturn(moduleResponse);
+
+        ModuleVersion moduleVersion = new ModuleVersion();
+        ModuleVersionAttributes versionAttributes = new ModuleVersionAttributes();
+        versionAttributes.setVersion("1.0.0");
+        versionAttributes.setGitTag(null);
+        moduleVersion.setAttributes(versionAttributes);
+
+        Response<List<ModuleVersion>> versionResponse = new Response<>();
+        versionResponse.setData(List.of(moduleVersion));
+        when(terrakubeClient.getAllVersionsByOrganizationIdAndModuleId("org-id", "module-id"))
+                .thenReturn(versionResponse);
+
+        org.mockito.ArgumentCaptor<io.terrakube.registry.service.git.ModuleVersionDownload> captor =
+                org.mockito.ArgumentCaptor.forClass(io.terrakube.registry.service.git.ModuleVersionDownload.class);
+        when(storageService.searchModule(anyString(), anyString(), anyString(), captor.capture()))
+                .thenReturn("https://registry.example.com/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip");
+
+        String result = moduleService.getModuleVersionPath("org", "module", "aws", "1.0.0");
+
+        assertEquals("https://registry.example.com/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip", result);
+        org.junit.jupiter.api.Assertions.assertNull(captor.getValue().gitTag());
+    }
+
+    @Test
+    void getModuleVersionPathWithNullVersionResponseDoesNotThrowException() {
+        context = new AnnotationConfigApplicationContext(TestConfig.class);
+        TerrakubeClient terrakubeClient = context.getBean(TerrakubeClient.class);
+        CommonSearchService commonSearchService = context.getBean(CommonSearchService.class);
+        StorageService storageService = context.getBean(StorageService.class);
+        ModuleService moduleService = context.getBean(ModuleService.class);
+
+        when(commonSearchService.getOrganizationId("org")).thenReturn("org-id");
+
+        Module module = new Module();
+        module.setId("module-id");
+        ModuleAttributes attributes = new ModuleAttributes();
+        attributes.setSource("git::https://example.com/org/module.git");
+        module.setAttributes(attributes);
+        Relationships relationships = new Relationships();
+        relationships.setVcs(new VcsData());
+        relationships.setSsh(new SshData());
+        module.setRelationships(relationships);
+
+        Response<List<Module>> moduleResponse = new Response<>();
+        moduleResponse.setData(List.of(module));
+        when(terrakubeClient.getModuleByNameAndProvider("org-id", "module", "aws")).thenReturn(moduleResponse);
+
+        when(terrakubeClient.getAllVersionsByOrganizationIdAndModuleId("org-id", "module-id"))
+                .thenReturn(null);
+
+        org.mockito.ArgumentCaptor<io.terrakube.registry.service.git.ModuleVersionDownload> captor =
+                org.mockito.ArgumentCaptor.forClass(io.terrakube.registry.service.git.ModuleVersionDownload.class);
+        when(storageService.searchModule(anyString(), anyString(), anyString(), captor.capture()))
+                .thenReturn("https://registry.example.com/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip");
+
+        String result = moduleService.getModuleVersionPath("org", "module", "aws", "1.0.0");
+
+        assertEquals("https://registry.example.com/terraform/modules/v1/download/org/module/aws/1.0.0/module.zip", result);
+        org.junit.jupiter.api.Assertions.assertNull(captor.getValue().gitTag());
+    }
+}

--- a/ui/src/__verify_ctrl_click.test.tsx
+++ b/ui/src/__verify_ctrl_click.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { List } from "antd";
+import { Link, MemoryRouter } from "react-router-dom";
 import OrganizationTable from "./modules/organizations/components/OrganizationTable/OrganizationTable";
 import OrganizationGridItem from "./modules/organizations/components/OrganizationGrid/OrganizationGridItem";
 import WorkspaceTable from "./modules/workspaces/components/WorkspaceTable/WorkspaceTable";
+import WorkspaceCard from "./modules/workspaces/components/WorkspaceCard";
 
 jest.mock("@/modules/permissions/useOrgPermissions", () => ({
   useOrgPermissions: () => ({ permissions: { managePermission: false }, loading: false }),
@@ -54,6 +56,37 @@ test("organization grid card is a real anchor pointing at the org workspaces URL
   expect(link.tagName).toBe("A");
   expect(link.getAttribute("href")).toBe("/organizations/org-1/workspaces");
   expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+});
+
+test("workspace card list item overlays a real anchor that stacks above the card", () => {
+  // The card list in OrganizationDetailsPage puts an absolutely-positioned <Link>
+  // behind each <WorkspaceCard>. antd's `.ant-card` is `position: relative`, so the
+  // card and its content paint in the same layer as (and, being later in the DOM,
+  // on top of) an overlay link with `z-index: 0` — which swallows every click.
+  // The overlay must carry a positive z-index to sit above the card.
+  render(
+    <MemoryRouter>
+      <List
+        dataSource={[workspace]}
+        renderItem={(item) => (
+          <List.Item style={{ position: "relative" }}>
+            <Link
+              to={`/organizations/org-1/workspaces/${item.id}`}
+              aria-label={`Open workspace ${item.name}`}
+              style={{ position: "absolute", inset: 0, zIndex: 1 }}
+            />
+            <WorkspaceCard tags={[]} item={item} />
+          </List.Item>
+        )}
+      />
+    </MemoryRouter>
+  );
+
+  const link = screen.getByRole("link", { name: /open workspace my workspace/i });
+  expect(link.tagName).toBe("A");
+  expect(link.getAttribute("href")).toBe("/organizations/org-1/workspaces/ws-1");
+  expect(link.style.position).toBe("absolute");
+  expect(Number(link.style.zIndex)).toBeGreaterThan(0);
 });
 
 test("workspace table row is a real anchor pointing at the workspace URL", () => {

--- a/ui/src/modules/organizations/OrganizationDetailsPage.tsx
+++ b/ui/src/modules/organizations/OrganizationDetailsPage.tsx
@@ -211,7 +211,7 @@ export default function OrganizationsDetailPage({ organizationName, setOrganizat
                 <Link
                   to={`/organizations/${id}/workspaces/${item.id}`}
                   aria-label={`Open workspace ${item.name}`}
-                  style={{ position: "absolute", inset: 0, zIndex: 0 }}
+                  style={{ position: "absolute", inset: 0, zIndex: 1 }}
                 />
                 <WorkspaceCard tags={tags} item={item} />
               </List.Item>

--- a/ui/src/modules/workspaces/components/WorkspaceCard.tsx
+++ b/ui/src/modules/workspaces/components/WorkspaceCard.tsx
@@ -64,7 +64,7 @@ export default function WorkspaceCard({ item, tags }: Props) {
                 target="_blank"
                 rel="noreferrer"
                 onClick={(e) => e.stopPropagation()}
-                style={{ position: "relative", zIndex: 1 }}
+                style={{ position: "relative", zIndex: 2 }}
               >
                 {item.normalizedSource ? getVcsNameFromUrl(item.normalizedSource) : "Unknown"}
               </Typography.Link>


### PR DESCRIPTION
Completes an approved job that has no remaining flow steps, and requires every approval permission path to transition only from `waitingApproval` to `approved` or `rejected`. Includes a scheduler regression test.