### PR TITLE
feat: workspace dependency graph and run triggers

### DIFF
--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationService.java
@@ -2,6 +2,7 @@ package io.terrakube.api.plugin.scheduler.reconciliation;
 
 import io.terrakube.api.plugin.notification.JobNotificationTrigger;
 import io.terrakube.api.plugin.scheduler.ScheduleJobService;
+import io.terrakube.api.plugin.scheduler.trigger.RunTriggerDispatchService;
 import io.terrakube.api.plugin.scheduler.reconciliation.ReconciliationResult.ReconciliationDisposition;
 import io.terrakube.api.plugin.scheduler.reconciliation.ReconciliationResult.StepEvidence;
 import io.terrakube.api.repository.JobRepository;
@@ -55,6 +56,7 @@ public class JobReconciliationService {
     private final ScheduleJobService scheduleJobService;
     private final Scheduler scheduler;
     private final JobReconciliationMetrics metrics;
+    private final RunTriggerDispatchService runTriggerDispatchService;
 
     @Transactional
     public ReconciliationResult reconcile(int jobId, boolean dryRun) {
@@ -103,6 +105,9 @@ public class JobReconciliationService {
         log.info("Reconciled job {} from {} to {} (derived {})", jobId, from, target, outcome);
 
         deleteTriggerAfterCommit(jobId);
+        if (target == JobStatus.completed) {
+            dispatchRunTriggersAfterCommit(jobId);
+        }
         return result(jobId, job, outcome, target, ReconciliationDisposition.APPLIED, evidence);
     }
 
@@ -153,6 +158,20 @@ public class JobReconciliationService {
         workspaceRepository.save(workspace);
     }
 
+    /**
+     * Fans out to the workspaces that depend on this one. Deliberately anchored here rather
+     * than in ScheduleJob: this method is the only routine that performs the transition to a
+     * terminal status, it does so under a row lock, and an already-terminal job never reaches
+     * this point - so a completed run dispatches its triggers exactly once even with several
+     * API replicas competing for the same job.
+     *
+     * <p>After commit, like the Quartz cleanup above, so that a dispatch problem can never
+     * roll back the completion of the run that fired it.
+     */
+    private void dispatchRunTriggersAfterCommit(int jobId) {
+        afterCommit(() -> runTriggerDispatchService.dispatchFor(jobId));
+    }
+
     private void deleteTriggerAfterCommit(int jobId) {
         Runnable delete = () -> {
             try {
@@ -169,15 +188,23 @@ public class JobReconciliationService {
                 log.warn("Could not remove Quartz trigger for reconciled job {}: {}", jobId, e.getMessage());
             }
         };
+        afterCommit(delete);
+    }
+
+    /**
+     * Runs the action once this method's transaction has committed, or immediately when there
+     * is none to wait for (the admin endpoint calls in without one).
+     */
+    private void afterCommit(Runnable action) {
         if (TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    delete.run();
+                    action.run();
                 }
             });
         } else {
-            delete.run();
+            action.run();
         }
     }
 }

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/trigger/CyclicDependencyException.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/trigger/CyclicDependencyException.java
@@ -1,0 +1,15 @@
+package io.terrakube.api.plugin.scheduler.trigger;
+
+import com.yahoo.elide.core.exceptions.HttpStatusException;
+import org.apache.hc.core5.http.HttpStatus;
+
+/**
+ * Raised when a run trigger would close a loop in the organization's dependency graph.
+ * Answered as 400: the request is well formed, the resulting graph is not.
+ */
+public class CyclicDependencyException extends HttpStatusException {
+
+    public CyclicDependencyException(String message) {
+        super(HttpStatus.SC_BAD_REQUEST, message);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/trigger/RunTriggerDispatchService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/trigger/RunTriggerDispatchService.java
@@ -1,0 +1,223 @@
+package io.terrakube.api.plugin.scheduler.trigger;
+
+import io.terrakube.api.plugin.notification.JobNotificationTrigger;
+import io.terrakube.api.plugin.scheduler.ScheduleJobService;
+import io.terrakube.api.plugin.scheduler.job.tcl.TclService;
+import io.terrakube.api.plugin.scheduler.job.tcl.model.FlowType;
+import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.repository.StepRepository;
+import io.terrakube.api.repository.WorkspaceRunTriggerRepository;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.JobVia;
+import io.terrakube.api.rs.job.step.Step;
+import io.terrakube.api.rs.workspace.Workspace;
+import io.terrakube.api.rs.workspace.trigger.WorkspaceRunTrigger;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Enqueues the downstream runs of a workspace whose run just changed state.
+ *
+ * <p>Called by {@link io.terrakube.api.plugin.scheduler.reconciliation.JobReconciliationService}
+ * after it commits a job's transition to {@code completed}, which is the one routine in the
+ * system that performs that transition. That placement is what gives dispatch its
+ * exactly-once property: the transition is taken under a row lock and an already-terminal job
+ * short-circuits, so only the caller that actually moved the job reaches this service, even
+ * with several API replicas racing on the same job.
+ *
+ * <p>Runs in its own transaction after the commit rather than inside it. A trigger that
+ * cannot be dispatched must never roll back the completion of the run that fired it, and the
+ * Quartz context created for each downstream job is not transactional to begin with.
+ */
+@Slf4j
+@Service
+@AllArgsConstructor
+public class RunTriggerDispatchService {
+
+    /**
+     * Flow types that change remote state. A run made only of plans leaves nothing for a
+     * dependent to react to, so it does not fire triggers. Mirrors the qualification
+     * ScheduleJob.isActiveApplyOrDestroyRunning already applies for queue admission.
+     */
+    private static final Set<String> STATE_CHANGING_FLOWS = Set.of(
+            FlowType.terraformApply.toString(),
+            FlowType.terraformDestroy.toString(),
+            FlowType.customScripts.toString());
+
+    private final JobRepository jobRepository;
+    private final StepRepository stepRepository;
+    private final WorkspaceRunTriggerRepository workspaceRunTriggerRepository;
+    private final TclService tclService;
+    private final JobNotificationTrigger jobNotificationTrigger;
+    private final ScheduleJobService scheduleJobService;
+    private final RunTriggerProperties properties;
+
+    /**
+     * Fans out from a job that has just completed. Takes the id rather than the entity because
+     * the caller invokes this after its own transaction has committed: re-reading here keeps
+     * every association attached to a live session instead of relying on what happened to be
+     * initialised upstream.
+     *
+     * <p>Never throws. The upstream run is already finished and recorded; a dispatch problem
+     * is an operational event to be logged, not a reason to surface an error on a run that
+     * succeeded.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void dispatchFor(int completedJobId) {
+        try {
+            dispatchInternal(completedJobId);
+        } catch (Exception e) {
+            log.error("Run trigger dispatch failed for job {}: {}", completedJobId, e.getMessage(), e);
+        }
+    }
+
+    private void dispatchInternal(int completedJobId) {
+        if (!properties.isEnabled()) {
+            return;
+        }
+
+        Job completedJob = jobRepository.findById(completedJobId).orElse(null);
+        if (completedJob == null || completedJob.getWorkspace() == null) {
+            return;
+        }
+
+        if (!changedState(completedJob)) {
+            log.debug("Job {} changed no state, no run trigger dispatched", completedJobId);
+            return;
+        }
+
+        // Checked before loading the edges: at the limit the answer is the same for every
+        // dependent, and saying so once is more useful than repeating it per edge.
+        int nextDepth = completedJob.getCascadeDepth() + 1;
+        if (nextDepth > properties.getMaxCascadeDepth()) {
+            log.warn("Job {} reached the run trigger cascade limit of {}, not dispatching further",
+                    completedJobId, properties.getMaxCascadeDepth());
+            return;
+        }
+
+        List<WorkspaceRunTrigger> triggers = workspaceRunTriggerRepository
+                .findEnabledBySourceWorkspaceId(completedJob.getWorkspace().getId());
+        if (triggers.isEmpty()) {
+            return;
+        }
+
+        List<WorkspaceRunTrigger> dispatchable = applyFanOutLimit(triggers, completedJob);
+
+        for (WorkspaceRunTrigger trigger : dispatchable) {
+            // Per-dependent isolation: one workspace missing a template, or failing to
+            // schedule, must not cost the dependents that come after it in the list.
+            try {
+                enqueue(trigger, completedJob, nextDepth);
+            } catch (Exception e) {
+                log.error("Could not enqueue run triggered by job {} on workspace {}: {}",
+                        completedJobId, destinationName(trigger), e.getMessage(), e);
+            }
+        }
+    }
+
+    /**
+     * True when at least one step that actually ran changed remote state. Steps are checked
+     * individually rather than trusting the job status: a plan/apply template whose apply was
+     * never executed still finishes as completed, and has nothing downstream to react to.
+     */
+    private boolean changedState(Job job) {
+        List<Step> steps = stepRepository.findByJobId(job.getId());
+        for (Step step : steps) {
+            if (step.getStatus() != JobStatus.completed) {
+                continue;
+            }
+            String flowType = tclService.getFlowTypeForStep(job, step.getStepNumber());
+            if (flowType != null && STATE_CHANGING_FLOWS.contains(flowType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Caps the fan-out, keeping a stable prefix so that a graph over the limit dispatches the
+     * same dependents on every apply instead of a different arbitrary subset each time.
+     */
+    private List<WorkspaceRunTrigger> applyFanOutLimit(List<WorkspaceRunTrigger> triggers, Job completedJob) {
+        int limit = properties.getMaxDependentsPerApply();
+        if (triggers.size() <= limit) {
+            return triggers;
+        }
+
+        List<WorkspaceRunTrigger> ordered = triggers.stream()
+                .sorted(Comparator.comparing(t -> t.getDestinationWorkspace().getId()))
+                .toList();
+        List<WorkspaceRunTrigger> skipped = ordered.subList(limit, ordered.size());
+        log.warn("Workspace {} has {} enabled run triggers, above the limit of {}. Job {} will not "
+                        + "dispatch to: {}",
+                completedJob.getWorkspace().getName(), triggers.size(), limit, completedJob.getId(),
+                skipped.stream().map(RunTriggerDispatchService::destinationName).toList());
+        return ordered.subList(0, limit);
+    }
+
+    private void enqueue(WorkspaceRunTrigger trigger, Job completedJob, int depth) throws Exception {
+        Workspace destination = trigger.getDestinationWorkspace();
+
+        String templateReference = resolveTemplate(trigger, destination);
+        if (templateReference == null || templateReference.isBlank()) {
+            log.warn("Run trigger {} has no template and workspace {} has no default template, skipping",
+                    trigger.getId(), destination.getName());
+            return;
+        }
+
+        Date now = new Date(System.currentTimeMillis());
+        Job job = new Job();
+        job.setWorkspace(destination);
+        job.setOrganization(destination.getOrganization());
+        job.setTemplateReference(templateReference);
+        job.setStatus(JobStatus.pending);
+        job.setRefresh(true);
+        job.setPlanChanges(true);
+        job.setRefreshOnly(false);
+        job.setVia(JobVia.RUN_TRIGGER.getValue());
+        job.setTriggeredByJobId(completedJob.getId());
+        job.setCascadeDepth(depth);
+        job.setCreatedBy("serviceAccount");
+        job.setUpdatedBy("serviceAccount");
+        job.setCreatedDate(now);
+        job.setUpdatedDate(now);
+
+        Job savedJob = jobRepository.save(job);
+
+        // A plain repository save bypasses Elide, so neither JobNotificationHook nor
+        // JobManageHook fires for this job: the status event and the Quartz context both have
+        // to be raised here, exactly as ScheduleJobTrigger does for scheduled runs.
+        jobNotificationTrigger.notifyStatusChanged(savedJob);
+        scheduleJobService.createJobContext(savedJob);
+
+        log.info("Job {} triggered job {} on workspace {} (depth {})",
+                completedJob.getId(), savedJob.getId(), destination.getName(), depth);
+    }
+
+    /**
+     * The trigger's own template wins, then the destination's default. A locked destination is
+     * deliberately not special-cased: the job is enqueued as pending and ScheduleJob admits it
+     * once the lock clears, because skipping would leave the dependent silently drifted, which
+     * is the very thing run triggers exist to prevent.
+     */
+    private String resolveTemplate(WorkspaceRunTrigger trigger, Workspace destination) {
+        if (trigger.getTemplate() != null) {
+            return trigger.getTemplate().getId().toString();
+        }
+        return destination.getDefaultTemplate();
+    }
+
+    private static String destinationName(WorkspaceRunTrigger trigger) {
+        Workspace destination = trigger.getDestinationWorkspace();
+        return destination != null ? destination.getName() : "unknown";
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/trigger/RunTriggerDispatchService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/trigger/RunTriggerDispatchService.java
@@ -9,18 +9,14 @@ import io.terrakube.api.repository.StepRepository;
 import io.terrakube.api.repository.WorkspaceRunTriggerRepository;
 import io.terrakube.api.rs.job.Job;
 import io.terrakube.api.rs.job.JobStatus;
-import io.terrakube.api.rs.job.JobVia;
 import io.terrakube.api.rs.job.step.Step;
 import io.terrakube.api.rs.workspace.Workspace;
 import io.terrakube.api.rs.workspace.trigger.WorkspaceRunTrigger;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
-import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -34,9 +30,16 @@ import java.util.Set;
  * short-circuits, so only the caller that actually moved the job reaches this service, even
  * with several API replicas racing on the same job.
  *
- * <p>Runs in its own transaction after the commit rather than inside it. A trigger that
- * cannot be dispatched must never roll back the completion of the run that fired it, and the
- * Quartz context created for each downstream job is not transactional to begin with.
+ * <p>Deliberately not transactional. Each dependent is committed on its own by
+ * {@link RunTriggerJobWriter}, and the Quartz trigger for it is created only afterwards: while
+ * an insert is still open its row is invisible to the Quartz worker, which reads on another
+ * connection and treats a job it cannot find as deleted. Holding one transaction across the
+ * fan-out would also let a single failed insert roll back every job created beside it, since
+ * catching the exception does not clear the rollback-only mark.
+ *
+ * <p>The reads it does need no outer transaction: the completed job materialises its workspace
+ * and organization eagerly, and the dispatch query fetches destination, organization and
+ * template through its entity graph.
  */
 @Slf4j
 @Service
@@ -57,6 +60,7 @@ public class RunTriggerDispatchService {
     private final StepRepository stepRepository;
     private final WorkspaceRunTriggerRepository workspaceRunTriggerRepository;
     private final TclService tclService;
+    private final RunTriggerJobWriter jobWriter;
     private final JobNotificationTrigger jobNotificationTrigger;
     private final ScheduleJobService scheduleJobService;
     private final RunTriggerProperties properties;
@@ -71,7 +75,6 @@ public class RunTriggerDispatchService {
      * is an operational event to be logged, not a reason to surface an error on a run that
      * succeeded.
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void dispatchFor(int completedJobId) {
         try {
             dispatchInternal(completedJobId);
@@ -167,6 +170,8 @@ public class RunTriggerDispatchService {
     private void enqueue(WorkspaceRunTrigger trigger, Job completedJob, int depth) throws Exception {
         Workspace destination = trigger.getDestinationWorkspace();
 
+        // Resolved here rather than in the writer: it reads fields already loaded by the
+        // dispatch query, so it costs nothing and keeps the writer to a single concern.
         String templateReference = resolveTemplate(trigger, destination);
         if (templateReference == null || templateReference.isBlank()) {
             log.warn("Run trigger {} has no template and workspace {} has no default template, skipping",
@@ -174,28 +179,12 @@ public class RunTriggerDispatchService {
             return;
         }
 
-        Date now = new Date(System.currentTimeMillis());
-        Job job = new Job();
-        job.setWorkspace(destination);
-        job.setOrganization(destination.getOrganization());
-        job.setTemplateReference(templateReference);
-        job.setStatus(JobStatus.pending);
-        job.setRefresh(true);
-        job.setPlanChanges(true);
-        job.setRefreshOnly(false);
-        job.setVia(JobVia.RUN_TRIGGER.getValue());
-        job.setTriggeredByJobId(completedJob.getId());
-        job.setCascadeDepth(depth);
-        job.setCreatedBy("serviceAccount");
-        job.setUpdatedBy("serviceAccount");
-        job.setCreatedDate(now);
-        job.setUpdatedDate(now);
+        Job savedJob = jobWriter.persist(destination, templateReference, completedJob, depth);
 
-        Job savedJob = jobRepository.save(job);
-
-        // A plain repository save bypasses Elide, so neither JobNotificationHook nor
-        // JobManageHook fires for this job: the status event and the Quartz context both have
-        // to be raised here, exactly as ScheduleJobTrigger does for scheduled runs.
+        // Only now that the row is committed and visible to other connections. A plain
+        // repository save also bypasses Elide, so neither JobNotificationHook nor JobManageHook
+        // fires for this job and both side effects have to be raised by hand, exactly as
+        // ScheduleJobTrigger does for scheduled runs.
         jobNotificationTrigger.notifyStatusChanged(savedJob);
         scheduleJobService.createJobContext(savedJob);
 

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/trigger/RunTriggerJobWriter.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/trigger/RunTriggerJobWriter.java
@@ -1,0 +1,67 @@
+package io.terrakube.api.plugin.scheduler.trigger;
+
+import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.JobVia;
+import io.terrakube.api.rs.workspace.Workspace;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+/**
+ * Commits one triggered job, and nothing else.
+ *
+ * <p>A separate bean on purpose. The transaction boundary has to be per dependent, and it has
+ * to close before the caller schedules the job with Quartz - two requirements that a
+ * {@code @Transactional} method called from inside {@link RunTriggerDispatchService} would not
+ * meet, because a self-invocation never passes through the Spring proxy.
+ *
+ * <p>Why per dependent: a failed insert marks its transaction rollback-only, and catching the
+ * exception does not clear that mark. Sharing one transaction across the fan-out would let a
+ * single bad dependent roll back every job already created beside it, right through the
+ * try/catch that exists to prevent exactly that.
+ *
+ * <p>Why it must commit before scheduling: {@code ScheduleJobService.createJobContext} fires
+ * the Quartz trigger immediately, and the worker picks the job up on another connection. While
+ * this transaction is open that row is invisible, and ScheduleJob treats a job it cannot find
+ * as deleted and drops the trigger for good. Elide's JobManageHook avoids the same trap by
+ * binding to POSTCOMMIT.
+ */
+@Service
+@AllArgsConstructor
+class RunTriggerJobWriter {
+
+    private final JobRepository jobRepository;
+
+    /**
+     * The destination and its organization arrive detached, from the caller's own read. That is
+     * safe here: both are plain ManyToOne associations with no cascade, so only their foreign
+     * keys are written.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Job persist(Workspace destination, String templateReference, Job completedJob, int depth) {
+        Date now = new Date(System.currentTimeMillis());
+
+        Job job = new Job();
+        job.setWorkspace(destination);
+        job.setOrganization(destination.getOrganization());
+        job.setTemplateReference(templateReference);
+        job.setStatus(JobStatus.pending);
+        job.setRefresh(true);
+        job.setPlanChanges(true);
+        job.setRefreshOnly(false);
+        job.setVia(JobVia.RUN_TRIGGER.getValue());
+        job.setTriggeredByJobId(completedJob.getId());
+        job.setCascadeDepth(depth);
+        job.setCreatedBy("serviceAccount");
+        job.setUpdatedBy("serviceAccount");
+        job.setCreatedDate(now);
+        job.setUpdatedDate(now);
+
+        return jobRepository.save(job);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/trigger/RunTriggerProperties.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/trigger/RunTriggerProperties.java
@@ -1,0 +1,35 @@
+package io.terrakube.api.plugin.scheduler.trigger;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Bounds on the run trigger dispatch engine. The defaults are deliberately conservative: a
+ * dependency graph that needs more than these numbers is more likely a mistake than a
+ * legitimate topology, and both limits exist so that a mistake degrades loudly instead of
+ * saturating the executors.
+ */
+@Component
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "io.terrakube.run-trigger")
+public class RunTriggerProperties {
+
+    /** Kill switch. When false no downstream run is ever enqueued; edges stay configurable. */
+    private boolean enabled = true;
+
+    /**
+     * How deep a chain of triggered runs may go. Phase 2 rejects cycles when an edge is
+     * created, but two concurrent creations can each pass validation and together close a
+     * loop; this is the runtime net that stops such a loop from running forever.
+     */
+    private int maxCascadeDepth = 10;
+
+    /**
+     * How many dependents a single apply may fan out to. Beyond this the extra dependents
+     * are skipped with a warning naming them, rather than the whole fan-out being dropped.
+     */
+    private int maxDependentsPerApply = 20;
+}

--- a/api/src/main/java/io/terrakube/api/plugin/scheduler/trigger/WorkspaceGraphValidationService.java
+++ b/api/src/main/java/io/terrakube/api/plugin/scheduler/trigger/WorkspaceGraphValidationService.java
@@ -1,0 +1,134 @@
+package io.terrakube.api.plugin.scheduler.trigger;
+
+import io.terrakube.api.repository.WorkspaceRunTriggerRepository;
+import io.terrakube.api.repository.WorkspaceRunTriggerRepository.TriggerEdge;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Keeps an organization's run trigger graph acyclic.
+ *
+ * A cycle would mean an apply on any of its workspaces re-triggering itself indefinitely.
+ * The runtime cascade limit bounds the damage, but a graph that cannot loop in the first
+ * place is better than one that stops looping after ten hops.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WorkspaceGraphValidationService {
+
+    private final WorkspaceRunTriggerRepository workspaceRunTriggerRepository;
+
+    /**
+     * Rejects an edge that would close a loop.
+     *
+     * @param organizationId owner of the graph
+     * @param triggerId      the edge being written, excluded from the graph so an update is
+     *                       validated against its new shape rather than its old one
+     * @param sourceId       upstream workspace
+     * @param destinationId  downstream workspace
+     */
+    public void validateAcyclic(UUID organizationId, UUID triggerId, UUID sourceId, UUID destinationId) {
+        if (organizationId == null || sourceId == null || destinationId == null) {
+            return;
+        }
+
+        // Caught earlier by the security check and by a database constraint; repeated here so
+        // the service is correct on its own rather than by arrangement with its callers.
+        if (sourceId.equals(destinationId)) {
+            throw new CyclicDependencyException(
+                    "A workspace cannot trigger itself.");
+        }
+
+        Map<UUID, Set<UUID>> adjacency = loadGraphExcluding(organizationId, triggerId);
+
+        // The new edge points source -> destination. It closes a loop only if the graph
+        // already lets you walk from destination back to source.
+        List<UUID> loop = findPath(adjacency, destinationId, sourceId);
+        if (loop != null) {
+            String path = describe(loop, destinationId);
+            log.warn("Rejecting run trigger in organization {}: it would create the cycle {}",
+                    organizationId, path);
+            throw new CyclicDependencyException(
+                    "This run trigger would create a circular dependency: " + path);
+        }
+    }
+
+    private Map<UUID, Set<UUID>> loadGraphExcluding(UUID organizationId, UUID excludedTriggerId) {
+        List<TriggerEdge> edges = workspaceRunTriggerRepository.findEdgesByOrganizationId(organizationId);
+        Map<UUID, Set<UUID>> adjacency = new HashMap<>();
+        for (TriggerEdge edge : edges) {
+            // On update the row is already flushed, so the edge under validation has to be
+            // left out or it would be mistaken for a pre-existing dependency.
+            if (excludedTriggerId != null && excludedTriggerId.equals(edge.getId())) {
+                continue;
+            }
+            adjacency.computeIfAbsent(edge.getSourceId(), k -> new HashSet<>())
+                    .add(edge.getDestinationId());
+        }
+        return adjacency;
+    }
+
+    /**
+     * Iterative depth-first search from {@code from} to {@code target}, returning the path
+     * when one exists. Iterative rather than recursive so a deep chain cannot overflow the
+     * stack, and visited-guarded so an existing cycle elsewhere in the graph cannot hang it.
+     */
+    private List<UUID> findPath(Map<UUID, Set<UUID>> adjacency, UUID from, UUID target) {
+        Set<UUID> visited = new HashSet<>();
+        Map<UUID, UUID> cameFrom = new HashMap<>();
+        Deque<UUID> stack = new ArrayDeque<>();
+
+        stack.push(from);
+        visited.add(from);
+
+        while (!stack.isEmpty()) {
+            UUID current = stack.pop();
+            if (current.equals(target)) {
+                return reconstruct(cameFrom, from, target);
+            }
+            for (UUID next : adjacency.getOrDefault(current, Set.of())) {
+                if (visited.add(next)) {
+                    cameFrom.put(next, current);
+                    stack.push(next);
+                }
+            }
+        }
+        return null;
+    }
+
+    private List<UUID> reconstruct(Map<UUID, UUID> cameFrom, UUID from, UUID target) {
+        List<UUID> path = new ArrayList<>();
+        UUID current = target;
+        path.add(current);
+        while (!current.equals(from)) {
+            current = cameFrom.get(current);
+            if (current == null) {
+                break;
+            }
+            path.add(current);
+        }
+        return path.reversed();
+    }
+
+    /** Renders the loop as source -> ... -> source so the error names the workspaces involved. */
+    private String describe(List<UUID> pathFromDestinationToSource, UUID destinationId) {
+        StringBuilder sb = new StringBuilder();
+        for (UUID node : pathFromDestinationToSource) {
+            sb.append(node).append(" -> ");
+        }
+        sb.append(destinationId);
+        return sb.toString();
+    }
+}

--- a/api/src/main/java/io/terrakube/api/repository/WorkspaceRunTriggerRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/WorkspaceRunTriggerRepository.java
@@ -23,11 +23,26 @@ public interface WorkspaceRunTriggerRepository extends JpaRepository<WorkspaceRu
     List<WorkspaceRunTrigger> findEnabledBySourceWorkspaceId(@Param("sourceId") UUID sourceId);
 
     /**
-     * Every edge of an organization, used to build the adjacency map for cycle detection.
-     * Only ids are needed there, so the workspaces are left lazy on purpose.
+     * Edges of an organization as bare ids, for building the adjacency map used by cycle
+     * detection. Returns a projection rather than entities so validating a graph never
+     * materializes workspaces.
+     *
+     * Disabled edges are included on purpose. Validating only the enabled ones would leave a
+     * hole: declare A -> B disabled, then B -> A (accepted, since the first does not count),
+     * then enable A -> B and the cycle exists without any validation having seen it. Keeping
+     * the declared graph acyclic means enabling an edge can never introduce one.
      */
-    @Query("SELECT t FROM workspace_run_trigger t WHERE t.organization.id = :organizationId AND t.enabled = true AND t.sourceWorkspace.deleted = false AND t.destinationWorkspace.deleted = false")
-    List<WorkspaceRunTrigger> findEnabledByOrganizationId(@Param("organizationId") UUID organizationId);
+    @Query("SELECT t.id AS id, t.sourceWorkspace.id AS sourceId, t.destinationWorkspace.id AS destinationId "
+            + "FROM workspace_run_trigger t WHERE t.organization.id = :organizationId "
+            + "AND t.sourceWorkspace.deleted = false AND t.destinationWorkspace.deleted = false")
+    List<TriggerEdge> findEdgesByOrganizationId(@Param("organizationId") UUID organizationId);
+
+    /** Projection of a single edge: which trigger, from where, to where. */
+    interface TriggerEdge {
+        UUID getId();
+        UUID getSourceId();
+        UUID getDestinationId();
+    }
 
     /** Triggers whose destination is the given workspace, for the UI's inbound list. */
     @EntityGraph(attributePaths = {"sourceWorkspace"})

--- a/api/src/main/java/io/terrakube/api/repository/WorkspaceRunTriggerRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/WorkspaceRunTriggerRepository.java
@@ -12,24 +12,26 @@ import java.util.UUID;
 public interface WorkspaceRunTriggerRepository extends JpaRepository<WorkspaceRunTrigger, UUID> {
 
     /**
-     * Enabled triggers fired by a source workspace. This runs on the dispatch path after
+     * Enabled triggers fired by a source workspace. Workspaces are soft-deleted, so the
+     * database FK cascade never fires and rows survive their endpoints; the explicit
+     * deleted = false guard is what keeps a removed destination out of the dispatch path. This runs on the dispatch path after
      * every completed apply, so it is backed by the (source_workspace_id, enabled) index and
      * fetches the destination eagerly to avoid a query per edge.
      */
     @EntityGraph(attributePaths = {"destinationWorkspace", "template"})
-    @Query("SELECT t FROM workspace_run_trigger t WHERE t.sourceWorkspace.id = :sourceId AND t.enabled = true")
+    @Query("SELECT t FROM workspace_run_trigger t WHERE t.sourceWorkspace.id = :sourceId AND t.enabled = true AND t.destinationWorkspace.deleted = false")
     List<WorkspaceRunTrigger> findEnabledBySourceWorkspaceId(@Param("sourceId") UUID sourceId);
 
     /**
      * Every edge of an organization, used to build the adjacency map for cycle detection.
      * Only ids are needed there, so the workspaces are left lazy on purpose.
      */
-    @Query("SELECT t FROM workspace_run_trigger t WHERE t.organization.id = :organizationId AND t.enabled = true")
+    @Query("SELECT t FROM workspace_run_trigger t WHERE t.organization.id = :organizationId AND t.enabled = true AND t.sourceWorkspace.deleted = false AND t.destinationWorkspace.deleted = false")
     List<WorkspaceRunTrigger> findEnabledByOrganizationId(@Param("organizationId") UUID organizationId);
 
     /** Triggers whose destination is the given workspace, for the UI's inbound list. */
     @EntityGraph(attributePaths = {"sourceWorkspace"})
-    @Query("SELECT t FROM workspace_run_trigger t WHERE t.destinationWorkspace.id = :destinationId")
+    @Query("SELECT t FROM workspace_run_trigger t WHERE t.destinationWorkspace.id = :destinationId AND t.sourceWorkspace.deleted = false")
     List<WorkspaceRunTrigger> findByDestinationWorkspaceId(@Param("destinationId") UUID destinationId);
 
     /** Guards the unique constraint with a friendly error instead of a DB violation. */

--- a/api/src/main/java/io/terrakube/api/repository/WorkspaceRunTriggerRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/WorkspaceRunTriggerRepository.java
@@ -1,0 +1,37 @@
+package io.terrakube.api.repository;
+
+import io.terrakube.api.rs.workspace.trigger.WorkspaceRunTrigger;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface WorkspaceRunTriggerRepository extends JpaRepository<WorkspaceRunTrigger, UUID> {
+
+    /**
+     * Enabled triggers fired by a source workspace. This runs on the dispatch path after
+     * every completed apply, so it is backed by the (source_workspace_id, enabled) index and
+     * fetches the destination eagerly to avoid a query per edge.
+     */
+    @EntityGraph(attributePaths = {"destinationWorkspace", "template"})
+    @Query("SELECT t FROM workspace_run_trigger t WHERE t.sourceWorkspace.id = :sourceId AND t.enabled = true")
+    List<WorkspaceRunTrigger> findEnabledBySourceWorkspaceId(@Param("sourceId") UUID sourceId);
+
+    /**
+     * Every edge of an organization, used to build the adjacency map for cycle detection.
+     * Only ids are needed there, so the workspaces are left lazy on purpose.
+     */
+    @Query("SELECT t FROM workspace_run_trigger t WHERE t.organization.id = :organizationId AND t.enabled = true")
+    List<WorkspaceRunTrigger> findEnabledByOrganizationId(@Param("organizationId") UUID organizationId);
+
+    /** Triggers whose destination is the given workspace, for the UI's inbound list. */
+    @EntityGraph(attributePaths = {"sourceWorkspace"})
+    @Query("SELECT t FROM workspace_run_trigger t WHERE t.destinationWorkspace.id = :destinationId")
+    List<WorkspaceRunTrigger> findByDestinationWorkspaceId(@Param("destinationId") UUID destinationId);
+
+    /** Guards the unique constraint with a friendly error instead of a DB violation. */
+    boolean existsBySourceWorkspaceIdAndDestinationWorkspaceId(UUID sourceWorkspaceId, UUID destinationWorkspaceId);
+}

--- a/api/src/main/java/io/terrakube/api/repository/WorkspaceRunTriggerRepository.java
+++ b/api/src/main/java/io/terrakube/api/repository/WorkspaceRunTriggerRepository.java
@@ -14,11 +14,15 @@ public interface WorkspaceRunTriggerRepository extends JpaRepository<WorkspaceRu
     /**
      * Enabled triggers fired by a source workspace. Workspaces are soft-deleted, so the
      * database FK cascade never fires and rows survive their endpoints; the explicit
-     * deleted = false guard is what keeps a removed destination out of the dispatch path. This runs on the dispatch path after
-     * every completed apply, so it is backed by the (source_workspace_id, enabled) index and
-     * fetches the destination eagerly to avoid a query per edge.
+     * deleted = false guard is what keeps a removed destination out of the dispatch path.
+     *
+     * This runs after every completed apply, so it is backed by the
+     * (source_workspace_id, enabled) index and fetches the destination eagerly to avoid a
+     * query per edge. The destination's organization comes along for a stronger reason than
+     * cost: dispatch happens on a Quartz worker thread with no open session, where reaching
+     * it lazily would throw LazyInitializationException.
      */
-    @EntityGraph(attributePaths = {"destinationWorkspace", "template"})
+    @EntityGraph(attributePaths = {"destinationWorkspace", "destinationWorkspace.organization", "template"})
     @Query("SELECT t FROM workspace_run_trigger t WHERE t.sourceWorkspace.id = :sourceId AND t.enabled = true AND t.destinationWorkspace.deleted = false")
     List<WorkspaceRunTrigger> findEnabledBySourceWorkspaceId(@Param("sourceId") UUID sourceId);
 

--- a/api/src/main/java/io/terrakube/api/rs/checks/trigger/TeamDeleteWorkspaceTrigger.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/trigger/TeamDeleteWorkspaceTrigger.java
@@ -1,0 +1,48 @@
+package io.terrakube.api.rs.checks.trigger;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.workspace.trigger.WorkspaceRunTrigger;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+/**
+ * Deleting a run trigger requires manage rights on the destination workspace only.
+ *
+ * Creating one also requires visibility of the source, but requiring that to remove it would
+ * be a trap: if the source is later moved into a project the destination team cannot see,
+ * they would be unable to detach a trigger that keeps firing runs on their own workspace.
+ * Removing an unwanted dependency should never need permission from the other end.
+ */
+@Slf4j
+@SecurityCheck(TeamDeleteWorkspaceTrigger.RULE)
+public class TeamDeleteWorkspaceTrigger extends OperationCheck<WorkspaceRunTrigger> {
+
+    public static final String RULE = "team delete workspace trigger";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    WorkspaceTriggerPermissions permissions;
+
+    @Override
+    public boolean ok(WorkspaceRunTrigger trigger, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+        log.debug("team delete workspace trigger {}", trigger.getId());
+
+        if (authenticatedUser.isSuperUser(requestScope.getUser())) {
+            return true;
+        }
+
+        if (trigger.getDestinationWorkspace() == null) {
+            return false;
+        }
+
+        return permissions.canManage(trigger.getDestinationWorkspace(), requestScope);
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/trigger/TeamManageWorkspaceTrigger.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/trigger/TeamManageWorkspaceTrigger.java
@@ -4,30 +4,24 @@ import com.yahoo.elide.annotation.SecurityCheck;
 import com.yahoo.elide.core.security.ChangeSpec;
 import com.yahoo.elide.core.security.RequestScope;
 import com.yahoo.elide.core.security.checks.OperationCheck;
-import io.terrakube.api.plugin.security.groups.GroupService;
-import io.terrakube.api.plugin.security.rbac.RbacService;
 import io.terrakube.api.plugin.security.user.AuthenticatedUser;
-import io.terrakube.api.rs.team.Team;
 import io.terrakube.api.rs.workspace.Workspace;
 import io.terrakube.api.rs.workspace.trigger.WorkspaceRunTrigger;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
- * Creating, changing or deleting a run trigger requires manage rights on the
- * <strong>destination</strong> workspace: that is the one whose runs will start firing, so
- * it is the side that carries the consequence.
+ * Creating or changing a run trigger requires manage rights on the <strong>destination</strong>
+ * workspace - the one whose runs start firing - plus visibility of the <strong>source</strong>.
+ * Without the second half, anyone with rights on a single workspace could attach it to any
+ * other workspace in the organization and learn when that one applies.
  *
- * The check is intentionally evaluated against both ends. Requiring manage on the
- * destination alone would let anyone with rights on a single workspace attach it to any
- * other workspace in the organization, including ones they cannot otherwise reach. Since a
- * trigger reveals when the source applies, this keeps the edge from becoming a side channel.
+ * Deletion is deliberately governed by {@link TeamDeleteWorkspaceTrigger} instead, so that
+ * losing access to the source cannot strand a trigger on a workspace you own.
  *
- * Permissions are enforced when the edge is configured, not on every dispatch — re-checking
- * at trigger time would make an unrelated permission change silently break a pipeline.
+ * Permissions are enforced when the edge is configured, not on every dispatch.
  */
 @Slf4j
 @SecurityCheck(TeamManageWorkspaceTrigger.RULE)
@@ -39,66 +33,58 @@ public class TeamManageWorkspaceTrigger extends OperationCheck<WorkspaceRunTrigg
     AuthenticatedUser authenticatedUser;
 
     @Autowired
-    GroupService groupService;
-
-    @Autowired
-    RbacService rbacService;
+    WorkspaceTriggerPermissions permissions;
 
     @Override
     public boolean ok(WorkspaceRunTrigger trigger, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
         log.debug("team manage workspace trigger {}", trigger.getId());
 
+        if (!isStructurallyValid(trigger)) {
+            return false;
+        }
+
         if (authenticatedUser.isSuperUser(requestScope.getUser())) {
             return true;
         }
 
+        return permissions.canManage(trigger.getDestinationWorkspace(), requestScope)
+                && permissions.canView(trigger.getSourceWorkspace(), requestScope);
+    }
+
+    /**
+     * Invariants that hold regardless of who is asking. Checked before the superuser
+     * shortcut on purpose: a self-loop or a cross-tenant edge is malformed data, not a
+     * privilege question, and a superuser should not be able to create one either.
+     */
+    private boolean isStructurallyValid(WorkspaceRunTrigger trigger) {
         Workspace destination = trigger.getDestinationWorkspace();
         Workspace source = trigger.getSourceWorkspace();
+
         if (destination == null || source == null) {
             return false;
         }
 
-        // An edge may only exist inside a single organization; a mismatch here means the
-        // payload is malformed, and letting it through would cross a tenant boundary.
-        if (destination.getOrganization() == null || source.getOrganization() == null
-                || !destination.getOrganization().getId().equals(source.getOrganization().getId())) {
-            log.warn("Rejecting run trigger {}: source and destination belong to different organizations",
-                    trigger.getId());
+        // A workspace triggering itself would re-run on every apply until the cascade limit.
+        if (destination.getId().equals(source.getId())) {
+            log.warn("Rejecting run trigger: workspace {} cannot trigger itself", destination.getId());
             return false;
         }
 
-        return canManage(destination, requestScope) && canView(source, requestScope);
-    }
-
-    private boolean canManage(Workspace workspace, RequestScope requestScope) {
-        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
-        List<Team> teamList = workspace.getOrganization().getTeam();
-        for (Team team : teamList) {
-            boolean member = isServiceAccount
-                    ? groupService.isServiceMember(requestScope.getUser(), team.getName())
-                    : groupService.isMember(requestScope.getUser(), team.getName());
-            if (member && rbacService.canManageWorkspace(team)) {
-                return true;
-            }
+        if (destination.getOrganization() == null || source.getOrganization() == null
+                || !destination.getOrganization().getId().equals(source.getOrganization().getId())) {
+            log.warn("Rejecting run trigger: source and destination belong to different organizations");
+            return false;
         }
-        return false;
-    }
 
-    /**
-     * Being able to see the source is enough to depend on it; managing it is not required,
-     * since the trigger does not change the source in any way.
-     */
-    private boolean canView(Workspace workspace, RequestScope requestScope) {
-        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
-        List<Team> teamList = workspace.getOrganization().getTeam();
-        for (Team team : teamList) {
-            boolean member = isServiceAccount
-                    ? groupService.isServiceMember(requestScope.getUser(), team.getName())
-                    : groupService.isMember(requestScope.getUser(), team.getName());
-            if (member) {
-                return true;
-            }
+        // The template override runs inside the destination's context, so a template from
+        // another organization would mean executing foreign TCL against these workspaces.
+        if (trigger.getTemplate() != null && trigger.getTemplate().getOrganization() != null
+                && !trigger.getTemplate().getOrganization().getId()
+                        .equals(destination.getOrganization().getId())) {
+            log.warn("Rejecting run trigger: template belongs to a different organization");
+            return false;
         }
-        return false;
+
+        return true;
     }
 }

--- a/api/src/main/java/io/terrakube/api/rs/checks/trigger/TeamManageWorkspaceTrigger.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/trigger/TeamManageWorkspaceTrigger.java
@@ -1,0 +1,104 @@
+package io.terrakube.api.rs.checks.trigger;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import io.terrakube.api.plugin.security.groups.GroupService;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.team.Team;
+import io.terrakube.api.rs.workspace.Workspace;
+import io.terrakube.api.rs.workspace.trigger.WorkspaceRunTrigger;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Creating, changing or deleting a run trigger requires manage rights on the
+ * <strong>destination</strong> workspace: that is the one whose runs will start firing, so
+ * it is the side that carries the consequence.
+ *
+ * The check is intentionally evaluated against both ends. Requiring manage on the
+ * destination alone would let anyone with rights on a single workspace attach it to any
+ * other workspace in the organization, including ones they cannot otherwise reach. Since a
+ * trigger reveals when the source applies, this keeps the edge from becoming a side channel.
+ *
+ * Permissions are enforced when the edge is configured, not on every dispatch — re-checking
+ * at trigger time would make an unrelated permission change silently break a pipeline.
+ */
+@Slf4j
+@SecurityCheck(TeamManageWorkspaceTrigger.RULE)
+public class TeamManageWorkspaceTrigger extends OperationCheck<WorkspaceRunTrigger> {
+
+    public static final String RULE = "team manage workspace trigger";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    GroupService groupService;
+
+    @Autowired
+    RbacService rbacService;
+
+    @Override
+    public boolean ok(WorkspaceRunTrigger trigger, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+        log.debug("team manage workspace trigger {}", trigger.getId());
+
+        if (authenticatedUser.isSuperUser(requestScope.getUser())) {
+            return true;
+        }
+
+        Workspace destination = trigger.getDestinationWorkspace();
+        Workspace source = trigger.getSourceWorkspace();
+        if (destination == null || source == null) {
+            return false;
+        }
+
+        // An edge may only exist inside a single organization; a mismatch here means the
+        // payload is malformed, and letting it through would cross a tenant boundary.
+        if (destination.getOrganization() == null || source.getOrganization() == null
+                || !destination.getOrganization().getId().equals(source.getOrganization().getId())) {
+            log.warn("Rejecting run trigger {}: source and destination belong to different organizations",
+                    trigger.getId());
+            return false;
+        }
+
+        return canManage(destination, requestScope) && canView(source, requestScope);
+    }
+
+    private boolean canManage(Workspace workspace, RequestScope requestScope) {
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
+        List<Team> teamList = workspace.getOrganization().getTeam();
+        for (Team team : teamList) {
+            boolean member = isServiceAccount
+                    ? groupService.isServiceMember(requestScope.getUser(), team.getName())
+                    : groupService.isMember(requestScope.getUser(), team.getName());
+            if (member && rbacService.canManageWorkspace(team)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Being able to see the source is enough to depend on it; managing it is not required,
+     * since the trigger does not change the source in any way.
+     */
+    private boolean canView(Workspace workspace, RequestScope requestScope) {
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
+        List<Team> teamList = workspace.getOrganization().getTeam();
+        for (Team team : teamList) {
+            boolean member = isServiceAccount
+                    ? groupService.isServiceMember(requestScope.getUser(), team.getName())
+                    : groupService.isMember(requestScope.getUser(), team.getName());
+            if (member) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/trigger/TeamViewWorkspaceTrigger.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/trigger/TeamViewWorkspaceTrigger.java
@@ -1,0 +1,48 @@
+package io.terrakube.api.rs.checks.trigger;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.workspace.trigger.WorkspaceRunTrigger;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+/**
+ * Reading a run trigger is open to any member of the organization that owns it, so the
+ * dependency graph is discoverable even by people who cannot change it.
+ *
+ * The edge itself is not sensitive: it says "workspace A feeds workspace B", not what
+ * flows between them.
+ */
+@Slf4j
+@SecurityCheck(TeamViewWorkspaceTrigger.RULE)
+public class TeamViewWorkspaceTrigger extends OperationCheck<WorkspaceRunTrigger> {
+
+    public static final String RULE = "team view workspace trigger";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    MembershipService membershipService;
+
+    @Override
+    public boolean ok(WorkspaceRunTrigger trigger, RequestScope requestScope, Optional<ChangeSpec> changeSpec) {
+        log.debug("team view workspace trigger {}", trigger.getId());
+
+        if (authenticatedUser.isSuperUser(requestScope.getUser())) {
+            return true;
+        }
+
+        if (trigger.getOrganization() == null) {
+            return false;
+        }
+
+        return membershipService.checkMembership(requestScope.getUser(), trigger.getOrganization().getTeam());
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/checks/trigger/WorkspaceTriggerPermissions.java
+++ b/api/src/main/java/io/terrakube/api/rs/checks/trigger/WorkspaceTriggerPermissions.java
@@ -1,0 +1,114 @@
+package io.terrakube.api.rs.checks.trigger;
+
+import io.terrakube.api.plugin.security.groups.GroupService;
+import io.terrakube.api.plugin.security.rbac.RbacService;
+import io.terrakube.api.plugin.security.user.AuthenticatedUser;
+import io.terrakube.api.rs.checks.membership.MembershipService;
+import io.terrakube.api.rs.project.Project;
+import io.terrakube.api.rs.team.Team;
+import io.terrakube.api.rs.workspace.Workspace;
+import io.terrakube.api.rs.workspace.access.Access;
+import io.terrakube.api.rs.project.access.ProjectAccess;
+import com.yahoo.elide.core.security.RequestScope;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * Workspace permission resolution shared by the run trigger checks.
+ *
+ * Terrakube grants workspace rights at three tiers - organization team, project access and
+ * workspace-level access - and a trigger check has to honour all three, otherwise a team
+ * that manages its workspace through a project is locked out of configuring triggers on it.
+ *
+ * The existing checks (TeamManageWorkspace and friends) cannot be reused directly: Elide
+ * instantiates them, they are not Spring beans, so they cannot be injected here. This
+ * component holds the equivalent logic in one place instead of duplicating it across the
+ * two trigger checks.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WorkspaceTriggerPermissions {
+
+    private final AuthenticatedUser authenticatedUser;
+    private final GroupService groupService;
+    private final RbacService rbacService;
+    private final MembershipService membershipService;
+
+    /** Manage rights on a workspace, across the three tiers. */
+    public boolean canManage(Workspace workspace, RequestScope requestScope) {
+        return canManageAtOrganization(workspace, requestScope)
+                || canManageAtProject(workspace, requestScope)
+                || canManageAtWorkspace(workspace, requestScope);
+    }
+
+    /**
+     * View rights on a workspace. Mirrors TeamViewWorkspace: a workspace that belongs to a
+     * project is only visible through that project's access, so plain organization
+     * membership is not enough to target it as a trigger source.
+     */
+    public boolean canView(Workspace workspace, RequestScope requestScope) {
+        if (authenticatedUser.isSuperUser(requestScope.getUser())) {
+            return true;
+        }
+        if (workspace.getOrganization() == null) {
+            return false;
+        }
+        List<Team> teamList = workspace.getOrganization().getTeam();
+
+        if (workspace.getProject() == null) {
+            return membershipService.checkMembership(requestScope.getUser(), teamList);
+        }
+        // Inside a project, visibility follows the same rules as managing it.
+        return canManage(workspace, requestScope);
+    }
+
+    private boolean canManageAtOrganization(Workspace workspace, RequestScope requestScope) {
+        if (workspace.getOrganization() == null) {
+            return false;
+        }
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
+        for (Team team : workspace.getOrganization().getTeam()) {
+            boolean member = isServiceAccount
+                    ? groupService.isServiceMember(requestScope.getUser(), team.getName())
+                    : groupService.isMember(requestScope.getUser(), team.getName());
+            if (member && rbacService.canManageWorkspace(team)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean canManageAtProject(Workspace workspace, RequestScope requestScope) {
+        Project project = workspace.getProject();
+        if (project == null) {
+            return false;
+        }
+        List<ProjectAccess> accessList = project.getProjectAccess();
+        if (accessList == null || accessList.isEmpty()) {
+            return false;
+        }
+        return membershipService.checkProjectMembership(
+                requestScope.getUser(), accessList, rbacService::canManageWorkspace);
+    }
+
+    private boolean canManageAtWorkspace(Workspace workspace, RequestScope requestScope) {
+        List<Access> accessList = workspace.getAccess();
+        if (accessList == null || accessList.isEmpty()) {
+            return false;
+        }
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
+        for (Access access : accessList) {
+            boolean member = isServiceAccount
+                    ? groupService.isServiceMember(requestScope.getUser(), access.getName())
+                    : groupService.isMember(requestScope.getUser(), access.getName());
+            if (member && rbacService.canManageWorkspace(access)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/hooks/trigger/WorkspaceRunTriggerHook.java
+++ b/api/src/main/java/io/terrakube/api/rs/hooks/trigger/WorkspaceRunTriggerHook.java
@@ -1,0 +1,48 @@
+package io.terrakube.api.rs.hooks.trigger;
+
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
+import com.yahoo.elide.core.lifecycle.LifeCycleHook;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import io.terrakube.api.plugin.scheduler.trigger.WorkspaceGraphValidationService;
+import io.terrakube.api.rs.workspace.trigger.WorkspaceRunTrigger;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * Rejects a run trigger that would close a loop in the organization's graph.
+ *
+ * Runs at PRECOMMIT: the row is already flushed by then, so the validation excludes the edge
+ * being written and aborts the transaction when it finds a path back. Deriving the
+ * organization is not done here - that needs @PrePersist, since PRECOMMIT is too late for a
+ * NOT NULL column.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WorkspaceRunTriggerHook implements LifeCycleHook<WorkspaceRunTrigger> {
+
+    private final WorkspaceGraphValidationService graphValidationService;
+
+    @Override
+    public void execute(LifeCycleHookBinding.Operation operation,
+                        LifeCycleHookBinding.TransactionPhase phase,
+                        WorkspaceRunTrigger trigger,
+                        RequestScope requestScope,
+                        Optional<ChangeSpec> changes) {
+
+        if (trigger.getSourceWorkspace() == null || trigger.getDestinationWorkspace() == null
+                || trigger.getOrganization() == null) {
+            return;
+        }
+
+        graphValidationService.validateAcyclic(
+                trigger.getOrganization().getId(),
+                trigger.getId(),
+                trigger.getSourceWorkspace().getId(),
+                trigger.getDestinationWorkspace().getId());
+    }
+}

--- a/api/src/main/java/io/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/Job.java
@@ -132,6 +132,8 @@ public class Job extends GenericAuditFields {
      * The job whose successful apply caused this one, when it was created by a run trigger.
      * Null for every job started by a person, a webhook or a schedule.
      */
+    @CreatePermission(expression = "user is a super service")
+    @UpdatePermission(expression = "user is a super service")
     @Column(name = "triggered_by_job_id")
     private Integer triggeredByJobId;
 
@@ -140,6 +142,8 @@ public class Job extends GenericAuditFields {
      * the Nth link of a chain. Bounds propagation if the graph ever contains a cycle that
      * static validation did not catch.
      */
+    @CreatePermission(expression = "user is a super service")
+    @UpdatePermission(expression = "user is a super service")
     @Column(name = "cascade_depth", nullable = false)
     private int cascadeDepth = 0;
 

--- a/api/src/main/java/io/terrakube/api/rs/job/Job.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/Job.java
@@ -128,6 +128,21 @@ public class Job extends GenericAuditFields {
     @Column(name = "pr_comment_error")
     private String prCommentError;
 
+    /**
+     * The job whose successful apply caused this one, when it was created by a run trigger.
+     * Null for every job started by a person, a webhook or a schedule.
+     */
+    @Column(name = "triggered_by_job_id")
+    private Integer triggeredByJobId;
+
+    /**
+     * How many trigger hops produced this job: 0 when it was started directly, N when it is
+     * the Nth link of a chain. Bounds propagation if the graph ever contains a cycle that
+     * static validation did not catch.
+     */
+    @Column(name = "cascade_depth", nullable = false)
+    private int cascadeDepth = 0;
+
     @ManyToOne
     private Organization organization;
 

--- a/api/src/main/java/io/terrakube/api/rs/job/JobVia.java
+++ b/api/src/main/java/io/terrakube/api/rs/job/JobVia.java
@@ -11,7 +11,8 @@ public enum JobVia {
    GITLAB("Gitlab"),
    BITBUCKET("Bitbucket"),
    AZURE_DEVOPS("AzureDevops"),
-   SCHEDULE("Schedule");
+   SCHEDULE("Schedule"),
+   RUN_TRIGGER("RunTrigger");
 
    private final String value;
 

--- a/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
@@ -152,11 +152,19 @@ public class Workspace extends GenericAuditFields {
     @OneToMany(mappedBy = "workspace", fetch = FetchType.LAZY)
     private List<Reference> reference;
 
-    /** Triggers that fire runs on THIS workspace when their source applies. */
+    /**
+     * Triggers that fire runs on THIS workspace when their source applies.
+     *
+     * Read-only through the workspace: edges are created and removed through the runTrigger
+     * resource, which carries the checks that validate both ends. Allowing them to be
+     * rewritten as a side effect of a workspace PATCH would bypass those.
+     */
+    @UpdatePermission(expression = "user is a superuser")
     @OneToMany(mappedBy = "destinationWorkspace", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<WorkspaceRunTrigger> runTriggers;
 
     /** Triggers where THIS workspace is the source, i.e. the runs it sets off. */
+    @UpdatePermission(expression = "user is a superuser")
     @OneToMany(mappedBy = "sourceWorkspace", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<WorkspaceRunTrigger> sourceRunTriggers;
 

--- a/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
@@ -20,6 +20,8 @@ import io.terrakube.api.rs.workspace.history.History;
 import io.terrakube.api.rs.workspace.parameters.Variable;
 import io.terrakube.api.rs.workspace.schedule.Schedule;
 import io.terrakube.api.rs.workspace.tag.WorkspaceTag;
+import io.terrakube.api.rs.workspace.trigger.WorkspaceRunTrigger;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -149,6 +151,14 @@ public class Workspace extends GenericAuditFields {
 
     @OneToMany(mappedBy = "workspace", fetch = FetchType.LAZY)
     private List<Reference> reference;
+
+    /** Triggers that fire runs on THIS workspace when their source applies. */
+    @OneToMany(mappedBy = "destinationWorkspace", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WorkspaceRunTrigger> runTriggers;
+
+    /** Triggers where THIS workspace is the source, i.e. the runs it sets off. */
+    @OneToMany(mappedBy = "sourceWorkspace", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WorkspaceRunTrigger> sourceRunTriggers;
 
     @OneToMany(mappedBy = "workspace")
     @UpdatePermission(expression = "user is a superuser OR team manage workspace OR team workspace admin manages access field")

--- a/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/Workspace.java
@@ -155,17 +155,25 @@ public class Workspace extends GenericAuditFields {
     /**
      * Triggers that fire runs on THIS workspace when their source applies.
      *
-     * Read-only through the workspace: edges are created and removed through the runTrigger
-     * resource, which carries the checks that validate both ends. Allowing them to be
-     * rewritten as a side effect of a workspace PATCH would bypass those.
+     * The permission mirrors the one on {@link #job}: edges are created and removed through
+     * the runTrigger resource, whose own Create/Update/Delete checks validate both ends, so
+     * the inverse side only has to be as guarded as seeing the workspace. Requiring more
+     * here does not add protection - Elide maintains the bidirectional relationship when a
+     * trigger is created, so a stricter rule on this field is evaluated on the ordinary
+     * create path and would lock out every non-superuser regardless of manage rights.
+     *
+     * No cascade or orphanRemoval: workspaces are soft deleted (see the SQLRestriction on
+     * this class), so a cascade would never fire for the case it appears to cover, while
+     * orphanRemoval would turn dropping an element from this collection into a row delete
+     * that never passes through the trigger's own DeletePermission.
      */
-    @UpdatePermission(expression = "user is a superuser")
-    @OneToMany(mappedBy = "destinationWorkspace", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @UpdatePermission(expression = "team view workspace OR team project limited view workspace OR team limited view workspace")
+    @OneToMany(mappedBy = "destinationWorkspace", fetch = FetchType.LAZY)
     private List<WorkspaceRunTrigger> runTriggers;
 
     /** Triggers where THIS workspace is the source, i.e. the runs it sets off. */
-    @UpdatePermission(expression = "user is a superuser")
-    @OneToMany(mappedBy = "sourceWorkspace", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @UpdatePermission(expression = "team view workspace OR team project limited view workspace OR team limited view workspace")
+    @OneToMany(mappedBy = "sourceWorkspace", fetch = FetchType.LAZY)
     private List<WorkspaceRunTrigger> sourceRunTriggers;
 
     @OneToMany(mappedBy = "workspace")

--- a/api/src/main/java/io/terrakube/api/rs/workspace/trigger/WorkspaceRunTrigger.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/trigger/WorkspaceRunTrigger.java
@@ -4,9 +4,11 @@ import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.LifeCycleHookBinding;
 import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import io.terrakube.api.plugin.security.audit.GenericAuditFields;
+import io.terrakube.api.rs.hooks.trigger.WorkspaceRunTriggerHook;
 import io.terrakube.api.rs.Organization;
 import io.terrakube.api.rs.template.Template;
 import io.terrakube.api.rs.workspace.Workspace;
@@ -42,6 +44,10 @@ import java.util.UUID;
 @CreatePermission(expression = "team manage workspace trigger")
 @UpdatePermission(expression = "team manage workspace trigger")
 @DeletePermission(expression = "team delete workspace trigger")
+@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE,
+        phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT, hook = WorkspaceRunTriggerHook.class)
+@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE,
+        phase = LifeCycleHookBinding.TransactionPhase.PRECOMMIT, hook = WorkspaceRunTriggerHook.class)
 @Include(name = "runTrigger")
 @Getter
 @Setter

--- a/api/src/main/java/io/terrakube/api/rs/workspace/trigger/WorkspaceRunTrigger.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/trigger/WorkspaceRunTrigger.java
@@ -1,0 +1,87 @@
+package io.terrakube.api.rs.workspace.trigger;
+
+import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.DeletePermission;
+import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.UpdatePermission;
+import io.terrakube.api.plugin.security.audit.GenericAuditFields;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.template.Template;
+import io.terrakube.api.rs.workspace.Workspace;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+
+import java.sql.Types;
+import java.util.UUID;
+
+/**
+ * A run trigger: the destination workspace subscribes to state-changing runs of the source
+ * workspace, so that a successful apply upstream enqueues a run downstream.
+ *
+ * The edge is directed and both ends must belong to the same organization. Reads are open to
+ * any member of the organization so the dependency graph is discoverable, while creating or
+ * changing an edge requires manage rights on the destination - see
+ * {@code TeamManageWorkspaceTrigger}.
+ */
+@ReadPermission(expression = "team view workspace trigger")
+@CreatePermission(expression = "team manage workspace trigger")
+@UpdatePermission(expression = "team manage workspace trigger")
+@DeletePermission(expression = "team manage workspace trigger")
+@Include(name = "runTrigger")
+@Getter
+@Setter
+@Entity(name = "workspace_run_trigger")
+@Table(name = "workspace_run_trigger", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_run_trigger_source_dest",
+                columnNames = {"source_workspace_id", "destination_workspace_id"})
+})
+public class WorkspaceRunTrigger extends GenericAuditFields {
+
+    @Id
+    @JdbcTypeCode(Types.VARCHAR)
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    /** The upstream workspace whose successful apply fires this trigger. */
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_workspace_id", nullable = false)
+    private Workspace sourceWorkspace;
+
+    /** The downstream workspace that gets a run when the source applies. */
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "destination_workspace_id", nullable = false)
+    private Workspace destinationWorkspace;
+
+    /**
+     * Template used for the triggered run. When null the destination workspace's
+     * defaultTemplate is used, which keeps the common case free of configuration.
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "template_id")
+    private Template template;
+
+    /**
+     * Denormalized owner of the edge. Both workspaces belong to it; keeping it here lets the
+     * cycle validation load an organization's whole graph in a single query instead of
+     * walking through the workspaces.
+     */
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id", nullable = false)
+    private Organization organization;
+
+    /** Lets an edge be turned off without losing its configuration. */
+    @Column(name = "enabled", nullable = false)
+    private boolean enabled = true;
+}

--- a/api/src/main/java/io/terrakube/api/rs/workspace/trigger/WorkspaceRunTrigger.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/trigger/WorkspaceRunTrigger.java
@@ -63,12 +63,20 @@ public class WorkspaceRunTrigger extends GenericAuditFields {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    /** The upstream workspace whose successful apply fires this trigger. */
+    /**
+     * The upstream workspace whose successful apply fires this trigger.
+     *
+     * Immutable once set: repointing an edge is deleting one dependency and declaring
+     * another, and both deserve to go through their own permission checks. PATCH remains
+     * open for enabled and template.
+     */
+    @UpdatePermission(expression = "user is a superuser")
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "source_workspace_id", nullable = false)
     private Workspace sourceWorkspace;
 
-    /** The downstream workspace that gets a run when the source applies. */
+    /** The downstream workspace that gets a run when the source applies. Immutable, as above. */
+    @UpdatePermission(expression = "user is a superuser")
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "destination_workspace_id", nullable = false)
     private Workspace destinationWorkspace;

--- a/api/src/main/java/io/terrakube/api/rs/workspace/trigger/WorkspaceRunTrigger.java
+++ b/api/src/main/java/io/terrakube/api/rs/workspace/trigger/WorkspaceRunTrigger.java
@@ -1,6 +1,7 @@
 package io.terrakube.api.rs.workspace.trigger;
 
 import com.yahoo.elide.annotation.CreatePermission;
+import com.yahoo.elide.annotation.Exclude;
 import com.yahoo.elide.annotation.DeletePermission;
 import com.yahoo.elide.annotation.Include;
 import com.yahoo.elide.annotation.ReadPermission;
@@ -17,6 +18,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
@@ -38,7 +41,7 @@ import java.util.UUID;
 @ReadPermission(expression = "team view workspace trigger")
 @CreatePermission(expression = "team manage workspace trigger")
 @UpdatePermission(expression = "team manage workspace trigger")
-@DeletePermission(expression = "team manage workspace trigger")
+@DeletePermission(expression = "team delete workspace trigger")
 @Include(name = "runTrigger")
 @Getter
 @Setter
@@ -73,10 +76,16 @@ public class WorkspaceRunTrigger extends GenericAuditFields {
     private Template template;
 
     /**
-     * Denormalized owner of the edge. Both workspaces belong to it; keeping it here lets the
-     * cycle validation load an organization's whole graph in a single query instead of
-     * walking through the workspaces.
+     * Denormalized owner of the edge, derived from the destination workspace by
+     * WorkspaceRunTriggerHook. Excluded from the API surface entirely rather than merely
+     * permission-guarded: a client has no reason to set it, and accepting it would let an
+     * edge be attributed to a tenant that owns neither workspace, exposing it to the wrong
+     * organization through the read check. Keeping it on the row lets the
+     * cycle validation load an organization's whole graph in a single indexed query instead
+     * of walking through the workspaces; letting a client set it would let the edge be
+     * attributed to a tenant that owns neither workspace.
      */
+    @Exclude
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "organization_id", nullable = false)
     private Organization organization;
@@ -84,4 +93,20 @@ public class WorkspaceRunTrigger extends GenericAuditFields {
     /** Lets an edge be turned off without losing its configuration. */
     @Column(name = "enabled", nullable = false)
     private boolean enabled = true;
+
+    /**
+     * Derives the owning organization from the destination workspace.
+     *
+     * This runs as a JPA callback rather than an Elide lifecycle hook on purpose: Elide's
+     * PRECOMMIT phase fires after Hibernate has already flushed the insert, which leaves a
+     * NOT NULL column unset and fails at the database. @PrePersist is guaranteed to run
+     * before the statement is built.
+     */
+    @PrePersist
+    @PreUpdate
+    private void deriveOrganization() {
+        if (destinationWorkspace != null) {
+            this.organization = destinationWorkspace.getOrganization();
+        }
+    }
 }

--- a/api/src/main/resources/db/changelog/changelog-demo.xml
+++ b/api/src/main/resources/db/changelog/changelog-demo.xml
@@ -18,4 +18,5 @@
     <include file="/db/changelog/demo-data/h2-test-values.xml" />
     <include file="/db/changelog/demo-data/rbac-v2-demo-data.xml" />
     <include file="/db/changelog/demo-data/project-access-demo-data.xml" />
+    <include file="/db/changelog/demo-data/run-trigger-scenarios.xml" />
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/changelog.xml
+++ b/api/src/main/resources/db/changelog/changelog.xml
@@ -123,4 +123,5 @@
     <include file="/db/changelog/local/changelog-2.33.0-provider-trust-signature.xml"/>
     <include file="/db/changelog/local/changelog-2.33.0-repo-webhook-delivery.xml" />
     <include file="/db/changelog/local/changelog-2.33.1-notification-outbox-job-status.xml" />
+    <include file="/db/changelog/local/changelog-2.34.0-workspace-run-trigger.xml" />
 </databaseChangeLog>

--- a/api/src/main/resources/db/changelog/demo-data/run-trigger-scenarios.xml
+++ b/api/src/main/resources/db/changelog/demo-data/run-trigger-scenarios.xml
@@ -1,0 +1,669 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <!--
+      A dependency graph big enough to be worth looking at.
+
+      Every workspace points at terrakube-docker-compose, whose root module is a
+      null_resource and a 30 second sleep - so a run really completes, quickly, with no
+      cloud credentials, and a cascade can be watched end to end in a dev environment.
+
+      The scenarios are named after their shape so a page tells you which one you are
+      looking at: fanout, chain, fanin, diamond, disabled, override, standalone, cascade.
+    -->
+    <changeSet author="demo-data" id="demo-run-trigger">
+
+        <!--
+        ******************
+        ***ORGANIZATION***
+        ******************
+        -->
+        <insert tableName="organization">
+            <column name="id"                      value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="name"                    value="simple-trigger" />
+            <column name="description"             value="run trigger scenarios for testing workspace dependencies" />
+        </insert>
+
+        <!--
+        ***********
+        ***TEAMS***
+        ***********
+        -->
+        <insert tableName="team">
+            <column name="id"                      value="b0f1c2d3-0000-4000-8000-000000000002" />
+            <column name="name"                    value="TERRAKUBE_ADMIN" />
+            <column name="role"                    value="admin" />
+            <column name="manage_workspace"        value="true" />
+            <column name="manage_module"           value="true" />
+            <column name="manage_provider"         value="true" />
+            <column name="manage_vcs"              value="true" />
+            <column name="manage_template"         value="true" />
+            <column name="manage_job"              value="true" />
+            <column name="manage_state"            value="true" />
+            <column name="manage_collection"       value="true" />
+            <column name="plan_job"                value="true" />
+            <column name="approve_job"             value="true" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+
+        <!--
+        ***************
+        ***TEMPLATES***
+        ***************
+        -->
+        <insert tableName="template">
+            <column name="id"                      value="b0f1c2d3-0000-4000-8000-000000000011" />
+            <column name="name"                    value="Plan" />
+            <column name="description"             value="Running terraform plan" />
+            <column name="version"                 value="1.0.0" />
+            <column name="tcl"                     value="ZmxvdzoKICAtIHR5cGU6ICJ0ZXJyYWZvcm1QbGFuIgogICAgbmFtZTogIlBsYW4iCiAgICBzdGVwOiAxMDAK" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+
+        <insert tableName="template">
+            <column name="id"                      value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="name"                    value="Plan and apply" />
+            <column name="description"             value="Running terraform plan and apply" />
+            <column name="version"                 value="1.0.0" />
+            <column name="tcl"                     value="ZmxvdzoKICAtIHR5cGU6ICJ0ZXJyYWZvcm1QbGFuIgogICAgc3RlcDogMTAwCiAgICBuYW1lOiAiUGxhbiIKICAtIHR5cGU6ICJ0ZXJyYWZvcm1BcHBseSIKICAgIHN0ZXA6IDIwMAogICAgbmFtZTogIkFwcGx5Ig==" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+
+        <!--
+        ****************
+        ***WORKSPACES***
+        ****************
+
+        Every one defaults to "Plan and apply", so a triggered run has a template to
+        resolve even when the edge does not name one.
+        -->
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000001" />
+            <column name="name"                    value="fanout-hub" />
+            <column name="description"             value="fan-out source: one apply wakes five consumers" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000002" />
+            <column name="name"                    value="fanout-app-1" />
+            <column name="description"             value="fan-out consumer 1 of 5" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000003" />
+            <column name="name"                    value="fanout-app-2" />
+            <column name="description"             value="fan-out consumer 2 of 5" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000004" />
+            <column name="name"                    value="fanout-app-3" />
+            <column name="description"             value="fan-out consumer 3 of 5" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000005" />
+            <column name="name"                    value="fanout-app-4" />
+            <column name="description"             value="fan-out consumer 4 of 5" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000006" />
+            <column name="name"                    value="fanout-app-5" />
+            <column name="description"             value="fan-out consumer 5 of 5" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000007" />
+            <column name="name"                    value="chain-01" />
+            <column name="description"             value="chain step 1 of 5" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000008" />
+            <column name="name"                    value="chain-02" />
+            <column name="description"             value="chain step 2 of 5" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000009" />
+            <column name="name"                    value="chain-03" />
+            <column name="description"             value="chain step 3 of 5" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000010" />
+            <column name="name"                    value="chain-04" />
+            <column name="description"             value="chain step 4 of 5" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000011" />
+            <column name="name"                    value="chain-05" />
+            <column name="description"             value="chain step 5 of 5" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000012" />
+            <column name="name"                    value="fanin-net" />
+            <column name="description"             value="fan-in source: network layer" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000013" />
+            <column name="name"                    value="fanin-dns" />
+            <column name="description"             value="fan-in source: dns layer" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000014" />
+            <column name="name"                    value="fanin-app" />
+            <column name="description"             value="fan-in target: runs after either source" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000015" />
+            <column name="name"                    value="diamond-root" />
+            <column name="description"             value="diamond root: reaches the join by two paths" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000016" />
+            <column name="name"                    value="diamond-left" />
+            <column name="description"             value="diamond left branch" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000017" />
+            <column name="name"                    value="diamond-right" />
+            <column name="description"             value="diamond right branch" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000018" />
+            <column name="name"                    value="diamond-join" />
+            <column name="description"             value="diamond join: two paths, two runs, no coalescing" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000019" />
+            <column name="name"                    value="disabled-upstream" />
+            <column name="description"             value="disabled edge source" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000020" />
+            <column name="name"                    value="disabled-downstream" />
+            <column name="description"             value="disabled edge target: configured but not firing" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000021" />
+            <column name="name"                    value="override-upstream" />
+            <column name="description"             value="template override source" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000022" />
+            <column name="name"                    value="override-downstream" />
+            <column name="description"             value="triggered with Plan instead of its default" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000023" />
+            <column name="name"                    value="standalone-01" />
+            <column name="description"             value="no run triggers in either direction" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000024" />
+            <column name="name"                    value="standalone-02" />
+            <column name="description"             value="no run triggers in either direction" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000025" />
+            <column name="name"                    value="standalone-03" />
+            <column name="description"             value="no run triggers in either direction" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000026" />
+            <column name="name"                    value="standalone-04" />
+            <column name="description"             value="no run triggers in either direction" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000027" />
+            <column name="name"                    value="cascade-01" />
+            <column name="description"             value="deep cascade step 1 of 12" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000028" />
+            <column name="name"                    value="cascade-02" />
+            <column name="description"             value="deep cascade step 2 of 12" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000029" />
+            <column name="name"                    value="cascade-03" />
+            <column name="description"             value="deep cascade step 3 of 12" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000030" />
+            <column name="name"                    value="cascade-04" />
+            <column name="description"             value="deep cascade step 4 of 12" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000031" />
+            <column name="name"                    value="cascade-05" />
+            <column name="description"             value="deep cascade step 5 of 12" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000032" />
+            <column name="name"                    value="cascade-06" />
+            <column name="description"             value="deep cascade step 6 of 12" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000033" />
+            <column name="name"                    value="cascade-07" />
+            <column name="description"             value="deep cascade step 7 of 12" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000034" />
+            <column name="name"                    value="cascade-08" />
+            <column name="description"             value="deep cascade step 8 of 12" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000035" />
+            <column name="name"                    value="cascade-09" />
+            <column name="description"             value="deep cascade step 9 of 12" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000036" />
+            <column name="name"                    value="cascade-10" />
+            <column name="description"             value="deep cascade step 10 of 12" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000037" />
+            <column name="name"                    value="cascade-11" />
+            <column name="description"             value="deep cascade step 11 of 12" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+        <insert tableName="workspace">
+            <column name="id"                      value="b0f1c2d3-0001-4000-8000-000000000038" />
+            <column name="name"                    value="cascade-12" />
+            <column name="description"             value="deep cascade step 12 of 12" />
+            <column name="source"                  value="https://github.com/terrakube-io/terrakube-docker-compose.git" />
+            <column name="branch"                  value="main" />
+            <column name="terraform_version"       value="1.5.7" />
+            <column name="default_template"        value="b0f1c2d3-0000-4000-8000-000000000012" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+        </insert>
+
+        <!--
+        ******************
+        ***RUN TRIGGERS***
+        ******************
+
+        The graph is acyclic by construction: every edge points at a higher numbered
+        step or at a leaf, so the phase 2 validation would accept each one.
+        -->
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000001" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000001" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000002" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000002" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000001" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000003" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000003" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000001" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000004" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000004" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000001" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000005" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000005" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000001" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000006" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000006" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000007" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000008" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000007" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000008" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000009" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000008" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000009" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000010" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000009" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000010" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000011" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000010" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000012" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000014" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000011" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000013" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000014" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000012" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000015" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000016" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000013" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000015" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000017" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000014" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000016" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000018" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000015" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000017" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000018" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000016" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000019" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000020" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="false" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000017" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000021" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000022" />
+            <column name="template_id"             value="b0f1c2d3-0000-4000-8000-000000000011" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000018" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000027" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000028" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000019" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000028" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000029" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000020" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000029" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000030" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000021" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000030" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000031" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000022" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000031" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000032" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000023" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000032" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000033" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000024" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000033" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000034" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000025" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000034" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000035" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000026" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000035" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000036" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000027" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000036" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000037" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+        <insert tableName="workspace_run_trigger">
+            <column name="id"                      value="b0f1c2d3-0002-4000-8000-000000000028" />
+            <column name="source_workspace_id"     value="b0f1c2d3-0001-4000-8000-000000000037" />
+            <column name="destination_workspace_id" value="b0f1c2d3-0001-4000-8000-000000000038" />
+            <column name="organization_id"         value="b0f1c2d3-0000-4000-8000-000000000001" />
+            <column name="enabled"                 valueBoolean="true" />
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.34.0-workspace-run-trigger.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.34.0-workspace-run-trigger.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <!--
+      Run triggers: the destination workspace subscribes to state-changing runs of the
+      source workspace. Both workspace FKs cascade on delete so removing either end does not
+      leave dangling edges; the organization FK does not, since deleting an organization
+      already removes its workspaces and the edges go with them.
+    -->
+    <changeSet id="2-34-0-workspace-run-trigger" author="kleber.rocha@cora.com.br">
+        <createTable tableName="workspace_run_trigger">
+            <column name="id" type="varchar(36)">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="source_workspace_id" type="varchar(36)">
+                <constraints nullable="false"
+                             foreignKeyName="fk_run_trigger_source_workspace"
+                             references="workspace(id)"
+                             deleteCascade="true"/>
+            </column>
+            <column name="destination_workspace_id" type="varchar(36)">
+                <constraints nullable="false"
+                             foreignKeyName="fk_run_trigger_destination_workspace"
+                             references="workspace(id)"
+                             deleteCascade="true"/>
+            </column>
+            <column name="template_id" type="varchar(36)">
+                <constraints foreignKeyName="fk_run_trigger_template"
+                             references="template(id)"/>
+            </column>
+            <column name="organization_id" type="varchar(36)">
+                <constraints nullable="false"
+                             foreignKeyName="fk_run_trigger_organization"
+                             references="organization(id)"/>
+            </column>
+            <column name="enabled" type="boolean" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_date" type="datetime"/>
+            <column name="created_by" type="varchar(255)"/>
+            <column name="updated_date" type="datetime"/>
+            <column name="updated_by" type="varchar(255)"/>
+        </createTable>
+
+        <!-- One edge per pair; a repeated declaration is a mistake, not a second trigger. -->
+        <addUniqueConstraint tableName="workspace_run_trigger"
+                             columnNames="source_workspace_id, destination_workspace_id"
+                             constraintName="uk_run_trigger_source_dest"/>
+
+        <!--
+          Dispatch path: looked up after every completed apply, filtered by enabled. The
+          composite index answers the query from the index alone.
+        -->
+        <createIndex tableName="workspace_run_trigger" indexName="idx_run_trigger_source_enabled">
+            <column name="source_workspace_id"/>
+            <column name="enabled"/>
+        </createIndex>
+
+        <!-- Inbound list in the UI, and cascade cleanup when a destination is removed. -->
+        <createIndex tableName="workspace_run_trigger" indexName="idx_run_trigger_destination">
+            <column name="destination_workspace_id"/>
+        </createIndex>
+
+        <!-- Cycle detection loads an organization's whole graph in one query. -->
+        <createIndex tableName="workspace_run_trigger" indexName="idx_run_trigger_organization">
+            <column name="organization_id"/>
+        </createIndex>
+    </changeSet>
+
+    <!--
+      Run lineage on the job itself: which job caused this one, and how many hops in.
+      Both are nullable/defaulted so existing rows need no backfill.
+    -->
+    <changeSet id="2-34-0-job-run-trigger-lineage" author="kleber.rocha@cora.com.br">
+        <addColumn tableName="job">
+            <column name="triggered_by_job_id" type="int"/>
+        </addColumn>
+        <addColumn tableName="job">
+            <column name="cascade_depth" type="int" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/main/resources/db/changelog/local/changelog-2.34.0-workspace-run-trigger.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-2.34.0-workspace-run-trigger.xml
@@ -71,6 +71,22 @@
     </changeSet>
 
     <!--
+      A workspace triggering itself would re-run on every apply until the cascade limit is
+      hit. The API rejects it, and this makes the invariant hold even for rows written
+      outside the API.
+    -->
+    <changeSet id="2-34-0-workspace-run-trigger-no-self" author="kleber.rocha@cora.com.br">
+        <sql>
+            ALTER TABLE workspace_run_trigger
+            ADD CONSTRAINT chk_run_trigger_no_self
+            CHECK (source_workspace_id != destination_workspace_id)
+        </sql>
+        <rollback>
+            ALTER TABLE workspace_run_trigger DROP CONSTRAINT chk_run_trigger_no_self
+        </rollback>
+    </changeSet>
+
+    <!--
       Run lineage on the job itself: which job caused this one, and how many hops in.
       Both are nullable/defaulted so existing rows need no backfill.
     -->

--- a/api/src/test/java/io/terrakube/api/RunTriggerDispatchIntegrationTest.java
+++ b/api/src/test/java/io/terrakube/api/RunTriggerDispatchIntegrationTest.java
@@ -53,12 +53,15 @@ public class RunTriggerDispatchIntegrationTest extends ServerApplicationTests {
     private WorkspaceRunTriggerRepository triggerRepository;
 
     private Set<Integer> jobsBefore;
+    private Set<UUID> triggersBefore;
 
     @BeforeEach
     public void setup() {
         MockitoAnnotations.openMocks(this);
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         jobsBefore = jobRepository.findAll().stream().map(Job::getId).collect(Collectors.toSet());
+        triggersBefore = triggerRepository.findAll().stream()
+                .map(WorkspaceRunTrigger::getId).collect(Collectors.toSet());
     }
 
     /**
@@ -75,7 +78,11 @@ public class RunTriggerDispatchIntegrationTest extends ServerApplicationTests {
      */
     @AfterEach
     public void cleanup() {
-        triggerRepository.deleteAll();
+        // Only this test's edges: run-trigger-scenarios.xml seeds a graph that the suite and
+        // the dev environment share, and deleteAll would take it with them.
+        triggerRepository.findAll().stream()
+                .filter(trigger -> !triggersBefore.contains(trigger.getId()))
+                .forEach(triggerRepository::delete);
         jobRepository.findAll().stream()
                 .filter(job -> !jobsBefore.contains(job.getId()))
                 .forEach(job -> {
@@ -176,6 +183,85 @@ public class RunTriggerDispatchIntegrationTest extends ServerApplicationTests {
         jobReconciliationService.reconcile(upstream.getId(), false);
 
         assertThat(triggeredJobsOn(destination)).isEmpty();
+    }
+
+    // ---------------------------------------------------------------- the seeded graph
+    //
+    // run-trigger-scenarios.xml seeds the simple-trigger organization with named shapes. The
+    // cases below run the engine over that graph rather than over edges built inline, which
+    // is what the fixture is for: the topology is declared once and every test reads it.
+
+    private static final String WS = "b0f1c2d3-0001-4000-8000-%012d";
+    private static final String FANOUT_HUB = String.format(WS, 1);
+    private static final String CHAIN_01 = String.format(WS, 7);
+    private static final String CHAIN_02 = String.format(WS, 8);
+    private static final String CHAIN_03 = String.format(WS, 9);
+    private static final String DIAMOND_ROOT = String.format(WS, 15);
+    private static final String DIAMOND_LEFT = String.format(WS, 16);
+    private static final String DIAMOND_RIGHT = String.format(WS, 17);
+    private static final String DIAMOND_JOIN = String.format(WS, 18);
+    private static final String DISABLED_UPSTREAM = String.format(WS, 19);
+    private static final String DISABLED_DOWNSTREAM = String.format(WS, 20);
+
+    /** Completes an apply on the given seeded workspace and returns the upstream job. */
+    private Job applyOn(String workspaceId) {
+        Job upstream = runningJob(workspace(workspaceId), JobStatus.completed);
+        jobReconciliationService.reconcile(upstream.getId(), false);
+        return upstream;
+    }
+
+    @Test
+    void fanOutReachesEveryDependent() {
+        Job upstream = applyOn(FANOUT_HUB);
+
+        List<Job> triggered = jobRepository.findAll().stream()
+                .filter(j -> JobVia.RUN_TRIGGER.getValue().equals(j.getVia()))
+                .filter(j -> Integer.valueOf(upstream.getId()).equals(j.getTriggeredByJobId()))
+                .toList();
+
+        assertThat(triggered).hasSize(5);
+        assertThat(triggered).allSatisfy(job -> assertThat(job.getCascadeDepth()).isEqualTo(1));
+        assertThat(triggered.stream().map(j -> j.getWorkspace().getName()))
+                .containsExactlyInAnyOrder("fanout-app-1", "fanout-app-2", "fanout-app-3",
+                        "fanout-app-4", "fanout-app-5");
+    }
+
+    /**
+     * A chain advances one step per run, rather than the whole chain firing at once: the
+     * engine only ever looks at the edges leaving the workspace that just applied.
+     */
+    @Test
+    void chainAdvancesOneStepPerRun() {
+        applyOn(CHAIN_01);
+
+        assertThat(triggeredJobsOn(workspace(CHAIN_02))).hasSize(1);
+        assertThat(triggeredJobsOn(workspace(CHAIN_03))).isEmpty();
+    }
+
+    /**
+     * The diamond, which is where the decision not to coalesce becomes visible. The root
+     * reaches the join through two branches, and each branch's apply enqueues its own run -
+     * two runs, not one.
+     */
+    @Test
+    void bothSidesOfADiamondReachTheJoin() {
+        applyOn(DIAMOND_ROOT);
+        assertThat(triggeredJobsOn(workspace(DIAMOND_LEFT))).hasSize(1);
+        assertThat(triggeredJobsOn(workspace(DIAMOND_RIGHT))).hasSize(1);
+        assertThat(triggeredJobsOn(workspace(DIAMOND_JOIN))).isEmpty();
+
+        applyOn(DIAMOND_LEFT);
+        assertThat(triggeredJobsOn(workspace(DIAMOND_JOIN))).hasSize(1);
+
+        applyOn(DIAMOND_RIGHT);
+        assertThat(triggeredJobsOn(workspace(DIAMOND_JOIN))).hasSize(2);
+    }
+
+    @Test
+    void aDisabledEdgeDispatchesNothing() {
+        applyOn(DISABLED_UPSTREAM);
+
+        assertThat(triggeredJobsOn(workspace(DISABLED_DOWNSTREAM))).isEmpty();
     }
 
     /** A source nobody depends on must not produce anything. */

--- a/api/src/test/java/io/terrakube/api/RunTriggerDispatchIntegrationTest.java
+++ b/api/src/test/java/io/terrakube/api/RunTriggerDispatchIntegrationTest.java
@@ -1,0 +1,193 @@
+package io.terrakube.api;
+
+import io.terrakube.api.plugin.scheduler.reconciliation.JobReconciliationService;
+import io.terrakube.api.repository.WorkspaceRunTriggerRepository;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.JobVia;
+import io.terrakube.api.rs.job.step.Step;
+import io.terrakube.api.rs.workspace.Workspace;
+import io.terrakube.api.rs.workspace.trigger.WorkspaceRunTrigger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * The dispatch path end to end, against the real database and the real reconciliation routine.
+ *
+ * <p>No executor is involved: {@code reconcile} is the routine that performs the transition to
+ * completed, so calling it directly exercises everything the engine depends on - the entity
+ * graph on the dispatch query, the TCL flow lookup, the foreign keys of the created job - in
+ * milliseconds and with no Kubernetes or HTTP anywhere.
+ *
+ * <p>The unit tests cover the branches. This one covers the wiring, which is what mocks cannot
+ * tell you: that the query really loads what the engine reads, and that the row it writes is
+ * actually accepted by the schema.
+ */
+public class RunTriggerDispatchIntegrationTest extends ServerApplicationTests {
+
+    private static final String WORKSPACE_SOURCE = "5ed411ca-7ab8-4d2f-b591-02d0d5788afc";
+    private static final String WORKSPACE_DESTINATION = "c20633b2-82cc-4105-9806-16e23ad0e1df";
+
+    /** "Plan and Apply" from simple.xml: terraformPlan at step 100, terraformApply at step 200. */
+    private static final String TEMPLATE_PLAN_APPLY = "2db36f7c-f549-4341-a789-315d47eb061d";
+    private static final String TCL_PLAN_APPLY =
+            "ZmxvdzoKICAtIHR5cGU6ICJ0ZXJyYWZvcm1QbGFuIgogICAgc3RlcDogMTAwCiAgICBuYW1lOiAiUGxhbiIKIC"
+            + "AtIHR5cGU6ICJ0ZXJyYWZvcm1BcHBseSIKICAgIHN0ZXA6IDIwMAogICAgbmFtZTogIkFwcGx5Ig==";
+
+    @Autowired
+    private JobReconciliationService jobReconciliationService;
+
+    @Autowired
+    private WorkspaceRunTriggerRepository triggerRepository;
+
+    private Set<Integer> jobsBefore;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        jobsBefore = jobRepository.findAll().stream().map(Job::getId).collect(Collectors.toSet());
+    }
+
+    /**
+     * Jobs created here are visible to every other test in the suite - ScheduleJob's admission
+     * query looks at a workspace's other jobs - so nothing may outlive this class. Only what
+     * appeared during the test is retired: a blanket deleteAll would also take jobs another
+     * test class created and still expects to find.
+     *
+     * <p>Soft deleted rather than deleted, which is what the product itself does for job
+     * pruning. A hard delete races the notification outbox: notifyStatusChanged writes a row
+     * referencing the job on another thread, and if it lands after the delete the foreign key
+     * rejects it. The entity's SQLRestriction makes a soft-deleted job invisible to every
+     * query anyway, which is all this cleanup needs.
+     */
+    @AfterEach
+    public void cleanup() {
+        triggerRepository.deleteAll();
+        jobRepository.findAll().stream()
+                .filter(job -> !jobsBefore.contains(job.getId()))
+                .forEach(job -> {
+                    job.setDeleted(true);
+                    jobRepository.save(job);
+                });
+    }
+
+    private Workspace workspace(String id) {
+        return workspaceRepository.findById(UUID.fromString(id)).orElseThrow();
+    }
+
+    private WorkspaceRunTrigger trigger(Workspace source, Workspace destination) {
+        WorkspaceRunTrigger trigger = new WorkspaceRunTrigger();
+        trigger.setSourceWorkspace(source);
+        trigger.setDestinationWorkspace(destination);
+        trigger.setOrganization(destination.getOrganization());
+        trigger.setEnabled(true);
+        return triggerRepository.save(trigger);
+    }
+
+    /** A run of the source workspace, one step short of terminal, ready to be reconciled. */
+    private Job runningJob(Workspace source, JobStatus applyStepStatus) {
+        Date now = new Date(System.currentTimeMillis());
+        Job job = new Job();
+        job.setWorkspace(source);
+        job.setOrganization(source.getOrganization());
+        job.setTemplateReference(TEMPLATE_PLAN_APPLY);
+        job.setTcl(TCL_PLAN_APPLY);
+        job.setStatus(JobStatus.running);
+        job.setCreatedBy("test");
+        job.setUpdatedBy("test");
+        job.setCreatedDate(now);
+        job.setUpdatedDate(now);
+        Job saved = jobRepository.save(job);
+
+        step(saved, 100, JobStatus.completed);
+        step(saved, 200, applyStepStatus);
+        return saved;
+    }
+
+    private void step(Job job, int stepNumber, JobStatus status) {
+        Step step = new Step();
+        step.setJob(job);
+        step.setStepNumber(stepNumber);
+        step.setName("step " + stepNumber);
+        step.setStatus(status);
+        stepRepository.save(step);
+    }
+
+    private List<Job> triggeredJobsOn(Workspace destination) {
+        return jobRepository.findAll().stream()
+                .filter(j -> j.getWorkspace() != null
+                        && j.getWorkspace().getId().equals(destination.getId()))
+                .filter(j -> JobVia.RUN_TRIGGER.getValue().equals(j.getVia()))
+                .toList();
+    }
+
+    @Test
+    void completingAnApplyCreatesTheDownstreamJob() {
+        Workspace source = workspace(WORKSPACE_SOURCE);
+        Workspace destination = workspace(WORKSPACE_DESTINATION);
+        destination.setDefaultTemplate(TEMPLATE_PLAN_APPLY);
+        workspaceRepository.save(destination);
+        trigger(source, destination);
+
+        Job upstream = runningJob(source, JobStatus.completed);
+
+        jobReconciliationService.reconcile(upstream.getId(), false);
+
+        List<Job> triggered = triggeredJobsOn(destination);
+        assertThat(triggered).hasSize(1);
+
+        Job downstream = triggered.get(0);
+        assertThat(downstream.getTriggeredByJobId()).isEqualTo(upstream.getId());
+        assertThat(downstream.getCascadeDepth()).isEqualTo(1);
+        assertThat(downstream.getTemplateReference()).isEqualTo(TEMPLATE_PLAN_APPLY);
+        assertThat(downstream.getOrganization().getId()).isEqualTo(destination.getOrganization().getId());
+        // Status is not asserted: the Quartz trigger fires at once and the scheduler owns it
+        // from here. Provenance is what this test is about, and it never changes.
+    }
+
+    /**
+     * The same run, with the apply never executed. It still reconciles to completed, so this is
+     * what separates reading step outcomes from reading job status - on real data rather than
+     * on a stubbed TclService.
+     */
+    @Test
+    void completingWithoutRunningTheApplyCreatesNothing() {
+        Workspace source = workspace(WORKSPACE_SOURCE);
+        Workspace destination = workspace(WORKSPACE_DESTINATION);
+        destination.setDefaultTemplate(TEMPLATE_PLAN_APPLY);
+        workspaceRepository.save(destination);
+        trigger(source, destination);
+
+        Job upstream = runningJob(source, JobStatus.notExecuted);
+
+        jobReconciliationService.reconcile(upstream.getId(), false);
+
+        assertThat(triggeredJobsOn(destination)).isEmpty();
+    }
+
+    /** A source nobody depends on must not produce anything. */
+    @Test
+    void completingAnApplyWithNoTriggerCreatesNothing() {
+        Workspace source = workspace(WORKSPACE_SOURCE);
+        Workspace destination = workspace(WORKSPACE_DESTINATION);
+
+        Job upstream = runningJob(source, JobStatus.completed);
+
+        jobReconciliationService.reconcile(upstream.getId(), false);
+
+        assertThat(triggeredJobsOn(destination)).isEmpty();
+    }
+}

--- a/api/src/test/java/io/terrakube/api/WorkspaceGraphValidationServiceTests.java
+++ b/api/src/test/java/io/terrakube/api/WorkspaceGraphValidationServiceTests.java
@@ -1,0 +1,149 @@
+package io.terrakube.api;
+
+import io.terrakube.api.plugin.scheduler.trigger.CyclicDependencyException;
+import io.terrakube.api.plugin.scheduler.trigger.WorkspaceGraphValidationService;
+import io.terrakube.api.repository.WorkspaceRunTriggerRepository;
+import io.terrakube.api.repository.WorkspaceRunTriggerRepository.TriggerEdge;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Cycle detection over the run trigger graph. Uses ids only, so no database is needed.
+ */
+class WorkspaceGraphValidationServiceTests {
+
+    private WorkspaceRunTriggerRepository repository;
+    private WorkspaceGraphValidationService service;
+
+    private final UUID org = UUID.randomUUID();
+    private final UUID a = UUID.randomUUID();
+    private final UUID b = UUID.randomUUID();
+    private final UUID c = UUID.randomUUID();
+    private final UUID d = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(WorkspaceRunTriggerRepository.class);
+        service = new WorkspaceGraphValidationService(repository);
+    }
+
+    private TriggerEdge edge(UUID id, UUID source, UUID destination) {
+        TriggerEdge e = mock(TriggerEdge.class);
+        when(e.getId()).thenReturn(id);
+        when(e.getSourceId()).thenReturn(source);
+        when(e.getDestinationId()).thenReturn(destination);
+        return e;
+    }
+
+    private void graph(TriggerEdge... edges) {
+        when(repository.findEdgesByOrganizationId(any())).thenReturn(List.of(edges));
+    }
+
+    @Test
+    void acceptsAnEdgeIntoAnEmptyGraph() {
+        graph();
+        assertDoesNotThrow(() -> service.validateAcyclic(org, null, a, b));
+    }
+
+    /** a -> b already exists; adding b -> c just extends the chain. */
+    @Test
+    void acceptsAChainExtension() {
+        graph(edge(UUID.randomUUID(), a, b));
+        assertDoesNotThrow(() -> service.validateAcyclic(org, null, b, c));
+    }
+
+    /** Two workspaces both feeding a third is a diamond, not a cycle. */
+    @Test
+    void acceptsFanInWhichIsNotACycle() {
+        graph(edge(UUID.randomUUID(), a, c), edge(UUID.randomUUID(), b, c));
+        assertDoesNotThrow(() -> service.validateAcyclic(org, null, a, b));
+    }
+
+    @Test
+    void rejectsADirectCycle() {
+        graph(edge(UUID.randomUUID(), a, b));
+        CyclicDependencyException thrown = assertThrows(CyclicDependencyException.class,
+                () -> service.validateAcyclic(org, null, b, a));
+        assertTrue(thrown.getMessage().contains("circular dependency"), thrown.getMessage());
+    }
+
+    /** a -> b -> c, so c -> a closes a three-hop loop. */
+    @Test
+    void rejectsAnIndirectCycle() {
+        graph(edge(UUID.randomUUID(), a, b), edge(UUID.randomUUID(), b, c));
+        assertThrows(CyclicDependencyException.class,
+                () -> service.validateAcyclic(org, null, c, a));
+    }
+
+    @Test
+    void rejectsALongerCycle() {
+        graph(edge(UUID.randomUUID(), a, b), edge(UUID.randomUUID(), b, c), edge(UUID.randomUUID(), c, d));
+        assertThrows(CyclicDependencyException.class,
+                () -> service.validateAcyclic(org, null, d, a));
+    }
+
+    @Test
+    void rejectsASelfTrigger() {
+        graph();
+        assertThrows(CyclicDependencyException.class,
+                () -> service.validateAcyclic(org, null, a, a));
+    }
+
+    /**
+     * On update the row is already flushed, so the edge under validation must be excluded -
+     * otherwise re-saving an existing a -> b would look like a cycle against itself.
+     */
+    @Test
+    void excludesTheEdgeBeingUpdated() {
+        UUID triggerId = UUID.randomUUID();
+        graph(edge(triggerId, a, b));
+        assertDoesNotThrow(() -> service.validateAcyclic(org, triggerId, a, b));
+    }
+
+    /**
+     * A cycle that already exists elsewhere must not hang the search for an unrelated edge.
+     * The graph should never contain one, but the traversal has to terminate regardless.
+     */
+    @Test
+    void terminatesWhenTheGraphAlreadyContainsACycle() {
+        graph(edge(UUID.randomUUID(), a, b), edge(UUID.randomUUID(), b, a));
+        assertDoesNotThrow(() -> service.validateAcyclic(org, null, c, d));
+    }
+
+    /** A deep chain must not overflow the stack: the search is iterative. */
+    @Test
+    void handlesADeepChainWithoutStackOverflow() {
+        int depth = 10_000;
+        UUID[] nodes = new UUID[depth + 1];
+        for (int i = 0; i <= depth; i++) {
+            nodes[i] = UUID.randomUUID();
+        }
+        TriggerEdge[] edges = new TriggerEdge[depth];
+        for (int i = 0; i < depth; i++) {
+            edges[i] = edge(UUID.randomUUID(), nodes[i], nodes[i + 1]);
+        }
+        graph(edges);
+
+        // last -> first closes the chain into a loop and must be caught
+        assertThrows(CyclicDependencyException.class,
+                () -> service.validateAcyclic(org, null, nodes[depth], nodes[0]));
+    }
+
+    @Test
+    void ignoresIncompleteInput() {
+        graph();
+        assertDoesNotThrow(() -> service.validateAcyclic(null, null, a, b));
+        assertDoesNotThrow(() -> service.validateAcyclic(org, null, null, b));
+        assertDoesNotThrow(() -> service.validateAcyclic(org, null, a, null));
+    }
+}

--- a/api/src/test/java/io/terrakube/api/WorkspaceRunTriggerTests.java
+++ b/api/src/test/java/io/terrakube/api/WorkspaceRunTriggerTests.java
@@ -1,12 +1,17 @@
 package io.terrakube.api;
 
 import io.terrakube.api.repository.WorkspaceRunTriggerRepository;
+import io.terrakube.api.rs.workspace.trigger.WorkspaceRunTrigger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
@@ -43,10 +48,15 @@ public class WorkspaceRunTriggerTests extends ServerApplicationTests {
     @Autowired
     private WorkspaceRunTriggerRepository triggerRepository;
 
+    private Set<UUID> triggersBefore;
+
     @BeforeEach
     public void setup() {
         MockitoAnnotations.openMocks(this);
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        triggersBefore = triggerRepository.findAll().stream()
+                .map(WorkspaceRunTrigger::getId)
+                .collect(Collectors.toSet());
     }
 
     /**
@@ -54,10 +64,16 @@ public class WorkspaceRunTriggerTests extends ServerApplicationTests {
      * cycle check reads the whole organization graph - so a test could otherwise fail for
      * an edge it never created. Cleaning here keeps every case independent of ordering
      * without touching the shared XML fixtures.
+     *
+     * <p>Only what this test created: run-trigger-scenarios.xml seeds a graph in the
+     * simple-trigger organization, and a blanket deleteAll would quietly destroy the demo
+     * data the whole suite and the dev environment share.
      */
     @AfterEach
     public void cleanupTriggers() {
-        triggerRepository.deleteAll();
+        triggerRepository.findAll().stream()
+                .filter(trigger -> !triggersBefore.contains(trigger.getId()))
+                .forEach(triggerRepository::delete);
     }
 
     private String triggerPayload(String sourceWorkspaceId, String destinationWorkspaceId) {

--- a/api/src/test/java/io/terrakube/api/WorkspaceRunTriggerTests.java
+++ b/api/src/test/java/io/terrakube/api/WorkspaceRunTriggerTests.java
@@ -1,8 +1,11 @@
 package io.terrakube.api;
 
+import io.terrakube.api.repository.WorkspaceRunTriggerRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 import static io.restassured.RestAssured.given;
@@ -26,10 +29,34 @@ public class WorkspaceRunTriggerTests extends ServerApplicationTests {
     // on a 404 for a non-existent entity rather than on the permission check.
     private static final String WORKSPACE_DESTINATION = "c20633b2-82cc-4105-9806-16e23ad0e1df";
 
+    // Member of the organization with manage_workspace, but not the instance owner group -
+    // the ordinary user this feature exists for.
+    private static final String GROUP_MANAGER = "TERRAKUBE_DEVELOPERS";
+
+    // Member of the same organization whose team has manage_workspace = false and which
+    // holds no project or workspace level access (project-access-demo-data.xml). Every
+    // other team of this organization can manage workspaces, so this is the only fixture
+    // group that genuinely exercises the denial path.
+    private static final String GROUP_NO_MANAGE = "PROJECT_TEAM_MEMBER";
+
+    @Autowired
+    private WorkspaceRunTriggerRepository triggerRepository;
+
     @BeforeEach
     public void setup() {
         MockitoAnnotations.openMocks(this);
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    /**
+     * Edges created by one test are visible to the next - they share a database and the
+     * cycle check reads the whole organization graph - so a test could otherwise fail for
+     * an edge it never created. Cleaning here keeps every case independent of ordering
+     * without touching the shared XML fixtures.
+     */
+    @AfterEach
+    public void cleanupTriggers() {
+        triggerRepository.deleteAll();
     }
 
     private String triggerPayload(String sourceWorkspaceId, String destinationWorkspaceId) {
@@ -107,13 +134,19 @@ public class WorkspaceRunTriggerTests extends ServerApplicationTests {
     }
 
     /**
-     * Writing requires manage rights on the destination: a member without them is refused
-     * even though both workspaces exist and are visible to the organization.
+     * The case the permission model exists for: an ordinary member with manage rights on
+     * the destination wires an edge, without being the instance owner.
+     *
+     * This is a regression test. An earlier revision guarded the inverse collections on
+     * Workspace with "user is a superuser", and because Elide maintains the bidirectional
+     * relationship on create, that rule fired on this ordinary path - no non-superuser
+     * could create a trigger at all, and the three tiers of WorkspaceTriggerPermissions
+     * were unreachable.
      */
     @Test
-    void memberWithoutManageCannotCreateRunTrigger() {
+    void memberWithManageCanCreateRunTrigger() {
         given()
-                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .headers("Authorization", "Bearer " + generatePAT(GROUP_MANAGER))
                 .contentType("application/vnd.api+json")
                 .body(triggerPayload(WORKSPACE_SOURCE, WORKSPACE_DESTINATION))
                 .when()
@@ -122,7 +155,30 @@ public class WorkspaceRunTriggerTests extends ServerApplicationTests {
                 .assertThat()
                 .log()
                 .all()
-                .statusCode(HttpStatus.FORBIDDEN.value());
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    /**
+     * Writing requires manage rights on the destination: a member without them is refused
+     * even though both workspaces exist and are visible to the organization.
+     */
+    @Test
+    void memberWithoutManageCannotCreateRunTrigger() {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT(GROUP_NO_MANAGE))
+                .contentType("application/vnd.api+json")
+                .body(triggerPayload(WORKSPACE_SOURCE, WORKSPACE_DESTINATION))
+                .when()
+                .post("/api/v1/runTrigger")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.FORBIDDEN.value())
+                // The denial must come from the trigger's own check. A previous revision
+                // passed this test on "UpdatePermission Denied" raised by an unrelated
+                // guard on Workspace, which hid the defect above.
+                .body("errors[0].detail", equalTo("CreatePermission Denied"));
     }
 
     /**
@@ -224,6 +280,100 @@ public class WorkspaceRunTriggerTests extends ServerApplicationTests {
                 .log()
                 .all()
                 .statusCode(HttpStatus.CREATED.value());
+    }
+
+    /**
+     * Both ends of an edge are immutable once set: repointing one is deleting a dependency
+     * and declaring another, and each deserves its own permission check.
+     *
+     * The PATCH of enabled comes first on purpose. Without it the two denials below would
+     * also pass if this caller simply could not update the resource at all, which is the
+     * failure mode that made an earlier version of this suite green for the wrong reason.
+     */
+    @Test
+    void runTriggerEndpointsAreImmutableForNonSuperUsers() {
+        String triggerId = createTriggerAsAdmin(WORKSPACE_SOURCE, WORKSPACE_DESTINATION);
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT(GROUP_MANAGER))
+                .contentType("application/vnd.api+json")
+                .body("{\"data\":{\"type\":\"runTrigger\",\"id\":\"" + triggerId + "\","
+                        + "\"attributes\":{\"enabled\":false}}}")
+                .when()
+                .patch("/api/v1/runTrigger/" + triggerId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        assertRelationshipIsImmutable(triggerId, "sourceWorkspace", WORKSPACE_TAG2);
+        assertRelationshipIsImmutable(triggerId, "destinationWorkspace", WORKSPACE_TAG3);
+    }
+
+    private String createTriggerAsAdmin(String sourceWorkspaceId, String destinationWorkspaceId) {
+        return given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
+                .contentType("application/vnd.api+json")
+                .body(triggerPayload(sourceWorkspaceId, destinationWorkspaceId))
+                .when()
+                .post("/api/v1/runTrigger")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract()
+                .path("data.id");
+    }
+
+    private void assertRelationshipIsImmutable(String triggerId, String relationship, String newWorkspaceId) {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT(GROUP_MANAGER))
+                .contentType("application/vnd.api+json")
+                .body("{\"data\":{\"type\":\"runTrigger\",\"id\":\"" + triggerId + "\","
+                        + "\"relationships\":{\"" + relationship + "\":{\"data\":"
+                        + "{\"type\":\"workspace\",\"id\":\"" + newWorkspaceId + "\"}}}}}")
+                .when()
+                .patch("/api/v1/runTrigger/" + triggerId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.FORBIDDEN.value())
+                .body("errors[0].detail", equalTo("UpdatePermission Denied"));
+    }
+
+    /**
+     * Clearing the inverse collection through the workspace must not destroy the edge.
+     *
+     * The trigger's own DeletePermission is the only sanctioned way to remove one, and it
+     * is not consulted when Hibernate drops an orphan - so the relationship deliberately
+     * carries neither cascade nor orphanRemoval. Run as the instance owner: if the strongest
+     * caller cannot delete an edge this way, no one can.
+     */
+    @Test
+    void clearingTriggersThroughWorkspaceDoesNotDeleteThem() {
+        String triggerId = createTriggerAsAdmin(WORKSPACE_SOURCE, WORKSPACE_DESTINATION);
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
+                .contentType("application/vnd.api+json")
+                .body("{\"data\":{\"type\":\"workspace\",\"id\":\"" + WORKSPACE_SOURCE + "\","
+                        + "\"relationships\":{\"sourceRunTriggers\":{\"data\":[]}}}}")
+                .when()
+                .patch("/api/v1/organization/" + ORGANIZATION + "/workspace/" + WORKSPACE_SOURCE)
+                .then()
+                .log()
+                .all();
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
+                .when()
+                .get("/api/v1/runTrigger/" + triggerId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value());
     }
 
     /** An anonymous caller must never reach the resource. */

--- a/api/src/test/java/io/terrakube/api/WorkspaceRunTriggerTests.java
+++ b/api/src/test/java/io/terrakube/api/WorkspaceRunTriggerTests.java
@@ -1,0 +1,117 @@
+package io.terrakube.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+
+import static io.restassured.RestAssured.given;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the persistence and permission surface of run triggers. The dispatch behaviour
+ * (a completed apply enqueueing downstream runs) arrives in a later phase and is not
+ * exercised here.
+ */
+public class WorkspaceRunTriggerTests extends ServerApplicationTests {
+
+    private static final String ORGANIZATION = "d9b58bd3-f3fc-4056-a026-1163297e80a8";
+    private static final String WORKSPACE_SOURCE = "5ed411ca-7ab8-4d2f-b591-02d0d5788afc";
+    private static final String WORKSPACE_DESTINATION = "58529721-425e-44d7-8b0d-1d515043c2f7";
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    private String triggerPayload(String sourceWorkspaceId) {
+        return "{\"data\":{\"type\":\"runTrigger\",\"attributes\":{\"enabled\":true},"
+                + "\"relationships\":{"
+                + "\"sourceWorkspace\":{\"data\":{\"type\":\"workspace\",\"id\":\"" + sourceWorkspaceId + "\"}},"
+                + "\"destinationWorkspace\":{\"data\":{\"type\":\"workspace\",\"id\":\"" + WORKSPACE_DESTINATION + "\"}},"
+                + "\"organization\":{\"data\":{\"type\":\"organization\",\"id\":\"" + ORGANIZATION + "\"}}"
+                + "}}}";
+    }
+
+    @Test
+    void adminCanListRunTriggers() {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
+                .when()
+                .get("/api/v1/runTrigger")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    /**
+     * Reads are open to any member of the organization, so the dependency graph stays
+     * discoverable even for people who cannot change it.
+     */
+    @Test
+    void organizationMemberCanReadRunTriggers() {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .when()
+                .get("/api/v1/runTrigger")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    /** Someone outside the organization must not see its edges at all. */
+    @Test
+    void nonMemberCannotReadRunTriggers() {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("NOT_A_MEMBER"))
+                .when()
+                .get("/api/v1/runTrigger")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value())
+                .body("data.size()", org.hamcrest.Matchers.equalTo(0));
+    }
+
+    /**
+     * Writing requires manage rights on the destination. A member without them is refused;
+     * Elide answers 404 rather than 403 when the caller cannot see the referenced
+     * workspaces, which is the safer of the two since it does not confirm they exist.
+     */
+    @Test
+    void memberWithoutManageCannotCreateRunTrigger() {
+        int status = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .contentType("application/vnd.api+json")
+                .body(triggerPayload(WORKSPACE_SOURCE))
+                .when()
+                .post("/api/v1/runTrigger")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .extract()
+                .statusCode();
+
+        org.junit.jupiter.api.Assertions.assertTrue(
+                status == HttpStatus.FORBIDDEN.value() || status == HttpStatus.NOT_FOUND.value(),
+                "creating a run trigger without manage rights must be denied, got " + status);
+    }
+
+    /** An anonymous caller must never reach the resource. */
+    @Test
+    void anonymousCannotReadRunTriggers() {
+        given()
+                .when()
+                .get("/api/v1/runTrigger")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+}

--- a/api/src/test/java/io/terrakube/api/WorkspaceRunTriggerTests.java
+++ b/api/src/test/java/io/terrakube/api/WorkspaceRunTriggerTests.java
@@ -20,6 +20,7 @@ public class WorkspaceRunTriggerTests extends ServerApplicationTests {
     private static final String WORKSPACE_SOURCE = "5ed411ca-7ab8-4d2f-b591-02d0d5788afc";
     private static final String WORKSPACE_TAG3 = "24480d33-2649-4c34-aabd-cbc988eb6265";
     private static final String WORKSPACE_TAG2 = "5a7873bd-9fd3-4193-b3df-33ba586fb146";
+
     // Both are real workspaces of the organization above (simple.xml / simple-tag.xml).
     // A previous revision used a team id here by mistake, which made the denial test pass
     // on a 404 for a non-existent entity rather than on the permission check.
@@ -159,6 +160,35 @@ public class WorkspaceRunTriggerTests extends ServerApplicationTests {
                 .then()
                 .assertThat()
                 .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+
+    /**
+     * The graph must stay acyclic: with source -> destination in place, the reverse edge
+     * closes a loop and is refused by the validation hook with 400.
+     */
+    @Test
+    void cyclicTriggerIsRejected() {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
+                .contentType("application/vnd.api+json")
+                .body(triggerPayload(WORKSPACE_TAG3, WORKSPACE_TAG2))
+                .when()
+                .post("/api/v1/runTrigger")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
+                .contentType("application/vnd.api+json")
+                .body(triggerPayload(WORKSPACE_TAG2, WORKSPACE_TAG3))
+                .when()
+                .post("/api/v1/runTrigger")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
     /** A workspace triggering itself would re-run on every apply until the cascade limit. */

--- a/api/src/test/java/io/terrakube/api/WorkspaceRunTriggerTests.java
+++ b/api/src/test/java/io/terrakube/api/WorkspaceRunTriggerTests.java
@@ -6,6 +6,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpStatus;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
 
 /**
@@ -17,7 +18,11 @@ public class WorkspaceRunTriggerTests extends ServerApplicationTests {
 
     private static final String ORGANIZATION = "d9b58bd3-f3fc-4056-a026-1163297e80a8";
     private static final String WORKSPACE_SOURCE = "5ed411ca-7ab8-4d2f-b591-02d0d5788afc";
-    private static final String WORKSPACE_DESTINATION = "58529721-425e-44d7-8b0d-1d515043c2f7";
+    private static final String WORKSPACE_TAG3 = "24480d33-2649-4c34-aabd-cbc988eb6265";
+    // Both are real workspaces of the organization above (simple.xml / simple-tag.xml).
+    // A previous revision used a team id here by mistake, which made the denial test pass
+    // on a 404 for a non-existent entity rather than on the permission check.
+    private static final String WORKSPACE_DESTINATION = "c20633b2-82cc-4105-9806-16e23ad0e1df";
 
     @BeforeEach
     public void setup() {
@@ -25,13 +30,16 @@ public class WorkspaceRunTriggerTests extends ServerApplicationTests {
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
     }
 
-    private String triggerPayload(String sourceWorkspaceId) {
+    private String triggerPayload(String sourceWorkspaceId, String destinationWorkspaceId) {
         return "{\"data\":{\"type\":\"runTrigger\",\"attributes\":{\"enabled\":true},"
                 + "\"relationships\":{"
                 + "\"sourceWorkspace\":{\"data\":{\"type\":\"workspace\",\"id\":\"" + sourceWorkspaceId + "\"}},"
-                + "\"destinationWorkspace\":{\"data\":{\"type\":\"workspace\",\"id\":\"" + WORKSPACE_DESTINATION + "\"}},"
-                + "\"organization\":{\"data\":{\"type\":\"organization\",\"id\":\"" + ORGANIZATION + "\"}}"
+                + "\"destinationWorkspace\":{\"data\":{\"type\":\"workspace\",\"id\":\"" + destinationWorkspaceId + "\"}}"
                 + "}}}";
+    }
+
+    private String payloadWithoutOrganization(String sourceWorkspaceId, String destinationWorkspaceId) {
+        return triggerPayload(sourceWorkspaceId, destinationWorkspaceId);
     }
 
     @Test
@@ -76,32 +84,78 @@ public class WorkspaceRunTriggerTests extends ServerApplicationTests {
                 .log()
                 .all()
                 .statusCode(HttpStatus.OK.value())
-                .body("data.size()", org.hamcrest.Matchers.equalTo(0));
+                .body("data.size()", equalTo(0));
     }
 
-    /**
-     * Writing requires manage rights on the destination. A member without them is refused;
-     * Elide answers 404 rather than 403 when the caller cannot see the referenced
-     * workspaces, which is the safer of the two since it does not confirm they exist.
-     */
+    /** The happy path: an admin wires two real workspaces of the same organization. */
     @Test
-    void memberWithoutManageCannotCreateRunTrigger() {
-        int status = given()
-                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+    void adminCanCreateRunTrigger() {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
                 .contentType("application/vnd.api+json")
-                .body(triggerPayload(WORKSPACE_SOURCE))
+                .body(triggerPayload(WORKSPACE_SOURCE, WORKSPACE_DESTINATION))
                 .when()
                 .post("/api/v1/runTrigger")
                 .then()
                 .assertThat()
                 .log()
                 .all()
-                .extract()
-                .statusCode();
+                .statusCode(HttpStatus.CREATED.value())
+                .body("data.attributes.enabled", equalTo(true));
+    }
 
-        org.junit.jupiter.api.Assertions.assertTrue(
-                status == HttpStatus.FORBIDDEN.value() || status == HttpStatus.NOT_FOUND.value(),
-                "creating a run trigger without manage rights must be denied, got " + status);
+    /**
+     * Writing requires manage rights on the destination: a member without them is refused
+     * even though both workspaces exist and are visible to the organization.
+     */
+    @Test
+    void memberWithoutManageCannotCreateRunTrigger() {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_DEVELOPERS"))
+                .contentType("application/vnd.api+json")
+                .body(triggerPayload(WORKSPACE_SOURCE, WORKSPACE_DESTINATION))
+                .when()
+                .post("/api/v1/runTrigger")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+    }
+
+    /** A workspace triggering itself would re-run on every apply until the cascade limit. */
+    @Test
+    void selfTriggerIsRejected() {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
+                .contentType("application/vnd.api+json")
+                .body(triggerPayload(WORKSPACE_SOURCE, WORKSPACE_SOURCE))
+                .when()
+                .post("/api/v1/runTrigger")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.FORBIDDEN.value());
+    }
+
+    /**
+     * The organization is derived from the destination workspace by the lifecycle hook, so
+     * omitting it must succeed rather than fail on the NOT NULL column.
+     */
+    @Test
+    void organizationIsDerivedWhenOmitted() {
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
+                .contentType("application/vnd.api+json")
+                .body(payloadWithoutOrganization(WORKSPACE_SOURCE, WORKSPACE_TAG3))
+                .when()
+                .post("/api/v1/runTrigger")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value());
     }
 
     /** An anonymous caller must never reach the resource. */

--- a/api/src/test/java/io/terrakube/api/WorkspaceRunTriggerTests.java
+++ b/api/src/test/java/io/terrakube/api/WorkspaceRunTriggerTests.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.mockito.Mockito.when;
 
 /**
@@ -373,6 +374,73 @@ public class WorkspaceRunTriggerTests extends ServerApplicationTests {
                 .assertThat()
                 .log()
                 .all()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    /**
+     * The exact query the Run Triggers page issues: one request for both directions, with the
+     * ends resolved through an include block.
+     *
+     * A comma is OR in Elide's filter syntax, so this returns the edges where the workspace is
+     * the source together with the ones where it is the destination. The unrelated edge is in
+     * the same organization and is what proves the filter discriminates rather than the caller
+     * simply seeing everything.
+     */
+    @Test
+    void filteringByEitherEndReturnsBothDirections() {
+        createTriggerAsAdmin(WORKSPACE_SOURCE, WORKSPACE_DESTINATION);
+        createTriggerAsAdmin(WORKSPACE_DESTINATION, WORKSPACE_TAG3);
+        createTriggerAsAdmin(WORKSPACE_TAG2, WORKSPACE_TAG3);
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
+                .queryParam("include", "sourceWorkspace,destinationWorkspace,template")
+                .queryParam(
+                        "filter[runTrigger]",
+                        "sourceWorkspace.id==" + WORKSPACE_DESTINATION
+                                + ",destinationWorkspace.id==" + WORKSPACE_DESTINATION)
+                .when()
+                .get("/api/v1/runTrigger")
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.OK.value())
+                .body("data.size()", equalTo(2))
+                // Without the names the page would show raw ids, so the include block matters
+                // as much as the filter.
+                .body("included.findAll { it.type == 'workspace' }.size()", greaterThan(0));
+    }
+
+    /**
+     * A DELETE that declares a JSON:API content type is refused, because it carries no body.
+     *
+     * This is asserted rather than merely known: the Run Triggers page deliberately omits the
+     * header on delete, and this is the test that explains why to whoever is tempted to add it
+     * back for symmetry with the other verbs.
+     */
+    @Test
+    void deleteDeclaringAContentTypeIsRejected() {
+        String triggerId = createTriggerAsAdmin(WORKSPACE_SOURCE, WORKSPACE_TAG2);
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
+                .contentType("application/vnd.api+json")
+                .when()
+                .delete("/api/v1/runTrigger/" + triggerId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+
+        // And the edge is still there, so the page's own delete has something to remove.
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
+                .when()
+                .get("/api/v1/runTrigger/" + triggerId)
+                .then()
+                .assertThat()
                 .statusCode(HttpStatus.OK.value());
     }
 

--- a/api/src/test/java/io/terrakube/api/WorkspaceRunTriggerTests.java
+++ b/api/src/test/java/io/terrakube/api/WorkspaceRunTriggerTests.java
@@ -19,6 +19,7 @@ public class WorkspaceRunTriggerTests extends ServerApplicationTests {
     private static final String ORGANIZATION = "d9b58bd3-f3fc-4056-a026-1163297e80a8";
     private static final String WORKSPACE_SOURCE = "5ed411ca-7ab8-4d2f-b591-02d0d5788afc";
     private static final String WORKSPACE_TAG3 = "24480d33-2649-4c34-aabd-cbc988eb6265";
+    private static final String WORKSPACE_TAG2 = "5a7873bd-9fd3-4193-b3df-33ba586fb146";
     // Both are real workspaces of the organization above (simple.xml / simple-tag.xml).
     // A previous revision used a team id here by mistake, which made the denial test pass
     // on a 404 for a non-existent entity rather than on the permission check.
@@ -121,6 +122,43 @@ public class WorkspaceRunTriggerTests extends ServerApplicationTests {
                 .log()
                 .all()
                 .statusCode(HttpStatus.FORBIDDEN.value());
+    }
+
+    /**
+     * Deletion is governed by TeamDeleteWorkspaceTrigger, which asks only for manage rights
+     * on the destination - so an admin can always detach a trigger from their own workspace.
+     */
+    @Test
+    void adminCanDeleteRunTrigger() {
+        String triggerId = given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
+                .contentType("application/vnd.api+json")
+                .body(triggerPayload(WORKSPACE_SOURCE, WORKSPACE_TAG2))
+                .when()
+                .post("/api/v1/runTrigger")
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract()
+                .path("data.id");
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
+                .when()
+                .delete("/api/v1/runTrigger/" + triggerId)
+                .then()
+                .assertThat()
+                .log()
+                .all()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+        given()
+                .headers("Authorization", "Bearer " + generatePAT("TERRAKUBE_ADMIN"))
+                .when()
+                .get("/api/v1/runTrigger/" + triggerId)
+                .then()
+                .assertThat()
+                .statusCode(HttpStatus.NOT_FOUND.value());
     }
 
     /** A workspace triggering itself would re-run on every apply until the cascade limit. */

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/reconciliation/JobReconciliationServiceTest.java
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.terrakube.api.helpers.FailUnkownMethod;
 import io.terrakube.api.plugin.notification.JobNotificationTrigger;
 import io.terrakube.api.plugin.scheduler.ScheduleJobService;
+import io.terrakube.api.plugin.scheduler.trigger.RunTriggerDispatchService;
 import io.terrakube.api.plugin.scheduler.reconciliation.ReconciliationResult.ReconciliationDisposition;
 import io.terrakube.api.repository.JobRepository;
 import io.terrakube.api.repository.StepRepository;
@@ -21,6 +22,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -36,6 +38,7 @@ class JobReconciliationServiceTest {
     JobNotificationTrigger jobNotificationTrigger;
     ScheduleJobService scheduleJobService;
     Scheduler scheduler;
+    RunTriggerDispatchService runTriggerDispatchService;
     JobReconciliationService subject;
 
     @BeforeEach
@@ -50,9 +53,11 @@ class JobReconciliationServiceTest {
         lenient().doAnswer(i -> i.getArgument(0)).when(jobRepository).save(any());
         lenient().doAnswer(i -> i.getArgument(0)).when(workspaceRepository).save(any());
         lenient().doReturn(null).when(jobRepository).findNextDispatchableExecutableJobId();
+        runTriggerDispatchService = mock(RunTriggerDispatchService.class);
         subject = new JobReconciliationService(jobRepository, stepRepository, workspaceRepository,
                 new JobTerminalStateDeriver(), jobNotificationTrigger, scheduleJobService,
-                scheduler, new JobReconciliationMetrics(new SimpleMeterRegistry()));
+                scheduler, new JobReconciliationMetrics(new SimpleMeterRegistry()),
+                runTriggerDispatchService);
     }
 
     private Job job(int id, JobStatus status) {
@@ -87,6 +92,56 @@ class JobReconciliationServiceTest {
         verify(jobNotificationTrigger, times(1)).notifyStatusChanged(j);
         verify(workspaceRepository, times(1)).save(j.getWorkspace());
         verify(scheduler, times(1)).deleteJob(any());
+    }
+
+    /**
+     * Anchoring dispatch to the transition, not to the job status, is what makes it fire once:
+     * a second caller finds the job already terminal and returns before this point.
+     */
+    @Test
+    void transitionToCompletedDispatchesRunTriggersOnce() {
+        Job j = job(755, JobStatus.approved);
+        doReturn(j).when(jobRepository).lockForUpdate(755);
+        doReturn(List.of(step(JobStatus.completed, 100))).when(stepRepository).findByJobId(755);
+
+        subject.reconcile(755, false);
+
+        verify(runTriggerDispatchService, times(1)).dispatchFor(755);
+    }
+
+    @Test
+    void transitionToFailedDispatchesNoRunTriggers() {
+        Job j = job(756, JobStatus.running);
+        doReturn(j).when(jobRepository).lockForUpdate(756);
+        doReturn(List.of(step(JobStatus.completed, 100), step(JobStatus.failed, 200)))
+                .when(stepRepository).findByJobId(756);
+
+        ReconciliationResult result = subject.reconcile(756, false);
+
+        assertThat(result.targetStatus()).isEqualTo(JobStatus.failed);
+        verify(runTriggerDispatchService, never()).dispatchFor(anyInt());
+    }
+
+    @Test
+    void alreadyTerminalDispatchesNoRunTriggers() {
+        Job j = job(755, JobStatus.completed);
+        doReturn(j).when(jobRepository).lockForUpdate(755);
+        doReturn(List.of(step(JobStatus.completed, 100))).when(stepRepository).findByJobId(755);
+
+        subject.reconcile(755, false);
+
+        verify(runTriggerDispatchService, never()).dispatchFor(anyInt());
+    }
+
+    @Test
+    void dryRunDispatchesNoRunTriggers() {
+        Job j = job(755, JobStatus.approved);
+        doReturn(j).when(jobRepository).lockForUpdate(755);
+        doReturn(List.of(step(JobStatus.completed, 100))).when(stepRepository).findByJobId(755);
+
+        subject.reconcile(755, true);
+
+        verify(runTriggerDispatchService, never()).dispatchFor(anyInt());
     }
 
     @Test

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/trigger/RunTriggerDispatchServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/trigger/RunTriggerDispatchServiceTest.java
@@ -1,0 +1,373 @@
+package io.terrakube.api.plugin.scheduler.trigger;
+
+import io.terrakube.api.plugin.notification.JobNotificationTrigger;
+import io.terrakube.api.plugin.scheduler.ScheduleJobService;
+import io.terrakube.api.plugin.scheduler.job.tcl.TclService;
+import io.terrakube.api.plugin.scheduler.job.tcl.model.FlowType;
+import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.repository.StepRepository;
+import io.terrakube.api.repository.WorkspaceRunTriggerRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.JobVia;
+import io.terrakube.api.rs.job.step.Step;
+import io.terrakube.api.rs.template.Template;
+import io.terrakube.api.rs.workspace.Workspace;
+import io.terrakube.api.rs.workspace.trigger.WorkspaceRunTrigger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class RunTriggerDispatchServiceTest {
+
+    private static final UUID SOURCE_ID = UUID.randomUUID();
+    private static final int COMPLETED_JOB_ID = 900;
+
+    JobRepository jobRepository;
+    StepRepository stepRepository;
+    WorkspaceRunTriggerRepository triggerRepository;
+    TclService tclService;
+    JobNotificationTrigger jobNotificationTrigger;
+    ScheduleJobService scheduleJobService;
+    RunTriggerProperties properties;
+    RunTriggerDispatchService subject;
+
+    private int nextJobId;
+
+    @BeforeEach
+    void setup() throws Exception {
+        jobRepository = mock(JobRepository.class);
+        stepRepository = mock(StepRepository.class);
+        triggerRepository = mock(WorkspaceRunTriggerRepository.class);
+        tclService = mock(TclService.class);
+        jobNotificationTrigger = mock(JobNotificationTrigger.class);
+        scheduleJobService = mock(ScheduleJobService.class);
+        properties = new RunTriggerProperties();
+        nextJobId = 1000;
+
+        // Assigning an id on save mirrors the database and lets the assertions distinguish
+        // the jobs created for each dependent.
+        lenient().doAnswer(i -> {
+            Job saved = i.getArgument(0);
+            saved.setId(nextJobId++);
+            return saved;
+        }).when(jobRepository).save(any(Job.class));
+
+        subject = new RunTriggerDispatchService(jobRepository, stepRepository, triggerRepository,
+                tclService, jobNotificationTrigger, scheduleJobService, properties);
+    }
+
+    // ---------------------------------------------------------------- fixtures
+
+    private Workspace workspace(String name, String defaultTemplate) {
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+        organization.setName("simple");
+
+        Workspace workspace = new Workspace();
+        workspace.setId(UUID.randomUUID());
+        workspace.setName(name);
+        workspace.setDefaultTemplate(defaultTemplate);
+        workspace.setOrganization(organization);
+        return workspace;
+    }
+
+    private Job completedJob(int cascadeDepth) {
+        Workspace source = workspace("source", null);
+        source.setId(SOURCE_ID);
+
+        Job job = new Job();
+        job.setId(COMPLETED_JOB_ID);
+        job.setWorkspace(source);
+        job.setStatus(JobStatus.completed);
+        job.setCascadeDepth(cascadeDepth);
+        doReturn(Optional.of(job)).when(jobRepository).findById(COMPLETED_JOB_ID);
+        return job;
+    }
+
+    /** One completed step whose flow type is what the test wants to exercise. */
+    private void stepsWithFlow(Job job, FlowType flowType, JobStatus stepStatus) {
+        Step step = new Step();
+        step.setId(UUID.randomUUID());
+        step.setStepNumber(200);
+        step.setStatus(stepStatus);
+        doReturn(List.of(step)).when(stepRepository).findByJobId(job.getId());
+        lenient().doReturn(flowType.toString()).when(tclService).getFlowTypeForStep(job, 200);
+    }
+
+    private WorkspaceRunTrigger trigger(Workspace destination, Template template) {
+        WorkspaceRunTrigger trigger = new WorkspaceRunTrigger();
+        trigger.setId(UUID.randomUUID());
+        trigger.setDestinationWorkspace(destination);
+        trigger.setTemplate(template);
+        trigger.setEnabled(true);
+        return trigger;
+    }
+
+    private void triggersFromSource(WorkspaceRunTrigger... triggers) {
+        doReturn(new ArrayList<>(List.of(triggers)))
+                .when(triggerRepository).findEnabledBySourceWorkspaceId(SOURCE_ID);
+    }
+
+    // ---------------------------------------------------------------- qualification
+
+    @Test
+    void applyDispatchesToTheDependent() throws Exception {
+        Job completed = completedJob(0);
+        stepsWithFlow(completed, FlowType.terraformApply, JobStatus.completed);
+        Workspace destination = workspace("consumer", "template-default");
+        triggersFromSource(trigger(destination, null));
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+
+        ArgumentCaptor<Job> captor = ArgumentCaptor.forClass(Job.class);
+        verify(jobRepository).save(captor.capture());
+        Job created = captor.getValue();
+
+        assertThat(created.getWorkspace()).isSameAs(destination);
+        assertThat(created.getOrganization()).isSameAs(destination.getOrganization());
+        assertThat(created.getTemplateReference()).isEqualTo("template-default");
+        assertThat(created.getStatus()).isEqualTo(JobStatus.pending);
+        assertThat(created.getVia()).isEqualTo(JobVia.RUN_TRIGGER.getValue());
+        assertThat(created.getTriggeredByJobId()).isEqualTo(COMPLETED_JOB_ID);
+        assertThat(created.getCascadeDepth()).isEqualTo(1);
+        assertThat(created.isPlanChanges()).isTrue();
+        assertThat(created.isRefresh()).isTrue();
+        assertThat(created.isRefreshOnly()).isFalse();
+
+        // Neither hook fires for a repository save, so both have to happen explicitly.
+        verify(jobNotificationTrigger).notifyStatusChanged(created);
+        verify(scheduleJobService).createJobContext(created);
+    }
+
+    @Test
+    void destroyDispatches() {
+        Job completed = completedJob(0);
+        stepsWithFlow(completed, FlowType.terraformDestroy, JobStatus.completed);
+        triggersFromSource(trigger(workspace("consumer", "template-default"), null));
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+
+        verify(jobRepository).save(any(Job.class));
+    }
+
+    @Test
+    void customScriptsDispatches() {
+        Job completed = completedJob(0);
+        stepsWithFlow(completed, FlowType.customScripts, JobStatus.completed);
+        triggersFromSource(trigger(workspace("consumer", "template-default"), null));
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+
+        verify(jobRepository).save(any(Job.class));
+    }
+
+    /** A run that only planned leaves nothing downstream to react to. */
+    @Test
+    void planOnlyRunDispatchesNothing() {
+        Job completed = completedJob(0);
+        stepsWithFlow(completed, FlowType.terraformPlan, JobStatus.completed);
+        triggersFromSource(trigger(workspace("consumer", "template-default"), null));
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+
+        verify(jobRepository, never()).save(any(Job.class));
+    }
+
+    /**
+     * A plan/apply template whose apply never executed still finishes as completed. Reading
+     * the step status rather than the job status is what keeps it from firing.
+     */
+    @Test
+    void applyStepThatDidNotRunDispatchesNothing() {
+        Job completed = completedJob(0);
+        stepsWithFlow(completed, FlowType.terraformApply, JobStatus.notExecuted);
+        triggersFromSource(trigger(workspace("consumer", "template-default"), null));
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+
+        verify(jobRepository, never()).save(any(Job.class));
+    }
+
+    @Test
+    void unparseableTclDispatchesNothing() {
+        Job completed = completedJob(0);
+        Step step = new Step();
+        step.setId(UUID.randomUUID());
+        step.setStepNumber(200);
+        step.setStatus(JobStatus.completed);
+        doReturn(List.of(step)).when(stepRepository).findByJobId(COMPLETED_JOB_ID);
+        doReturn(null).when(tclService).getFlowTypeForStep(completed, 200);
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+
+        verify(jobRepository, never()).save(any(Job.class));
+    }
+
+    // ---------------------------------------------------------------- bounds
+
+    @Test
+    void cascadeStopsAtTheConfiguredDepth() {
+        properties.setMaxCascadeDepth(3);
+        Job completed = completedJob(3);
+        stepsWithFlow(completed, FlowType.terraformApply, JobStatus.completed);
+        triggersFromSource(trigger(workspace("consumer", "template-default"), null));
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+
+        verify(jobRepository, never()).save(any(Job.class));
+    }
+
+    @Test
+    void cascadeDispatchesOnTheStepBelowTheLimit() {
+        properties.setMaxCascadeDepth(3);
+        Job completed = completedJob(2);
+        stepsWithFlow(completed, FlowType.terraformApply, JobStatus.completed);
+        triggersFromSource(trigger(workspace("consumer", "template-default"), null));
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+
+        ArgumentCaptor<Job> captor = ArgumentCaptor.forClass(Job.class);
+        verify(jobRepository).save(captor.capture());
+        assertThat(captor.getValue().getCascadeDepth()).isEqualTo(3);
+    }
+
+    @Test
+    void fanOutIsCappedAndTheSurvivingSubsetIsStable() {
+        properties.setMaxDependentsPerApply(3);
+        Job completed = completedJob(0);
+        stepsWithFlow(completed, FlowType.terraformApply, JobStatus.completed);
+
+        WorkspaceRunTrigger[] triggers = IntStream.range(0, 5)
+                .mapToObj(i -> trigger(workspace("consumer-" + i, "template-default"), null))
+                .toArray(WorkspaceRunTrigger[]::new);
+        triggersFromSource(triggers);
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+        ArgumentCaptor<Job> first = ArgumentCaptor.forClass(Job.class);
+        verify(jobRepository, times(3)).save(first.capture());
+        List<String> firstRun = first.getAllValues().stream().map(j -> j.getWorkspace().getName()).toList();
+
+        // Same graph, same apply: the cap must not pick a different arbitrary subset.
+        List<WorkspaceRunTrigger> shuffled = new ArrayList<>(List.of(triggers));
+        java.util.Collections.reverse(shuffled);
+        doReturn(shuffled).when(triggerRepository).findEnabledBySourceWorkspaceId(SOURCE_ID);
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+        ArgumentCaptor<Job> second = ArgumentCaptor.forClass(Job.class);
+        verify(jobRepository, times(6)).save(second.capture());
+        List<String> secondRun = second.getAllValues().subList(3, 6).stream()
+                .map(j -> j.getWorkspace().getName()).toList();
+
+        assertThat(secondRun).containsExactlyInAnyOrderElementsOf(firstRun);
+    }
+
+    @Test
+    void killSwitchDispatchesNothing() {
+        properties.setEnabled(false);
+        completedJob(0);
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+
+        verify(jobRepository, never()).save(any(Job.class));
+        verify(stepRepository, never()).findByJobId(anyInt());
+    }
+
+    // ---------------------------------------------------------------- template resolution
+
+    @Test
+    void triggerTemplateWinsOverTheWorkspaceDefault() {
+        Job completed = completedJob(0);
+        stepsWithFlow(completed, FlowType.terraformApply, JobStatus.completed);
+
+        Template template = new Template();
+        template.setId(UUID.randomUUID());
+        triggersFromSource(trigger(workspace("consumer", "template-default"), template));
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+
+        ArgumentCaptor<Job> captor = ArgumentCaptor.forClass(Job.class);
+        verify(jobRepository).save(captor.capture());
+        assertThat(captor.getValue().getTemplateReference()).isEqualTo(template.getId().toString());
+    }
+
+    @Test
+    void dependentWithNoTemplateAtAllIsSkippedWithoutThrowing() {
+        Job completed = completedJob(0);
+        stepsWithFlow(completed, FlowType.terraformApply, JobStatus.completed);
+        triggersFromSource(trigger(workspace("consumer", null), null));
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+
+        verify(jobRepository, never()).save(any(Job.class));
+    }
+
+    // ---------------------------------------------------------------- fault isolation
+
+    /**
+     * The reason each dependent is wrapped: without it, the first workspace that cannot be
+     * scheduled would cost every dependent listed after it.
+     */
+    @Test
+    void oneFailingDependentDoesNotStopTheOthers() throws Exception {
+        Job completed = completedJob(0);
+        stepsWithFlow(completed, FlowType.terraformApply, JobStatus.completed);
+
+        Workspace broken = workspace("broken", "template-default");
+        Workspace healthy = workspace("healthy", "template-default");
+        // Ordered so the failure is not the last one processed.
+        broken.setId(UUID.fromString("00000000-0000-0000-0000-00000000000a"));
+        healthy.setId(UUID.fromString("00000000-0000-0000-0000-00000000000b"));
+        triggersFromSource(trigger(broken, null), trigger(healthy, null));
+
+        doThrow(new IllegalStateException("scheduler down"))
+                .when(scheduleJobService).createJobContext(argThatTargets(broken));
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+
+        verify(scheduleJobService).createJobContext(argThatTargets(healthy));
+    }
+
+    /** Dispatch must never surface an error on a run that already succeeded. */
+    @Test
+    void dispatchNeverThrows() {
+        completedJob(0);
+        doThrow(new IllegalStateException("database gone")).when(stepRepository).findByJobId(anyInt());
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+    }
+
+    @Test
+    void unknownJobIsIgnored() {
+        doReturn(Optional.empty()).when(jobRepository).findById(COMPLETED_JOB_ID);
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+
+        verify(jobRepository, never()).save(any(Job.class));
+    }
+
+    private static Job argThatTargets(Workspace workspace) {
+        return org.mockito.ArgumentMatchers.argThat(job -> job != null
+                && job.getWorkspace() != null
+                && job.getWorkspace().getId().equals(workspace.getId()));
+    }
+}

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/trigger/RunTriggerDispatchServiceTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/trigger/RunTriggerDispatchServiceTest.java
@@ -18,6 +18,8 @@ import io.terrakube.api.rs.workspace.trigger.WorkspaceRunTrigger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,12 +30,14 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -46,6 +50,7 @@ class RunTriggerDispatchServiceTest {
     StepRepository stepRepository;
     WorkspaceRunTriggerRepository triggerRepository;
     TclService tclService;
+    RunTriggerJobWriter jobWriter;
     JobNotificationTrigger jobNotificationTrigger;
     ScheduleJobService scheduleJobService;
     RunTriggerProperties properties;
@@ -64,16 +69,19 @@ class RunTriggerDispatchServiceTest {
         properties = new RunTriggerProperties();
         nextJobId = 1000;
 
-        // Assigning an id on save mirrors the database and lets the assertions distinguish
-        // the jobs created for each dependent.
+        // The writer owns the shape of the job and its transaction boundary, both covered by
+        // RunTriggerJobWriterTest. Here it stands in for a committed row, so the assertions can
+        // stay on what the dispatcher decides: who gets one, with which template, at what depth.
+        jobWriter = mock(RunTriggerJobWriter.class);
         lenient().doAnswer(i -> {
-            Job saved = i.getArgument(0);
+            Job saved = new Job();
             saved.setId(nextJobId++);
+            saved.setWorkspace(i.getArgument(0));
             return saved;
-        }).when(jobRepository).save(any(Job.class));
+        }).when(jobWriter).persist(any(), any(), any(), anyInt());
 
         subject = new RunTriggerDispatchService(jobRepository, stepRepository, triggerRepository,
-                tclService, jobNotificationTrigger, scheduleJobService, properties);
+                tclService, jobWriter, jobNotificationTrigger, scheduleJobService, properties);
     }
 
     // ---------------------------------------------------------------- fixtures
@@ -140,23 +148,18 @@ class RunTriggerDispatchServiceTest {
         subject.dispatchFor(COMPLETED_JOB_ID);
 
         ArgumentCaptor<Job> captor = ArgumentCaptor.forClass(Job.class);
-        verify(jobRepository).save(captor.capture());
+        verify(jobWriter).persist(eq(destination), eq("template-default"), eq(completed), eq(1));
+        verify(jobNotificationTrigger).notifyStatusChanged(captor.capture());
         Job created = captor.getValue();
 
-        assertThat(created.getWorkspace()).isSameAs(destination);
-        assertThat(created.getOrganization()).isSameAs(destination.getOrganization());
-        assertThat(created.getTemplateReference()).isEqualTo("template-default");
-        assertThat(created.getStatus()).isEqualTo(JobStatus.pending);
-        assertThat(created.getVia()).isEqualTo(JobVia.RUN_TRIGGER.getValue());
-        assertThat(created.getTriggeredByJobId()).isEqualTo(COMPLETED_JOB_ID);
-        assertThat(created.getCascadeDepth()).isEqualTo(1);
-        assertThat(created.isPlanChanges()).isTrue();
-        assertThat(created.isRefresh()).isTrue();
-        assertThat(created.isRefreshOnly()).isFalse();
-
-        // Neither hook fires for a repository save, so both have to happen explicitly.
-        verify(jobNotificationTrigger).notifyStatusChanged(created);
+        // Neither Elide hook fires for a repository save, so both side effects are explicit.
         verify(scheduleJobService).createJobContext(created);
+
+        // The order is the fix for the Quartz race: createJobContext fires the trigger at once,
+        // and the worker reads on another connection, so the row has to be committed first.
+        InOrder ordered = inOrder(jobWriter, scheduleJobService);
+        ordered.verify(jobWriter).persist(any(), any(), any(), anyInt());
+        ordered.verify(scheduleJobService).createJobContext(created);
     }
 
     @Test
@@ -167,7 +170,7 @@ class RunTriggerDispatchServiceTest {
 
         subject.dispatchFor(COMPLETED_JOB_ID);
 
-        verify(jobRepository).save(any(Job.class));
+        verify(jobWriter).persist(any(), any(), any(), anyInt());
     }
 
     @Test
@@ -178,7 +181,7 @@ class RunTriggerDispatchServiceTest {
 
         subject.dispatchFor(COMPLETED_JOB_ID);
 
-        verify(jobRepository).save(any(Job.class));
+        verify(jobWriter).persist(any(), any(), any(), anyInt());
     }
 
     /** A run that only planned leaves nothing downstream to react to. */
@@ -190,7 +193,7 @@ class RunTriggerDispatchServiceTest {
 
         subject.dispatchFor(COMPLETED_JOB_ID);
 
-        verify(jobRepository, never()).save(any(Job.class));
+        verify(jobWriter, never()).persist(any(), any(), any(), anyInt());
     }
 
     /**
@@ -205,7 +208,7 @@ class RunTriggerDispatchServiceTest {
 
         subject.dispatchFor(COMPLETED_JOB_ID);
 
-        verify(jobRepository, never()).save(any(Job.class));
+        verify(jobWriter, never()).persist(any(), any(), any(), anyInt());
     }
 
     @Test
@@ -220,7 +223,7 @@ class RunTriggerDispatchServiceTest {
 
         subject.dispatchFor(COMPLETED_JOB_ID);
 
-        verify(jobRepository, never()).save(any(Job.class));
+        verify(jobWriter, never()).persist(any(), any(), any(), anyInt());
     }
 
     // ---------------------------------------------------------------- bounds
@@ -234,7 +237,7 @@ class RunTriggerDispatchServiceTest {
 
         subject.dispatchFor(COMPLETED_JOB_ID);
 
-        verify(jobRepository, never()).save(any(Job.class));
+        verify(jobWriter, never()).persist(any(), any(), any(), anyInt());
     }
 
     @Test
@@ -246,9 +249,7 @@ class RunTriggerDispatchServiceTest {
 
         subject.dispatchFor(COMPLETED_JOB_ID);
 
-        ArgumentCaptor<Job> captor = ArgumentCaptor.forClass(Job.class);
-        verify(jobRepository).save(captor.capture());
-        assertThat(captor.getValue().getCascadeDepth()).isEqualTo(3);
+        verify(jobWriter).persist(any(), any(), any(), eq(3));
     }
 
     @Test
@@ -263,9 +264,9 @@ class RunTriggerDispatchServiceTest {
         triggersFromSource(triggers);
 
         subject.dispatchFor(COMPLETED_JOB_ID);
-        ArgumentCaptor<Job> first = ArgumentCaptor.forClass(Job.class);
-        verify(jobRepository, times(3)).save(first.capture());
-        List<String> firstRun = first.getAllValues().stream().map(j -> j.getWorkspace().getName()).toList();
+        ArgumentCaptor<Workspace> first = ArgumentCaptor.forClass(Workspace.class);
+        verify(jobWriter, times(3)).persist(first.capture(), any(), any(), anyInt());
+        List<String> firstRun = first.getAllValues().stream().map(Workspace::getName).toList();
 
         // Same graph, same apply: the cap must not pick a different arbitrary subset.
         List<WorkspaceRunTrigger> shuffled = new ArrayList<>(List.of(triggers));
@@ -273,10 +274,10 @@ class RunTriggerDispatchServiceTest {
         doReturn(shuffled).when(triggerRepository).findEnabledBySourceWorkspaceId(SOURCE_ID);
 
         subject.dispatchFor(COMPLETED_JOB_ID);
-        ArgumentCaptor<Job> second = ArgumentCaptor.forClass(Job.class);
-        verify(jobRepository, times(6)).save(second.capture());
+        ArgumentCaptor<Workspace> second = ArgumentCaptor.forClass(Workspace.class);
+        verify(jobWriter, times(6)).persist(second.capture(), any(), any(), anyInt());
         List<String> secondRun = second.getAllValues().subList(3, 6).stream()
-                .map(j -> j.getWorkspace().getName()).toList();
+                .map(Workspace::getName).toList();
 
         assertThat(secondRun).containsExactlyInAnyOrderElementsOf(firstRun);
     }
@@ -288,7 +289,7 @@ class RunTriggerDispatchServiceTest {
 
         subject.dispatchFor(COMPLETED_JOB_ID);
 
-        verify(jobRepository, never()).save(any(Job.class));
+        verify(jobWriter, never()).persist(any(), any(), any(), anyInt());
         verify(stepRepository, never()).findByJobId(anyInt());
     }
 
@@ -305,9 +306,7 @@ class RunTriggerDispatchServiceTest {
 
         subject.dispatchFor(COMPLETED_JOB_ID);
 
-        ArgumentCaptor<Job> captor = ArgumentCaptor.forClass(Job.class);
-        verify(jobRepository).save(captor.capture());
-        assertThat(captor.getValue().getTemplateReference()).isEqualTo(template.getId().toString());
+        verify(jobWriter).persist(any(), eq(template.getId().toString()), any(), anyInt());
     }
 
     @Test
@@ -318,7 +317,7 @@ class RunTriggerDispatchServiceTest {
 
         subject.dispatchFor(COMPLETED_JOB_ID);
 
-        verify(jobRepository, never()).save(any(Job.class));
+        verify(jobWriter, never()).persist(any(), any(), any(), anyInt());
     }
 
     // ---------------------------------------------------------------- fault isolation
@@ -327,16 +326,38 @@ class RunTriggerDispatchServiceTest {
      * The reason each dependent is wrapped: without it, the first workspace that cannot be
      * scheduled would cost every dependent listed after it.
      */
+    /**
+     * The case the per-dependent transaction exists for. A failed insert marks its transaction
+     * rollback-only and catching the exception does not clear that, so a shared transaction
+     * would take every job created beside it down at commit - through the try/catch meant to
+     * prevent exactly that. Only a boundary per dependent makes this assertion true.
+     */
     @Test
-    void oneFailingDependentDoesNotStopTheOthers() throws Exception {
+    void oneFailingInsertDoesNotStopTheOthers() throws Exception {
         Job completed = completedJob(0);
         stepsWithFlow(completed, FlowType.terraformApply, JobStatus.completed);
 
-        Workspace broken = workspace("broken", "template-default");
-        Workspace healthy = workspace("healthy", "template-default");
-        // Ordered so the failure is not the last one processed.
-        broken.setId(UUID.fromString("00000000-0000-0000-0000-00000000000a"));
-        healthy.setId(UUID.fromString("00000000-0000-0000-0000-00000000000b"));
+        Workspace broken = brokenFirst();
+        Workspace healthy = healthySecond();
+        triggersFromSource(trigger(broken, null), trigger(healthy, null));
+
+        doThrow(new DataIntegrityViolationException("constraint violation"))
+                .when(jobWriter).persist(eq(broken), any(), any(), anyInt());
+
+        subject.dispatchFor(COMPLETED_JOB_ID);
+
+        verify(jobWriter).persist(eq(healthy), any(), any(), anyInt());
+        verify(scheduleJobService).createJobContext(argThatTargets(healthy));
+    }
+
+    /** The same guarantee for a failure on the scheduling side rather than the insert. */
+    @Test
+    void oneFailingScheduleDoesNotStopTheOthers() throws Exception {
+        Job completed = completedJob(0);
+        stepsWithFlow(completed, FlowType.terraformApply, JobStatus.completed);
+
+        Workspace broken = brokenFirst();
+        Workspace healthy = healthySecond();
         triggersFromSource(trigger(broken, null), trigger(healthy, null));
 
         doThrow(new IllegalStateException("scheduler down"))
@@ -345,6 +366,19 @@ class RunTriggerDispatchServiceTest {
         subject.dispatchFor(COMPLETED_JOB_ID);
 
         verify(scheduleJobService).createJobContext(argThatTargets(healthy));
+    }
+
+    /** Ids fix the processing order, so the failure is never the last one handled. */
+    private Workspace brokenFirst() {
+        Workspace broken = workspace("broken", "template-default");
+        broken.setId(UUID.fromString("00000000-0000-0000-0000-00000000000a"));
+        return broken;
+    }
+
+    private Workspace healthySecond() {
+        Workspace healthy = workspace("healthy", "template-default");
+        healthy.setId(UUID.fromString("00000000-0000-0000-0000-00000000000b"));
+        return healthy;
     }
 
     /** Dispatch must never surface an error on a run that already succeeded. */
@@ -362,7 +396,7 @@ class RunTriggerDispatchServiceTest {
 
         subject.dispatchFor(COMPLETED_JOB_ID);
 
-        verify(jobRepository, never()).save(any(Job.class));
+        verify(jobWriter, never()).persist(any(), any(), any(), anyInt());
     }
 
     private static Job argThatTargets(Workspace workspace) {

--- a/api/src/test/java/io/terrakube/api/plugin/scheduler/trigger/RunTriggerJobWriterTest.java
+++ b/api/src/test/java/io/terrakube/api/plugin/scheduler/trigger/RunTriggerJobWriterTest.java
@@ -1,0 +1,70 @@
+package io.terrakube.api.plugin.scheduler.trigger;
+
+import io.terrakube.api.repository.JobRepository;
+import io.terrakube.api.rs.Organization;
+import io.terrakube.api.rs.job.Job;
+import io.terrakube.api.rs.job.JobStatus;
+import io.terrakube.api.rs.job.JobVia;
+import io.terrakube.api.rs.workspace.Workspace;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/** The shape of the job a run trigger produces. */
+class RunTriggerJobWriterTest {
+
+    JobRepository jobRepository;
+    RunTriggerJobWriter subject;
+
+    @BeforeEach
+    void setup() {
+        jobRepository = mock(JobRepository.class);
+        doAnswer(i -> {
+            Job saved = i.getArgument(0);
+            saved.setId(1001);
+            return saved;
+        }).when(jobRepository).save(any(Job.class));
+        subject = new RunTriggerJobWriter(jobRepository);
+    }
+
+    @Test
+    void writesTheCanonicalTriggeredJob() {
+        Organization organization = new Organization();
+        organization.setId(UUID.randomUUID());
+
+        Workspace destination = new Workspace();
+        destination.setId(UUID.randomUUID());
+        destination.setName("consumer");
+        destination.setOrganization(organization);
+
+        Job completedJob = new Job();
+        completedJob.setId(900);
+
+        Job returned = subject.persist(destination, "template-ref", completedJob, 3);
+
+        ArgumentCaptor<Job> captor = ArgumentCaptor.forClass(Job.class);
+        verify(jobRepository).save(captor.capture());
+        Job created = captor.getValue();
+
+        assertThat(returned).isSameAs(created);
+        assertThat(created.getWorkspace()).isSameAs(destination);
+        assertThat(created.getOrganization()).isSameAs(organization);
+        assertThat(created.getTemplateReference()).isEqualTo("template-ref");
+        assertThat(created.getStatus()).isEqualTo(JobStatus.pending);
+        assertThat(created.getVia()).isEqualTo(JobVia.RUN_TRIGGER.getValue());
+        assertThat(created.getTriggeredByJobId()).isEqualTo(900);
+        assertThat(created.getCascadeDepth()).isEqualTo(3);
+        assertThat(created.isPlanChanges()).isTrue();
+        assertThat(created.isRefresh()).isTrue();
+        assertThat(created.isRefreshOnly()).isFalse();
+        assertThat(created.getCreatedBy()).isEqualTo("serviceAccount");
+    }
+}

--- a/ui/src/components/layout/AppSidebar/AppSidebar.tsx
+++ b/ui/src/components/layout/AppSidebar/AppSidebar.tsx
@@ -18,6 +18,7 @@ import {
   KeyOutlined,
   LeftOutlined,
   LockOutlined,
+  NodeIndexOutlined,
   ProjectOutlined,
   RobotOutlined,
   SafetyCertificateOutlined,
@@ -363,6 +364,15 @@ export default function AppSidebar({
                   </Link>
                 ),
                 icon: <ScheduleOutlined />,
+              },
+              {
+                key: "run-triggers",
+                label: (
+                  <Link to={`${workspaceBasePath}/run-triggers`} onClick={() => handleOrgMenuClick("run-triggers")}>
+                    Run Triggers
+                  </Link>
+                ),
+                icon: <NodeIndexOutlined />,
               },
               {
                 key: "settings",

--- a/ui/src/domain/Home/App.tsx
+++ b/ui/src/domain/Home/App.tsx
@@ -373,6 +373,14 @@ const router = createBrowserRouter(
           element: <WorkspaceDetailsRoute selectedTab="5" />,
         },
         {
+          path: "/workspaces/:id/run-triggers",
+          element: <WorkspaceDetailsRoute selectedTab="7" />,
+        },
+        {
+          path: "/organizations/:orgid/workspaces/:id/run-triggers",
+          element: <WorkspaceDetailsRoute selectedTab="7" />,
+        },
+        {
           path: "/workspaces/:id/settings",
           element: <WorkspaceDetailsRoute selectedTab="6" />,
         },

--- a/ui/src/domain/Jobs/Details.tsx
+++ b/ui/src/domain/Jobs/Details.tsx
@@ -15,6 +15,7 @@ import {
 } from "antd";
 import { AxiosResponse } from "axios";
 import { cloneElement, useCallback, useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
 import { ORGANIZATION_ARCHIVE } from "../../config/actionTypes";
 import axiosInstance, { axiosAuxiliary } from "../../config/axiosConfig";
 import { useAbortController, usePolling, useStructuredOutputStream } from "../../hooks";
@@ -79,6 +80,11 @@ export const DetailsJob = ({ jobId }: Props) => {
   const [workspaceVcsId, setWorkspaceVcsId] = useState<string>();
   const [workspaceVcsName, setWorkspaceVcsName] = useState<string>();
   const [steps, setSteps] = useState<JobStep[]>([]);
+  const [triggeredBy, setTriggeredBy] = useState<{
+    jobId: number;
+    workspaceId: string;
+    workspaceName: string;
+  } | null>(null);
   // Controlled per-step Collapse open/closed state, keyed by step id. Was previously driven by
   // Collapse's uncontrolled defaultActiveKey with `${item.id}-${item.status}` as the element key -
   // every status transition (pending -> running -> completed) therefore remounted the whole step
@@ -138,7 +144,6 @@ export const DetailsJob = ({ jobId }: Props) => {
   const isAbortError = (error: unknown) => {
     return error instanceof Error && (error.name === "AbortError" || error.name === "CanceledError");
   };
-
 
   const parseIncompleteVariableGuard = (jobOutput?: string): IncompleteVariableGuard | null => {
     if (jobOutput == null) {
@@ -405,6 +410,29 @@ export const DetailsJob = ({ jobId }: Props) => {
     if (a.stepNumber > b.stepNumber) return 1;
     return 0;
   };
+
+  // The upstream run of a job started by a run trigger. Resolved separately because the job
+  // only carries the id, and the link needs the workspace it belongs to. Run triggers never
+  // cross organizations, so the current one is always the right place to look.
+  const upstreamJobId = job?.data?.attributes?.triggeredByJobId;
+  useEffect(() => {
+    if (!upstreamJobId || !organizationId) {
+      setTriggeredBy(null);
+      return;
+    }
+    axiosInstance
+      .get(`organization/${organizationId}/job/${upstreamJobId}?include=workspace`)
+      .then((response) => {
+        const workspace = (response.data.included ?? []).find((item: any) => item.type === "workspace");
+        setTriggeredBy({
+          jobId: upstreamJobId,
+          workspaceId: workspace?.id ?? "",
+          workspaceName: workspace?.attributes?.name ?? "",
+        });
+      })
+      // The upstream run may have been pruned from history; the id alone is still worth showing.
+      .catch(() => setTriggeredBy({ jobId: upstreamJobId, workspaceId: "", workspaceName: "" }));
+  }, [upstreamJobId, organizationId]);
 
   const loadJob = useCallback(async () => {
     const requestId = ++jobRequestRef.current;
@@ -685,6 +713,30 @@ export const DetailsJob = ({ jobId }: Props) => {
             <WorkspaceStatusTag status={job.data.attributes.status} />{" "}
             <h2 style={{ display: "inline" }}>Triggered via {formatJobVia(job.data.attributes.via)}</h2>
           </div>
+          {triggeredBy && (
+            <Alert
+              type="info"
+              showIcon
+              style={{ marginTop: 8, marginBottom: 8 }}
+              description={
+                <>
+                  This run started because{" "}
+                  {triggeredBy.workspaceId ? (
+                    <Link
+                      to={`/organizations/${organizationId}/workspaces/${triggeredBy.workspaceId}/runs/${triggeredBy.jobId}`}
+                    >
+                      run #{triggeredBy.jobId} on {triggeredBy.workspaceName}
+                    </Link>
+                  ) : (
+                    <b>run #{triggeredBy.jobId}</b>
+                  )}{" "}
+                  changed state.
+                  {(job.data.attributes.cascadeDepth ?? 0) > 1 &&
+                    ` It is ${job.data.attributes.cascadeDepth} triggers deep in the chain.`}
+                </>
+              }
+            />
+          )}
 
           <Collapse
             items={[

--- a/ui/src/domain/Workspaces/Details.tsx
+++ b/ui/src/domain/Workspaces/Details.tsx
@@ -56,6 +56,7 @@ import {
 } from "../types.js";
 import { CLIDriven } from "../Workspaces/CLIDriven";
 import { ResourceDrawer } from "../Workspaces/ResourceDrawer";
+import { RunTriggers } from "../Workspaces/RunTriggers";
 import { Schedules } from "../Workspaces/Schedules";
 import { Tags } from "../Workspaces/Tags";
 import { Variables } from "../Workspaces/Variables";
@@ -85,6 +86,7 @@ const WORKSPACE_SECTION_LABELS: Record<string, string> = {
   "4": "Variables",
   "5": "Schedules",
   "6": "Settings",
+  "7": "Run Triggers",
 };
 
 const WORKSPACE_SETTINGS_SECTION_LABELS: Record<string, string> = {
@@ -299,6 +301,9 @@ export const WorkspaceDetails = ({
         break;
       case "6":
         navigate(`/organizations/${organizationId}/workspaces/${id}/settings`);
+        break;
+      case "7":
+        navigate(`/organizations/${organizationId}/workspaces/${id}/run-triggers`);
         break;
       default:
         break;
@@ -732,6 +737,15 @@ export const WorkspaceDetails = ({
           <Schedules schedules={schedule} manageWorkspace={manageWorkspace} reload={() => loadWorkspace(false)} />
         ) : (
           <p>Loading...</p>
+        );
+      case "7":
+        return (
+          <RunTriggers
+            organizationId={organizationId!}
+            workspaceId={id!}
+            workspaceName={workspaceName}
+            manageWorkspace={manageWorkspace}
+          />
         );
       case "6":
         return (

--- a/ui/src/domain/Workspaces/RunTriggers.tsx
+++ b/ui/src/domain/Workspaces/RunTriggers.tsx
@@ -164,6 +164,16 @@ export const RunTriggers = ({ organizationId, workspaceId, workspaceName, manage
       .catch((err) => message.error(getErrorMessage(err)));
   };
 
+  /**
+   * Sources already wired to this workspace are left out: the unique constraint would refuse
+   * the duplicate, so offering it is an invitation to a 409. The workspace itself is excluded
+   * when the list loads, since it cannot trigger itself either.
+   */
+  const selectableSources = useMemo(
+    () => workspaces.filter((item) => !incoming.some((row) => row.workspaceId === item.id)),
+    [workspaces, incoming]
+  );
+
   const workspaceLink = (row: RunTriggerRow) => (
     <Link to={`/organizations/${organizationId}/workspaces/${row.workspaceId}`}>{row.workspaceName}</Link>
   );
@@ -329,7 +339,7 @@ export const RunTriggers = ({ organizationId, workspaceId, workspaceName, manage
               showSearch
               placeholder="Select a workspace"
               optionFilterProp="label"
-              options={workspaces.map((item) => ({ label: item.attributes.name, value: item.id }))}
+              options={selectableSources.map((item) => ({ label: item.attributes.name, value: item.id }))}
             />
           </Form.Item>
           <Form.Item name="templateId" label="Template" extra="Leave empty to use this workspace's default template.">

--- a/ui/src/domain/Workspaces/RunTriggers.tsx
+++ b/ui/src/domain/Workspaces/RunTriggers.tsx
@@ -1,0 +1,344 @@
+import { DeleteOutlined, PlusOutlined } from "@ant-design/icons";
+import { Alert, Button, Form, message, Modal, Popconfirm, Select, Space, Switch, Table, Tag, Typography } from "antd";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import axiosInstance, { getErrorMessage } from "../../config/axiosConfig";
+import { RunTrigger, RunTriggerRow, Template, Workspace } from "../types";
+
+type Props = {
+  organizationId: string;
+  workspaceId: string;
+  workspaceName: string;
+  manageWorkspace: boolean;
+};
+
+type TriggerForm = {
+  sourceWorkspaceId: string;
+  templateId?: string;
+};
+
+/** Every resource in an include block, keyed so an edge can resolve its own ends. */
+type IncludedIndex = Record<string, { id: string; attributes: { name: string } }>;
+
+const indexIncluded = (included: any[] | undefined): IncludedIndex => {
+  const index: IncludedIndex = {};
+  (included ?? []).forEach((item) => {
+    index[`${item.type}:${item.id}`] = item;
+  });
+  return index;
+};
+
+const nameOf = (index: IncludedIndex, type: string, id: string | undefined) =>
+  id ? (index[`${type}:${id}`]?.attributes?.name ?? id) : undefined;
+
+export const RunTriggers = ({ organizationId, workspaceId, workspaceName, manageWorkspace }: Props) => {
+  const [form] = Form.useForm<TriggerForm>();
+  const [incoming, setIncoming] = useState<RunTriggerRow[]>([]);
+  const [outgoing, setOutgoing] = useState<RunTriggerRow[]>([]);
+  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [visible, setVisible] = useState(false);
+
+  const loadTriggers = useCallback(() => {
+    setLoading(true);
+    axiosInstance
+      .get("runTrigger", {
+        params: {
+          include: "sourceWorkspace,destinationWorkspace,template",
+          // Both directions in one round trip: a comma is OR in Elide's filter syntax.
+          "filter[runTrigger]": `sourceWorkspace.id==${workspaceId},destinationWorkspace.id==${workspaceId}`,
+        },
+      })
+      .then((response) => {
+        const index = indexIncluded(response.data.included);
+        const edges: RunTrigger[] = response.data.data ?? [];
+
+        const toRow = (trigger: RunTrigger, otherEnd: "sourceWorkspace" | "destinationWorkspace"): RunTriggerRow => {
+          const otherId = trigger.relationships[otherEnd]?.data?.id;
+          const templateId = trigger.relationships.template?.data?.id;
+          return {
+            id: trigger.id,
+            enabled: trigger.attributes.enabled,
+            workspaceId: otherId,
+            workspaceName: nameOf(index, "workspace", otherId) ?? otherId,
+            templateId,
+            templateName: nameOf(index, "template", templateId),
+          };
+        };
+
+        setIncoming(
+          edges
+            .filter((edge) => edge.relationships.destinationWorkspace?.data?.id === workspaceId)
+            .map((edge) => toRow(edge, "sourceWorkspace"))
+        );
+        setOutgoing(
+          edges
+            .filter((edge) => edge.relationships.sourceWorkspace?.data?.id === workspaceId)
+            .map((edge) => toRow(edge, "destinationWorkspace"))
+        );
+        setLoading(false);
+      })
+      .catch((err) => {
+        message.error(getErrorMessage(err));
+        setLoading(false);
+      });
+  }, [workspaceId]);
+
+  useEffect(() => {
+    loadTriggers();
+  }, [loadTriggers]);
+
+  const loadPickerData = useCallback(() => {
+    axiosInstance
+      .get(`organization/${organizationId}/workspace`)
+      .then((response) => {
+        // A workspace cannot trigger itself, so it is not offered as a source.
+        setWorkspaces((response.data.data ?? []).filter((item: Workspace) => item.id !== workspaceId));
+      })
+      .catch((err) => message.error(getErrorMessage(err)));
+
+    axiosInstance
+      .get(`organization/${organizationId}/template`)
+      .then((response) => setTemplates(response.data.data ?? []))
+      .catch((err) => message.error(getErrorMessage(err)));
+  }, [organizationId, workspaceId]);
+
+  const onAdd = () => {
+    loadPickerData();
+    form.resetFields();
+    setVisible(true);
+  };
+
+  const onCreate = (values: TriggerForm) => {
+    const relationships: Record<string, unknown> = {
+      // This workspace is the destination: it is the one that will start running. That is
+      // also the end the API checks manage rights on, so this is the direction that can be
+      // configured from here.
+      sourceWorkspace: { data: { type: "workspace", id: values.sourceWorkspaceId } },
+      destinationWorkspace: { data: { type: "workspace", id: workspaceId } },
+    };
+    if (values.templateId) {
+      relationships.template = { data: { type: "template", id: values.templateId } };
+    }
+
+    axiosInstance
+      .post(
+        "runTrigger",
+        { data: { type: "runTrigger", attributes: { enabled: true }, relationships } },
+        { headers: { "Content-Type": "application/vnd.api+json" } }
+      )
+      .then(() => {
+        message.success("Run trigger created successfully");
+        setVisible(false);
+        form.resetFields();
+        loadTriggers();
+      })
+      .catch((err) => message.error(getErrorMessage(err)));
+  };
+
+  const onToggle = (row: RunTriggerRow, enabled: boolean) => {
+    axiosInstance
+      .patch(
+        `runTrigger/${row.id}`,
+        { data: { type: "runTrigger", id: row.id, attributes: { enabled } } },
+        { headers: { "Content-Type": "application/vnd.api+json" } }
+      )
+      .then(() => {
+        message.success(enabled ? "Run trigger enabled" : "Run trigger disabled");
+        loadTriggers();
+      })
+      .catch((err) => message.error(getErrorMessage(err)));
+  };
+
+  const onDelete = (id: string) => {
+    axiosInstance
+      .delete(`runTrigger/${id}`, { headers: { "Content-Type": "application/vnd.api+json" } })
+      .then(() => {
+        message.success("Run trigger deleted successfully");
+        loadTriggers();
+      })
+      .catch((err) => message.error(getErrorMessage(err)));
+  };
+
+  const workspaceLink = (row: RunTriggerRow) => (
+    <Link to={`/organizations/${organizationId}/workspaces/${row.workspaceId}`}>{row.workspaceName}</Link>
+  );
+
+  const incomingColumns = useMemo(
+    () => [
+      {
+        title: "Source workspace",
+        key: "workspace",
+        render: (_: string, record: RunTriggerRow) => workspaceLink(record),
+      },
+      {
+        title: "Template",
+        key: "template",
+        render: (_: string, record: RunTriggerRow) =>
+          record.templateName ? (
+            <Tag color="default">{record.templateName}</Tag>
+          ) : (
+            <Typography.Text type="secondary">Default template</Typography.Text>
+          ),
+      },
+      {
+        title: "Enabled",
+        key: "enabled",
+        render: (_: string, record: RunTriggerRow) => (
+          <Switch
+            checked={record.enabled}
+            disabled={!manageWorkspace}
+            onChange={(checked) => onToggle(record, checked)}
+          />
+        ),
+      },
+      {
+        title: "Actions",
+        key: "action",
+        render: (_: string, record: RunTriggerRow) => (
+          <Popconfirm
+            okButtonProps={{ danger: true }}
+            onConfirm={() => onDelete(record.id)}
+            title={
+              <p>
+                This will stop <b>{workspaceName}</b> from running after <b>{record.workspaceName}</b>.
+                <br />
+                Are you sure?
+              </p>
+            }
+            okText="Yes"
+            cancelText="No"
+          >
+            <Button danger type="link" icon={<DeleteOutlined />} disabled={!manageWorkspace}>
+              Delete
+            </Button>
+          </Popconfirm>
+        ),
+      },
+    ],
+    [manageWorkspace, organizationId, workspaceName]
+  );
+
+  const outgoingColumns = useMemo(
+    () => [
+      {
+        title: "Destination workspace",
+        key: "workspace",
+        render: (_: string, record: RunTriggerRow) => workspaceLink(record),
+      },
+      {
+        title: "Template",
+        key: "template",
+        render: (_: string, record: RunTriggerRow) =>
+          record.templateName ? (
+            <Tag color="default">{record.templateName}</Tag>
+          ) : (
+            <Typography.Text type="secondary">Default template</Typography.Text>
+          ),
+      },
+      {
+        title: "Enabled",
+        key: "enabled",
+        render: (_: string, record: RunTriggerRow) =>
+          record.enabled ? <Tag color="green">Enabled</Tag> : <Tag>Disabled</Tag>,
+      },
+    ],
+    [organizationId]
+  );
+
+  return (
+    <div>
+      <Typography.Title level={2} style={{ margin: 0 }}>
+        Run Triggers
+      </Typography.Title>
+      <Typography.Paragraph type="secondary" style={{ marginTop: 8 }}>
+        A run trigger starts a run on one workspace after another one changes state. Only runs that apply, destroy or
+        execute custom scripts fire them - a plan on its own does not.
+      </Typography.Paragraph>
+
+      <Typography.Title level={4}>Runs after</Typography.Title>
+      <Typography.Paragraph type="secondary">
+        <b>{workspaceName}</b> starts a run when any of these workspaces finishes changing state.
+      </Typography.Paragraph>
+      <Space orientation="vertical" style={{ width: "100%" }}>
+        <Button type="primary" icon={<PlusOutlined />} onClick={onAdd} disabled={!manageWorkspace}>
+          Add source workspace
+        </Button>
+        <Table
+          dataSource={incoming}
+          columns={incomingColumns}
+          rowKey="id"
+          loading={loading}
+          pagination={false}
+          locale={{ emptyText: "This workspace does not run after any other workspace." }}
+        />
+      </Space>
+
+      <Typography.Title level={4} style={{ marginTop: 32 }}>
+        Triggers
+      </Typography.Title>
+      <Typography.Paragraph type="secondary">
+        These workspaces start a run when <b>{workspaceName}</b> changes state. They are managed from their own page,
+        because configuring a trigger requires manage rights on the workspace that will run.
+      </Typography.Paragraph>
+      <Table
+        dataSource={outgoing}
+        columns={outgoingColumns}
+        rowKey="id"
+        loading={loading}
+        pagination={false}
+        locale={{ emptyText: "No workspace runs after this one." }}
+      />
+
+      <Modal
+        width="600px"
+        open={visible}
+        title="Add source workspace"
+        okText="Create"
+        onCancel={() => setVisible(false)}
+        onOk={() => {
+          form
+            .validateFields()
+            .then(onCreate)
+            .catch(() => {});
+        }}
+      >
+        <Alert
+          type="info"
+          showIcon
+          style={{ marginBottom: 16 }}
+          description={
+            <>
+              <b>{workspaceName}</b> will start a run every time the workspace you pick finishes a run that changed
+              state. A dependency that would close a loop is rejected.
+            </>
+          }
+        />
+        <Form form={form} layout="vertical" name="runTriggerForm">
+          <Form.Item
+            name="sourceWorkspaceId"
+            label="Source workspace"
+            rules={[{ required: true, message: "Source workspace is required!" }]}
+            extra="The workspace whose runs will trigger this one."
+          >
+            <Select
+              showSearch
+              placeholder="Select a workspace"
+              optionFilterProp="label"
+              options={workspaces.map((item) => ({ label: item.attributes.name, value: item.id }))}
+            />
+          </Form.Item>
+          <Form.Item name="templateId" label="Template" extra="Leave empty to use this workspace's default template.">
+            <Select
+              allowClear
+              placeholder="Default template"
+              optionFilterProp="label"
+              options={templates.map((item) => ({ label: item.attributes.name, value: item.id }))}
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
+    </div>
+  );
+};

--- a/ui/src/domain/Workspaces/RunTriggers.tsx
+++ b/ui/src/domain/Workspaces/RunTriggers.tsx
@@ -152,8 +152,11 @@ export const RunTriggers = ({ organizationId, workspaceId, workspaceName, manage
   };
 
   const onDelete = (id: string) => {
+    // No content type on purpose: the request has no body, and Elide answers 400 when one is
+    // declared anyway. Other pages set it here, which is safe only as long as axios drops the
+    // header on a bodyless request.
     axiosInstance
-      .delete(`runTrigger/${id}`, { headers: { "Content-Type": "application/vnd.api+json" } })
+      .delete(`runTrigger/${id}`)
       .then(() => {
         message.success("Run trigger deleted successfully");
         loadTriggers();

--- a/ui/src/domain/Workspaces/__tests__/RunTriggers.test.tsx
+++ b/ui/src/domain/Workspaces/__tests__/RunTriggers.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { RunTriggers } from "../RunTriggers";
 
@@ -126,6 +127,33 @@ describe("RunTriggers", () => {
     await screen.findByRole("link", { name: "network" });
     expect(screen.getByRole("button", { name: /add source workspace/i })).toBeDisabled();
     expect(screen.getByRole("button", { name: /delete/i })).toBeDisabled();
+  });
+
+  /**
+   * The unique constraint refuses a duplicate edge, so a source already wired to this
+   * workspace must not be offered again - picking it could only end in a 409.
+   */
+  it("does not offer a source that is already wired", async () => {
+    getMock.mockImplementation((url: string) => {
+      if (url === "runTrigger") return Promise.resolve(bothDirections);
+      if (url.includes("/template")) return Promise.resolve({ data: { data: [] } });
+      return Promise.resolve({
+        data: {
+          data: [
+            { id: SOURCE, attributes: { name: "network" } },
+            { id: "ws-free", attributes: { name: "free-to-pick" } },
+          ],
+        },
+      });
+    });
+    renderPage();
+    await screen.findByRole("link", { name: "network" });
+
+    await userEvent.click(screen.getByRole("button", { name: /add source workspace/i }));
+    await userEvent.click(await screen.findByRole("combobox", { name: /source workspace/i }));
+
+    expect(await screen.findByTitle("free-to-pick")).toBeInTheDocument();
+    expect(screen.queryByTitle("network")).toBeNull();
   });
 
   it("says so when nothing depends on this workspace", async () => {

--- a/ui/src/domain/Workspaces/__tests__/RunTriggers.test.tsx
+++ b/ui/src/domain/Workspaces/__tests__/RunTriggers.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { RunTriggers } from "../RunTriggers";
+
+const getMock = jest.fn();
+const deleteMock = jest.fn();
+
+jest.mock("../../../config/axiosConfig", () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => getMock(...args),
+    delete: (...args: unknown[]) => deleteMock(...args),
+    post: jest.fn(),
+    patch: jest.fn(),
+  },
+  getErrorMessage: () => "error",
+}));
+
+const WORKSPACE = "ws-self";
+const SOURCE = "ws-upstream";
+const DESTINATION = "ws-downstream";
+
+/**
+ * One edge in each direction, as the API returns them: a single collection where this
+ * workspace appears sometimes as source and sometimes as destination.
+ */
+const bothDirections = {
+  data: {
+    data: [
+      {
+        id: "edge-incoming",
+        attributes: { enabled: true },
+        relationships: {
+          sourceWorkspace: { data: { type: "workspace", id: SOURCE } },
+          destinationWorkspace: { data: { type: "workspace", id: WORKSPACE } },
+          template: { data: { type: "template", id: "tpl-1" } },
+        },
+      },
+      {
+        id: "edge-outgoing",
+        attributes: { enabled: false },
+        relationships: {
+          sourceWorkspace: { data: { type: "workspace", id: WORKSPACE } },
+          destinationWorkspace: { data: { type: "workspace", id: DESTINATION } },
+        },
+      },
+    ],
+    included: [
+      { type: "workspace", id: SOURCE, attributes: { name: "network" } },
+      { type: "workspace", id: DESTINATION, attributes: { name: "vpn" } },
+      { type: "template", id: "tpl-1", attributes: { name: "Plan and Apply" } },
+    ],
+  },
+};
+
+const renderPage = (manageWorkspace = true) =>
+  render(
+    <MemoryRouter>
+      <RunTriggers
+        organizationId="org-1"
+        workspaceId={WORKSPACE}
+        workspaceName="platform"
+        manageWorkspace={manageWorkspace}
+      />
+    </MemoryRouter>
+  );
+
+describe("RunTriggers", () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    deleteMock.mockReset();
+    getMock.mockResolvedValue(bothDirections);
+  });
+
+  it("asks the API for both directions in a single request", async () => {
+    renderPage();
+
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    const [url, config] = getMock.mock.calls[0];
+    expect(url).toBe("runTrigger");
+    expect(config.params["filter[runTrigger]"]).toBe(
+      `sourceWorkspace.id==${WORKSPACE},destinationWorkspace.id==${WORKSPACE}`
+    );
+    expect(config.params.include).toContain("sourceWorkspace");
+    expect(config.params.include).toContain("destinationWorkspace");
+  });
+
+  /**
+   * The split is the whole point of the page: the same collection has to land in the right
+   * table, or a dependency reads backwards.
+   */
+  it("separates incoming from outgoing edges", async () => {
+    renderPage();
+
+    const runsAfter = await screen.findByRole("link", { name: "network" });
+    const triggers = await screen.findByRole("link", { name: "vpn" });
+
+    const tables = screen.getAllByRole("table");
+    expect(within(tables[0]).getByRole("link", { name: "network" })).toBe(runsAfter);
+    expect(within(tables[1]).getByRole("link", { name: "vpn" })).toBe(triggers);
+  });
+
+  it("names the trigger's own template and falls back to the default", async () => {
+    renderPage();
+
+    expect(await screen.findByText("Plan and Apply")).toBeInTheDocument();
+    expect(screen.getByText("Default template")).toBeInTheDocument();
+  });
+
+  /**
+   * The outgoing table is read-only on purpose: removing one of those edges needs manage
+   * rights on the other workspace, which is where the API enforces it.
+   */
+  it("offers no delete for edges this workspace only feeds", async () => {
+    renderPage();
+
+    await screen.findByRole("link", { name: "vpn" });
+    const tables = screen.getAllByRole("table");
+    expect(within(tables[0]).getAllByRole("button", { name: /delete/i })).toHaveLength(1);
+    expect(within(tables[1]).queryByRole("button", { name: /delete/i })).toBeNull();
+  });
+
+  it("disables every control without manage rights", async () => {
+    renderPage(false);
+
+    await screen.findByRole("link", { name: "network" });
+    expect(screen.getByRole("button", { name: /add source workspace/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /delete/i })).toBeDisabled();
+  });
+
+  it("says so when nothing depends on this workspace", async () => {
+    getMock.mockResolvedValue({ data: { data: [], included: [] } });
+    renderPage();
+
+    expect(await screen.findByText("This workspace does not run after any other workspace.")).toBeInTheDocument();
+    expect(screen.getByText("No workspace runs after this one.")).toBeInTheDocument();
+  });
+});

--- a/ui/src/domain/types.ts
+++ b/ui/src/domain/types.ts
@@ -128,6 +128,7 @@ export enum JobVia {
   Bitbucket = "Bitbucket",
   AzureDevops = "AzureDevops",
   Schedule = "Schedule",
+  RunTrigger = "RunTrigger",
 }
 
 export const formatJobVia = (via?: JobVia | string): string => {
@@ -171,6 +172,10 @@ export type JobAttributes = {
   commitId: string;
   prNumber?: number;
   prCommentError?: string;
+  /** Set only on a run started by a run trigger: the upstream run that fired it. */
+  triggeredByJobId?: number;
+  /** How many triggered runs deep this one is. Zero for a run nobody triggered. */
+  cascadeDepth?: number;
 } & AuditFieldBase;
 
 export type JobStep = {
@@ -476,6 +481,31 @@ export type ScheduleAttributes = {
 export type FlatSchedule = {
   id: string;
 } & ScheduleAttributes;
+
+// Run triggers
+export type RunTrigger = {
+  id: string;
+  attributes: RunTriggerAttributes;
+  relationships: {
+    sourceWorkspace: RelationshipItem;
+    destinationWorkspace: RelationshipItem;
+    template?: RelationshipItem;
+  };
+};
+
+export type RunTriggerAttributes = {
+  enabled: boolean;
+} & AuditFieldBase;
+
+/** One edge as the run trigger table renders it, with the other end already resolved. */
+export type RunTriggerRow = {
+  id: string;
+  enabled: boolean;
+  workspaceId: string;
+  workspaceName: string;
+  templateId?: string;
+  templateName?: string;
+};
 
 // Projects
 export type Project = {

--- a/ui/src/domain/types.ts
+++ b/ui/src/domain/types.ts
@@ -159,6 +159,9 @@ export const formatJobVia = (via?: JobVia | string): string => {
     case JobVia.Ui:
     case "UI":
       return "UI";
+    case JobVia.RunTrigger:
+    case "RunTrigger":
+      return "Run Trigger";
     default:
       return via;
   }


### PR DESCRIPTION
Implements the workspace dependency graph and run triggers designed in #3520, built and reviewed in four phases against that thread.

A run trigger is a directed edge between two workspaces of the same organization: when the **source** finishes a run that changed remote state, the **destination** gets a run enqueued. It closes the gap that otherwise leaves people applying a VPC and then remembering to go apply the VPN that reads its outputs.

## Architecture

### The edge (phase 1)

`WorkspaceRunTrigger` is exposed as `runTrigger`, with `sourceWorkspace`, `destinationWorkspace`, an optional `template` override and an `enabled` flag.

**Permissions.** Creating or changing an edge requires manage rights on the **destination** — the workspace whose runs start firing — plus visibility of the source. Without the second half, anyone with rights on a single workspace could attach it to any other and learn when that one applies. Deletion asks only for the destination, so losing access to a source cannot strand a trigger on a workspace you own. All three tiers of Terrakube's model are honoured: organization team, `ProjectAccess`, and workspace-level `Access`.

**Immutability.** Both endpoints carry `@UpdatePermission("user is a superuser")`. Repointing an edge is deleting one dependency and declaring another, and each deserves its own check; `enabled` and `template` stay editable.

**Tenancy.** The owning organization is derived from the destination and `@Exclude`d from the API surface rather than merely guarded — a client has no reason to set it, and accepting it would let an edge be attributed to a tenant owning neither workspace. It is derived in a JPA `@PrePersist` callback, not an Elide hook: `PRECOMMIT` fires after Hibernate has already flushed, which leaves the `NOT NULL` column unset.

### Cycle validation (phase 2)

A `PRECOMMIT` hook rejects any edge that would close a loop, with the offending path in the message.

Four decisions worth naming. Validation considers **disabled edges too** — otherwise you could create A→B disabled, then B→A, then enable A→B, and no validation ever saw the cycle. The edge being written is **excluded from the graph** it is validated against, since at `PRECOMMIT` its own row is already flushed. The traversal is **iterative, not recursive**, and visited-guarded, so a pre-existing cycle cannot hang it; there is a test with a 10,000 node chain. And the graph loads as an **id projection**, so validating never materialises workspaces.

Known limit, deliberately accepted: two concurrent creations can each pass validation and together close a loop. Closing that would need a lock over the whole organization. The runtime cascade limit is the net.

### Dispatch (phase 3)

Anchored in `JobReconciliationService`, not `ScheduleJob`. That service is the only routine that performs a job's transition to a terminal status, it takes the transition under `lockForUpdate`, and an already-terminal job short-circuits before reaching the dispatch call. **Exactly-once per completed run, across replicas, with no dedup table.** It also covers every completion path for free — inline, the 30s sweep, the admin endpoint, and CLI/TFE runs, which hand their job to the scheduler as pending and terminate through the same routine.

Dispatch runs **after commit, in its own transaction**, and never throws: a trigger that cannot be dispatched must not roll back the run that fired it.

**Qualification reads step outcomes, not job status.** A plan/apply template whose apply never executed still finishes as `completed`, so the engine requires a step that is both `completed` and of a state-changing flow type — `terraformApply`, `terraformDestroy` or `customScripts`, the set `ScheduleJob` already uses for queue admission. A plan on its own fires nothing.

**Each dependent commits in its own transaction** (`RunTriggerJobWriter`), and its Quartz context is created only afterwards. Both halves matter: `createJobContext` fires the trigger immediately and the worker reads on another connection, so an uncommitted row is invisible and `ScheduleJob` would treat the job as deleted and drop the trigger permanently — the trap Elide avoids by binding `JobManageHook` to `POSTCOMMIT`. And a failed insert marks its transaction rollback-only, which catching the exception does not clear, so a shared transaction would take every sibling down with one bad dependent.

**A locked destination enqueues rather than skips.** Skipping would leave the dependent silently drifted, which is the problem the feature exists to solve; `ScheduleJob` admits the pending job once the lock clears. **No coalescing**: consecutive runs evaluate quickly with no changes, and debouncing would add a timeout with failure modes of its own.

Bounds under `io.terrakube.run-trigger`: `enabled` (true), `max-cascade-depth` (10) as the runtime net for a cycle that slipped past validation, and `max-dependents-per-apply` (20), which truncates a stable prefix ordered by destination id so an over-wide graph dispatches the same subset on every apply rather than an arbitrary one.

### UI (phase 4)

The Run Triggers page splits the graph the way the **permission model** does, not the way the data does. "Runs after" — edges where this workspace is the destination — is configurable here, because this is the workspace you already have rights on. "Triggers" — where it is the source — is read-only and links to the other workspace, since removing one of those needs rights over there. The UI therefore never offers an action the API would refuse.

Both halves come from one request: a comma is `OR` in Elide's filter syntax, so `sourceWorkspace.id==X,destinationWorkspace.id==X` returns both directions, and the include block resolves names without a follow-up call.

Runs started by a trigger now say so, linking to the upstream run that changed state — `triggeredByJobId` and `cascadeDepth` have existed since phase 1 and nothing displayed either.

### Demo data

A `simple-trigger` organization with 38 workspaces and 28 edges seeds every canonical shape: fan-out, chain, fan-in, diamond, a disabled edge, a template override, standalone workspaces for the empty state, and a 12-step cascade that runs past the depth limit. Every workspace points at `terrakube-docker-compose`, whose root module is a `null_resource` and a 30 second sleep, so a cascade can be watched end to end with no cloud credentials.

## Two defects found and fixed during review

**Elide evaluates an inverse relationship's `UpdatePermission` on create.** The `runTriggers` collections on `Workspace` were guarded with `user is a superuser`; because Elide maintains the bidirectional relationship when a trigger is created, that rule fired on the ordinary create path. No non-superuser could create a trigger at all, and all three permission tiers were unreachable code. The inverse side now mirrors what `Workspace.job` already does. `cascade`/`orphanRemoval` went too: workspaces are soft deleted, so the cascade never fired for the case it appeared to cover, while orphanRemoval turned dropping an element from the collection into a row delete that bypassed `DeletePermission`.

**Elide answers 400 to a bodyless DELETE that declares a content type.** The page's delete was copied from Schedules, which sets one — so deleting a trigger from the UI would have failed, and nothing would have caught it, because the API test deletes without the header. There is now a test asserting the 400 with the reason written down.

## Testing

**1121 API tests, 0 failures. 470 UI tests, 0 failures.**

Beyond the unit coverage, `RunTriggerDispatchIntegrationTest` drives the real `reconcile` against the database — no executor needed — and reads the seeded graph: fan-out reaches all five dependents, a chain advances one step per run, a disabled edge dispatches nothing, and the diamond walks 0 → 1 → 2 runs on the join as each branch applies.

Verified in a browser on Codespaces against Postgres: both directions render on the correct side, and create, toggle and delete all work.

## Notes

- Rebased onto current `main`. `formatJobVia` from #3539 landed while this branch was open and fixes the same hardcoded heading, better; that version won the rebase and `RunTrigger` was added to it.
- `Schedules.tsx` and `Variables.tsx` set the same content type on their deletes. Left alone as out of scope, but the same 400 applies if axios ever stops dropping the header.
- The MinIO checksum conflict hit while setting up the devcontainer was fixed independently on `main` by #3529.

Closes #3520.
