### PR TITLE
fix: downgrade FlowConfig log from INFO to DEBUG to prevent false ERROR detection (#3544)

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/TclService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/TclService.java
@@ -66,7 +66,7 @@ public class TclService {
             } else {
                 flowConfig = getFlowConfig(job.getTcl());
             }
-            log.info("Custom Job Setup: \n {}", flowConfig.toString());
+            log.debug("Custom Job Setup: \n {}", flowConfig.toString());
 
             // Sequential on purpose: these save() calls must participate in this method's
             // transaction. parallelStream() would run them on ForkJoinPool worker threads that
@@ -97,9 +97,11 @@ public class TclService {
         Yaml yaml = new Yaml(new Constructor(FlowConfig.class, new LoaderOptions()));
         FlowConfig flowConfig = null;
         try {
-            FlowConfig temp = yaml.load(new String(Base64.getDecoder().decode(tcl)));
-            log.info("FlowConfig: \n {}", temp);
             flowConfig = yaml.load(new String(Base64.getDecoder().decode(tcl)));
+            // Log at DEBUG to avoid keyword-based monitors (e.g. Datadog, CloudWatch, Loki)
+            // flagging the FlowConfig toString() output (which contains "error=null" field text)
+            // as ERROR-level events in healthy runs. See: https://github.com/terrakube-io/terrakube/issues/3544
+            log.debug("FlowConfig: \n {}", flowConfig);
 
             if (flowConfig.getFlow().isEmpty()) {
                 log.error("Exception parsing yaml: template with no flows");


### PR DESCRIPTION
## Summary

Fixes #3544

Downgrade two verbose diagnostic log statements in `TclService` from `INFO` to `DEBUG`, and remove a redundant double YAML parse that existed purely to support one of them.

---

## Problem

On every Terrakube job execution, `TclService.getFlowConfig()` logs the parsed `FlowConfig` object at `INFO` level:

```
1789065579476    2026-09-10T18:39:39.476Z     FlowConfig(flow=[Flow(type=terraformPlan, team=null, name=Plan, ignoreError=false, error=null, step=100, ...)])
```

Because `FlowConfig` and `Flow` use Lombok `@ToString`, the resulting string **contains the field name `error=null`**. Keyword-based log monitoring systems (Datadog, CloudWatch Logs Insights, Grafana Loki, Splunk, etc.) commonly match lines containing the word `error` and flag them as `ERROR`-severity events — even though the run completed successfully.

This creates false-positive alerts that degrade the signal-to-noise ratio of production monitoring and make it harder to detect real failures.

A secondary issue: `getFlowConfig()` decoded and parsed the Base64 YAML **twice** — first into a `temp` variable that was only used for the log statement, and then again into `flowConfig` which was actually used. This was wasteful and unnecessary.

---

## Changes

**File:** `api/src/main/java/io/terrakube/api/plugin/scheduler/job/tcl/TclService.java`

### `getFlowConfig(String tcl)`

- **Remove** the intermediate `temp` variable and the redundant second `yaml.load()` call. The single `flowConfig` result is now reused for both logging and the empty-flow check.
- **Downgrade** `log.info("FlowConfig: \n {}", ...)` → `log.debug(...)` with an explanatory comment referencing this issue.

### `initJobConfiguration(Job job)`

- **Downgrade** `log.info("Custom Job Setup: \n {}", flowConfig.toString())` → `log.debug(...)`. This statement logs the same `FlowConfig` object and is subject to the same false-positive risk.

---

## Before / After

### Before
```java
private FlowConfig getFlowConfig(String tcl) {
    Yaml yaml = new Yaml(new Constructor(FlowConfig.class, new LoaderOptions()));
    FlowConfig flowConfig = null;
    try {
        FlowConfig temp = yaml.load(new String(Base64.getDecoder().decode(tcl)));
        log.info("FlowConfig: \n {}", temp);           // ← INFO, triggers monitors
        flowConfig = yaml.load(new String(Base64.getDecoder().decode(tcl)));  // ← redundant parse

        if (flowConfig.getFlow().isEmpty()) { ... }
    } catch (Exception ex) { ... }
    return flowConfig;
}
```

### After
```java
private FlowConfig getFlowConfig(String tcl) {
    Yaml yaml = new Yaml(new Constructor(FlowConfig.class, new LoaderOptions()));
    FlowConfig flowConfig = null;
    try {
        flowConfig = yaml.load(new String(Base64.getDecoder().decode(tcl)));  // single parse
        // Log at DEBUG to avoid keyword-based monitors (e.g. Datadog, CloudWatch, Loki)
        // flagging the FlowConfig toString() output (which contains "error=null" field text)
        // as ERROR-level events in healthy runs. See: https://github.com/terrakube-io/terrakube/issues/3544
        log.debug("FlowConfig: \n {}", flowConfig);    // ← DEBUG only

        if (flowConfig.getFlow().isEmpty()) { ... }
    } catch (Exception ex) { ... }
    return flowConfig;
}
```

---

## Impact

- **No functional change.** The fix is purely in log level and eliminates a redundant computation.
- **Operators** who need this diagnostic output can enable `DEBUG` logging for `io.terrakube.api.plugin.scheduler.job.tcl.TclService` at runtime without redeployment.
- **Monitoring reliability** is improved: `log.error(...)` calls in `TclService` now only fire on genuine failures (empty flow or YAML parse exception), so error alerts become meaningful again.

---

## Testing

- Existing unit tests for `TclService` / `ScheduleJob` continue to pass unchanged — the log level change does not affect behavior under test.
- Manually verified with a standard plan+apply run: no `FlowConfig` lines appear in INFO logs; genuine YAML-parse errors still log at ERROR.

---

## Related

- Closes #3544
- Branch: `fix/3544-flowconfig-log-level-noise`